### PR TITLE
feat: worktree-sync + session lifecycle + enforcement triangle

### DIFF
--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,0 +1,60 @@
+---
+allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/handoff *), Bash(git status:*), Bash(git log:*), Bash(git branch:*)
+description: End a session cleanly — write handoff, warn on dirty state, report readiness
+---
+
+# Session End
+
+Clean session teardown. Writes the handoff, warns about uncommitted work, and reports readiness for captain pickup.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional trigger reason (e.g., "end-of-day", "switching-context"). Defaults to "session-end".
+
+## Instructions
+
+### Step 1: Check dirty state
+
+Run `git status --porcelain`. If there are uncommitted changes:
+
+**Warn the user:**
+> You have N uncommitted files. Commit them before ending, or they'll be left as dirty state for the next session.
+
+List the files. Ask if they want to commit first.
+
+### Step 2: Archive and get handoff path
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/handoff write --trigger session-end
+```
+
+The tool archives the current handoff and reports the path for the new one.
+
+### Step 3: Write handoff content
+
+Write the handoff file at the path reported by the tool. Include:
+- Current phase/iteration status
+- What was done this session
+- What's next
+- Key decisions or context for a fresh session
+- Open items or blockers
+
+### Step 4: Verify handoff
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/handoff read
+```
+
+Confirm the handoff was written correctly.
+
+### Step 5: Report readiness
+
+Report to the user:
+- **Branch:** `git branch --show-current`
+- **Last commit:** `git log --oneline -1`
+- **Dirty files:** count (0 = ready for captain)
+- **Handoff:** written ✓
+
+If dirty files remain, note: "Captain pickup may miss uncommitted work."
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/session-resume/SKILL.md
+++ b/.claude/skills/session-resume/SKILL.md
@@ -1,0 +1,56 @@
+---
+allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/worktree-sync *), Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/handoff *), Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch *), Bash(git status:*), Bash(git log:*), Bash(git branch:*)
+description: Resume a worktree session — sync master, read handoff, check dispatches, report state
+---
+
+# Session Resume
+
+Full session startup for worktree agents. Syncs with master, reads your handoff, checks for dispatches, and reports session state.
+
+On SessionStart, Steps 1-2 run automatically via hooks (worktree-sync + session-handoff). Step 3 (dispatch check) requires manual invocation. Use this skill for full mid-session sync including dispatches.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional. No arguments needed.
+
+## Instructions
+
+### Step 1: Sync with master
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/worktree-sync --auto
+```
+
+This stashes dirty work if needed, merges master, copies settings, runs sandbox-sync, and unstashes. If on master, it silently skips.
+
+### Step 2: Read the handoff
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/handoff read
+```
+
+Display the handoff contents. This is your context for what was happening before this session.
+
+### Step 3: Check for dispatches
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch check
+```
+
+Surface any unread dispatches. If found, read them with `/dispatch read <file>`.
+
+### Step 4: Report session state
+
+Report to the user:
+- **Branch:** `git branch --show-current`
+- **Last commit:** `git log --oneline -1`
+- **Dirty files:** `git status --porcelain | wc -l` (0 = clean)
+- **Sync result:** what changed from Step 1
+- **Handoff summary:** key points from Step 2
+- **Dispatches:** any unread from Step 3
+
+### Note
+
+On master, Step 1 silently skips — the rest still runs. This skill works on any branch.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/worktree-sync/SKILL.md
+++ b/.claude/skills/worktree-sync/SKILL.md
@@ -1,0 +1,42 @@
+---
+allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/worktree-sync *)
+description: Sync worktree with master — merge, copy settings, run sandbox-sync, report changes
+---
+
+# Worktree Sync
+
+Sync your worktree branch with master. Merges master, copies settings.json from the main checkout, runs sandbox-sync, and reports what changed.
+
+## Arguments
+
+- `$ARGUMENTS`: Optional. No arguments needed for normal use.
+
+## Instructions
+
+### Step 1: Run the tool
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/worktree-sync
+```
+
+If your working tree is dirty, commit or stash first — the tool will refuse.
+
+### Step 2: Interpret the report
+
+The tool reports:
+- Files changed by the merge (in `claude/` and `.claude/`)
+- Whether settings.json was updated
+- New dispatches found
+- Whether CLAUDE.md was updated
+
+### Step 3: Act on changes
+
+- **If CLAUDE.md was updated:** Re-read CLAUDE.md now. Methodology or project instructions changed.
+- **If dispatches found:** Read them with `/dispatch read <file>`.
+- **If settings.json updated:** New hooks or permissions are active.
+
+### Note
+
+This skill is for **worktree agents only**. On master, use `/sync-all` instead.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/CLAUDE-THEAGENCY.md
+++ b/claude/CLAUDE-THEAGENCY.md
@@ -201,6 +201,19 @@ When drafting feedback or bug reports **for Anthropic / Claude Code** (via `/fee
 - **No unactionable noise** — every warning must trigger action or get fixed at the source.
 - **Verify, don't assume** — read the docs, check the data, debug with evidence. Don't cargo-cult patterns.
 - **Enforce conventions mechanically** — hooks and rules, not prose. Prose gets forgotten.
+
+### The Enforcement Triangle
+
+Every capability follows the same three-part pattern:
+
+| Layer | What | Why |
+|-------|------|-----|
+| **Tool** (bash, `claude/tools/`) | Does the work. Pre-approved in `settings.json`. | Permissions. No prompts for approved operations. |
+| **Skill** (markdown, `.claude/commands/` or `.claude/skills/`) | Tells the agent when and how to use the tool. | Discovery. Agents find it via `/` autocomplete. |
+| **Hookify rule** (`claude/hookify/`) | Blocks the raw alternative. Points to the skill. | Compliance. Can't bypass. |
+
+When building a new capability: build the tool, wrap it in a skill, block the raw alternative with a hookify rule. All three. Not one, not two. The tool handles permissions, the skill handles discovery, the hookify rule handles compliance. *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
+
 - **No stale artifacts** — unused config, orphaned files, outdated docs — delete or update. Version control remembers.
 
 **When something fails:**

--- a/claude/hookify/hookify.block-raw-git-merge-master.md
+++ b/claude/hookify/hookify.block-raw-git-merge-master.md
@@ -1,0 +1,17 @@
+---
+name: block-raw-git-merge-master
+enabled: true
+event: bash
+pattern: git merge (--\S+\s+)*(origin/)?master
+action: warn
+---
+
+**Use `/worktree-sync` instead of raw `git merge master`.**
+
+The worktree-sync tool handles the full sync: merge master, copy settings.json, run sandbox-sync, and report what changed. Raw `git merge master` skips all of that.
+
+```
+/worktree-sync
+```
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/tools/tests/test-worktree-sync.sh
+++ b/claude/tools/tests/test-worktree-sync.sh
@@ -1,0 +1,307 @@
+#!/bin/bash
+#
+# test-worktree-sync.sh — Tests for claude/tools/worktree-sync
+#
+# Run: bash claude/tools/tests/test-worktree-sync.sh
+#
+# Creates temp git repos to test all code paths.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOOL="$TOOLS_DIR/worktree-sync"
+
+PASS=0
+FAIL=0
+ERRORS=""
+TMPBASE=""
+
+# --- Test harness ---
+assert_eq() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected: ${expected}\n    actual:   ${actual}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_contains() {
+    local test_name="$1" expected="$2" actual="$3"
+    if echo "$actual" | grep -qF "$expected"; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected to contain: ${expected}\n    actual: ${actual}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_valid_json() {
+    local test_name="$1" content="$2"
+    if echo "$content" | jq . >/dev/null 2>&1; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    invalid JSON: ${content}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+# --- Setup: create a temp git repo with a worktree ---
+setup_repo() {
+    TMPBASE=$(mktemp -d)
+
+    # Create main repo with master branch (tool hardcodes "master")
+    git init "$TMPBASE/main" --quiet --initial-branch=master
+    cd "$TMPBASE/main"
+    git config user.email "test@test.com"
+    git config user.name "Test"
+
+    # Create initial structure
+    mkdir -p claude/tools .claude
+    echo '{"permissions":{}}' > .claude/settings.json
+    cp "$TOOL" claude/tools/worktree-sync
+    chmod +x claude/tools/worktree-sync
+
+    # Don't copy log helper — it uses python3 for UUID generation which can hang in temp repos
+    # The tool handles missing _log-helper gracefully (logging is optional)
+
+    # Don't copy sandbox-sync — temp repo doesn't have claude/usr/ structure
+    # The tool handles missing sandbox-sync gracefully
+
+    git add -A
+    git commit -m "initial" --quiet
+
+    # Create worktree on feature branch
+    git branch feature
+    git worktree add "$TMPBASE/worktree" feature --quiet 2>/dev/null
+
+    cd "$TMPBASE/worktree"
+}
+
+cleanup() {
+    if [[ -n "$TMPBASE" ]] && [[ -d "$TMPBASE" ]]; then
+        cd /tmp
+        # Remove worktree first
+        git -C "$TMPBASE/main" worktree remove "$TMPBASE/worktree" --force 2>/dev/null || true
+        rm -rf "$TMPBASE"
+    fi
+}
+
+# ========================================
+echo "=== worktree-sync tests ==="
+echo ""
+
+# --- Test 1: --version ---
+echo "Test: --version"
+OUTPUT=$(bash "$TOOL" --version 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_contains "prints version" "1.0.0" "$OUTPUT"
+echo ""
+
+# --- Test 2: --help ---
+echo "Test: --help"
+OUTPUT=$(bash "$TOOL" --help 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_contains "prints usage" "Usage:" "$OUTPUT"
+echo ""
+
+# --- Test 3: unknown arg ---
+echo "Test: unknown argument"
+OUTPUT=$(bash "$TOOL" --bogus 2>&1 || true)
+assert_contains "error message" "unknown argument" "$OUTPUT"
+echo ""
+
+# --- Test 4: master guard (manual) ---
+echo "Test: master guard — manual mode"
+setup_repo
+cd "$TMPBASE/main"  # on master
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1 || true)
+EXIT=${PIPESTATUS[0]:-1}
+assert_contains "refuses on master" "use /sync-all instead" "$OUTPUT"
+cleanup
+echo ""
+
+# --- Test 5: master guard (auto) — soft skip ---
+echo "Test: master guard — auto mode (soft skip)"
+setup_repo
+cd "$TMPBASE/main"
+OUTPUT=$(bash claude/tools/worktree-sync --auto 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_valid_json "valid JSON output" "$OUTPUT"
+assert_contains "skip message" "skipped" "$OUTPUT"
+cleanup
+echo ""
+
+# --- Test 6: dirty tree (manual) — refuse ---
+echo "Test: dirty tree — manual mode"
+setup_repo
+echo "dirty" > dirty.txt
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1 || true)
+assert_contains "refuses on dirty" "dirty" "$OUTPUT"
+assert_contains "file count" "modified files" "$OUTPUT"
+cleanup
+echo ""
+
+# --- Test 7: already up to date ---
+echo "Test: already up to date"
+setup_repo
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_contains "up to date" "already up to date" "$OUTPUT"
+cleanup
+echo ""
+
+# --- Test 8: merge master (with changes) ---
+echo "Test: merge master with changes"
+setup_repo
+# Add a commit to master
+cd "$TMPBASE/main"
+echo "new content" > claude/tools/new-tool
+git add claude/tools/new-tool
+git commit -m "add new tool" --quiet
+# Back to worktree
+cd "$TMPBASE/worktree"
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_contains "merge report" "merged master" "$OUTPUT"
+assert_contains "file in report" "new-tool" "$OUTPUT"
+# Verify the file actually arrived
+assert_eq "file merged" "new content" "$(cat claude/tools/new-tool 2>/dev/null || echo 'missing')"
+cleanup
+echo ""
+
+# --- Test 9: settings.json copy ---
+echo "Test: settings.json copy from main checkout"
+setup_repo
+# Update settings in main checkout only (not via git)
+echo '{"permissions":{"allow":["new"]}}' > "$TMPBASE/main/.claude/settings.json"
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1)
+assert_contains "settings copied" "settings.json" "$OUTPUT"
+# Verify copy happened
+WORKTREE_SETTINGS=$(cat .claude/settings.json)
+assert_contains "settings match" '"new"' "$WORKTREE_SETTINGS"
+cleanup
+echo ""
+
+# --- Test 10: CLAUDE.md change detection ---
+echo "Test: CLAUDE.md change detection"
+setup_repo
+cd "$TMPBASE/main"
+echo "updated methodology" > CLAUDE.md
+git add CLAUDE.md
+git commit -m "update CLAUDE.md" --quiet
+cd "$TMPBASE/worktree"
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1)
+assert_contains "claude.md detected" "re-read recommended" "$OUTPUT"
+cleanup
+echo ""
+
+# --- Test 11: auto mode — stash and unstash ---
+echo "Test: auto mode — stash/merge/unstash"
+setup_repo
+# Add commit to master
+cd "$TMPBASE/main"
+echo "master change" > claude/tools/master-file
+git add claude/tools/master-file
+git commit -m "master commit" --quiet
+# Back to worktree with dirty file (different from master's change)
+cd "$TMPBASE/worktree"
+echo "local work" > local-work.txt
+OUTPUT=$(bash claude/tools/worktree-sync --auto 2>&1)
+EXIT=$?
+assert_eq "exit code 0" "0" "$EXIT"
+assert_valid_json "valid JSON" "$OUTPUT"
+# Verify local work survived the stash/unstash
+assert_eq "local work preserved" "local work" "$(cat local-work.txt 2>/dev/null || echo 'missing')"
+# Verify master change arrived
+assert_eq "master file merged" "master change" "$(cat claude/tools/master-file 2>/dev/null || echo 'missing')"
+cleanup
+echo ""
+
+# --- Test 12: merge conflict ---
+echo "Test: merge conflict"
+setup_repo
+# Both master and worktree modify the same file
+cd "$TMPBASE/main"
+echo "master version" > conflict-file.txt
+git add conflict-file.txt
+git commit -m "master side" --quiet
+cd "$TMPBASE/worktree"
+echo "worktree version" > conflict-file.txt
+git add conflict-file.txt
+git commit -m "worktree side" --quiet
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1 || true)
+assert_contains "conflict detected" "merge conflict" "$OUTPUT"
+# Verify worktree is clean (merge aborted)
+MERGE_STATE=$(git rev-parse --verify MERGE_HEAD 2>/dev/null || echo "no-merge")
+assert_eq "merge aborted" "no-merge" "$MERGE_STATE"
+cleanup
+echo ""
+
+# --- Test 13: auto mode conflict produces valid JSON ---
+echo "Test: auto mode conflict — valid JSON"
+setup_repo
+cd "$TMPBASE/main"
+echo "master version" > conflict-file.txt
+git add conflict-file.txt
+git commit -m "master side" --quiet
+cd "$TMPBASE/worktree"
+echo "worktree version" > conflict-file.txt
+git add conflict-file.txt
+git commit -m "worktree side" --quiet
+OUTPUT=$(bash claude/tools/worktree-sync --auto 2>&1 || true)
+# Extract just the JSON line (last line of output)
+JSON_LINE=$(echo "$OUTPUT" | grep '{"systemMessage"' || echo "")
+if [[ -n "$JSON_LINE" ]]; then
+    assert_valid_json "conflict JSON is valid" "$JSON_LINE"
+else
+    FAIL=$((FAIL + 1))
+    ERRORS="${ERRORS}\n  FAIL: conflict JSON is valid\n    no JSON found in output"
+    printf "  ✗ %s\n" "conflict JSON is valid"
+fi
+cleanup
+echo ""
+
+# --- Test 14: dispatch detection ---
+echo "Test: dispatch detection"
+setup_repo
+cd "$TMPBASE/main"
+mkdir -p claude/usr/jordan/captain/dispatches
+echo "dispatch content" > claude/usr/jordan/captain/dispatches/dispatch-test-20260401.md
+git add -A
+git commit -m "add dispatch" --quiet
+cd "$TMPBASE/worktree"
+OUTPUT=$(bash claude/tools/worktree-sync 2>&1)
+assert_contains "dispatch detected" "dispatch" "$OUTPUT"
+cleanup
+echo ""
+
+# ========================================
+echo ""
+echo "=== Results ==="
+echo "  Passed: $PASS"
+echo "  Failed: $FAIL"
+
+if [ $FAIL -gt 0 ]; then
+    echo ""
+    echo "Failures:"
+    printf "$ERRORS\n"
+    exit 1
+fi
+
+echo ""
+echo "All tests passed."
+exit 0

--- a/claude/tools/worktree-sync
+++ b/claude/tools/worktree-sync
@@ -1,0 +1,289 @@
+#!/bin/bash
+#
+# worktree-sync — Sync a worktree with master
+#
+# Usage:
+#   worktree-sync              — manual mode (refuse on dirty tree)
+#   worktree-sync --auto       — automatic mode (stash/merge/unstash for dirty tree)
+#   worktree-sync --version    — show version
+#   worktree-sync --help       — show help
+#
+# Exit codes:
+#   0 — success (merged, already up to date, or skipped on master in --auto mode)
+#   1 — error (not a worktree, merge conflict, on master in manual mode)
+#   2 — dirty tree refused (manual mode only)
+#
+# The enforcement triangle:
+#   Tool: this file (claude/tools/worktree-sync)
+#   Skill: /worktree-sync, /session-resume, /session-end
+#   Hookify: block-raw-git-merge-master
+
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source log helper if available
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+    source "$SCRIPT_DIR/lib/_log-helper"
+fi
+
+# --- PATH resolution ---
+[ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH"
+[ -d "$HOME/.asdf/shims" ] && export PATH="$HOME/.asdf/shims:$PATH"
+
+# --- Require jq ---
+if ! command -v jq &>/dev/null; then
+    echo "worktree-sync: jq is required but not installed" >&2
+    exit 1
+fi
+
+# --- Args ---
+AUTO_MODE=false
+MODE="manual"
+STASHED=false
+
+# EXIT trap: ensure stash is always popped if script aborts mid-flight
+_cleanup() {
+    if [[ "$STASHED" == true ]]; then
+        git stash pop --quiet 2>/dev/null || true
+    fi
+}
+trap _cleanup EXIT
+
+show_help() {
+    echo "Usage: worktree-sync [--auto] [--version] [--help]"
+    echo ""
+    echo "Sync a worktree with master: merge, copy settings, run sandbox-sync, report."
+    echo ""
+    echo "Modes:"
+    echo "  (default)    Manual — refuse on dirty tree"
+    echo "  --auto       Automatic — stash dirty tree, merge, unstash"
+    echo ""
+    echo "Options:"
+    echo "  --version    Show version"
+    echo "  --help       Show this help"
+}
+
+for arg in "$@"; do
+    case "$arg" in
+        --auto) AUTO_MODE=true; MODE="auto" ;;
+        --version) echo "worktree-sync $VERSION"; exit 0 ;;
+        --help) show_help; exit 0 ;;
+        *) echo "worktree-sync: unknown argument '$arg'" >&2; exit 1 ;;
+    esac
+done
+
+# --- Start logging ---
+RUN_ID=""
+if type log_start &>/dev/null; then
+    RUN_ID=$(log_start "worktree-sync" "$MODE")
+fi
+
+# --- Resolve paths ---
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "worktree-sync: not in a git repository" >&2
+    exit 1
+}
+
+MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+if [[ -z "$MAIN_CHECKOUT" ]] || [[ ! -d "$MAIN_CHECKOUT" ]]; then
+    echo "worktree-sync: cannot determine main checkout" >&2
+    exit 1
+fi
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+# --- Guard: not master ---
+if [[ "$BRANCH" == "master" || "$BRANCH" == "main" ]]; then
+    if [[ "$AUTO_MODE" == true ]]; then
+        # Auto mode on master: soft skip, no error
+        if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+            log_end "$RUN_ID" "success" 0 0 "skipped — on master"
+        fi
+        printf '{"systemMessage": "worktree-sync: skipped — on master"}'
+        exit 0
+    else
+        echo "worktree-sync: on master — use /sync-all instead" >&2
+        if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+            log_end "$RUN_ID" "failure" 1 0 "on master"
+        fi
+        exit 1
+    fi
+fi
+
+# --- Guard: dirty tree ---
+DIRTY=$(git status --porcelain 2>/dev/null)
+
+if [[ -n "$DIRTY" ]]; then
+    if [[ "$AUTO_MODE" == true ]]; then
+        git stash --quiet 2>/dev/null
+        STASHED=true
+    else
+        DIRTY_COUNT=$(echo "$DIRTY" | grep -c . || echo 0)
+        echo "worktree-sync: working tree is dirty — commit or stash first" >&2
+        echo "  $DIRTY_COUNT modified files" >&2
+        if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+            log_end "$RUN_ID" "failure" 2 0 "dirty tree — $DIRTY_COUNT files"
+        fi
+        exit 2
+    fi
+fi
+
+# --- Capture pre-merge HEAD (don't rely on ORIG_HEAD) ---
+PRE_MERGE_HEAD=$(git rev-parse HEAD 2>/dev/null)
+
+# --- Check if already up to date ---
+MERGE_BASE=$(git merge-base HEAD master 2>/dev/null || echo "")
+MASTER_HEAD=$(git rev-parse master 2>/dev/null || echo "")
+
+if [[ "$MERGE_BASE" == "$MASTER_HEAD" ]]; then
+    # Already up to date — skip merge, still sync settings + sandbox
+    MERGED=false
+    MERGE_MSG="already up to date"
+    COMMITS=0
+else
+    # --- Merge master ---
+    MERGED=true
+    MERGE_OUTPUT=$(git merge master 2>&1) || {
+        # Merge conflict — abort and restore
+        ABORT_OK=true
+        git merge --abort 2>/dev/null || ABORT_OK=false
+        CONFLICT_FILES=$(echo "$MERGE_OUTPUT" | grep "CONFLICT" || echo "(unknown)")
+
+        echo "worktree-sync: merge conflict with master" >&2
+        echo "$CONFLICT_FILES" >&2
+
+        if [[ "$ABORT_OK" == false ]]; then
+            echo "worktree-sync: WARNING — git merge --abort failed" >&2
+        fi
+
+        # Unstash if we stashed (disable trap since we're handling it)
+        if [[ "$STASHED" == true ]]; then
+            STASHED=false
+            if ! git stash pop --quiet 2>/dev/null; then
+                echo "worktree-sync: WARNING — stash pop failed after merge abort. Work is safe in git stash." >&2
+            fi
+        fi
+
+        if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+            log_end "$RUN_ID" "failure" 1 0 "merge conflict"
+        fi
+
+        if [[ "$AUTO_MODE" == true ]]; then
+            jq -n -c --arg msg "worktree-sync: merge conflict with master. Resolve manually." '{"systemMessage": $msg}'
+        fi
+        exit 1
+    }
+    COMMITS=$(git rev-list "$PRE_MERGE_HEAD"..HEAD --count 2>/dev/null || echo "?")
+    MERGE_MSG="merged master ($COMMITS commits)"
+fi
+
+# --- Copy settings.json from main checkout ---
+SETTINGS_COPIED=false
+SETTINGS_SRC="$MAIN_CHECKOUT/.claude/settings.json"
+SETTINGS_DST="$ROOT/.claude/settings.json"
+
+if [[ -f "$SETTINGS_SRC" ]]; then
+    if ! cmp -s "$SETTINGS_SRC" "$SETTINGS_DST" 2>/dev/null; then
+        cp "$SETTINGS_SRC" "$SETTINGS_DST" 2>/dev/null && SETTINGS_COPIED=true
+    fi
+fi
+
+# --- Run sandbox-sync ---
+SANDBOX_MSG=""
+if [[ -x "$ROOT/claude/tools/sandbox-sync" ]]; then
+    SANDBOX_OUTPUT=$("$ROOT/claude/tools/sandbox-sync" --quiet 2>&1) || true
+    if [[ -n "$SANDBOX_OUTPUT" ]]; then
+        SANDBOX_MSG="$SANDBOX_OUTPUT"
+    fi
+fi
+
+# --- Build change report ---
+CHANGED_FILES=""
+CLAUDE_MD_CHANGED=false
+DISPATCHES=""
+
+if [[ "$MERGED" == true ]]; then
+    # Files changed in claude/ namespace
+    CHANGED_FILES=$(git diff "$PRE_MERGE_HEAD"..HEAD --name-only -- claude/ .claude/ CLAUDE.md 2>/dev/null || echo "")
+
+    # Check for CLAUDE.md changes
+    if echo "$CHANGED_FILES" | grep -qE "CLAUDE\.md|CLAUDE-THEAGENCY\.md" 2>/dev/null; then
+        CLAUDE_MD_CHANGED=true
+    fi
+
+    # Check for new dispatches
+    DISPATCHES=$(echo "$CHANGED_FILES" | grep -E "dispatch" 2>/dev/null || echo "")
+fi
+
+# --- Unstash if we stashed ---
+UNSTASH_CONFLICT=false
+if [[ "$STASHED" == true ]]; then
+    STASHED=false  # Disable trap — we're handling it
+    if ! git stash pop --quiet 2>/dev/null; then
+        UNSTASH_CONFLICT=true
+    fi
+fi
+
+# --- Format output ---
+REPORT="worktree-sync: $MERGE_MSG"
+
+if [[ "$SETTINGS_COPIED" == true ]]; then
+    REPORT="$REPORT
+  changed: .claude/settings.json (copied from main checkout)"
+fi
+
+if [[ -n "$CHANGED_FILES" ]]; then
+    while IFS= read -r file; do
+        [[ -z "$file" ]] && continue
+        REPORT="$REPORT
+  changed: $file"
+    done <<< "$CHANGED_FILES"
+fi
+
+if [[ -n "$DISPATCHES" ]]; then
+    DISPATCH_COUNT=$(echo "$DISPATCHES" | grep -c . || echo 0)
+    REPORT="$REPORT
+  $DISPATCH_COUNT new dispatch(es)"
+fi
+
+if [[ "$CLAUDE_MD_CHANGED" == true ]]; then
+    REPORT="$REPORT
+  CLAUDE.md updated — re-read recommended"
+fi
+
+if [[ -n "$SANDBOX_MSG" ]]; then
+    REPORT="$REPORT
+  sandbox-sync: $SANDBOX_MSG"
+fi
+
+if [[ "$UNSTASH_CONFLICT" == true ]]; then
+    REPORT="$REPORT
+  WARNING: unstash conflict — your stashed changes conflict with the merge. Work is safe in git stash. Run 'git stash show' to see it."
+fi
+
+# --- Log end ---
+if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+    LOG_STATUS="success"
+    [[ "$UNSTASH_CONFLICT" == true ]] && LOG_STATUS="failure"
+    log_end "$RUN_ID" "$LOG_STATUS" 0 0 "$MERGE_MSG"
+fi
+
+# --- Output ---
+if [[ "$AUTO_MODE" == true ]]; then
+    # JSON systemMessage for hook context
+    JSON_MSG=$(echo "$REPORT" | tr '\n' ' ' | sed 's/  */ /g')
+    if [[ "$CLAUDE_MD_CHANGED" == true ]]; then
+        JSON_MSG="$JSON_MSG Re-read CLAUDE.md now."
+    fi
+    jq -n -c --arg msg "$JSON_MSG" '{"systemMessage": $msg}'
+else
+    # Plain text for manual invocation
+    echo "$REPORT"
+    if [[ -n "$RUN_ID" ]] && type tool_output &>/dev/null; then
+        tool_output "worktree-sync" "$RUN_ID" "$MERGE_MSG"
+    fi
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- worktree-sync tool: merge master, copy settings.json, run sandbox-sync, report changes
- 3 session lifecycle skills: /worktree-sync, /session-resume, /session-end
- Hookify rule: block-raw-git-merge-master
- Enforcement Triangle documented in CLAUDE-THEAGENCY.md
- 28 tests

## Context
Contributed from monofolk. Solves the worktree-to-master sync gap where agents had to run raw `git merge master` to pick up infrastructure changes. The enforcement triangle (tool + skill + hookify) is now the standard pattern for all new capabilities.

## Test plan
- [x] 28 bash tests passing (test-worktree-sync.sh)
- [x] Master guard (manual + auto modes)
- [x] Dirty tree handling (refuse + stash)
- [x] Merge conflict detection + abort
- [x] Settings copy + CLAUDE.md detection
- [x] Valid JSON output in auto mode

🐈‍⬛ OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!

🤖 Generated with [Claude Code](https://claude.com/claude-code)