### PR TITLE
feat: port flag.md from monofolk

### DIFF
--- a/.claude/skills/flag/SKILL.md
+++ b/.claude/skills/flag/SKILL.md
@@ -18,7 +18,7 @@ Zero-friction capture of observations during work. Flag something now, discuss i
 If `$ARGUMENTS` is a message (not a subcommand):
 
 ```
-bash $CLAUDE_PROJECT_DIR/claude/tools/flag $ARGUMENTS
+bash $CLAUDE_PROJECT_DIR/claude/tools/flag "$ARGUMENTS"
 ```
 
 Confirm: "Flagged. N items in queue."


### PR DESCRIPTION
## Source
`claude/usr/jordan/commands/flag.md` → `.claude/skills/flag/SKILL.md`

Contributed from monofolk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)