### PR TITLE
feat: agency-init design — rsync + manifest model

### DIFF
--- a/claude/tools/git-commit
+++ b/claude/tools/git-commit
@@ -28,7 +28,7 @@
 # Options:
 #   --work-item, -w   Work item ID (REQUEST-jordan-0065, SPRINT-web-2026w03, etc.)
 #   --stage, -s       Stage: impl, review, tests (required if work-item provided)
-#   --adhoc           Escape hatch for ad-hoc work (logs to ADHOC-WORKLOG.md)
+#   --adhoc           Escape hatch for ad-hoc work (no work-item required)
 #   --body, -b        Detailed commit body
 #   --principal, -p   Override principal (default: from config or work item)
 #   --no-verify       Skip pre-commit hooks
@@ -362,27 +362,7 @@ main() {
         COMMIT_HASH=$(git log -1 --format='%h')
         echo "Committed: $COMMIT_HASH"
 
-        # Log to ADHOC-WORKLOG.md if --adhoc was used
-        if [ "$ADHOC" = true ]; then
-            REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
-            # Validate AGENT to prevent path traversal
-            if [[ ! "$AGENT" =~ ^[a-z][a-z0-9-]*$ ]]; then
-                log_warn "Invalid agent name for adhoc log: $AGENT"
-            else
-                ADHOC_LOG="$REPO_ROOT/claude/agents/${AGENT}/ADHOC-WORKLOG.md"
-                if [ -f "$ADHOC_LOG" ]; then
-                    DATE_NOW=$(date +%Y-%m-%d)
-                    TIME_NOW=$(date +%H:%M)
-                    echo "" >> "$ADHOC_LOG"
-                    echo "### $DATE_NOW $TIME_NOW - Ad-hoc: $MESSAGE" >> "$ADHOC_LOG"
-                    echo "- Commit: $COMMIT_HASH" >> "$ADHOC_LOG"
-                    echo "- Agent: ${WORKSTREAM}/${AGENT}" >> "$ADHOC_LOG"
-                    verbose_echo "Logged to ADHOC-WORKLOG.md"
-                else
-                    log_warn "ADHOC-WORKLOG.md not found at $ADHOC_LOG"
-                fi
-            fi
-        fi
+        # ADHOC-WORKLOG.md append removed — telemetry captures this via log_end
 
         echo "✓"
 

--- a/claude/workstreams/agency/seeds/agency-init-design-20260331.md
+++ b/claude/workstreams/agency/seeds/agency-init-design-20260331.md
@@ -2,7 +2,8 @@
 
 **Source:** /discuss session, 2026-03-31
 **Participants:** jordan (principal), captain (agent)
-**Status:** Draft — pending review cycle
+**Status:** Revised — post multi-agent review (design, code, security)
+**Review:** 3 CRITICAL, 7 MAJOR, 8 MINOR findings addressed in this revision
 
 ---
 
@@ -10,18 +11,35 @@
 
 `agency-init` and `agency-update` are the two entry points for installing and maintaining the Agency framework in any git repo. They follow the Rails model: template-driven generation at init time, rsync-style sync with conflict resolution at update time.
 
+### Preconditions
+
+The target must be a git repo before agency-init runs. The expected sequence:
+
+- **Bare repo:** `git init` → `claude init` → `agency-init`
+- **Existing repo:** `claude init` (if needed) → `agency-init`
+
+agency-init validates that git is initialized. It does not create the repo.
+
 ### Principles
 
 - **Copy, don't symlink.** Framework files are copied into the target repo and committed. The project owns them.
 - **Manifest-driven updates.** A manifest tracks what was installed, at what version, with what checksum. Updates compare against manifest to detect user modifications.
 - **Three file tiers.** Every installed file has a tier (framework, config, scaffold) that governs update behavior.
 - **Tools are tools.** No distinction by implementation language — bash, python, rust, compiled binary. All live in `claude/tools/`.
+- **Single namespace.** Everything Agency-related lives under `claude/`. One top-level directory. Good neighbor in someone else's repo.
+- **Git is the safety net.** Updates don't auto-commit. `git checkout -- claude/` is the rollback. No custom staging or backup mechanism needed.
+
+### Trust Model
+
+**v1:** The user trusts the source they point agency-init/update at. Source is a local filesystem path (clone of the-agency repo, AGENCY_SOURCE env var, or auto-detected). No cryptographic verification of source integrity. This is the same trust model as Rails generators and gstack.
+
+**Post-v1 (public release):** Source authentication via signed checksums (CHECKSUMS.sha256 signed by release process) or GPG-signed manifests. Decision deferred to the public release milestone.
 
 ---
 
 ## Target Repo Structure
 
-After `agency-init`, a bare repo looks like this:
+After `agency-init`, a bare repo looks like this. Everything Agency-related is under `claude/`.
 
 ```
 my-project/
@@ -30,13 +48,14 @@ my-project/
 │
 ├── .claude/                               # Claude Code's space
 │   ├── settings.json                      # scaffold
+│   ├── worktrees/                         # gitignored — transient worktree copies
 │   ├── commands/
 │   │   └── discuss.md                     # framework
 │   └── skills/
 │       ├── define/                        # framework
 │       └── design/                        # framework
 │
-├── claude/                                # Agency framework
+├── claude/                                # Agency framework — single namespace
 │   ├── README-THEAGENCY.md                # framework
 │   ├── README-GETTINGSTARTED.md           # framework
 │   ├── config/
@@ -44,6 +63,7 @@ my-project/
 │   │   ├── CLAUDE.md                      # framework
 │   │   ├── agency.yaml                    # scaffold (generated with project values)
 │   │   ├── agency-dependencies.yaml       # framework
+│   │   ├── settings-template.json         # framework — canonical permissions/hooks
 │   │   └── manifest.json                  # managed by init/update
 │   ├── agents/                            # agent CLASS definitions
 │   │   ├── README.md                      # framework
@@ -81,8 +101,7 @@ my-project/
 │   │   ├── quality-check.sh               # config
 │   │   ├── plan-capture.sh                # config
 │   │   ├── branch-freshness.sh            # config
-│   │   ├── tool-telemetry.sh              # config
-│   │   └── ghostty-status.sh              # config
+│   │   └── tool-telemetry.sh              # config
 │   ├── hookify/
 │   │   ├── README.md                      # framework
 │   │   ├── CLAUDE.md                      # framework
@@ -101,10 +120,14 @@ my-project/
 │   │   │   ├── _log-helper               # framework
 │   │   │   ├── _path-resolve             # framework
 │   │   │   └── _provider-resolve         # framework
+│   │   ├── agency-init                    # framework
+│   │   ├── agency-update                  # framework
 │   │   ├── agency-verify                  # framework
 │   │   ├── agency-whoami                  # framework
 │   │   ├── code-review                    # framework
 │   │   ├── commit-precheck                # framework
+│   │   ├── dependencies-check             # framework
+│   │   ├── dependencies-install           # framework
 │   │   ├── git-commit                     # framework
 │   │   ├── git-fetch                      # framework
 │   │   ├── git-sync                       # framework
@@ -113,62 +136,63 @@ my-project/
 │   │   ├── now                            # framework
 │   │   ├── review-spawn                   # framework
 │   │   ├── secret-vault                   # framework
+│   │   ├── settings-merge                 # framework
 │   │   ├── terminal-setup                 # framework
 │   │   ├── terminal-setup-ghostty         # framework
 │   │   ├── platform-setup                 # framework
 │   │   ├── platform-setup-macos           # framework
 │   │   ├── platform-setup-linux           # framework
+│   │   ├── telemetry                      # framework
 │   │   ├── test-run                       # framework
 │   │   ├── tool-create                    # framework
 │   │   ├── worktree-create                # framework
 │   │   ├── worktree-list                  # framework
 │   │   └── worktree-delete                # framework
+│   ├── usr/                               # agent INSTANCES (per-principal)
+│   │   ├── README.md                      # scaffold
+│   │   ├── CLAUDE.md                      # scaffold — explains class vs instance
+│   │   └── {principal}/
+│   │       ├── README.md                  # scaffold
+│   │       ├── CLAUDE.md                  # scaffold
+│   │       ├── claude/
+│   │       │   ├── commands/
+│   │       │   ├── hookify/
+│   │       │   ├── hooks/
+│   │       │   └── agents/
+│   │       └── captain/                   # instance of captain class
+│   │           ├── CLAUDE.md              # scaffold
+│   │           ├── handoff.md             # scaffold
+│   │           ├── dispatches/
+│   │           ├── transcripts/
+│   │           └── history/
+│   ├── workstreams/                       # bodies of work
+│   │   ├── README.md                      # scaffold
+│   │   ├── CLAUDE.md                      # scaffold — explains workstream model
+│   │   └── ops/                           # default workstream (coordination/maintenance)
+│   │       ├── README.md                  # scaffold
+│   │       ├── CLAUDE.md                  # scaffold
+│   │       ├── seeds/
+│   │       └── history/
 │   └── src/                               # --dev only
 │       ├── README.md                      # framework
 │       └── CLAUDE.md                      # framework
-│
-├── usr/                                   # agent INSTANCES (per-principal)
-│   ├── README.md                          # scaffold
-│   ├── CLAUDE.md                          # scaffold — explains class vs instance
-│   └── {principal}/
-│       ├── README.md                      # scaffold
-│       ├── CLAUDE.md                      # scaffold
-│       ├── claude/
-│       │   ├── commands/
-│       │   ├── hookify/
-│       │   ├── hooks/
-│       │   └── agents/
-│       └── captain/                       # instance of captain class
-│           ├── CLAUDE.md                  # scaffold
-│           ├── handoff.md                 # scaffold
-│           ├── dispatches/
-│           ├── transcripts/
-│           ├── history/
-│
-├── workstreams/                           # bodies of work
-│   ├── README.md                          # scaffold
-│   ├── CLAUDE.md                          # scaffold — explains workstream model
-│   └── ops/                               # default workstream (coordination/maintenance)
-│       ├── README.md                      # scaffold
-│       ├── CLAUDE.md                      # scaffold
-│       ├── seeds/
-│       └── history/
 ```
 
 ### Directory Semantics
 
 | Directory | Purpose | Audience |
 |-----------|---------|----------|
-| `.claude/` | Claude Code configuration (settings, commands, skills) | Claude Code |
-| `claude/` | Agency framework (tools, agents, hooks, docs, config) | Agency |
-| `usr/` | Agent instances — a principal's deployment of agent classes | Per-principal |
-| `workstreams/` | Bodies of work with artifacts (PVR, A&D, Plan, QGR, Ref) | Per-workstream |
+| `.claude/` | Claude Code configuration (settings, commands, skills, worktrees) | Claude Code |
+| `claude/` | Agency framework — everything Agency-related | Agency |
+| `claude/agents/` | Agent class definitions — what a role IS | Framework |
+| `claude/usr/` | Agent instances — a principal's deployment of agent classes | Per-principal |
+| `claude/workstreams/` | Bodies of work with artifacts (PVR, A&D, Plan, QGR, Ref) | Per-workstream |
 
 ### Key Relationships
 
 - **Agent class** (`claude/agents/tech-lead/agent.md`) — what the role IS
-- **Agent instance** (`usr/jordan/devex/`) — who's filling the role, on what workstream
-- **Workstream** (`workstreams/devex/`) — the body of work
+- **Agent instance** (`claude/usr/jordan/devex/`) — who's filling the role, on what workstream
+- **Workstream** (`claude/workstreams/devex/`) — the body of work
 
 Names can overlap. A workstream called `devex` can have an agent instance called `devex` (which is a tech-lead assigned to the devex workstream). The directory location disambiguates.
 
@@ -178,14 +202,14 @@ Every directory gets both:
 - **README.md** — for humans browsing the repo
 - **CLAUDE.md** — for agents working in the repo
 
-CLAUDE.md replaces the former KNOWLEDGE.md. Claude Code discovers CLAUDE.md files automatically via hierarchical reading.
+CLAUDE.md replaces the former KNOWLEDGE.md. Claude Code discovers CLAUDE.md files automatically via hierarchical reading. Existing KNOWLEDGE.md files should be renamed to CLAUDE.md during migration.
 
 ### Workstream Artifacts
 
 All artifacts are peers at the workstream root:
 
 ```
-workstreams/devex/
+claude/workstreams/devex/
   devex-pvr-YYYYMMDD.md          # Product Vision & Requirements
   devex-ad-YYYYMMDD.md           # Architecture & Design
   devex-plan-YYYYMMDD.md         # Plan (phases, iterations)
@@ -202,11 +226,17 @@ No `bugs/` directory. A bug is a finding in a QGR, which becomes a work item in 
 Any agent can dispatch to any agent. Dispatches live in the receiving agent's instance:
 
 ```
-usr/{principal}/{agent}/dispatches/
+claude/usr/{principal}/{agent}/dispatches/
   dispatch-{slug}-YYYYMMDD.md
 ```
 
 Current model: markdown files, agents prompted to read them. Future: ISCP (dispatch #3) designs proper inter-agent communication.
+
+### Worktrees
+
+Worktrees live at `.claude/worktrees/{name}/` (gitignored). They are Claude Code's concern — transient, not committed. The Agency worktree tools (`worktree-create`, `worktree-list`, `worktree-delete`) manage this location.
+
+**Known issue (ISS-012):** Some repos have worktrees in both `.claude/worktrees/` and `.git/worktrees/`. The tooling must be consolidated to use a single location.
 
 ---
 
@@ -222,40 +252,53 @@ Three tiers govern update behavior:
 
 ### Tier Assignment by Path
 
+Tier is assigned by directory pattern, not per-file lists. Add a tool to `claude/tools/` in the source — it's automatically framework tier. Add a hook to `claude/hooks/` — automatically config tier.
+
+**Precedence rule:** More specific patterns win. `claude/usr/**` (scaffold) takes precedence over `claude/*/CLAUDE.md` (framework) because `claude/usr/` is explicitly listed as scaffold.
+
 ```
 framework:
   - claude/tools/**
   - claude/tools/lib/**
   - claude/docs/**
   - claude/agents/*/agent.md
+  - claude/agents/*/README.md
+  - claude/agents/*/CLAUDE.md
   - claude/templates/**
   - claude/config/agency-dependencies.yaml
+  - claude/config/settings-template.json
   - claude/README-*.md
-  - claude/*/README.md (framework directories)
-  - claude/*/CLAUDE.md (framework directories)
   - .claude/commands/**
   - .claude/skills/**
 
 config:
-  - claude/hooks/**
-  - claude/hookify/*.md (shipped rules only)
+  - claude/hooks/** (excluding README.md, CLAUDE.md which are framework)
+  - claude/hookify/*.md (shipped rules only — distinguished by presence in manifest)
 
 scaffold:
-  - CLAUDE.md
-  - README.md
+  - CLAUDE.md (repo root)
+  - README.md (repo root)
   - claude/config/agency.yaml
   - .claude/settings.json
-  - usr/**
-  - workstreams/**
+  - claude/usr/**
+  - claude/workstreams/**
 ```
 
-Tier is assigned by directory pattern, not per-file lists. Add a tool to `claude/tools/` in the source — it's automatically framework tier. Add a hook to `claude/hooks/` — automatically config tier.
+**Distinguishing shipped vs user hookify rules:** A hookify rule is "shipped" if it exists in the source at init/update time and is tracked in the manifest. User-added rules in `claude/hookify/` are not in the manifest and are never touched.
+
+**Deleted config-tier files:** If a user deletes a config-tier file that is in the manifest, agency-update treats the missing file as a user modification (intentional deletion) and skips it. The update summary warns: "Skipped (deleted by user): claude/hooks/foo.sh".
 
 Update only touches files tracked in the manifest. User-added files in any directory are never deleted.
 
-### Known Limitation: Config Merge
+### Settings Merge
 
-`.claude/settings.json` and `claude/config/agency.yaml` are scaffold — never overwritten. When a new Agency version ships new hooks or config keys, users don't get them automatically. Agency-update surfaces this in its summary ("new hooks available, add manually"). A merge strategy is deferred to a future version.
+`.claude/settings.json` is scaffold — never overwritten by agency-update. New tools and hooks from updates require permission entries that the user doesn't have yet.
+
+**Solution:** `claude/config/settings-template.json` is a framework-tier file (always current). The `settings-merge` tool diffs the template against the user's `.claude/settings.json` and adds missing permission entries and hook entries. It never removes or modifies existing entries.
+
+- **agency-update summary prompts:** "Run `./claude/tools/settings-merge` to pick up new permissions and hooks."
+- **If `.claude/settings.json` is malformed:** `settings-merge` prints the exact JSON fragments to add manually instead of attempting a merge.
+- **`claude/config/agency.yaml`** follows the same pattern — scaffold, never overwritten, manual merge for new config keys.
 
 ---
 
@@ -270,6 +313,7 @@ Lives at `claude/config/manifest.json`.
   "updated_at": "2026-04-01T10:00:00Z",
   "source": {
     "repo": "the-agency-ai/the-agency",
+    "path": "/Users/jordan/code/the-agency",
     "commit": "944c5c8",
     "version": "2.0.0"
   },
@@ -297,11 +341,12 @@ Lives at `claude/config/manifest.json`.
 }
 ```
 
-- **Per-file hash** — SHA-256 of file contents at install/update time
+- **Per-file hash** — SHA-256 of file contents at install/update time. Hash prefix (`sha256:`) required for forward-compatibility with algorithm migration.
 - **Per-file tier** — drives update behavior
 - **No `modified` boolean** — computed at update time by comparing current file hash to manifest hash
-- **Source tracking** — repo, commit, version of what was installed
-- **Options** — remember what flags were used (for re-running)
+- **Source tracking** — repo slug, local filesystem path, commit, version
+- **Options** — remember what flags were used (for re-running with `--dev`)
+- **Schema version validation** — agency-update refuses to process a manifest with an unrecognized `schema_version`. Prevents older tooling from corrupting a newer manifest.
 
 ---
 
@@ -311,44 +356,50 @@ Lives at `claude/config/manifest.json`.
 agency-init <target> [--principal <name>] [--project <name>] [--dev]
 ```
 
-1. **Validate** — target is a git repo (or offer to `git init`). Agency source exists (AGENCY_SOURCE env var or auto-detect).
+1. **Validate** — target is a git repo (abort if not — do not offer to create). Agency source exists (AGENCY_SOURCE env var or auto-detect from script location).
 2. **Check not initialized** — if `claude/config/manifest.json` exists, abort with "use agency-update".
-3. **Resolve defaults** — principal from `whoami`, project from directory name, timezone from system.
+3. **Resolve defaults** — principal from `whoami` (lowercased, validated: `^[a-z][a-z0-9-]*$`), project from directory name, timezone from system.
 4. **Copy framework files** — all framework tier files from source to target.
 5. **Copy config files** — all config tier files from source to target.
-6. **Generate scaffold files** — CLAUDE.md (from template + project name), README.md, agency.yaml (from args), .claude/settings.json (with hooks + permissions), usr/{principal}/ directory tree, workstreams/ops/ directory tree. All README.md and CLAUDE.md files for scaffold directories.
-7. **If `--dev`** — copy `claude/src/` with source code, tests, build scripts.
-8. **Write manifest** — hash every installed file, record tier, source commit, options.
-9. **Commit** — scoped to Agency files only (not `git add -A`).
-10. **Print next steps** — launch instructions, captain bootstrap prompt.
+6. **Generate scaffold files** — CLAUDE.md (from template + project name), README.md, agency.yaml (from args), .claude/settings.json (from settings-template.json), claude/usr/{principal}/ directory tree, claude/workstreams/ops/ directory tree. All README.md and CLAUDE.md files for scaffold directories.
+7. **If `--dev`** — copy `claude/src/` with source code, tests, build scripts. Dev files are tracked in the manifest with their tier and `options.dev` is set to true.
+8. **Set permissions** — `chmod +x` only on files copied by agency-init (explicit list from manifest, not glob).
+9. **Write manifest** — hash every installed file, record tier, source commit/path, options.
+10. **Commit** — stage only files tracked in the manifest (explicit `git add` per file, not `git add -A`).
+11. **Print next steps** — launch instructions, captain bootstrap prompt, reminder to run `settings-merge` if customizing.
 
 ---
 
 ## agency-update Flow
 
 ```
-agency-update [--source <path>]
+agency-update [--source <path>] [--dry-run]
 ```
 
-1. **Read manifest** — load `claude/config/manifest.json`. If missing, abort ("not an Agency project, use agency-init").
-2. **Resolve source** — AGENCY_SOURCE env var, --source flag, or saved source path from manifest.
-3. **For each file in the new source:**
+1. **Read manifest** — load `claude/config/manifest.json`. If missing, abort ("not an Agency project, use agency-init"). If `schema_version` is unrecognized, abort with version mismatch error.
+2. **Resolve source** — `--source` flag first, then AGENCY_SOURCE env var, then `source.path` from manifest. Validate that the resolved path exists and contains `claude/config/agency-dependencies.yaml`.
+3. **If `--dry-run`** — perform all comparisons and print the summary (step 7) without writing any files. Exit.
+4. **For each file in the new source:**
    - **Framework tier** — overwrite always.
-   - **Config tier** — hash current local file. If hash matches manifest → overwrite (user hasn't touched it). If hash differs → skip, add to conflict list.
+   - **Config tier** — hash current local file. If file missing → skip, warn as "deleted by user". If hash matches manifest → overwrite (user hasn't touched it). If hash differs → skip, add to conflict list.
    - **Scaffold tier** — skip always.
    - **New file** (not in manifest) — copy, add to manifest with appropriate tier.
-4. **Removed files** (in manifest but not in new source) — warn as deprecated. Do not delete.
-5. **Update manifest** — new hashes, new source commit, updated_at timestamp.
-6. **Print summary:**
+5. **Removed files** (in manifest but not in new source) — warn as deprecated. Do not delete.
+6. **Set permissions** — `chmod +x` only on files written in this update (explicit list, not glob).
+7. **Update manifest** — new hashes, new source commit/path, updated_at timestamp.
+8. **Print summary:**
    ```
-   agency-update complete
+   agency-update complete (git is your undo — review changes before committing)
      Updated: 14 files (framework)
      Updated: 3 files (config, untouched)
      Skipped: 2 files (config, user-modified)
+     Skipped: 1 file (config, deleted by user)
      Added:   4 files (new in this version)
      Deprecated: 1 file (removed upstream)
+
+   Run ./claude/tools/settings-merge to pick up new permissions and hooks.
    ```
-7. **No auto-commit** — user reviews changes and commits when ready.
+9. **No auto-commit** — user reviews changes with `git diff` and commits when ready. Rollback: `git checkout -- claude/`.
 
 ---
 
@@ -371,8 +422,8 @@ The `source/services/agency-service/` directory and its 10 embedded services are
 
 Actions:
 - Delete `source/services/agency-service/` entirely
-- Rewrite `.github/workflows/test.yml` to run bats tests directly
-- Fix `.github/workflows/starter-verify.yml` stale tool paths
+- Rewrite `.github/workflows/test.yml` to install bats and run `bats tests/` directly (no service startup, no health checks, no HTTP API)
+- Fix `.github/workflows/starter-verify.yml`: update `tools/myclaude` → `claude/tools/agency-verify` (or remove if myclaude was a starter-only artifact), update `source/services/agency-service` references → remove, update `tools/` → `claude/tools/` paths
 - Remove agency-service from manifest components
 
 ---
@@ -387,12 +438,26 @@ Default install ships runnable tools only. `--dev` adds:
 
 Today all tools are bash scripts, so `--dev` adds tests only. As compiled artifacts ship (mdpal, mockandmark, future services), their source goes in `claude/src/`.
 
+`agency-update` respects the `options.dev` flag from the manifest. If a repo was initialized with `--dev`, updates include dev files. To add dev files to an existing non-dev install, run `agency-init --dev` (which detects the existing manifest and offers to upgrade rather than aborting).
+
+---
+
+## KNOWLEDGE.md Migration
+
+KNOWLEDGE.md is replaced by CLAUDE.md. Existing repos may have KNOWLEDGE.md files that agents no longer read by default (Claude Code auto-discovers CLAUDE.md, not KNOWLEDGE.md).
+
+**agency-init:** Does not create KNOWLEDGE.md. Only creates CLAUDE.md.
+
+**agency-update:** Detects KNOWLEDGE.md files that have no corresponding CLAUDE.md. Warns in the update summary: "Found KNOWLEDGE.md without CLAUDE.md — rename recommended: {path}". Does not rename automatically (user may have both intentionally).
+
 ---
 
 ## Open Items (Deferred)
 
-- **Config merge strategy** — how to deliver new hooks/config keys to scaffold files
+- **Source authentication** — signed checksums or GPG for public release (v1 trusts the source)
 - **Starter-packs** — what they look like, how they're shipped
 - **ISCP** — proper inter-agent communication (dispatch #3)
 - **Test management** — multi-framework test tracking and boundary run definitions
 - **Human-to-agent findings** — reporting mechanism for principals
+- **Worktree consolidation (ISS-012)** — resolve worktrees appearing in both `.claude/worktrees/` and `.git/worktrees/`
+- **Terminal-specific hooks** — ghostty-status.sh should be conditional on `terminal.provider` config, not shipped to all users

--- a/claude/workstreams/agency/seeds/agency-init-design-20260331.md
+++ b/claude/workstreams/agency/seeds/agency-init-design-20260331.md
@@ -1,0 +1,398 @@
+# Agency Init & Update Design
+
+**Source:** /discuss session, 2026-03-31
+**Participants:** jordan (principal), captain (agent)
+**Status:** Draft — pending review cycle
+
+---
+
+## Overview
+
+`agency-init` and `agency-update` are the two entry points for installing and maintaining the Agency framework in any git repo. They follow the Rails model: template-driven generation at init time, rsync-style sync with conflict resolution at update time.
+
+### Principles
+
+- **Copy, don't symlink.** Framework files are copied into the target repo and committed. The project owns them.
+- **Manifest-driven updates.** A manifest tracks what was installed, at what version, with what checksum. Updates compare against manifest to detect user modifications.
+- **Three file tiers.** Every installed file has a tier (framework, config, scaffold) that governs update behavior.
+- **Tools are tools.** No distinction by implementation language — bash, python, rust, compiled binary. All live in `claude/tools/`.
+
+---
+
+## Target Repo Structure
+
+After `agency-init`, a bare repo looks like this:
+
+```
+my-project/
+├── README.md                              # scaffold
+├── CLAUDE.md                              # scaffold
+│
+├── .claude/                               # Claude Code's space
+│   ├── settings.json                      # scaffold
+│   ├── commands/
+│   │   └── discuss.md                     # framework
+│   └── skills/
+│       ├── define/                        # framework
+│       └── design/                        # framework
+│
+├── claude/                                # Agency framework
+│   ├── README-THEAGENCY.md                # framework
+│   ├── README-GETTINGSTARTED.md           # framework
+│   ├── config/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   ├── agency.yaml                    # scaffold (generated with project values)
+│   │   ├── agency-dependencies.yaml       # framework
+│   │   └── manifest.json                  # managed by init/update
+│   ├── agents/                            # agent CLASS definitions
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework — explains these are role defs
+│   │   ├── captain/
+│   │   │   └── agent.md                   # framework
+│   │   ├── project-manager/
+│   │   │   └── agent.md                   # framework
+│   │   ├── cos/
+│   │   │   └── agent.md                   # framework
+│   │   ├── reviewer-code/
+│   │   │   └── agent.md                   # framework
+│   │   ├── reviewer-design/
+│   │   │   └── agent.md                   # framework
+│   │   ├── reviewer-security/
+│   │   │   └── agent.md                   # framework
+│   │   ├── reviewer-test/
+│   │   │   └── agent.md                   # framework
+│   │   └── reviewer-scorer/
+│   │       └── agent.md                   # framework
+│   ├── docs/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   ├── QUALITY-GATE.md                # framework
+│   │   ├── DEVELOPMENT-METHODOLOGY.md     # framework
+│   │   ├── CODE-REVIEW-LIFECYCLE.md       # framework
+│   │   ├── FEEDBACK-FORMAT.md             # framework
+│   │   ├── PR-LIFECYCLE.md                # framework
+│   │   └── TELEMETRY.md                   # framework
+│   ├── hooks/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   ├── ref-injector.sh                # config
+│   │   ├── session-handoff.sh             # config
+│   │   ├── quality-check.sh               # config
+│   │   ├── plan-capture.sh                # config
+│   │   ├── branch-freshness.sh            # config
+│   │   ├── tool-telemetry.sh              # config
+│   │   └── ghostty-status.sh              # config
+│   ├── hookify/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   └── *.md                           # config (shipped rules)
+│   ├── templates/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   ├── principal-v2/                  # framework
+│   │   ├── CLAUDE-USER.md                 # framework
+│   │   ├── CLAUDE-PROJECT.md              # framework
+│   │   └── PROVIDER.sh                    # framework
+│   ├── tools/
+│   │   ├── README.md                      # framework
+│   │   ├── CLAUDE.md                      # framework
+│   │   ├── lib/
+│   │   │   ├── _log-helper               # framework
+│   │   │   ├── _path-resolve             # framework
+│   │   │   └── _provider-resolve         # framework
+│   │   ├── agency-verify                  # framework
+│   │   ├── agency-whoami                  # framework
+│   │   ├── code-review                    # framework
+│   │   ├── commit-precheck                # framework
+│   │   ├── git-commit                     # framework
+│   │   ├── git-fetch                      # framework
+│   │   ├── git-sync                       # framework
+│   │   ├── git-tag                        # framework
+│   │   ├── handoff                        # framework
+│   │   ├── now                            # framework
+│   │   ├── review-spawn                   # framework
+│   │   ├── secret-vault                   # framework
+│   │   ├── terminal-setup                 # framework
+│   │   ├── terminal-setup-ghostty         # framework
+│   │   ├── platform-setup                 # framework
+│   │   ├── platform-setup-macos           # framework
+│   │   ├── platform-setup-linux           # framework
+│   │   ├── test-run                       # framework
+│   │   ├── tool-create                    # framework
+│   │   ├── worktree-create                # framework
+│   │   ├── worktree-list                  # framework
+│   │   └── worktree-delete                # framework
+│   └── src/                               # --dev only
+│       ├── README.md                      # framework
+│       └── CLAUDE.md                      # framework
+│
+├── usr/                                   # agent INSTANCES (per-principal)
+│   ├── README.md                          # scaffold
+│   ├── CLAUDE.md                          # scaffold — explains class vs instance
+│   └── {principal}/
+│       ├── README.md                      # scaffold
+│       ├── CLAUDE.md                      # scaffold
+│       ├── claude/
+│       │   ├── commands/
+│       │   ├── hookify/
+│       │   ├── hooks/
+│       │   └── agents/
+│       └── captain/                       # instance of captain class
+│           ├── CLAUDE.md                  # scaffold
+│           ├── handoff.md                 # scaffold
+│           ├── dispatches/
+│           ├── transcripts/
+│           ├── history/
+│
+├── workstreams/                           # bodies of work
+│   ├── README.md                          # scaffold
+│   ├── CLAUDE.md                          # scaffold — explains workstream model
+│   └── ops/                               # default workstream (coordination/maintenance)
+│       ├── README.md                      # scaffold
+│       ├── CLAUDE.md                      # scaffold
+│       ├── seeds/
+│       └── history/
+```
+
+### Directory Semantics
+
+| Directory | Purpose | Audience |
+|-----------|---------|----------|
+| `.claude/` | Claude Code configuration (settings, commands, skills) | Claude Code |
+| `claude/` | Agency framework (tools, agents, hooks, docs, config) | Agency |
+| `usr/` | Agent instances — a principal's deployment of agent classes | Per-principal |
+| `workstreams/` | Bodies of work with artifacts (PVR, A&D, Plan, QGR, Ref) | Per-workstream |
+
+### Key Relationships
+
+- **Agent class** (`claude/agents/tech-lead/agent.md`) — what the role IS
+- **Agent instance** (`usr/jordan/devex/`) — who's filling the role, on what workstream
+- **Workstream** (`workstreams/devex/`) — the body of work
+
+Names can overlap. A workstream called `devex` can have an agent instance called `devex` (which is a tech-lead assigned to the devex workstream). The directory location disambiguates.
+
+### README.md vs CLAUDE.md
+
+Every directory gets both:
+- **README.md** — for humans browsing the repo
+- **CLAUDE.md** — for agents working in the repo
+
+CLAUDE.md replaces the former KNOWLEDGE.md. Claude Code discovers CLAUDE.md files automatically via hierarchical reading.
+
+### Workstream Artifacts
+
+All artifacts are peers at the workstream root:
+
+```
+workstreams/devex/
+  devex-pvr-YYYYMMDD.md          # Product Vision & Requirements
+  devex-ad-YYYYMMDD.md           # Architecture & Design
+  devex-plan-YYYYMMDD.md         # Plan (phases, iterations)
+  devex-ref-YYYYMMDD.md          # Reference (final docs)
+  devex-qgr-{scope}-YYYYMMDD.md  # Quality Gate Reports
+  seeds/                          # input materials
+  history/                        # archived artifact versions
+```
+
+No `bugs/` directory. A bug is a finding in a QGR, which becomes a work item in the plan. QGRs are workstream artifacts, not dispatches.
+
+### Dispatches
+
+Any agent can dispatch to any agent. Dispatches live in the receiving agent's instance:
+
+```
+usr/{principal}/{agent}/dispatches/
+  dispatch-{slug}-YYYYMMDD.md
+```
+
+Current model: markdown files, agents prompted to read them. Future: ISCP (dispatch #3) designs proper inter-agent communication.
+
+---
+
+## File Classification
+
+Three tiers govern update behavior:
+
+| Tier | On init | On update | Description |
+|------|---------|-----------|-------------|
+| **framework** | Copy from source | Always overwrite | Framework-owned files. Users should not modify. |
+| **config** | Copy from source | Overwrite if untouched (hash matches manifest). Skip + warn if user modified. | Framework-provided defaults that users may customize. |
+| **scaffold** | Generate or copy | Never touch | Project-specific files generated at init time. User owns completely. |
+
+### Tier Assignment by Path
+
+```
+framework:
+  - claude/tools/**
+  - claude/tools/lib/**
+  - claude/docs/**
+  - claude/agents/*/agent.md
+  - claude/templates/**
+  - claude/config/agency-dependencies.yaml
+  - claude/README-*.md
+  - claude/*/README.md (framework directories)
+  - claude/*/CLAUDE.md (framework directories)
+  - .claude/commands/**
+  - .claude/skills/**
+
+config:
+  - claude/hooks/**
+  - claude/hookify/*.md (shipped rules only)
+
+scaffold:
+  - CLAUDE.md
+  - README.md
+  - claude/config/agency.yaml
+  - .claude/settings.json
+  - usr/**
+  - workstreams/**
+```
+
+Tier is assigned by directory pattern, not per-file lists. Add a tool to `claude/tools/` in the source — it's automatically framework tier. Add a hook to `claude/hooks/` — automatically config tier.
+
+Update only touches files tracked in the manifest. User-added files in any directory are never deleted.
+
+### Known Limitation: Config Merge
+
+`.claude/settings.json` and `claude/config/agency.yaml` are scaffold — never overwritten. When a new Agency version ships new hooks or config keys, users don't get them automatically. Agency-update surfaces this in its summary ("new hooks available, add manually"). A merge strategy is deferred to a future version.
+
+---
+
+## Manifest Schema (v2)
+
+Lives at `claude/config/manifest.json`.
+
+```json
+{
+  "schema_version": "2.0",
+  "installed_at": "2026-04-01T10:00:00Z",
+  "updated_at": "2026-04-01T10:00:00Z",
+  "source": {
+    "repo": "the-agency-ai/the-agency",
+    "commit": "944c5c8",
+    "version": "2.0.0"
+  },
+  "options": {
+    "dev": false,
+    "principal": "jordan"
+  },
+  "files": {
+    "claude/tools/git-commit": {
+      "hash": "sha256:abc123...",
+      "tier": "framework",
+      "installed_version": "2.0.0"
+    },
+    "claude/hooks/ref-injector.sh": {
+      "hash": "sha256:def456...",
+      "tier": "config",
+      "installed_version": "2.0.0"
+    },
+    "CLAUDE.md": {
+      "hash": "sha256:ghi789...",
+      "tier": "scaffold",
+      "installed_version": "2.0.0"
+    }
+  }
+}
+```
+
+- **Per-file hash** — SHA-256 of file contents at install/update time
+- **Per-file tier** — drives update behavior
+- **No `modified` boolean** — computed at update time by comparing current file hash to manifest hash
+- **Source tracking** — repo, commit, version of what was installed
+- **Options** — remember what flags were used (for re-running)
+
+---
+
+## agency-init Flow
+
+```
+agency-init <target> [--principal <name>] [--project <name>] [--dev]
+```
+
+1. **Validate** — target is a git repo (or offer to `git init`). Agency source exists (AGENCY_SOURCE env var or auto-detect).
+2. **Check not initialized** — if `claude/config/manifest.json` exists, abort with "use agency-update".
+3. **Resolve defaults** — principal from `whoami`, project from directory name, timezone from system.
+4. **Copy framework files** — all framework tier files from source to target.
+5. **Copy config files** — all config tier files from source to target.
+6. **Generate scaffold files** — CLAUDE.md (from template + project name), README.md, agency.yaml (from args), .claude/settings.json (with hooks + permissions), usr/{principal}/ directory tree, workstreams/ops/ directory tree. All README.md and CLAUDE.md files for scaffold directories.
+7. **If `--dev`** — copy `claude/src/` with source code, tests, build scripts.
+8. **Write manifest** — hash every installed file, record tier, source commit, options.
+9. **Commit** — scoped to Agency files only (not `git add -A`).
+10. **Print next steps** — launch instructions, captain bootstrap prompt.
+
+---
+
+## agency-update Flow
+
+```
+agency-update [--source <path>]
+```
+
+1. **Read manifest** — load `claude/config/manifest.json`. If missing, abort ("not an Agency project, use agency-init").
+2. **Resolve source** — AGENCY_SOURCE env var, --source flag, or saved source path from manifest.
+3. **For each file in the new source:**
+   - **Framework tier** — overwrite always.
+   - **Config tier** — hash current local file. If hash matches manifest → overwrite (user hasn't touched it). If hash differs → skip, add to conflict list.
+   - **Scaffold tier** — skip always.
+   - **New file** (not in manifest) — copy, add to manifest with appropriate tier.
+4. **Removed files** (in manifest but not in new source) — warn as deprecated. Do not delete.
+5. **Update manifest** — new hashes, new source commit, updated_at timestamp.
+6. **Print summary:**
+   ```
+   agency-update complete
+     Updated: 14 files (framework)
+     Updated: 3 files (config, untouched)
+     Skipped: 2 files (config, user-modified)
+     Added:   4 files (new in this version)
+     Deprecated: 1 file (removed upstream)
+   ```
+7. **No auto-commit** — user reviews changes and commits when ready.
+
+---
+
+## agency-service Deprecation
+
+The `source/services/agency-service/` directory and its 10 embedded services are deprecated.
+
+| Service | Decision | Replacement |
+|---------|----------|-------------|
+| test-service | FUTURE | `test-run` tool + bats (interim). Test management system needed later. |
+| log-service | REPLACED | JSONL telemetry via `_log-helper` |
+| secret-service | REPLACED | `secret-vault` tool |
+| request-service | KILL | Dead |
+| bug-service | FUTURE | Bugs are QGR findings (interim). Human-to-agent finding reports needed later. |
+| idea-service | KILL | Dead |
+| observation-service | KILL | Dead |
+| dispatch-service | FUTURE | File-based dispatches (interim). ISCP designs proper replacement. |
+| messages-service | FUTURE | File-based dispatches (interim). ISCP designs proper replacement. |
+| product-service | KILL | Dead |
+
+Actions:
+- Delete `source/services/agency-service/` entirely
+- Rewrite `.github/workflows/test.yml` to run bats tests directly
+- Fix `.github/workflows/starter-verify.yml` stale tool paths
+- Remove agency-service from manifest components
+
+---
+
+## `--dev` Flag
+
+Default install ships runnable tools only. `--dev` adds:
+
+- `claude/src/` — source code for compiled tools, apps, services
+- `tests/` — test suites (bats, etc.)
+- Build scripts and dev tooling
+
+Today all tools are bash scripts, so `--dev` adds tests only. As compiled artifacts ship (mdpal, mockandmark, future services), their source goes in `claude/src/`.
+
+---
+
+## Open Items (Deferred)
+
+- **Config merge strategy** — how to deliver new hooks/config keys to scaffold files
+- **Starter-packs** — what they look like, how they're shipped
+- **ISCP** — proper inter-agent communication (dispatch #3)
+- **Test management** — multi-framework test tracking and boundary run definitions
+- **Human-to-agent findings** — reporting mechanism for principals

--- a/claude/workstreams/agency/seeds/browser-access-bug-20260331.md
+++ b/claude/workstreams/agency/seeds/browser-access-bug-20260331.md
@@ -1,0 +1,74 @@
+# Bug: No Working Path for Autonomous Web Browsing
+
+**Date:** 2026-03-31
+**Filed by:** captain
+**Severity:** High — blocks all web content retrieval workflows
+
+## Problem
+
+Agents have zero autonomous web browsing capability. Every available path is broken or restricted.
+
+## Attempted Paths (All Failed)
+
+### 1. Browser MCP (`mcp__browser-mcp__*`)
+- **Server:** `npx @browsermcp/mcp` configured in `/Users/jdm/.claude.json`
+- **Chrome extension:** "Claude (MCP)" tab installed and shows green checkmark
+- **Initial state:** `/mcp` shows `browser-mcp · ✓ connected`
+- **On first tool call:** returns "No connection to browser extension" — server process is running but can't reach the Chrome extension
+- **After repeated attempts:** server crashes, `/mcp` shows `browser-mcp · ✗ failed`
+- **Stale health check:** `claude mcp list` still reports "✓ Connected" AFTER the server has failed
+- **Tools deregistered:** Once server crashes, all `mcp__browser-mcp__*` tools are permanently removed from the session. Cannot recover without restarting Claude Code.
+- **Possible trigger:** Server may have crashed when Chrome opened a new tab
+
+### 2. Computer Use MCP (`mcp__computer-use__*`)
+- **Works** for screenshots — can see screen content
+- **Hardcoded read-only tier for browsers** — "granted at tier 'read' (visible in screenshots only; no clicks or typing)"
+- **Cannot** navigate, click, type, or interact with Chrome in any way
+- **macOS accessibility permissions** are granted (user confirmed, re-approved for latest Claude Code binary)
+- **Tier guidance says** to use "Claude-in-Chrome MCP" (`mcp__Claude_in_Chrome__*`) which doesn't exist as a configured tool
+- **Root cause:** Computer Use MCP policy decision — browsers are always read-only regardless of user permission
+
+### 3. WebFetch
+- Works for simple, unauthenticated sites
+- **Fails on X/Twitter** — bot detection, login walls, JS-heavy rendering
+- **Not a browser** — can't handle modern web apps
+
+### 4. Nitter Mirrors (X/Twitter workaround)
+- `nitter.poast.org` — 503 Service Unavailable
+- `nitter.privacydev.net` — ECONNREFUSED
+- All known public Nitter instances appear dead as of 2026-03-31
+
+## Impact
+
+- Cannot fetch X/Twitter posts for knowledge base capture
+- Cannot browse documentation sites that require JS
+- Cannot navigate to any URL autonomously
+- Principal must manually navigate browser and either paste content or position windows for screenshots
+- Dispatch #4 (Browser Protocol) assumes working browser MCP — it doesn't work
+
+## Bugs to File
+
+### 1. Browser MCP: Server crashes mid-session
+- Server starts and shows connected, but crashes on first tool use or shortly after
+- `claude mcp list` reports stale "Connected" status after crash
+- Tools are permanently deregistered from session — no recovery path
+- **Debug step:** Relaunch with `claude --debug` to capture server crash logs
+
+### 2. Computer Use MCP: Read-only browser tier too restrictive
+- User explicitly grants Chrome access and macOS accessibility permissions
+- System overrides user intent by hardcoding browser tier to read-only
+- Tier guidance references "Claude-in-Chrome MCP" which may not be configured
+- **Feedback:** User should be able to grant full browser control when they choose to
+
+### 3. Browser MCP: "No connection to browser extension" despite extension showing connected
+- Chrome extension tab shows green checkmark and "Claude (MCP)" label
+- MCP server process running and reporting healthy
+- But the WebSocket(?) link between server and extension is not established
+- May require specific Chrome extension interaction to establish connection
+
+## Next Steps
+
+1. Relaunch with `claude --debug` to capture browser-mcp crash logs
+2. Investigate Browser MCP Chrome extension connection protocol
+3. File Anthropic feedback on Computer Use read-only browser tier
+4. Document working setup once fixed

--- a/claude/workstreams/agency/seeds/skills-article-trq212-20260331.md
+++ b/claude/workstreams/agency/seeds/skills-article-trq212-20260331.md
@@ -1,6 +1,6 @@
 # Lessons from Building Claude Code: How We Use Skills
 
-**Source:** @bcherny on X/Twitter — `https://x.com/bcherny/status/2038454336355999749`
+**Source:** @trq212 on X/Twitter — `https://x.com/trq212/status/2033949937936085378`
 **Captured:** 2026-03-31
 **Type:** Anthropic internal practices shared publicly
 

--- a/usr/jordan/captain/dispatches/dispatch-agency-init-design-20260331.md
+++ b/usr/jordan/captain/dispatches/dispatch-agency-init-design-20260331.md
@@ -1,0 +1,105 @@
+# Dispatch: Agency Init & Update Design
+
+**From:** captain (the-agency)
+**To:** monofolk/captain
+**Date:** 2026-03-31
+**Priority:** HIGH
+**Status:** Finalized — ready for incorporation
+
+---
+
+## Summary
+
+The agency-init and agency-update tools have been redesigned. This dispatch contains the finalized design decisions that monofolk/captain needs to incorporate into CLAUDE.md, README work, and downstream tooling.
+
+**Full design document:** `claude/workstreams/agency/seeds/agency-init-design-20260331.md`
+
+---
+
+## Key Decisions
+
+### 1. Single Namespace: Everything Under `claude/`
+
+All Agency-related directories live under `claude/`. One top-level directory in the target repo.
+
+```
+my-project/
+├── README.md
+├── CLAUDE.md
+├── .claude/              # Claude Code (settings, commands, skills, worktrees)
+└── claude/               # Agency — single namespace
+    ├── agents/           # agent CLASS definitions
+    ├── config/           # agency.yaml, manifest.json, settings-template.json
+    ├── docs/             # framework documentation
+    ├── hooks/            # Claude Code hooks
+    ├── hookify/          # behavioral rules
+    ├── templates/        # scaffolding templates
+    ├── tools/            # all tools (bash, python, rust, compiled)
+    ├── usr/              # agent INSTANCES (per-principal)
+    │   └── {principal}/
+    │       └── captain/  # instance with handoff, dispatches, transcripts
+    ├── workstreams/      # bodies of work
+    │   └── ops/          # default workstream
+    └── src/              # --dev only (source code, tests)
+```
+
+**Rationale:** Good neighbor in someone else's repo. No top-level pollution. No breaking change from current `claude/workstreams/` layout.
+
+### 2. Three File Tiers
+
+| Tier | On init | On update |
+|------|---------|-----------|
+| **framework** | Copy | Always overwrite |
+| **config** | Copy | Overwrite if untouched, skip if user-modified |
+| **scaffold** | Generate | Never touch |
+
+Tier assigned by directory pattern. More specific patterns win (e.g., `claude/usr/**` scaffold beats `claude/*/CLAUDE.md` framework).
+
+### 3. Init Preconditions
+
+- **Bare repo:** `git init` → `claude init` → `agency-init`
+- **Existing repo:** `claude init` (if needed) → `agency-init`
+- agency-init validates git exists, does not create it.
+
+### 4. Settings Merge
+
+`.claude/settings.json` is scaffold (never overwritten). New tools/hooks delivered via:
+- `claude/config/settings-template.json` — framework tier, always current
+- `./claude/tools/settings-merge` — diffs template against current settings, adds missing entries
+- Fallback: if JSON malformed, prints exact fragments for manual paste
+
+### 5. Git Is the Rollback
+
+Updates don't auto-commit. `git checkout -- claude/` undoes any botched update. `agency-update --dry-run` previews changes without writing.
+
+### 6. Trust Model
+
+- **v1:** Trust the source (local filesystem path). Same as Rails/gstack.
+- **Public release:** Signed checksums or GPG-signed manifests. Deferred.
+
+### 7. KNOWLEDGE.md → CLAUDE.md
+
+KNOWLEDGE.md replaced by CLAUDE.md everywhere. Every directory gets README.md (humans) + CLAUDE.md (agents). agency-update warns about orphaned KNOWLEDGE.md files.
+
+### 8. agency-service Deprecated
+
+All 10 embedded services killed or deferred. File-based dispatches are the interim ISCP. `test-run` + bats replaces test-service. `secret-vault` replaces secret-service. JSONL telemetry replaces log-service.
+
+---
+
+## Action Items for monofolk/captain
+
+1. **Update CLAUDE.md** to reflect `claude/usr/` and `claude/workstreams/` paths (already correct — confirm no stale references to repo-root `usr/` or `workstreams/`)
+2. **Update README** with the bare repo structure shown above
+3. **Incorporate settings-merge** into the tooling documentation
+4. **Plan KNOWLEDGE.md → CLAUDE.md migration** for existing directories
+5. **Note ISS-012** (worktree consolidation) as an open item in the ops workstream
+
+---
+
+## Review History
+
+- **Multi-agent review:** 3 reviewers (design, code, security) — 3 CRITICAL, 7 MAJOR, 8 MINOR findings
+- **Principal discussion:** 4 items resolved via 1B1 protocol
+- **Revision:** All 18 findings addressed
+- **Transcript:** `usr/jordan/captain/transcripts/transcript-agency-init-review-20260331.md`

--- a/usr/jordan/captain/transcripts/transcript-agency-init-review-20260331.md
+++ b/usr/jordan/captain/transcripts/transcript-agency-init-review-20260331.md
@@ -13,62 +13,56 @@ Three parallel reviewers (design, code, security) reviewed the design document. 
 
 - **3 CRITICAL:** workstream path relocation (undocumented breaking change), no update rollback/atomicity, no source authentication
 - **7 MAJOR:** tier rule ambiguity, settings.json divergence, manifest schema gap, incomplete tool list, unsigned manifest, supply-chain escalation path, KNOWLEDGE.md migration missing
-- **8 MINOR:** various (all will be addressed in revision)
-
----
-
-## Discussion Items
-
--> 1. [Workstream & usr/ location + worktrees — ACTIVE]
-   2. [Source authentication for v1]
-   3. [Update atomicity / rollback]
-   4. [settings.json divergence strategy]
+- **8 MINOR:** various (all addressed in revision)
 
 ---
 
 ## Item 1: Workstream & usr/ Location + Worktrees
 
-### Captain's Position
+**Decision: Option A — everything under `claude/`.** Single namespace. Good neighbor in someone else's repo. No breaking change from current `claude/workstreams/` layout.
 
-The design puts `usr/` and `workstreams/` at repo root. Three reviewers flagged this as the top issue — not the decision itself, but the undocumented breaking change from `claude/workstreams/`.
+Worktrees stay at `.claude/worktrees/` — transient, gitignored, Claude Code's concern. ISS-012 (worktrees in two locations in monofolk) noted as open item.
 
-**The question is really:** what is the Agency's namespace boundary?
+## Item 2: Source Authentication
 
-**Option A: Everything under `claude/`**
-```
-claude/
-  usr/
-  workstreams/
-  tools/
-  agents/
-  ...
-```
-- Pro: Single namespace. Clean. `claude/` is the Agency. Everything else is the project.
-- Pro: No top-level pollution — repos with lots of their own directories stay clean.
-- Pro: No breaking change from current `claude/workstreams/` location.
-- Con: Deep nesting. `claude/usr/jordan/captain/handoff.md` is a mouthful.
-- Con: Conceptually, workstreams are "the project's work" not "framework internals."
+**Decision: Option A for v1 — trust the source.** Document the trust model explicitly. Same as Rails and gstack.
 
-**Option B: Both at repo root**
-```
-usr/
-workstreams/
-claude/
-```
-- Pro: Workstreams and agent instances are first-class project citizens.
-- Pro: Shorter paths.
-- Con: Three top-level directories claimed by Agency in someone else's repo.
-- Con: Breaking change from current layout — needs migration.
-- Con: `usr/` is a Unix-ism that may confuse non-Unix developers.
+**Post-v1 (public release): Option C or D** — signed checksums or GPG-signed manifests. Deferred to that milestone.
 
-**Related: Worktrees**
+## Item 3: Update Atomicity / Rollback
 
-Currently at `.claude/worktrees/{name}/`. The design document doesn't address worktrees. Wherever we land on the namespace question, worktrees need a home. Options:
-- Stay at `.claude/worktrees/` (hidden, gitignored — current)
-- Move to `claude/worktrees/` (visible but gitignored)
-- Move to `.worktrees/` (hidden, project-level)
+**Decision: Option A — git is the rollback.** Updates don't auto-commit. `git checkout -- claude/` is the undo. Add `--dry-run` flag to agency-update. No custom staging or backup mechanism.
 
-Worktrees are transient (gitignored), so they don't follow the same rules as committed directories. The main concern is discoverability vs clutter.
+**Init preconditions clarified:** Bare repo: `git init` → `claude init` → `agency-init`. Existing repo: `claude init` (if needed) → `agency-init`. agency-init validates git exists, does not create it.
 
-**My lean:** Option A (`claude/`). The framework should stay in its lane. One top-level directory. The nesting cost is real but the "good neighbor" property matters more for adoption. Worktrees stay at `.claude/worktrees/` — they're Claude Code's concern, not the project's.
+## Item 4: settings.json Divergence
 
+**Decision: Option D + A fallback.** Ship `claude/config/settings-template.json` as framework tier (always current). Provide `settings-merge` tool that diffs template against current `.claude/settings.json` and adds missing entries. User runs it explicitly after update. If merge fails (malformed JSON), emit exact JSON fragments for manual paste.
+
+---
+
+## Additional Findings Addressed in Revision
+
+All minor/nit findings resolved without principal input:
+- Tier precedence rule added (more specific patterns win)
+- Deleted config-tier file handling specified (treat as intentional deletion, skip)
+- Tool list completed (added dependencies-check, dependencies-install, settings-merge, telemetry, agency-init, agency-update)
+- Manifest `source.path` field added
+- Schema version validation added
+- `--dev` flag interaction with agency-update specified
+- KNOWLEDGE.md migration path documented
+- Ghostty-specific hook moved to open items (should be conditional on terminal.provider)
+- Hookify shipped vs user rules: distinguished by manifest presence
+- Init commit scoped to manifest file list (not git add -A)
+- chmod +x applied per explicit file list (not glob)
+- Input validation for --principal specified
+- Error suppression patterns noted for fix
+
+---
+
+## Decisions Summary
+
+1. **Namespace:** Everything under `claude/`. Single top-level directory.
+2. **Source auth:** Trust the source for v1. Signed checksums post-v1.
+3. **Rollback:** Git is the safety net. Add `--dry-run`. No custom backup.
+4. **settings.json:** Template + merge tool. Manual fallback for broken JSON.

--- a/usr/jordan/captain/transcripts/transcript-agency-init-review-20260331.md
+++ b/usr/jordan/captain/transcripts/transcript-agency-init-review-20260331.md
@@ -1,0 +1,74 @@
+# Transcript: agency-init Design Review
+
+**Date:** 2026-03-31
+**Participants:** jordan (principal), captain (agent)
+**Context:** Review/revise/finalize cycle on `agency-init-design-20260331.md`
+**Trigger:** Multi-agent review (design, code, security) produced findings; resolving items needing principal input
+
+---
+
+## Multi-Agent Review Summary
+
+Three parallel reviewers (design, code, security) reviewed the design document. Consolidated findings:
+
+- **3 CRITICAL:** workstream path relocation (undocumented breaking change), no update rollback/atomicity, no source authentication
+- **7 MAJOR:** tier rule ambiguity, settings.json divergence, manifest schema gap, incomplete tool list, unsigned manifest, supply-chain escalation path, KNOWLEDGE.md migration missing
+- **8 MINOR:** various (all will be addressed in revision)
+
+---
+
+## Discussion Items
+
+-> 1. [Workstream & usr/ location + worktrees — ACTIVE]
+   2. [Source authentication for v1]
+   3. [Update atomicity / rollback]
+   4. [settings.json divergence strategy]
+
+---
+
+## Item 1: Workstream & usr/ Location + Worktrees
+
+### Captain's Position
+
+The design puts `usr/` and `workstreams/` at repo root. Three reviewers flagged this as the top issue — not the decision itself, but the undocumented breaking change from `claude/workstreams/`.
+
+**The question is really:** what is the Agency's namespace boundary?
+
+**Option A: Everything under `claude/`**
+```
+claude/
+  usr/
+  workstreams/
+  tools/
+  agents/
+  ...
+```
+- Pro: Single namespace. Clean. `claude/` is the Agency. Everything else is the project.
+- Pro: No top-level pollution — repos with lots of their own directories stay clean.
+- Pro: No breaking change from current `claude/workstreams/` location.
+- Con: Deep nesting. `claude/usr/jordan/captain/handoff.md` is a mouthful.
+- Con: Conceptually, workstreams are "the project's work" not "framework internals."
+
+**Option B: Both at repo root**
+```
+usr/
+workstreams/
+claude/
+```
+- Pro: Workstreams and agent instances are first-class project citizens.
+- Pro: Shorter paths.
+- Con: Three top-level directories claimed by Agency in someone else's repo.
+- Con: Breaking change from current layout — needs migration.
+- Con: `usr/` is a Unix-ism that may confuse non-Unix developers.
+
+**Related: Worktrees**
+
+Currently at `.claude/worktrees/{name}/`. The design document doesn't address worktrees. Wherever we land on the namespace question, worktrees need a home. Options:
+- Stay at `.claude/worktrees/` (hidden, gitignored — current)
+- Move to `claude/worktrees/` (visible but gitignored)
+- Move to `.worktrees/` (hidden, project-level)
+
+Worktrees are transient (gitignored), so they don't follow the same rules as committed directories. The main concern is discoverability vs clutter.
+
+**My lean:** Option A (`claude/`). The framework should stay in its lane. One top-level directory. The nesting cost is real but the "good neighbor" property matters more for adoption. Worktrees stay at `.claude/worktrees/` — they're Claude Code's concern, not the project's.
+


### PR DESCRIPTION
## Summary

- Agency-init/update redesign document: rsync + manifest model for installing and maintaining the Agency framework in any git repo
- Three file tiers (framework/config/scaffold) with manifest-driven updates
- Single namespace: everything under `claude/` (usr/, workstreams/, tools, agents, config)
- Multi-agent review (design, code, security): 18 findings addressed
- Dispatch to monofolk/captain for CLAUDE.md and README incorporation
- Also includes: git-commit ADHOC-WORKLOG fix, skills article attribution fix, browser access bug seed

## Key Decisions

1. **Namespace:** Everything under `claude/`. One top-level directory in target repos.
2. **Trust model:** v1 trusts the source. Post-v1: signed checksums.
3. **Rollback:** Git is the safety net. `--dry-run` flag for previewing updates.
4. **settings.json:** Template + `settings-merge` tool. Manual fallback for broken JSON.

## Test plan

- [ ] Review design document completeness
- [ ] Verify dispatch covers all decisions for monofolk/captain
- [ ] Confirm no stale path references in revised document

🤖 Generated with [Claude Code](https://claude.com/claude-code)