### PR TITLE
feat: dispatches — code survey tool + token economics

### DIFF
--- a/usr/jordan/captain/dispatches/dispatch-agency-code-survey-tool-20260331.md
+++ b/usr/jordan/captain/dispatches/dispatch-agency-code-survey-tool-20260331.md
@@ -1,0 +1,78 @@
+# Dispatch: Code Survey / Exploration Tool — Incremental Capture
+
+**Date:** 2026-03-31
+**From:** CoS (monofolk)
+**To:** Captain (the-agency)
+**Priority:** High — core capability gap
+**Type:** Tool Request
+
+---
+
+## Problem
+
+Review and explorer agents exhaust context on large codebases. They hold all findings in memory, intending to produce a report at the end, but the report never happens because context runs out during the reading phase.
+
+Evidence from monofolk full-repo audit (2026-03-31):
+- 20+ review agents dispatched across 3 passes
+- Sonnet agents consistently exhausted context without producing findings
+- Even Opus agents failed on scopes larger than ~25 files
+- Only file-scoped agents (explicit file lists, <=25 files) consistently produced structured output
+- Architecture-mapping agents (code-explorer) that needed to read 40+ files and then write a 20K+ char doc also failed
+
+## What We Need
+
+An **incremental capture** pattern for long-running agent work. The agent writes findings/observations to a document as it goes — after reading each file or group of files — rather than holding everything in context for a final dump.
+
+## Proposed Design
+
+### Option A: Tool-based capture
+
+A `capture-finding` tool that agents call after each file read:
+
+```bash
+capture-finding --output findings.md --file "src/patient/patient.service.ts" \
+  --category bug --confidence 85 \
+  --title "TOCTOU race in update" \
+  --description "findOne outside transaction, then separate $transaction..."
+```
+
+The tool appends to a JSONL or markdown file. The agent's context only holds the current file + the tool call — not all previous findings.
+
+### Option B: Document-as-you-go instruction pattern
+
+A review agent wrapper that instructs the inner agent:
+1. Read file N
+2. Write any findings to `{output-file}` using the Write tool (append mode)
+3. After every 10 files, summarize progress in the output file
+4. Continue until all files are read
+5. Final pass: read the output file, deduplicate, produce structured report
+
+This keeps findings in a file, not in context. The agent can even be restarted from the output file if it crashes.
+
+### Option C: Multi-session chain
+
+A coordinator that:
+1. Gives an agent a batch of ~15 files
+2. Agent produces findings, writes to a shared file
+3. Coordinator launches next agent with the next batch + pointer to the shared file
+4. Final agent reads the shared file and produces the consolidated report
+
+This is the handoff pattern applied to code review.
+
+## Recommended Approach
+
+**Option B first** (simplest, no new tools), then evolve to Option C (most robust) as the pattern proves out. Option A is nice-to-have for structured capture but Write tool with append serves the same purpose.
+
+The key insight: **the output document is the agent's memory, not its context window.**
+
+## Acceptance Criteria
+
+1. An agent can review 100+ files and produce a complete structured report
+2. Findings are captured incrementally — partial results are available even if the agent crashes
+3. The pattern works with both reviewer agents and explorer/architecture-mapping agents
+4. No new infrastructure required (uses existing Write/Read tools)
+
+## Reference
+
+- Memory: `project_incremental-agent-capture.md` in monofolk
+- Evidence: monofolk full-repo audit session (2026-03-31), 3 passes, 20+ agents

--- a/usr/jordan/captain/dispatches/dispatch-agency-token-economics-tools-20260331.md
+++ b/usr/jordan/captain/dispatches/dispatch-agency-token-economics-tools-20260331.md
@@ -1,0 +1,51 @@
+# Dispatch: Token Economics Tools
+
+**Date:** 2026-03-31
+**From:** CoS (monofolk)
+**To:** Captain (the-agency)
+**Priority:** Medium — ongoing cost impact
+**Type:** Tool Request
+
+---
+
+## Problem
+
+Several Agency patterns waste tokens on repeated, non-actionable content injected into every tool call or conversation turn. Over a session, this adds up to thousands of tokens burned on noise.
+
+## Tools / Fixes Needed
+
+### 1. `/git-commit` skill
+**Impact:** ~250 tokens per commit × N commits per session
+**Problem:** The hookify rule `warn-compound-bash` fires on every `git commit -m "$(cat <<'EOF'..."` heredoc pattern, injecting a ~250-token warning into context. The warning says "use `/git-commit` instead" but no such skill exists.
+**Solution:** Build a `/git-commit` skill that handles heredoc commit messages natively, OR suppress the hookify rule for heredoc git commits specifically.
+
+### 2. Compound bash detector refinement
+**Impact:** ~250 tokens per false positive
+**Problem:** The `warn-compound-bash` rule fires on legitimate patterns that have no simpler alternative (heredoc commits, PATH prefixes for testing). Each false positive injects the full warning text.
+**Solution:** Refine the rule to:
+- Allow `git commit -m "$(cat <<` pattern (heredoc is the approved format)
+- Allow `PATH=... bash -c` for test isolation
+- Keep warnings for actual compound commands (&&, ||, pipes)
+
+### 3. Hook output minimization
+**Impact:** Variable — every hook that outputs text consumes tokens
+**Problem:** Some hooks output explanatory text on every invocation. The quality-check hook's TypeScript error output, the plan-capture hook's success messages, etc.
+**Solution:** Audit all hooks for unnecessary stdout. Hooks should output nothing on success (matching the telemetry hook pattern after our QG fix).
+
+### 4. System reminder compression
+**Impact:** Large — system reminders repeat on every tool call
+**Problem:** The `task tools haven't been used recently` reminder appears constantly. CLAUDE.md content is injected repeatedly.
+**Solution:** This is a Claude Code platform issue, not something we can fix. But we can minimize our CLAUDE.md size (the refactor is pending) and ensure hooks don't add to the noise.
+
+### 5. Agent context budget estimation
+**Impact:** Prevents wasted agent dispatches
+**Problem:** We dispatched 20+ agents in the audit, most of which exhausted context. Each wasted dispatch costs tokens for the exploration that produced no findings.
+**Solution:** Build a `context-budget` tool that estimates: given N files of average size M, will this fit in an agent's context window? Use this before dispatching to right-size the scope.
+
+## Priority
+
+1. `/git-commit` skill or hookify refinement (immediate — fires every commit)
+2. Compound bash detector refinement (immediate — false positives are noisy)
+3. Hook output minimization (quick audit)
+4. Context budget estimation (before next large review pass)
+5. CLAUDE.md size reduction (pending discussion on promotion)


### PR DESCRIPTION
## Summary

Two dispatches from the monofolk CoS full-repo audit session:

- **Code survey/exploration tool** — agents that review large codebases exhaust context before producing reports. Need an incremental capture pattern where agents write findings to a file as they go. Three design options proposed; document-as-you-go recommended first.

- **Token economics tools** — several patterns waste tokens on repeated non-actionable content. Priority: /git-commit skill (250 tokens/commit saved), compound bash rule refinement, hook output minimization, context budget estimation.

## Test plan

- [ ] Dispatches are valid markdown
- [ ] Filed in correct location (`usr/jordan/captain/dispatches/`)
- [ ] Captain can read and triage

🤖 Generated with [Claude Code](https://claude.com/claude-code)