### PR TITLE
feat: sandbox-sync, ghostty integration, handoff/dispatch skills

### DIFF
--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,0 +1,50 @@
+---
+allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch *), Bash(bash claude/tools/dispatch *), Read, Write
+description: Manage dispatches — list, read, create, resolve
+---
+
+# Dispatch Management
+
+Manage dispatch files for inter-agent communication (code review findings, task assignments).
+
+## Arguments
+
+- `$ARGUMENTS`: Subcommand and arguments. One of:
+  - `list` — list dispatches for the current project
+  - `list --all` — list all dispatches across projects
+  - `read <file>` — read a dispatch and mark as read
+  - `create <project> <slug>` — create a new dispatch
+  - `resolve <file>` — mark a dispatch as resolved
+  - `check` — check for unread dispatches
+  - `status <file>` — show dispatch lifecycle status
+
+If empty, defaults to `list`.
+
+## Instructions
+
+### list / list --all
+
+Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch $ARGUMENTS` and display results.
+
+### read
+
+1. Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch read <file>` to display and mark as read.
+2. Summarize the findings for the user.
+
+### create
+
+1. Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch create <project> <slug>` to scaffold a new dispatch.
+2. Report the created file path so the user or agent can fill in the content.
+
+### resolve
+
+1. Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch resolve <file>` to mark as resolved.
+2. Confirm resolution status.
+
+### check
+
+Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch check` and report any unread dispatches.
+
+### status
+
+Run `bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch status <file>` and display the lifecycle state.

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,0 +1,39 @@
+---
+allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/handoff *), Read, Write
+description: Write a session handoff using the handoff tool — archive, write, verify
+---
+
+# Session Handoff
+
+Write a handoff file for session continuity. **Always use the handoff tool** — never write handoff files manually.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional trigger name (e.g., `pre-restart`, `phase-complete`, `discussion-milestone`). Defaults to `manual`.
+
+## Instructions
+
+### Step 1: Archive and signal
+
+Run the handoff tool to archive the current handoff and prepare for a new one:
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/handoff write --trigger $ARGUMENTS
+```
+
+If `$ARGUMENTS` is empty, use `--trigger manual`.
+
+### Step 2: Write the handoff
+
+Write the handoff file at the path the tool reported. Include:
+
+1. **Date and context** — date, branch, session/agent name
+2. **What was done** — completed work this session, key changes
+3. **What's next** — immediate next steps for a fresh session
+4. **Key decisions** — anything a new session needs to know
+5. **Open items/blockers** — unresolved issues, pending discussions
+6. **Discussion queue** — carried-forward discussion items
+
+### Step 3: Verify
+
+Run `bash $CLAUDE_PROJECT_DIR/claude/tools/handoff read` to verify the handoff was written correctly.

--- a/claude/CLAUDE-THEAGENCY.md
+++ b/claude/CLAUDE-THEAGENCY.md
@@ -169,6 +169,8 @@ Handoff files are a first-class Agency primitive for context bootstrapping. They
 
 Handoffs are not just session continuity — they bootstrap context for any purpose: agent-to-agent transfer, cold start, project setup, compaction survival, or spinning up a new agent into a desired state. The tool handles infrastructure; the agent writes the content.
 
+**Always use the handoff tool.** Run `bash $CLAUDE_PROJECT_DIR/claude/tools/handoff write --trigger <reason>` to write handoffs. The tool archives the previous handoff to `history/` with a timestamp, resolves the correct path for your project, and ensures consistent formatting. Never write handoff files manually — always use the tool. The `SessionEnd` and `PreCompact` hooks call it automatically, but agents must also call it explicitly at boundary commands and discussion milestones.
+
 **When to write:** At boundary commands (`/iteration-complete`, `/phase-complete`, `/plan-complete`, `/pre-phase-review`), automatically on `PreCompact` and `SessionEnd` hooks, after `/sync-all` (lightweight), and at discussion milestones (PVR draft, key A&D decision, plan revision).
 
 **What to include:** Current phase/iteration status, what was just done, what's next, key decisions or context for a fresh session, open items or blockers.

