### PR TITLE
feat: agency-init — bootstrap Agency 2.0 in any git repo

### DIFF
--- a/tools/agency-init
+++ b/tools/agency-init
@@ -1,0 +1,434 @@
+#!/bin/bash
+#
+# agency-init — Initialize Agency 2.0 in a git repo
+#
+# Usage:
+#   agency-init [target-dir]              # Initialize target directory (default: cwd)
+#   agency-init --principal <name>        # Override principal name
+#   agency-init --project <name>          # Set project name
+#   agency-init --timezone <tz>           # Set timezone (default: UTC)
+#
+# What it does:
+#   1. Validates target is a git repo
+#   2. Copies Agency 2.0 framework files (agents, hooks, tools, docs, hookify, templates)
+#   3. Creates CLAUDE.md from template
+#   4. Creates .claude/ config (settings, commands)
+#   5. Configures agency.yaml for this project
+#   6. Scaffolds usr/{principal}/ directory
+#   7. Makes an initial commit
+#
+# Requires: the-agency repo as source (AGENCY_SOURCE or auto-detect)
+
+set -euo pipefail
+
+# Tool version
+TOOL_VERSION="2.0.0-20260329-000001"
+
+# Source log helper
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENCY_SOURCE="${AGENCY_SOURCE:-$(cd "$SCRIPT_DIR/.." && pwd)}"
+if [[ -f "$SCRIPT_DIR/_log-helper" ]]; then
+    source "$SCRIPT_DIR/_log-helper"
+fi
+RUN_ID=$(log_start "agency-init" "agency-tool" "$@" 2>/dev/null) || true
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Defaults
+VERBOSE=false
+TARGET_DIR=""
+PRINCIPAL=""
+PROJECT_NAME=""
+TIMEZONE="UTC"
+
+# Logging
+log_info() { [[ "$VERBOSE" == "true" ]] && echo -e "${GREEN}[INFO]${NC} $1" || true; }
+log_warn() { echo -e "${YELLOW}[WARN]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
+
+show_help() {
+    cat << 'EOF'
+agency-init — Initialize Agency 2.0 in a git repo
+
+Usage:
+  agency-init [target-dir]              Initialize target (default: cwd)
+  agency-init --principal <name>        Override principal name
+  agency-init --project <name>          Set project name
+  agency-init --timezone <tz>           Set timezone (default: UTC)
+
+Options:
+  --verbose        Show detailed output
+  --version, -v    Show version
+  --help, -h       Show this help
+
+Examples:
+  cd ~/code/my-project && agency-init
+  agency-init ~/code/my-project --principal jordan --project my-project
+EOF
+}
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version|-v) echo "agency-init $TOOL_VERSION"; exit 0 ;;
+        --help|-h) show_help; exit 0 ;;
+        --verbose) VERBOSE=true; shift ;;
+        --principal) PRINCIPAL="$2"; shift 2 ;;
+        --project) PROJECT_NAME="$2"; shift 2 ;;
+        --timezone) TIMEZONE="$2"; shift 2 ;;
+        -*) log_error "Unknown option: $1"; show_help; exit 1 ;;
+        *) TARGET_DIR="$1"; shift ;;
+    esac
+done
+
+main() {
+    trap 'log_end "$RUN_ID" "failure" $? 0 "Unexpected exit" 2>/dev/null || true' EXIT
+
+    echo "agency-init [run: ${RUN_ID:-none}]"
+
+    # --- Resolve target ---
+    TARGET_DIR="${TARGET_DIR:-$(pwd)}"
+    TARGET_DIR="$(cd "$TARGET_DIR" 2>/dev/null && pwd)" || {
+        log_error "Target directory does not exist: $TARGET_DIR"
+        exit 1
+    }
+
+    # --- Validate git repo ---
+    if [[ ! -d "$TARGET_DIR/.git" ]]; then
+        log_error "Not a git repo: $TARGET_DIR"
+        echo "Run 'git init' first."
+        exit 1
+    fi
+
+    # --- Validate agency source ---
+    if [[ ! -f "$AGENCY_SOURCE/claude/config/agency.yaml" ]]; then
+        log_error "Agency source not found at: $AGENCY_SOURCE"
+        echo "Set AGENCY_SOURCE to the-agency repo path."
+        exit 1
+    fi
+
+    # --- Check not already initialized ---
+    if [[ -f "$TARGET_DIR/claude/config/agency.yaml" ]]; then
+        log_warn "Agency already initialized in $TARGET_DIR"
+        echo "Use 'agency-update' to update an existing installation."
+        exit 1
+    fi
+
+    # --- Resolve defaults ---
+    PRINCIPAL="${PRINCIPAL:-$(whoami)}"
+    PRINCIPAL=$(echo "$PRINCIPAL" | tr '[:upper:]' '[:lower:]')
+    PROJECT_NAME="${PROJECT_NAME:-$(basename "$TARGET_DIR")}"
+
+    echo ""
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BLUE}  Agency 2.0 Init${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "  Target:    $TARGET_DIR"
+    echo "  Project:   $PROJECT_NAME"
+    echo "  Principal: $PRINCIPAL"
+    echo "  Timezone:  $TIMEZONE"
+    echo "  Source:    $AGENCY_SOURCE"
+    echo ""
+
+    # =====================================================================
+    # Step 1: CLAUDE.md
+    # =====================================================================
+    log_step "Creating CLAUDE.md"
+
+    if [[ -f "$TARGET_DIR/CLAUDE.md" ]]; then
+        log_warn "CLAUDE.md already exists — appending Agency section"
+        echo "" >> "$TARGET_DIR/CLAUDE.md"
+        cat "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" >> "$TARGET_DIR/CLAUDE.md"
+    else
+        cp "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/CLAUDE.md"
+    fi
+
+    # Inject project name
+    if [[ "$(uname)" == "Darwin" ]]; then
+        sed -i '' "s/^# Agency Development Instructions/# $PROJECT_NAME\n\n## Agency Development Instructions/" "$TARGET_DIR/CLAUDE.md"
+    else
+        sed -i "s/^# Agency Development Instructions/# $PROJECT_NAME\n\n## Agency Development Instructions/" "$TARGET_DIR/CLAUDE.md"
+    fi
+
+    log_info "Created CLAUDE.md"
+
+    # =====================================================================
+    # Step 2: .claude/ directory
+    # =====================================================================
+    log_step "Setting up .claude/"
+
+    mkdir -p "$TARGET_DIR/.claude/commands"
+
+    # Settings — start from a clean template, not the-agency's full settings
+    cat > "$TARGET_DIR/.claude/settings.json" << 'SETTINGS_EOF'
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/branch-freshness.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/session-handoff.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/ref-injector.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "ExitPlanMode",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/plan-capture.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "Bash|Edit|Write|MultiEdit|Agent|Skill",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/tool-telemetry.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/quality-check.sh",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  },
+  "enabledPlugins": {
+    "hookify@claude-plugins-official": true
+  },
+  "permissions": {
+    "allow": [
+      "Bash(./tools/worktree-create*)",
+      "Bash(./tools/worktree-list*)",
+      "Bash(./tools/worktree-delete*)"
+    ]
+  }
+}
+SETTINGS_EOF
+
+    # Commands
+    cp "$AGENCY_SOURCE/.claude/commands/discuss.md" "$TARGET_DIR/.claude/commands/"
+
+    log_info "Created .claude/ with settings, hooks, commands"
+
+    # =====================================================================
+    # Step 3: claude/ framework directory
+    # =====================================================================
+    log_step "Copying Agency framework"
+
+    # Config
+    mkdir -p "$TARGET_DIR/claude/config"
+    cat > "$TARGET_DIR/claude/config/agency.yaml" << YAML_EOF
+# Agency Configuration for $PROJECT_NAME
+
+principals:
+  # Map system usernames to principal names
+  # The principal_name should match a directory in usr/{principal_name}/
+  $PRINCIPAL: $PRINCIPAL
+  default: unknown
+
+project:
+  name: "$PROJECT_NAME"
+  timezone: "$TIMEZONE"
+
+agents:
+  default_model: "opus"
+
+methodology:
+  numbering: "phase.iteration"
+  work_pattern: "discuss-plan-review-revise-finalize-implement"
+
+sandbox:
+  principal_dirs: true
+
+worktrees:
+  enabled: true
+  base_dir: ".worktrees"
+
+secrets:
+  provider: "vault"
+
+telemetry:
+  providers: ["jsonl"]
+YAML_EOF
+
+    # Docs
+    mkdir -p "$TARGET_DIR/claude/docs"
+    for doc in QUALITY-GATE.md DEVELOPMENT-METHODOLOGY.md CODE-REVIEW-LIFECYCLE.md FEEDBACK-FORMAT.md PR-LIFECYCLE.md TELEMETRY.md; do
+        [[ -f "$AGENCY_SOURCE/claude/docs/$doc" ]] && cp "$AGENCY_SOURCE/claude/docs/$doc" "$TARGET_DIR/claude/docs/"
+    done
+
+    # Agents
+    for agent in project-manager reviewer-code reviewer-design reviewer-scorer reviewer-security reviewer-test cos captain; do
+        if [[ -d "$AGENCY_SOURCE/claude/agents/$agent" ]]; then
+            mkdir -p "$TARGET_DIR/claude/agents/$agent"
+            cp "$AGENCY_SOURCE/claude/agents/$agent/agent.md" "$TARGET_DIR/claude/agents/$agent/"
+        fi
+    done
+
+    # Hooks
+    mkdir -p "$TARGET_DIR/claude/hooks"
+    for hook in ref-injector.sh session-handoff.sh quality-check.sh plan-capture.sh branch-freshness.sh tool-telemetry.sh ghostty-status.sh; do
+        [[ -f "$AGENCY_SOURCE/claude/hooks/$hook" ]] && cp "$AGENCY_SOURCE/claude/hooks/$hook" "$TARGET_DIR/claude/hooks/"
+    done
+    chmod +x "$TARGET_DIR/claude/hooks/"*.sh 2>/dev/null || true
+
+    # Hookify rules
+    mkdir -p "$TARGET_DIR/claude/hookify"
+    cp "$AGENCY_SOURCE/claude/hookify/"*.md "$TARGET_DIR/claude/hookify/" 2>/dev/null || true
+
+    # Templates
+    mkdir -p "$TARGET_DIR/claude/templates"
+    [[ -d "$AGENCY_SOURCE/claude/templates/principal-v2" ]] && cp -r "$AGENCY_SOURCE/claude/templates/principal-v2" "$TARGET_DIR/claude/templates/"
+    [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" "$TARGET_DIR/claude/templates/"
+    [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/claude/templates/"
+
+    log_info "Copied agents, hooks, hookify, docs, templates"
+
+    # =====================================================================
+    # Step 4: Tools
+    # =====================================================================
+    log_step "Installing tools"
+
+    mkdir -p "$TARGET_DIR/tools"
+    for tool in _log-helper _path-resolve worktree-create worktree-list worktree-delete ghostty-setup; do
+        [[ -f "$AGENCY_SOURCE/tools/$tool" ]] && cp "$AGENCY_SOURCE/tools/$tool" "$TARGET_DIR/tools/"
+    done
+    chmod +x "$TARGET_DIR/tools/"* 2>/dev/null || true
+
+    log_info "Installed core tools"
+
+    # =====================================================================
+    # Step 5: Principal directory
+    # =====================================================================
+    log_step "Scaffolding usr/$PRINCIPAL/"
+
+    mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/claude"/{commands,hookify,hooks,agents,refs}
+    mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/scripts"
+    mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/captain"/{transcripts,code-reviews,history}
+
+    cat > "$TARGET_DIR/usr/$PRINCIPAL/README.md" << USR_EOF
+# Principal: $PRINCIPAL
+
+## Projects
+- \`captain/\` — captain coordination
+USR_EOF
+
+    log_info "Scaffolded usr/$PRINCIPAL/"
+
+    # =====================================================================
+    # Step 6: Plans directory
+    # =====================================================================
+    mkdir -p "$TARGET_DIR/docs/plans"
+
+    # =====================================================================
+    # Step 7: .gitignore additions
+    # =====================================================================
+    log_step "Updating .gitignore"
+
+    GITIGNORE="$TARGET_DIR/.gitignore"
+    touch "$GITIGNORE"
+
+    for pattern in ".claude/settings.local.json" ".claude/*.user.local.md" ".worktrees/" "*.DS_Store"; do
+        if ! grep -qF "$pattern" "$GITIGNORE" 2>/dev/null; then
+            echo "$pattern" >> "$GITIGNORE"
+        fi
+    done
+
+    log_info "Updated .gitignore"
+
+    # =====================================================================
+    # Step 8: Initial commit
+    # =====================================================================
+    log_step "Creating initial commit"
+
+    cd "$TARGET_DIR"
+    git add -A
+    git commit -m "feat: initialize Agency 2.0 framework
+
+Agency 2.0 initialized via agency-init. Includes:
+- CLAUDE.md (project instructions)
+- 8 agents (PM, 5 reviewers, CoS, captain)
+- 7 hooks (ref-injector, session-handoff, quality-check, plan-capture,
+  branch-freshness, tool-telemetry, ghostty-status)
+- 15 hookify behavioral rules
+- /discuss skill for structured 1B1 discussions
+- Worktree tools (create, list, delete)
+- Reference docs (quality gate, methodology, code review, feedback,
+  PR lifecycle, telemetry)
+- usr/$PRINCIPAL/ principal directory (v2)
+- Core tools (_log-helper, _path-resolve, ghostty-setup)
+
+Source: the-agency $(cd "$AGENCY_SOURCE" && git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+" || {
+        log_warn "Commit failed — you may need to commit manually"
+    }
+
+    # =====================================================================
+    # Done
+    # =====================================================================
+    echo ""
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${GREEN}  Agency 2.0 Initialized!${NC}"
+    echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo ""
+    echo "  Project:   $PROJECT_NAME"
+    echo "  Principal: $PRINCIPAL"
+    echo "  Location:  $TARGET_DIR"
+    echo ""
+    echo "Next steps:"
+    echo ""
+    echo "  1. Run Ghostty setup (if using Ghostty):"
+    echo "     ./tools/ghostty-setup"
+    echo ""
+    echo "  2. Launch Claude Code:"
+    echo "     claude"
+    echo ""
+    echo "  3. Bootstrap the captain with this prompt:"
+    echo ""
+    echo "     You are the captain of $PROJECT_NAME — a new Agency 2.0 project."
+    echo "     Read CLAUDE.md, claude/docs/DEVELOPMENT-METHODOLOGY.md, and"
+    echo "     claude/config/agency.yaml. Verify hooks fired on startup."
+    echo "     Write your first handoff at usr/$PRINCIPAL/captain/handoff.md."
+    echo "     Tell me you're ready and ask what we're building."
+    echo ""
+
+    trap - EXIT
+    log_end "$RUN_ID" "success" 0 0 "Initialized $PROJECT_NAME for $PRINCIPAL" 2>/dev/null || true
+}
+
+main

--- a/usr/jordan/captain/guide-agency-init-presence-monitor-20260329.md
+++ b/usr/jordan/captain/guide-agency-init-presence-monitor-20260329.md
@@ -1,0 +1,75 @@
+# Guide: Initialize presence-monitor with Agency 2.0
+
+**For:** Jordan (Principal)
+**From:** CoS (monofolk session)
+**Date:** 2026-03-29
+
+---
+
+## Steps
+
+### Step 1: Create the repo
+
+```bash
+mkdir ~/code/presence-monitor
+cd ~/code/presence-monitor
+git init
+```
+
+### Step 2: Run agency-init
+
+```bash
+~/code/the-agency/tools/agency-init --principal jordan --project presence-monitor --timezone Asia/Singapore
+```
+
+This copies the Agency 2.0 framework from the-agency, configures it for presence-monitor, scaffolds `usr/jordan/`, and makes the initial commit.
+
+### Step 3: Set up Ghostty (if using Ghostty)
+
+```bash
+./tools/ghostty-setup
+```
+
+### Step 4: Launch Claude Code
+
+```bash
+claude
+```
+
+### Step 5: Bootstrap the captain
+
+Paste this prompt:
+
+```
+You are the captain of presence-monitor — a new Agency 2.0 project.
+
+Read CLAUDE.md, claude/docs/DEVELOPMENT-METHODOLOGY.md, and claude/config/agency.yaml.
+Verify hooks fired on startup (you should see branch-freshness and session-handoff messages).
+Write your first handoff at usr/jordan/captain/handoff.md.
+Tell me you're ready and ask what we're building.
+```
+
+---
+
+## After Bootstrap
+
+The captain is live. You can:
+- Start a project with `/discuss`
+- Create worktrees with `./tools/worktree-create <name>`
+- Quality gates run automatically via the PM agent
+
+---
+
+## Troubleshooting
+
+### agency-init fails with "Not a git repo"
+Run `git init` first.
+
+### agency-init fails with "Agency source not found"
+Set the source path: `AGENCY_SOURCE=~/code/the-agency ~/code/the-agency/tools/agency-init`
+
+### Hooks not firing
+Check `.claude/settings.json` is present and has hooks wired.
+
+### Hookify rules not active
+Verify `"hookify@claude-plugins-official": true` in `.claude/settings.json`.


### PR DESCRIPTION
## Summary

`tools/agency-init` — the command that bootstraps Agency 2.0 in any git repo.

```bash
mkdir ~/code/my-project
cd ~/code/my-project
git init
~/code/the-agency/tools/agency-init --principal jordan --project my-project
claude
```

### What it does
1. Validates target is a git repo
2. Copies framework files from the-agency (agents, hooks, tools, docs, hookify, templates)
3. Creates CLAUDE.md from template
4. Creates clean .claude/settings.json with hooks wired
5. Generates agency.yaml configured for this project
6. Scaffolds usr/{principal}/ directory
7. Updates .gitignore
8. Makes initial commit
9. Prints bootstrap prompt for the captain

### Includes
- Guide for presence-monitor (first real use case)

## Test plan

- [ ] `tools/agency-init --version` works
- [ ] `tools/agency-init --help` shows usage
- [ ] Initialize a fresh git repo and verify all files are created
- [ ] Launch claude in initialized repo and verify hooks fire
- [ ] Captain bootstrap prompt produces a working session

🤖 Generated with [Claude Code](https://claude.com/claude-code)