### PR TITLE
housekeeping: session 9 — browser bugs filed, skills article captured

### DIFF
--- a/claude/config/agency-dependencies.yaml
+++ b/claude/config/agency-dependencies.yaml
@@ -124,6 +124,14 @@ dependencies:
       linux: "sudo apt-get install -y ripgrep"
     breaks: "fast code search"
 
+  # PDF processing
+  - name: pdftotext
+    check: "command -v pdftotext"
+    install:
+      darwin: "brew install poppler"
+      linux: "sudo apt-get install -y poppler-utils"
+    breaks: "PDF reading in Claude Code (Read tool)"
+
   # Rust (for Tauri/AgencyBench builds)
   - name: cargo
     min_version: "1.70"

--- a/claude/workstreams/agency/seeds/skills-article-bcherny-20260331.md
+++ b/claude/workstreams/agency/seeds/skills-article-bcherny-20260331.md
@@ -1,0 +1,81 @@
+# Lessons from Building Claude Code: How We Use Skills
+
+**Source:** @bcherny on X/Twitter — `https://x.com/bcherny/status/2038454336355999749`
+**Captured:** 2026-03-31
+**Type:** Anthropic internal practices shared publicly
+
+## Summary
+
+Boris Cherny (Anthropic) shares lessons from extensive internal use of skills in Claude Code — hundreds in active use. Covers skill taxonomy, authoring best practices, distribution, and measurement.
+
+## Key Takeaways
+
+### Skills Are Folders, Not Files
+- Common misconception: "just markdown files"
+- Skills are folders with scripts, assets, data that the agent discovers and manipulates
+- Configuration options include registering dynamic hooks
+- File system as progressive disclosure — split into references/, assets/, etc.
+
+### 9 Skill Categories
+
+1. **Library & API Reference** — internal libs, CLIs, SDKs, gotchas
+2. **Product Verification** — test/verify code works (paired with playwright, tmux, etc.)
+3. **Data Fetching & Analysis** — connect to data/monitoring stacks
+4. **Business Process & Team Automation** — repetitive workflows → one command
+5. **Code Scaffolding & Templates** — framework boilerplate generation
+6. **Code Quality & Review** — enforce code quality, review code
+7. **CI/CD & Deployment** — fetch, push, deploy code
+8. **Runbooks** — symptom → investigation → structured report
+9. **Infrastructure Operations** — routine maintenance with guardrails
+
+### Authoring Best Practices
+
+- **Don't state the obvious** — focus on info that pushes Claude out of its normal patterns
+- **Build a Gotchas section** — highest-signal content, built from common failure points
+- **Use progressive disclosure** — point to other files, Claude reads them when appropriate
+- **Avoid railroading** — give info + flexibility, don't over-specify
+- **Think through setup** — store user config in config.json, use AskUserQuestion for structured input
+- **Description field is for the model** — it's a trigger condition, not a summary
+
+### Memory & Data Storage
+
+- Skills can store data (text logs, JSON, SQLite)
+- Example: standup-post keeps standups.log for history
+- Use `${CLAUDE_PLUGIN_DATA}` for stable storage that survives skill upgrades
+
+### Scripts & Code Generation
+
+- Give Claude scripts and libraries for composition
+- Example: data science skill with helper functions → Claude generates analysis scripts on the fly
+
+### On-Demand Hooks
+
+- Skills can register hooks active only during the skill's session
+- Examples: `/careful` blocks destructive commands, `/freeze` blocks edits outside a directory
+
+### Distribution
+
+- **Repo-checked** — `.claude/skills/` — good for small teams
+- **Plugin marketplace** — internal marketplace, users install what they want
+- Organic curation: sandbox folder → traction → PR to marketplace
+- Warning: easy to create bad/redundant skills, need curation
+
+### Measurement
+
+- PreToolUse hook logs skill usage company-wide
+- Find popular skills or ones undertriggering vs expectations
+
+### Composition
+
+- Skills can reference other skills by name
+- No native dependency management yet — model invokes referenced skills if installed
+
+## Relevance to The Agency
+
+This article validates several Agency patterns and suggests enhancements:
+- Agency skills (slash commands) already follow the folder-with-scripts pattern
+- The 9-category taxonomy is useful for auditing our skill coverage
+- On-demand hooks pattern maps directly to hookify rules
+- The marketplace/distribution model is relevant for multi-principal scenarios
+- Measurement via PreToolUse hook is directly implementable
+- Progressive disclosure and gotchas sections are actionable improvements for existing skills

--- a/usr/jordan/captain/handoff.md
+++ b/usr/jordan/captain/handoff.md
@@ -2,53 +2,34 @@
 
 **Agent:** captain (housekeeping)
 **Principal:** jordan