--- a/claude/tools/ghostty-claude-hook
+++ b/claude/tools/ghostty-claude-hook
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# ghostty-claude-hook.sh — Claude Code hook for Ghostty tab title + background
+#
+# Uses Ghostty's AppleScript API (set_tab_title) for persistent tab titles
+# that survive Claude Code's continuous OSC 2 overwrites.
+# Uses OSC 11 for background color tints.
+#
+# Does NOT touch Claude Code's statusline.sh — completely independent concern.
+
+# --- Guard: only run inside Ghostty ---
+if [[ "$TERM_PROGRAM" != "ghostty" ]]; then
+  exit 0
+fi
+
+# --- Guard: /dev/tty must be writable ---
+if [[ ! -w /dev/tty ]]; then
+  exit 0
+fi
+
+# --- Read event from stdin ---
+input=$(cat)
+
+# --- Require jq ---
+if ! command -v jq > /dev/null 2>&1; then
+  exit 0
+fi
+
+# --- Extract event name ---
+event=$(echo "$input" | jq -r '.hook_event_name // .event // ""' 2>/dev/null)
+
+# --- Determine session name ---
+# Cache file persists the name across hook invocations within a session.
+# SessionStart writes it; subsequent hooks read it.
+# Use session_id from stdin JSON as stable key across hook invocations
+SESSION_KEY=$(echo "$input" | jq -r '.session_id // "unknown"' 2>/dev/null)
+CACHE_FILE="/tmp/ghostty-session-name-${SESSION_KEY}"
+
+# Resolve branch from the correct directory (worktree, not main checkout)
+_get_branch() {
+  local dir="${CLAUDE_PROJECT_DIR:-.}"
+  git -C "$dir" branch --show-current 2>/dev/null || echo "Claude"
+}
+
+if [[ -n "${CLAUDE_SESSION_NAME:-}" ]]; then
+  session_name="$CLAUDE_SESSION_NAME"
+  echo "$session_name" > "$CACHE_FILE"
+elif [[ "$event" == "SessionStart" ]]; then
+  session_name=$(_get_branch)
+  echo "$session_name" > "$CACHE_FILE"
+elif [[ -f "$CACHE_FILE" ]]; then
+  session_name=$(cat "$CACHE_FILE")
+else
+  session_name=$(_get_branch)
+  echo "$session_name" > "$CACHE_FILE"
+fi
+
+# --- Color definitions (on light background) ---
+# Blue = available/idle, Green = working, Red = needs attention, White = no Claude
+BG_DEFAULT="#FFFFFF"      # pure white — plain shell (no Claude session)
+BG_IDLE="#E3F2FD"        # blue — available, idle, ready
+BG_WORKING="#E8F5E9"     # green — agent is working
+BG_INPUT="#FFF0F0"       # red — needs your attention
+
+# --- OSC helper for background (write to /dev/tty) ---
+set_bg() { printf '\e]11;%s\a' "$1" > /dev/tty; }
+
+# --- Tab title via OSC 2 (session-scoped via /dev/tty) ---
+# Writing to /dev/tty ensures each session sets its OWN tab title,
+# not whichever tab happens to be focused. AppleScript was abandoned
+# because it targets "focused terminal" or matches by cwd which
+# cross-contaminates tabs in multi-session setups.
+set_title() { printf '\e]2;%s\a' "$1" > /dev/tty; }
+
+# --- Map event to state ---
+case "$event" in
+  # Session ended — restore plain shell appearance
+  "SessionEnd")
+    set_title "– zsh"
+    set_bg "$BG_DEFAULT"
+    rm -f "$CACHE_FILE"
+    ;;
+
+  # Claude finished responding — available, your turn if you want
+  "Stop")
+    set_title "○ ${session_name}"
+    set_bg "$BG_IDLE"
+    ;;
+
+  # Needs attention — permission prompt or truly waiting
+  "Notification")
+    set_title "⚠ ${session_name}"
+    set_bg "$BG_INPUT"
+    ;;
+
+  # Agent is actively working
+  "PreToolUse"|"PostToolUse"|"PreCompact")
+    set_title "◑ ${session_name}"
+    set_bg "$BG_WORKING"
+    ;;
+
+  # Session just started — available
+  "SessionStart")
+    set_title "○ ${session_name}"
+    set_bg "$BG_IDLE"
+    ;;
+
+  # Default — available
+  *)
+    set_title "○ ${session_name}"
+    set_bg "$BG_IDLE"
+    ;;
+esac

