### PR TITLE
Fix tech-lead checklists + statusline portability

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ All tools emit minimal stdout to conserve context. Currently in `./tools/`, futu
 ✓
 ```
 
-Verbose output goes to the log service. Investigate with: `./tools/agency-service log run {run-id}`
+Verbose output goes to `.claude/logs/tool-runs.jsonl`. Investigate with: `./tools/tool-log {run-id}`
 
 ## Agents
 

--- a/claude/agents/tech-lead/agent.md
+++ b/claude/agents/tech-lead/agent.md
@@ -21,7 +21,8 @@ Drive toward a complete Product Vision & Requirements using the `/define` skill 
 - Problem statement — what problem are we solving?
 - Target users — who is this for?
 - Use cases — what do they do with it?
-- Requirements — functional and non-functional
+- Functional requirements — what must it do?
+- Non-functional requirements — performance, scalability, reliability, accessibility
 - Constraints — technical, business, regulatory
 - Success criteria — how do we know it works?
 - Non-goals — what are we explicitly NOT doing?
@@ -42,6 +43,8 @@ Drive toward a complete Architecture & Design using the `/design` skill (or `/di
 - Trade-offs — what we chose and what we gave up (with why)
 - Failure modes — what can go wrong and how we handle it
 - Security considerations — auth, data protection, attack surface
+- Deployment & operations — how it runs, environments, monitoring, scaling
+- Open technical questions — what needs prototyping or research?
 
 PVR and A&D evolve side by side. Update both during discussion.
 

--- a/claude/tools/statusline.sh
+++ b/claude/tools/statusline.sh
@@ -86,22 +86,27 @@ fi
 usage_info=""
 
 # Format reset timestamp to human-readable ETA
+# Supports both macOS (date -r) and Linux (date -d @)
 format_reset() {
     local reset_ts="$1"
     if [ -z "$reset_ts" ]; then
         return
     fi
-    local now_ts
-    now_ts=$(date +%s)
-    local reset_date
     local now_date
-    # Same day? Show HH:MM. Different day? Show Day HH:MM.
-    reset_date=$(date -r "$reset_ts" +%Y-%m-%d 2>/dev/null) || return
     now_date=$(date +%Y-%m-%d)
+
+    # Try macOS first, then Linux
+    local reset_date
+    reset_date=$(date -r "$reset_ts" +%Y-%m-%d 2>/dev/null) \
+        || reset_date=$(date -d "@$reset_ts" +%Y-%m-%d 2>/dev/null) \
+        || return
+
     if [ "$reset_date" = "$now_date" ]; then
-        date -r "$reset_ts" +%H:%M 2>/dev/null
+        date -r "$reset_ts" +%H:%M 2>/dev/null \
+            || date -d "@$reset_ts" +%H:%M 2>/dev/null
     else
-        date -r "$reset_ts" +"%a %H:%M" 2>/dev/null
+        date -r "$reset_ts" +"%a %H:%M" 2>/dev/null \
+            || date -d "@$reset_ts" +"%a %H:%M" 2>/dev/null
     fi
 }
 
@@ -112,15 +117,21 @@ if [ -n "$five_h_pct" ]; then
     if [ -n "$five_h_eta" ]; then
         h5="${h5} → ${five_h_eta}"
     fi
+    usage_info="${h5}"
+fi
 
+if [ -n "$seven_d_pct" ]; then
     seven_d_int=${seven_d_pct%.*}
     d7="7d: ${seven_d_int}%"
     seven_d_eta=$(format_reset "$seven_d_reset")
     if [ -n "$seven_d_eta" ]; then
         d7="${d7} → ${seven_d_eta}"
     fi
-
-    usage_info="${h5} ${d7}"
+    if [ -n "$usage_info" ]; then
+        usage_info="${usage_info} ${d7}"
+    else
+        usage_info="${d7}"
+    fi
 fi
 
 # --- Cost + duration ---


### PR DESCRIPTION
## Summary

- Tech-lead PVR checklist: split Requirements into Functional + Non-Functional (now 9 items, aligns with /define)
- Tech-lead A&D checklist: added Deployment & Operations + Open Technical Questions (now 10 items, aligns with /design)
- CLAUDE.md: tool-log reference replaces agency-service
- Statusline: independent 5h/7d guards + Linux date portability

🤖 Generated with [Claude Code](https://claude.com/claude-code)