-**Updated:** 2026-03-31 (session 8, post-compact)
+**Updated:** 2026-03-31 (session 9)
 
 ## Current State
 
-On `feat/tool-refactor` branch. 7 commits ahead of main (including merge of origin/main). All quality gates passing. Ready for PR.
+On `main` branch. Tool refactor PR #18 merged. Two post-merge fixes committed. Clean working tree.
 
-## Session 8 Work
+## Immediate Priority: Fix Browser Access
 
-### Dispatch 5: Tool Refactor (COMPLETE — 5 commits + merge)
+**Bug report:** `claude/workstreams/agency/seeds/browser-access-bug-20260331.md`
 
-1. **489ddb6** — Delete 24 deprecated tools, clean agency-service refs
-2. **9dee22b** — Move ~95 tools `tools/` → `claude/tools/`, rename (git-commit, git-tag, git-sync, agency-whoami, tool-create), new tools (git-fetch, telemetry), standardize JSONL logging, fix code-review false positive
-3. **d6e7a6b** — Update TOOL.sh/PROVIDER.sh templates, CLAUDE.md, all test files, add missing permissions
-4. **f67e11b** — Update all docs (17 files), agent templates (12 files), commands (3 files), hookify rules (3 files), agency-init shipped tool list + permissions, captain agent.md
-5. **eddd5b2** — Clean stale tool refs from agent templates (collaborate, doc-commit, test-coverage)
+Browser MCP (`npx @browsermcp/mcp`) is non-functional:
+- Server starts, `/mcp` shows "✓ connected"
+- On first tool use (or when Chrome opens a new tab): server crashes
+- `claude mcp list` reports stale "Connected" status after crash
+- All `mcp__browser-mcp__*` tools permanently deregistered from session — no recovery without restart
+- Computer Use MCP is read-only for browsers (hardcoded tier, not user-overridable)
 
-Also merged origin/main which brought in two new dispatches.
+**Next step:** Relaunch with `claude --debug` to capture browser-mcp crash logs. Test immediately in fresh session before server crashes.
 
-### Dispatch 6: QG Hardening (COMPLETE)
-Verified all 17 QG fixes from PR #16.
+**Blocked:** Two X/Twitter posts to capture into knowledge base:
+- `https://x.com/trq212/status/2033949937936085378`
+- `https://x.com/bcherny/status/2038454336355999749`
 
-### Computer Use MCP Feedback (COMPLETE)
-Filed 3 issues via `/feedback`.
+## Session 9 Work (this session)
 
-### Token Economics (PARTIAL — from new dispatch)
-- Refined `warn-compound-bash` hookify rule: added `exclude_pattern` for heredoc commits, `PATH=... bash -c`, stderr redirects, head/tail pipes
-- Remaining items: hook output audit, context-budget tool, CLAUDE.md size reduction
-
-## New Dispatches (from origin)
-
-Two dispatches fetched and merged:
-
-1. **Code Survey / Incremental Capture** (`dispatch-agency-code-survey-tool-20260331.md`)
-   - Problem: review/explorer agents exhaust context on large codebases
-   - Proposed: incremental capture pattern (write findings as you go)
-   - Recommended: Option B (document-as-you-go) → Option C (multi-session chain)
-   - Status: READ, needs `/discuss` + plan
-
-2. **Token Economics Tools** (`dispatch-agency-token-economics-tools-20260331.md`)
-   - 5 items: /git-commit skill, compound bash refinement, hook output minimization, system reminder compression, context budget estimation
-   - Status: Item 2 (compound bash) DONE. Rest needs `/discuss` + plan
-
-## Next Steps
-
-1. **Create PR** for `feat/tool-refactor` → `main` — run through QG first
-2. **`/discuss` the new dispatches** — both are for discussion then planning
-3. **Remaining dispatch queue**: 3 (ISCP Design), 4 (Browser Protocol)
+- Updated handoff, archived session 8
+- Browser-mcp tools are deregistered from current session (server crashed earlier)
+- Need session restart to pick up tools again
 
 ## Dispatch Queue
 
@@ -58,8 +39,8 @@ Two dispatches fetched and merged:
 | 2 | Agency 2.0 Bootstrap | MERGED |
 | — | Workstream Bootstrap | MERGED |
 | 3 | ISCP Design | NOT STARTED |