--- a/claude/tools/ghostty-config
+++ b/claude/tools/ghostty-config
@@ -1,0 +1,39 @@
+# Ghostty terminal configuration
+# Install: copy or symlink to ~/.config/ghostty/config
+#
+# Source of truth: claude/tools/ghostty-config in the repo.
+# To activate: ln -sf <repo>/claude/tools/ghostty-config ~/.config/ghostty/config
+
+# --- Theme ---
+theme = GitHub Light Default
+
+# --- Font ---
+font-family = JetBrains Mono
+font-size = 14
+
+# --- Window ---
+window-padding-x = 8
+window-padding-y = 4
+window-decoration = true
+macos-titlebar-style = tabs
+
+# --- Shell integration ---
+# Disable Ghostty's built-in title management so our scripts control it
+# via OSC 2. Keep cursor and sudo integration active.
+shell-integration-features = cursor,sudo,no-title
+
+# --- Cursor ---
+cursor-style = bar
+cursor-style-blink = true
+
+# --- Clipboard ---
+clipboard-read = allow
+clipboard-write = allow
+copy-on-select = clipboard
+
+# --- Scrollback ---
+scrollback-limit = 4294967295
+
+# --- Behavior ---
+confirm-close-surface = false
+mouse-hide-while-typing = true

--- a/claude/tools/ghostty-debug-hook
+++ b/claude/tools/ghostty-debug-hook
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Debug hook — dump everything to a file so we can see what's available
+# Only runs when GHOSTTY_DEBUG_HOOK=1 is set explicitly
+[[ -z "$GHOSTTY_DEBUG_HOOK" ]] && exit 0
+input=$(cat)
+{
+  echo "=== $(date) ==="
+  echo "STDIN: $input"
+  echo "CLAUDE_PROJECT_DIR: ${CLAUDE_PROJECT_DIR:-UNSET}"
+  echo "CLAUDE_SESSION_NAME: ${CLAUDE_SESSION_NAME:-UNSET}"
+  echo "CLAUDE_SESSION_ID: ${CLAUDE_SESSION_ID:-UNSET}"
+  echo "PWD: $(pwd)"
+  echo "GIT_BRANCH: $(git branch --show-current 2>/dev/null || echo NONE)"
+  echo ""
+} >> /tmp/ghostty-hook-debug.log

--- a/claude/tools/ghostty-integration
+++ b/claude/tools/ghostty-integration
@@ -1,0 +1,100 @@
+#!/usr/bin/env zsh
+# ghostty-integration.sh — Ghostty terminal tab title + background color integration
+#
+# Provides:
+#   - Default tab title: "– zsh <directory>" for plain shells
+#   - Claude Code tab title + background color updates via exported functions
+#   - Functions: ghostty_set_title, ghostty_set_bg, ghostty_set_state
+#
+# Source this from ~/.zshrc:
+#   source <repo>/claude/tools/ghostty-integration
+#
+# Does NOT modify Claude Code's statusline.sh — these are separate concerns.
+# The statusline is the bottom bar inside Claude Code.
+# This script controls the terminal chrome (tab title) and content area (bg color).
+
+# --- Guard: only run inside Ghostty ---
+if [[ "$TERM_PROGRAM" != "ghostty" ]]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+# --- Color definitions (subtle tints on light background) ---
+# These are very subtle shifts from white — just enough to notice
+GHOSTTY_BG_DEFAULT="#FFFFFF"      # pure white — plain shell
+GHOSTTY_BG_IDLE="#F0F4FA"        # very faint blue — Claude idle
+GHOSTTY_BG_WORKING="#F0FAF2"     # very faint green — Claude working
+GHOSTTY_BG_INPUT="#FAF0F0"       # very faint red — Claude needs input
+
+# --- Low-level OSC helpers ---
+
+# Set tab/window title via OSC 2
+ghostty_set_title() {
+  printf '\e]2;%s\a' "$1"
+}
+
+# Set terminal background color via OSC 11
+ghostty_set_bg() {
+  printf '\e]11;%s\a' "$1"
+}
+
+# Reset background to default
+ghostty_reset_bg() {
+  printf '\e]11;%s\a' "$GHOSTTY_BG_DEFAULT"
+}
+
+# --- State management ---
+
+# Combined state setter for Claude Code integration
+# Usage: ghostty_set_state <state> <session-name>
+#   state: idle | working | input
+#   session-name: the Claude Code session name
+ghostty_set_state() {
+  local state="$1"
+  local session_name="$2"
+
+  case "$state" in
+    idle)
+      ghostty_set_title "○ ${session_name}"
+      ghostty_set_bg "$GHOSTTY_BG_IDLE"
+      ;;
+    working)
+      ghostty_set_title "◑ ${session_name}"
+      ghostty_set_bg "$GHOSTTY_BG_WORKING"
+      ;;
+    input)
+      ghostty_set_title "⚠ ${session_name}"
+      ghostty_set_bg "$GHOSTTY_BG_INPUT"
+      ;;
+    plain)
+      # Reset to plain shell state
+      ghostty_set_title "– zsh ${PWD##*/}"
+      ghostty_reset_bg
+      ;;
+    *)
+      # Unknown state — treat as plain
+      ghostty_set_title "– zsh ${PWD##*/}"
+      ghostty_reset_bg
+      ;;
+  esac
+}
+
+# --- zsh precmd hook: default tab title for plain shell ---
+# This fires before every prompt. If Claude Code is running, its hooks
+# will override this. For plain shells, it sets "– zsh <dir>".
+
+_ghostty_precmd() {
+  # If CLAUDE_CODE_SESSION is set, don't override — Claude hooks manage the title
+  if [[ -n "$CLAUDE_CODE_SESSION" ]]; then
+    return
+  fi
+  ghostty_set_title "– zsh ${PWD##*/}"
+}
+
+# Register the precmd hook (idempotent — won't double-register)
+if (( ! ${precmd_functions[(Ie)_ghostty_precmd]} )); then
+  precmd_functions+=(_ghostty_precmd)
+fi
+
+# --- Initial state ---
+# Set plain shell title on source (will be overridden if Claude Code starts)
+ghostty_set_title "– zsh ${PWD##*/}"

