### PR TITLE
fix: resolve ISS-002 through ISS-007 + agency-bench removal dispatch

### DIFF
--- a/claude/agents/templates/docs/agent.md
+++ b/claude/agents/templates/docs/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** docs
 
 ## Purpose

--- a/claude/agents/templates/generic/agent.md
+++ b/claude/agents/templates/generic/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 
 ## Purpose
 

--- a/claude/agents/templates/reviewer/agent.md
+++ b/claude/agents/templates/reviewer/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** reviewer
 
 ## Purpose

--- a/claude/agents/templates/security/agent.md
+++ b/claude/agents/templates/security/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** security
 
 ## Purpose

--- a/claude/agents/templates/services/agent.md
+++ b/claude/agents/templates/services/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** services
 
 ## Purpose

--- a/claude/agents/templates/tester/agent.md
+++ b/claude/agents/templates/tester/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** tester
 
 ## Purpose

--- a/claude/agents/templates/ux-dev/agent.md
+++ b/claude/agents/templates/ux-dev/agent.md
@@ -2,7 +2,7 @@
 
 **Created:** {{TIMESTAMP}}
 **Workstream:** {{WORKSTREAM}}
-**Model:** Opus 4.5 (default)
+**Model:** Opus 4.6 (default)
 **Type:** ux-dev
 
 ## Purpose

--- a/claude/docs/guides/model-selection.md
+++ b/claude/docs/guides/model-selection.md
@@ -4,7 +4,7 @@
 
 ## Opus as Conductor Pattern (Default)
 
