### PR TITLE
fix: remove invalid if field from ref-injector hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -62,7 +62,6 @@
         "hooks": [
           {
             "type": "command",
-            "if": "Skill(*iteration-complete*)|Skill(*phase-complete*)|Skill(*plan-complete*)|Skill(*quality-gate*)|Skill(*pre-phase-review*)|Skill(*captain-review*)|Skill(*code-review*)|Skill(*review-pr*)|Skill(*feedback*)",
             "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/ref-injector.sh"
           }
         ]


### PR DESCRIPTION
## Summary

The `if` field added in the previous commit used invalid syntax:
- Pipe-separated OR (`Skill(*a*)|Skill(*b*)`) is not supported in `if` — only in `matcher`
- `Skill(...)` is not a valid permission rule tool name

Verified against Claude Code hooks documentation (v2.1.85+). Valid `if` tool names are: Bash, Edit, Write, Read, Glob, Grep, WebFetch, WebSearch, Agent, mcp__*.

Removed the `if` field. The `matcher: "Skill"` already scopes correctly. The ref-injector's internal case statement handles per-skill routing and exits with no output when no ref matches — preserving the token savings from eliminating empty `{}` responses.

## Test plan

- [ ] Invoke a skill with a ref mapping (e.g., /iteration-complete) — ref content should inject
- [ ] Invoke a skill without a ref mapping — no system message should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)