--- a/claude/tools/ghostty-setup
+++ b/claude/tools/ghostty-setup
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# ghostty-setup.sh — One-time setup for Ghostty terminal integration
+#
+# Creates ~/.config/ghostty/ and symlinks the config from the monorepo.
+# Adds the zsh integration source line to ~/.zshrc if not already present.
+#
+# Safe to re-run — idempotent.
+#
+# Usage: bash claude/tools/ghostty-setup
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+GHOSTTY_CONFIG_DIR="$HOME/.config/ghostty"
+GHOSTTY_CONFIG_SRC="$REPO_DIR/claude/tools/ghostty-config"
+GHOSTTY_CONFIG_DST="$GHOSTTY_CONFIG_DIR/config"
+ZSH_INTEGRATION_SRC="$REPO_DIR/claude/tools/ghostty-integration"
+ZSHRC="$HOME/.zshrc"
+
+echo "=== Ghostty Setup ==="
+echo ""
+
+# --- Step 1: Create config directory ---
+if [[ ! -d "$GHOSTTY_CONFIG_DIR" ]]; then
+  echo "Creating $GHOSTTY_CONFIG_DIR"
+  mkdir -p "$GHOSTTY_CONFIG_DIR"
+else
+  echo "Config directory exists: $GHOSTTY_CONFIG_DIR"
+fi
+
+# --- Step 2: Symlink config ---
+if [[ -L "$GHOSTTY_CONFIG_DST" ]]; then
+  existing=$(readlink "$GHOSTTY_CONFIG_DST")
+  if [[ "$existing" == "$GHOSTTY_CONFIG_SRC" ]]; then
+    echo "Config symlink already correct: $GHOSTTY_CONFIG_DST -> $GHOSTTY_CONFIG_SRC"
+  else
+    echo "Updating config symlink (was: $existing)"
+    ln -sf "$GHOSTTY_CONFIG_SRC" "$GHOSTTY_CONFIG_DST"
+    echo "Symlinked: $GHOSTTY_CONFIG_DST -> $GHOSTTY_CONFIG_SRC"
+  fi
+elif [[ -f "$GHOSTTY_CONFIG_DST" ]]; then
+  echo "WARNING: $GHOSTTY_CONFIG_DST exists as a regular file."
+  echo "  Back it up and remove it, then re-run this script."
+  echo "  Backup: cp $GHOSTTY_CONFIG_DST ${GHOSTTY_CONFIG_DST}.bak"
+  exit 1
+else
+  ln -sf "$GHOSTTY_CONFIG_SRC" "$GHOSTTY_CONFIG_DST"
+  echo "Symlinked: $GHOSTTY_CONFIG_DST -> $GHOSTTY_CONFIG_SRC"
+fi
+
+# --- Step 3: Add zsh integration to .zshrc ---
+INTEGRATION_LINE="source \"$ZSH_INTEGRATION_SRC\""
+
+if grep -qF "$ZSH_INTEGRATION_SRC" "$ZSHRC" 2>/dev/null; then
+  echo "zsh integration already in $ZSHRC"
+else
+  echo "" >> "$ZSHRC"
+  echo "# Ghostty terminal integration (tab titles + background color hints)" >> "$ZSHRC"
+  echo "$INTEGRATION_LINE" >> "$ZSHRC"
+  echo "Added to $ZSHRC:"
+  echo "  $INTEGRATION_LINE"
+fi
+
+echo ""
+echo "=== Done ==="
+echo ""
+echo "Next steps:"
+echo "  1. Open Ghostty (/Applications/Ghostty.app)"
+echo "  2. The config will be loaded automatically"
+echo "  3. Start a new zsh session — tab should show '- zsh <dir>'"
+echo "  4. Start Claude Code — tab should show 'o <session>' with blue tint"
+echo ""
+echo "To modify the theme or font, edit:"
+echo "  $GHOSTTY_CONFIG_SRC"
+echo ""