-All agents run as **Opus 4.5** by default. Opus acts as the "conductor" - coordinating work, making architectural decisions, and spawning subagents (Sonnet/Haiku) for parallel execution.
+All agents run as **Opus 4.6** by default. Opus acts as the "conductor" - coordinating work, making architectural decisions, and spawning subagents (Sonnet/Haiku) for parallel execution.
 
 ```bash
 # Launch with myclaude

--- a/claude/knowledge/claude-code/01-overview.md
+++ b/claude/knowledge/claude-code/01-overview.md
@@ -77,8 +77,8 @@ Claude Code is Anthropic's official agentic coding tool that operates directly i
 
 ## Supported Models
 
-- Claude Opus 4.5 (highest capability)
-- Claude Sonnet 4.5 (default, balanced)
+- Claude Opus 4.6 (highest capability)
+- Claude Sonnet 4.6 (default, balanced)
 - Claude Haiku 4.5 (fastest, cheapest)
 
 Enterprise users can deploy via Amazon Bedrock or Google Cloud Vertex AI.

--- a/tools/agent-create
+++ b/tools/agent-create
@@ -1,14 +1,16 @@
 #!/bin/bash
 # Create a new agent identity
 #
-# Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>]
+# Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>] [--description=<text>] [--seeds=<path>]
 #
 # Many-to-one mapping: Multiple agents can work on the same workstream
 # Agent name may differ from workstream name
 #
 # Options:
-#   --type=<template>  Use a specific agent template (default: generic)
-#   --verbose          Show detailed logging
+#   --type=<template>       Use a specific agent template (default: generic)
+#   --description=<text>    Description for the agent (used in agent.md and Claude Code registration)
+#   --seeds=<path>          Path to seed files directory (added as reference in agent.md)
+#   --verbose               Show detailed logging
 #
 # Creates:
 #   claude/agents/{agentname}/
@@ -64,23 +66,26 @@ fi
 if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
     echo "agent-create - Create a new agent identity"
     echo ""
-    echo "Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>] [--verbose]"
+    echo "Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>] [--description=<text>] [--seeds=<path>] [--verbose]"
     echo ""
     echo "Arguments:"
     echo "  agentname     Name for the new agent"
     echo "  workstream    Workstream the agent belongs to (must exist)"
     echo ""
     echo "Options:"
-    echo "  --type=<template>  Use a specific agent template (default: generic)"
-    echo "  --list-types       List available agent templates"
-    echo "  --verbose          Show detailed logging"
-    echo "  --version, -v      Show version"
-    echo "  --help, -h         Show this help"
+    echo "  --type=<template>       Use a specific agent template (default: generic)"
+    echo "  --description=<text>    Description for the agent (used in agent.md and Claude Code agent)"
+    echo "  --seeds=<path>          Path to seed files directory (added as reference in agent.md)"
+    echo "  --list-types            List available agent templates"
+    echo "  --verbose               Show detailed logging"
+    echo "  --version, -v           Show version"
+    echo "  --help, -h              Show this help"
     echo ""
     echo "Examples:"
     echo "  ./tools/agent-create agent-manager agents"
     echo "  ./tools/agent-create ui-specialist web --type=ux-dev"
-    echo "  ./tools/agent-create backend-dev api --type=generic"
+    echo "  ./tools/agent-create backend-dev api --type=generic --description='Backend development specialist'"
+    echo "  ./tools/agent-create researcher research --seeds=usr/jordan/researcher/"
     echo ""
     echo "Available templates:"
     if [[ -d "$TEMPLATE_DIR" ]]; then
@@ -116,11 +121,19 @@ fi
 AGENTNAME=""
 WORKSTREAM=""
 AGENT_TYPE="generic"
+DESCRIPTION=""
+SEEDS_PATH=""
 
 for arg in "$@"; do
     case $arg in
         --type=*)
             AGENT_TYPE="${arg#*=}"
+            ;;
+        --description=*)
+            DESCRIPTION="${arg#*=}"
+            ;;
+        --seeds=*)
+            SEEDS_PATH="${arg#*=}"
             ;;
         --verbose)
             VERBOSE=true
@@ -141,7 +154,7 @@ done
 if [ -z "$AGENTNAME" ] || [ -z "$WORKSTREAM" ]; then
   log_error "Missing required arguments"
   echo ""
-  echo "Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>] [--verbose]"
+  echo "Usage: ./tools/agent-create <agentname> <workstream> [--type=<template>] [--description=<text>] [--seeds=<path>] [--verbose]"
   echo ""
   echo "Examples:"
   echo "  ./tools/agent-create agent-manager agents"
@@ -230,6 +243,13 @@ main() {
     apply_template "$AGENT_TEMPLATE_DIR/KNOWLEDGE.md" "$DIR/KNOWLEDGE.md"
     apply_template "$AGENT_TEMPLATE_DIR/ONBOARDING.md" "$DIR/ONBOARDING.md"
 
+    # Replace placeholder description in agent.md if --description was provided
+    if [[ -n "$DESCRIPTION" && -f "$DIR/agent.md" ]]; then
+        local desc_escaped
+        desc_escaped=$(escape_sed "$DESCRIPTION")
+        sed -i '' "s/\[Description of this agent's role\]/$desc_escaped/" "$DIR/agent.md"
+    fi
+
     # WORKLOG.md (not templated - standard format)
     cat > "$DIR/WORKLOG.md" << EOF
 # $AGENTNAME Work Log
@@ -285,6 +305,55 @@ EOF
 | Date | Tool | Command | Reason | Outcome |
 |------|------|---------|--------|---------|
 EOF
+
+    # Auto-detect seed files from principal directories
+    if [[ -z "$SEEDS_PATH" ]]; then
+        for principal_dir in claude/principals/*/; do
+            principal_name=$(basename "$principal_dir")
+            candidate="usr/${principal_name}/${AGENTNAME}/"
+            if [[ -d "$candidate" ]]; then
+                SEEDS_PATH="$candidate"
+                log_info "Auto-detected seed files at $SEEDS_PATH"
+                break
+            fi
+        done
+    fi
+
+    # Append Seed Files section to agent.md if seeds path is set
+    if [[ -n "$SEEDS_PATH" ]]; then
+        cat >> "$DIR/agent.md" << SEEDEOF
+
+## Seed Files
+
+- \`${SEEDS_PATH}\` - Seed files and reference material for this agent
+SEEDEOF
+        verbose_echo "Added seed files reference: $SEEDS_PATH"
+    fi
+
+    # Register with Claude Code if .claude/ directory exists
+    CLAUDE_AGENTS_DIR=".claude/agents"
+    if [[ -d ".claude" ]]; then
+        mkdir -p "$CLAUDE_AGENTS_DIR"
+
+        # Determine description for Claude Code agent
+        if [[ -n "$DESCRIPTION" ]]; then
+            CC_DESCRIPTION="$DESCRIPTION"
+        else
+            CC_DESCRIPTION="Agency agent for the ${WORKSTREAM} workstream"
+        fi
+
+        cat > "$CLAUDE_AGENTS_DIR/${AGENTNAME}.md" << CCEOF
+---
+name: ${AGENTNAME}
+description: "${CC_DESCRIPTION}"
+model: opus
+---
+
+Read your identity and responsibilities from \`claude/agents/${AGENTNAME}/agent.md\`.
+Read your project knowledge from \`claude/workstreams/${WORKSTREAM}/KNOWLEDGE.md\`.
+CCEOF
+        verbose_echo "Registered Claude Code agent: $CLAUDE_AGENTS_DIR/${AGENTNAME}.md"
+    fi
 
     # Create agent folder in all principal cloud storage locations
     verbose_echo ""

--- a/tools/workstream-create
+++ b/tools/workstream-create
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Create a new workstream directory structure
 #
-# Usage: ./tools/workstream-create <name> [--verbose]
+# Usage: ./tools/workstream-create <name> [--description=<text>] [--verbose]
 #
 # Creates:
 #   claude/workstreams/{name}/
@@ -43,12 +43,40 @@ if [[ "${1:-}" == "--version" || "${1:-}" == "-v" ]]; then
     exit 0
 fi
 
+# Help
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+    echo "workstream-create - Create a new workstream directory structure"
+    echo ""
+    echo "Usage: ./tools/workstream-create <name> [--description=<text>] [--verbose]"
+    echo ""
+    echo "Arguments:"
+    echo "  name    Name for the new workstream"
+    echo ""
+    echo "Options:"
+    echo "  --description=<text>  Description for the workstream KNOWLEDGE.md"
+    echo "  --verbose             Show detailed logging"
+    echo "  --version, -v         Show version"
+    echo "  --help, -h            Show this help"
+    echo ""
+    echo "Examples:"
+    echo "  ./tools/workstream-create billing"
+    echo "  ./tools/workstream-create billing --description='Payment processing and invoicing'"
+    exit 0
+fi
+
 # Parse arguments
 NAME=""
+DESCRIPTION=""
 for arg in "$@"; do
     case $arg in
         --verbose)
             VERBOSE=true
+            ;;
+        --description=*)
+            DESCRIPTION="${arg#*=}"
+            ;;
+        --*)
+            # Skip other options
             ;;
         *)
             if [[ -z "$NAME" ]]; then
@@ -61,7 +89,7 @@ done
 if [ -z "$NAME" ]; then
   log_error "Missing required argument"
   echo ""
-  echo "Usage: ./tools/workstream-create <name> [--verbose]"
+  echo "Usage: ./tools/workstream-create <name> [--description=<text>] [--verbose]"
   echo ""
   echo "Example: ./tools/workstream-create billing"
   exit 1
@@ -89,6 +117,13 @@ main() {
     mkdir -p "$DIR/epic001"
     mkdir -p "$DIR/epic002"
 
+    # Set description text
+    if [[ -n "$DESCRIPTION" ]]; then
+        OVERVIEW_TEXT="$DESCRIPTION"
+    else
+        OVERVIEW_TEXT="TODO: describe this workstream"
+    fi
+
     cat > "$DIR/KNOWLEDGE.md" << EOF
 # $NAME Workstream Knowledge
 
@@ -96,19 +131,19 @@ main() {
 
 ## Overview
 
-[Description of what this workstream covers]
+$OVERVIEW_TEXT
 
 ## Key Concepts
 
-[Domain-specific knowledge]
+TODO: add domain-specific knowledge
 
 ## Patterns
 
-[Common patterns used]
+TODO: document common patterns used
 
 ## References
 
-- [Relevant documentation links]
+- TODO: add relevant documentation links
 EOF
 
     echo "Created:"

--- a/usr/jordan/captain/dispatch-remove-agency-bench-20260329.md
+++ b/usr/jordan/captain/dispatch-remove-agency-bench-20260329.md
@@ -1,0 +1,14 @@
+# Dispatch: Remove agency-bench
+
+**From:** CoS (monofolk)
+**To:** the-agency captain
+**Date:** 2026-03-29
+**Priority:** High
+
+---
+
+Remove `source/apps/agency-bench/` from the repo. It is the sole source of all 12 open Dependabot alerts (3 high, 9 moderate). The idea is past its prime — Jordan's decision.
+
+Clean up all references, regenerate lockfiles, verify alerts clear after merge.
+
+PR branch, not direct to main.


### PR DESCRIPTION
## Summary

Fixes 5 issues found by the captain during Agency 2.0 transition, plus dispatches ISS-008.

### ISS-002: workstream-create --help
`--help` flag now parsed before any directory creation. Previously created a `claude/workstreams/--help/` directory.

### ISS-003: Opus 4.5 → 4.6
Updated all 7 agent templates + model-selection guide + knowledge overview.

### ISS-004: workstream-create --description
New `--description` flag populates KNOWLEDGE.md. Placeholder text improved with TODO prefixes.

### ISS-005: agent-create --seeds
New `--seeds` flag adds seed file references to agent.md. Auto-detects `usr/{principal}/{name}/` if it exists.

### ISS-007: agent-create registers with Claude Code
Now creates `.claude/agents/{name}.md` so `claude --agent {name}` works. Description is quoted in YAML frontmatter (QG fix — unquoted values break on colons/hashes).

### ISS-008: Dispatch
Dispatch file for captain to remove `source/apps/agency-bench/` — sole source of all 12 Dependabot alerts.

## QG

Reviewed by code-reviewer agent. Two findings:
1. Unquoted YAML description (confidence 85) — fixed
2. Remaining 4.5 refs in docs (confidence 80) — fixed

## Test plan

- [ ] `./tools/workstream-create --help` shows usage, does NOT create directory
- [ ] `./tools/workstream-create test --description="Test workstream"` populates KNOWLEDGE.md
- [ ] `./tools/agent-create test housekeeping --seeds=usr/jordan/test/` adds seed section
- [ ] `./tools/agent-create test housekeeping` creates `.claude/agents/test.md`
- [ ] Grep for "4.5" in templates returns zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)