-| 4 | Browser Protocol | NOT STARTED |
-| 5 | Tool Refactor | DONE (needs PR) |
+| 4 | Browser Protocol | NOT STARTED (bug blocks this) |
+| 5 | Tool Refactor | DONE (PR #18 merged) |
 | 6 | QG Hardening | DONE |
 | 7 | Code Survey / Incremental Capture | READ (needs /discuss) |
 | 8 | Token Economics Tools | PARTIAL (needs /discuss) |
@@ -73,8 +54,13 @@ Two dispatches fetched and merged:
 | ISS-009 | Open — status line redundant worktree naming |
 | ISS-012 | Open — worktrees in two locations |
 
+## Parked Topics
+
+- **Status line for agent activity** — needs `/discuss` with principal
+- **Token Economics** — compound bash rule done, 4 items remain
+
 ## Git State
 
-- Branch: `feat/tool-refactor` (7 commits ahead of main)
-- HEAD: eddd5b2
-- Working tree: clean (except handoff)
+- Branch: `main`
+- HEAD: 9632a86
+- Working tree: clean (except handoff + history)

--- a/usr/jordan/captain/handoff.md
+++ b/usr/jordan/captain/handoff.md
@@ -2,34 +2,45 @@
 
 **Agent:** captain (housekeeping)
 **Principal:** jordan
-**Updated:** 2026-03-31 (session 9)
+**Updated:** 2026-03-31 (session 9, post-filing)
 
 ## Current State
 
-On `main` branch. Tool refactor PR #18 merged. Two post-merge fixes committed. Clean working tree.
+On `main` branch. Clean working tree. Tool refactor PR #18 merged.
 
-## Immediate Priority: Fix Browser Access
+## Session 9 Work
 
-**Bug report:** `claude/workstreams/agency/seeds/browser-access-bug-20260331.md`
+### Browser Access Investigation (COMPLETE — bugs filed, not fixed)
 
-Browser MCP (`npx @browsermcp/mcp`) is non-functional:
-- Server starts, `/mcp` shows "✓ connected"
-- On first tool use (or when Chrome opens a new tab): server crashes
-- `claude mcp list` reports stale "Connected" status after crash
-- All `mcp__browser-mcp__*` tools permanently deregistered from session — no recovery without restart
-- Computer Use MCP is read-only for browsers (hardcoded tier, not user-overridable)
+Relaunched with `--debug`. Findings:
 
-**Next step:** Relaunch with `claude --debug` to capture browser-mcp crash logs. Test immediately in fresh session before server crashes.
+1. **Browser MCP (`@browsermcp/mcp`)** — third-party package, needs its own Chrome extension which is NOT installed. The "Claude (MCP)" tab is served by the npm server, not a Chrome extension. User rightfully won't install untrusted third-party extensions.
+2. **Claude in Chrome (v1.0.49)** — Anthropic's extension, but has CSP errors blocking its own inline scripts. Non-functional. Does NOT expose `mcp__Claude_in_Chrome__*` tools to Claude Code.
+3. **Computer Use MCP** — tier guidance references `mcp__Claude_in_Chrome__*` tools that don't exist.
+4. **`/feedback` command** — fails with HTTP 413 (payload too large). Bundles entire conversation context. Misleading "try again" UX — retry appears to succeed but silently drops.
+5. **`claude mcp list`** — reports stale "Connected" after server crash.
+6. **browser-mcp crashed again** during this session (tools deregistered mid-conversation).
 
-**Blocked:** Two X/Twitter posts to capture into knowledge base:
+### GitHub Issues Filed (7 total)
+
+| Issue | Title |
+|-------|-------|
+| anthropics/claude-code#41363 | `/feedback` fails with HTTP 413 — oversized context, silent drop |
+| anthropics/claude-code#41367 | `claude mcp list` stale "Connected" after server crash |
+| anthropics/claude-code#41370 | Computer Use tier references nonexistent `mcp__Claude_in_Chrome__*` tools |
+| anthropics/claude-code#41371 | Claude in Chrome CSP errors block inline scripts |
+| anthropics/claude-code#41099 | `request_access` lacks binary path and actionable guidance |
+| anthropics/claude-code#41101 | Permissions reset on every CLI update (version-pinned binary) |
+| anthropics/claude-code#41104 | No Safari browser automation support |
+
+All cross-referenced. Thread: **zero working paths to autonomous browser interaction from CLI**.
+
+## Blocked Items
+
+**Two X/Twitter posts** — blocked on browser access (no working path):
 - `https://x.com/trq212/status/2033949937936085378`
 - `https://x.com/bcherny/status/2038454336355999749`
-
-## Session 9 Work (this session)
-
-- Updated handoff, archived session 8
-- Browser-mcp tools are deregistered from current session (server crashed earlier)
-- Need session restart to pick up tools again
+- Workaround: principal pastes content manually
 
 ## Dispatch Queue
 
@@ -39,13 +50,13 @@ Browser MCP (`npx @browsermcp/mcp`) is non-functional:
 | 2 | Agency 2.0 Bootstrap | MERGED |
 | — | Workstream Bootstrap | MERGED |
 | 3 | ISCP Design | NOT STARTED |
-| 4 | Browser Protocol | NOT STARTED (bug blocks this) |
+| 4 | Browser Protocol | BLOCKED (bugs filed, no working browser path) |
 | 5 | Tool Refactor | DONE (PR #18 merged) |
 | 6 | QG Hardening | DONE |
 | 7 | Code Survey / Incremental Capture | READ (needs /discuss) |
 | 8 | Token Economics Tools | PARTIAL (needs /discuss) |
 
-## Open Issues
+## Open Issues (Internal)
 
 | Issue | Status |
 |-------|--------|
@@ -58,9 +69,10 @@ Browser MCP (`npx @browsermcp/mcp`) is non-functional:
 
 - **Status line for agent activity** — needs `/discuss` with principal
 - **Token Economics** — compound bash rule done, 4 items remain
+- **Weekly/Session limit discrepancies** — Team vs Personal Max20, mentioned in #41363, needs separate investigation
 
 ## Git State
 
 - Branch: `main`
-- HEAD: 9632a86
-- Working tree: clean (except handoff + history)
+- HEAD: d12025f
+- Working tree: clean (except handoff)

--- a/usr/jordan/captain/history/handoff-20260331-session8.md
+++ b/usr/jordan/captain/history/handoff-20260331-session8.md
@@ -1,0 +1,42 @@
+# Captain Handoff (Session 8 Archive)
+
+**Agent:** captain (housekeeping)
+**Principal:** jordan
+**Updated:** 2026-03-31 (session 8, post-compact)
+
+## Session 8 Work
+
+### Dispatch 5: Tool Refactor (COMPLETE — PR #18 MERGED)
+
+1. **489ddb6** — Delete 24 deprecated tools, clean agency-service refs
+2. **9dee22b** — Move ~95 tools `tools/` → `claude/tools/`, rename (git-commit, git-tag, git-sync, agency-whoami, tool-create), new tools (git-fetch, telemetry), standardize JSONL logging, fix code-review false positive
+3. **d6e7a6b** — Update TOOL.sh/PROVIDER.sh templates, CLAUDE.md, all test files, add missing permissions
+4. **f67e11b** — Update all docs (17 files), agent templates (12 files), commands (3 files), hookify rules (3 files), agency-init shipped tool list + permissions, captain agent.md
+5. **eddd5b2** — Clean stale tool refs from agent templates (collaborate, doc-commit, test-coverage)
+
+### QG Results (Pre-PR)
+
+Full QG with 3 parallel review agents found 16 issues:
+- 7 critical PROJECT_ROOT bugs (dependencies-check, dependencies-install, add-principal, starter-update, session-archive, version-bump, myclaude)
+- 8 broken cross-references (release→git-tag, nit-resolve/nit-add→git-sync+agency-whoami, context-save/commit-prefix/restore→agency-whoami, tool-create TOOLS_DIR, myclaude _log-helper)
+- Test fixes: git-operations.bats (8 old tool names), gh.bats (5 paths), tool-new-provider.bats (1 path)
+- Doc fixes: 6 files with stale tool paths
+- Dead code: stop-check.py HTTP dispatch call
+
+### Post-Merge Fixes
+
+- **9632a86** — Fix test isolation: git-operations.bats tests 14-18 were creating real commits in main repo
+- **99d8615** — Gitignore `.claude/logs/` and untrack `tool-runs.jsonl`
+
+### Browser Access Bug (DOCUMENTED, NOT FIXED)
+
+Filed `claude/workstreams/agency/seeds/browser-access-bug-20260331.md`. Four paths all broken:
+1. Browser MCP crashes mid-session, tools permanently deregistered
+2. Computer Use MCP hardcodes browsers to read-only tier
+3. WebFetch can't handle JS-heavy sites
+4. All Nitter mirrors dead
+
+### Dispatches Read
+
+- Code Survey / Incremental Capture — needs `/discuss`
+- Token Economics Tools — compound bash rule done, rest needs `/discuss`


### PR DESCRIPTION
## Summary

- Session 9 handoffs (browser-mcp debugging, 7 bugs filed)
- Captured bcherny skills article into `claude/workstreams/agency/seeds/`
- Added `poppler` (pdftotext) to `agency-dependencies.yaml`

### GitHub Issues Filed (anthropics/claude-code)

| Issue | Title |
|-------|-------|
| #41363 | `/feedback` fails with HTTP 413 |
| #41367 | `claude mcp list` stale status after crash |
| #41370 | Computer Use tier references nonexistent tools |
| #41371 | Claude in Chrome CSP errors |
| #41380 | Computer Use can't switch macOS Spaces |

(Plus 3 filed earlier: #41099, #41101, #41104)

## Test plan

- [ ] `./claude/tools/dependencies-check --verbose` passes with poppler listed
- [ ] Seed file renders correctly in markdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)