--- a/claude/tools/sandbox-sync
+++ b/claude/tools/sandbox-sync
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sandbox Sync — bulk symlink activation for commands and hookify rules
+# Usage:
+#   bash claude/tools/sandbox-sync           # normal output
+#   bash claude/tools/sandbox-sync --quiet    # only report if changes made
+#
+# Creates symlinks from usr/<engineer>/claude/ into .claude/ discovery locations.
+# Idempotent — safe to run repeatedly. Works from any worktree.
+
+QUIET="${1:-}"
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"
+if [ -z "$ROOT" ]; then
+  echo "error: not in a git repository" >&2
+  exit 1
+fi
+
+# Safe glob handling — empty globs expand to nothing
+shopt -s nullglob
+
+# Detect engineer — prefer $USER match, fall back to first found
+ENGINEER=""
+if [ -d "$ROOT/claude/usr/${USER:-}" ]; then
+  ENGINEER="$USER"
+else
+  for dir in "$ROOT"/claude/usr/*/; do
+    [ -d "$dir" ] || continue
+    name="$(basename "$dir")"
+    [ "$name" = "README.md" ] && continue
+    ENGINEER="$name"
+    break
+  done
+fi
+
+if [ -z "$ENGINEER" ]; then
+  echo "error: no engineer sandbox found in claude/usr/" >&2
+  exit 1
+fi
+
+# Validate engineer name contains only safe characters
+if ! printf '%s' "$ENGINEER" | grep -qE '^[a-zA-Z0-9_-]+$'; then
+  echo "error: invalid engineer name '$ENGINEER' — must be [a-zA-Z0-9_-]+" >&2
+  exit 1
+fi
+
+SANDBOX="$ROOT/claude/usr/$ENGINEER"
+CREATED=0
+EXISTING=0
+UPDATED=0
+
+# Sync commands
+COMMANDS_SRC="$SANDBOX/commands"
+COMMANDS_DST="$ROOT/.claude/commands"
+
+if [ -d "$COMMANDS_SRC" ]; then
+  mkdir -p "$COMMANDS_DST"
+
+  for src in "$COMMANDS_SRC"/*.md; do
+    [ -f "$src" ] || continue
+    name="$(basename "$src")"
+    [ "$name" = ".gitkeep" ] && continue
+
+    target="$COMMANDS_DST/usr-${ENGINEER}.${name}"
+    relative="../../claude/usr/$ENGINEER/commands/$name"
+
+    if [ -L "$target" ]; then
+      current="$(readlink "$target")"
+      if [ "$current" = "$relative" ]; then
+        EXISTING=$((EXISTING + 1))
+      else
+        ln -sf "$relative" "$target"
+        UPDATED=$((UPDATED + 1))
+      fi
+    else
+      ln -sf "$relative" "$target"
+      CREATED=$((CREATED + 1))
+    fi
+  done
+fi
+
+# Sync hookify rules
+HOOKIFY_SRC="$SANDBOX/hookify"
+HOOKIFY_DST="$ROOT/.claude"
+
+if [ -d "$HOOKIFY_SRC" ]; then
+  for src in "$HOOKIFY_SRC"/*.md; do
+    [ -f "$src" ] || continue
+    name="$(basename "$src")"
+    [ "$name" = ".gitkeep" ] && continue
+
+    # Hookify naming: .claude/hookify.usr-<engineer>.<name>
+    # But source files may already have hookify. prefix — strip it for the target name
+    clean_name="${name#hookify.}"
+    target="$HOOKIFY_DST/hookify.usr-${ENGINEER}.${clean_name}"
+    # .claude/ is one level deep from root, so relative path needs ../
+    relative="../claude/usr/$ENGINEER/hookify/$name"
+
+    if [ -L "$target" ]; then
+      current="$(readlink "$target")"
+      if [ "$current" = "$relative" ]; then
+        EXISTING=$((EXISTING + 1))
+      else
+        ln -sf "$relative" "$target"
+        UPDATED=$((UPDATED + 1))
+      fi
+    else
+      ln -sf "$relative" "$target"
+      CREATED=$((CREATED + 1))
+    fi
+  done
+fi
+
+# Sync hooks
+HOOKS_SRC="$SANDBOX/hooks"
+HOOKS_DST="$ROOT/.claude/hooks"
+
+if [ -d "$HOOKS_SRC" ]; then
+  mkdir -p "$HOOKS_DST"
+
+  for src in "$HOOKS_SRC"/*; do
+    [ -f "$src" ] || continue
+    name="$(basename "$src")"
+    [ "$name" = ".gitkeep" ] && continue
+
+    target="$HOOKS_DST/usr-${ENGINEER}.${name}"
+    relative="../../claude/usr/$ENGINEER/hooks/$name"
+
+    if [ -L "$target" ]; then
+      current="$(readlink "$target")"
+      if [ "$current" = "$relative" ]; then
+        EXISTING=$((EXISTING + 1))
+      else
+        ln -sf "$relative" "$target"
+        UPDATED=$((UPDATED + 1))
+      fi
+    else
+      ln -sf "$relative" "$target"
+      CREATED=$((CREATED + 1))
+    fi
+  done
+fi
+
+# Sync agents
+AGENTS_SRC="$SANDBOX/agents"
+AGENTS_DST="$ROOT/.claude/agents"
+
+if [ -d "$AGENTS_SRC" ]; then
+  mkdir -p "$AGENTS_DST"
+
+  for agent_dir in "$AGENTS_SRC"/*/; do
+    [ -d "$agent_dir" ] || continue
+    agent_name="$(basename "$agent_dir")"
+
+    target_dir="$AGENTS_DST/usr-${ENGINEER}.${agent_name}"
+    relative_dir="../../claude/usr/$ENGINEER/agents/$agent_name"
+
+    if [ -L "$target_dir" ]; then
+      current="$(readlink "$target_dir")"
+      if [ "$current" = "$relative_dir" ]; then
+        EXISTING=$((EXISTING + 1))
+      else
+        ln -sfn "$relative_dir" "$target_dir"
+        UPDATED=$((UPDATED + 1))
+      fi
+    else
+      ln -sfn "$relative_dir" "$target_dir"
+      CREATED=$((CREATED + 1))
+    fi
+  done
+fi
+
+# Sync settings.local.json
+# settings.local.json is gitignored — it only exists in the main checkout.
+# In worktrees, we symlink to the main checkout's copy using an absolute path.
+MAIN_CHECKOUT=$(git worktree list | head -1 | awk '{print $1}')
+SETTINGS_SRC_MAIN="$MAIN_CHECKOUT/claude/usr/$ENGINEER/settings.local.json"
+SETTINGS_DST="$ROOT/.claude/settings.local.json"
+
+if [ -f "$SETTINGS_SRC_MAIN" ]; then
+  # Use absolute path — gitignored files don't exist in worktrees
+  target="$SETTINGS_SRC_MAIN"
+
+  if [ -L "$SETTINGS_DST" ]; then
+    current="$(readlink "$SETTINGS_DST")"
+    if [ "$current" = "$target" ]; then
+      EXISTING=$((EXISTING + 1))
+    else
+      ln -sf "$target" "$SETTINGS_DST"
+      UPDATED=$((UPDATED + 1))
+    fi
+  else
+    [ -f "$SETTINGS_DST" ] && rm "$SETTINGS_DST"
+    ln -sf "$target" "$SETTINGS_DST"
+    CREATED=$((CREATED + 1))
+  fi
+fi
+
+TOTAL=$((CREATED + EXISTING + UPDATED))
+COMMANDS_COUNT=0
+HOOKIFY_COUNT=0
+[ -d "$COMMANDS_SRC" ] && COMMANDS_COUNT="$(find "$COMMANDS_SRC" -name "*.md" ! -name ".gitkeep" 2>/dev/null | wc -l | tr -d ' ')"
+[ -d "$HOOKIFY_SRC" ] && HOOKIFY_COUNT="$(find "$HOOKIFY_SRC" -name "*.md" ! -name ".gitkeep" 2>/dev/null | wc -l | tr -d ' ')"
+
+if [ "$QUIET" = "--quiet" ]; then
+  # Only output if something changed
+  if [ "$CREATED" -gt 0 ] || [ "$UPDATED" -gt 0 ]; then
+    echo "sandbox-sync: $COMMANDS_COUNT commands, $HOOKIFY_COUNT hookify — $CREATED created, $UPDATED updated"
+  fi
+else
+  echo "sandbox-sync: $COMMANDS_COUNT commands, $HOOKIFY_COUNT hookify rules"
+  echo "  created:  $CREATED new symlinks"
+  echo "  updated:  $UPDATED changed symlinks"
+  echo "  existing: $EXISTING already current"
+  echo "  total:    $TOTAL active"
+fi


### PR DESCRIPTION
## Summary

Ported tooling from the monofolk project to the-agency framework:

- **sandbox-sync tool** (`claude/tools/sandbox-sync`): Bulk symlink activation for commands, hookify rules, hooks, agents, and settings.local.json from user sandboxes to `.claude/` discovery locations. Idempotent, safe to re-run. Referenced in docs but was missing implementation.
- **Ghostty terminal integration** (5 files in `claude/tools/`):
  - `ghostty-claude-hook`: Claude Code hook that sets tab indicators (○ idle / ◑ working / ⚠ needs attention) and background color tints per session state
  - `ghostty-config`: Base Ghostty terminal config (theme, font, shell integration flags)
  - `ghostty-integration`: zsh integration sourced from `.zshrc` — exports `ghostty_set_state` and manages default tab titles
  - `ghostty-setup`: One-time setup script (creates config symlink, adds zsh source line)
  - `ghostty-debug-hook`: Debug hook for troubleshooting (opt-in via env var)
- **`/handoff` skill** (`.claude/skills/handoff/SKILL.md`): Wraps `claude/tools/handoff` for session continuity — archive, write, verify workflow
- **`/dispatch` skill** (`.claude/skills/dispatch/SKILL.md`): Wraps `claude/tools/dispatch` for inter-agent communication — list, read, create, resolve, check, status subcommands
- **CLAUDE-THEAGENCY.md update**: Added "Always use the handoff tool" paragraph to Session Handoff section, enforcing tool usage over manual file writes

## Modified files

| File | Change |
|------|--------|
| `claude/CLAUDE-THEAGENCY.md` | Added handoff tool enforcement paragraph |
| `claude/tools/sandbox-sync` | New — bulk sandbox symlink activation |
| `claude/tools/ghostty-claude-hook` | New — Claude Code session hook |
| `claude/tools/ghostty-config` | New — Ghostty terminal config |
| `claude/tools/ghostty-integration` | New — zsh integration for tab titles |
| `claude/tools/ghostty-setup` | New — one-time setup script |
| `claude/tools/ghostty-debug-hook` | New — opt-in debug hook |
| `.claude/skills/handoff/SKILL.md` | New — /handoff skill |
| `.claude/skills/dispatch/SKILL.md` | New — /dispatch skill |

## Test plan

- [ ] Verify `sandbox-sync` runs cleanly in a repo with a `claude/usr/<engineer>/` sandbox
- [ ] Verify ghostty-claude-hook sets tab titles correctly when sourced by Claude Code hooks
- [ ] Verify `/handoff` and `/dispatch` skills are discoverable via Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)