### PR TITLE
Session 18: content, hookify testuser block, voice guide

### DIFF
--- a/claude/hookify/hookify.block-testuser-paths.md
+++ b/claude/hookify/hookify.block-testuser-paths.md
@@ -1,0 +1,11 @@
+---
+name: block-testuser-paths
+enabled: true
+event: bash
+pattern: usr/testuser
+action: block
+---
+
+STOP. You are writing to `usr/testuser/` — this means `AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite into your shell environment. Run `unset AGENCY_PRINCIPAL` and retry. The flag tool (and any tool using `_path-resolve`) will resolve to the wrong principal until this is cleared.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/hookify/hookify.block-testuser-paths.md
+++ b/claude/hookify/hookify.block-testuser-paths.md
@@ -8,4 +8,6 @@ action: block
 
 STOP. You are writing to `usr/testuser/` — this means `AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite into your shell environment. Run `unset AGENCY_PRINCIPAL` and retry. The flag tool (and any tool using `_path-resolve`) will resolve to the wrong principal until this is cleared.
 
+See `claude/CLAUDE-THEAGENCY.md` § "Agent & Principal Addressing" — principal resolution uses `agency.yaml`, not raw env vars.
+
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/content/content-queue.md
+++ b/usr/jordan/captain/content/content-queue.md
@@ -1,0 +1,19 @@
+---
+type: content-queue
+date: 2026-04-04
+---
+
+# Content Queue
+
+Planned articles/posts for @AgencyGroupAI (X) and LinkedIn.
+
+## Published
+- [x] **The Enforcement Triangle** — why AI agents break their own rules (X article + LinkedIn) — 2026-04-04
+
+## Next Up
+- [ ] **The Continual Improvement Loop** — how we build learning into the AIADLC
+- [ ] **Why We're Building mdpal** — section-oriented Markdown for AI workflows
+- [ ] **Why We Want M&M** (not M&Ms) — Mock and Mark, and when it's coming
+
+## Backlog
+- [ ] Content pieces for mdpal and M&M (product announcements, demos)

--- a/usr/jordan/captain/content/jordans-voice.md
+++ b/usr/jordan/captain/content/jordans-voice.md
@@ -1,0 +1,41 @@
+---
+type: style-guide
+date: 2026-04-04
+purpose: Capture Jordan's writing voice for content drafting
+---
+
+# Jordan's Voice
+
+Style notes derived from the Enforcement Triangle article revision.
+
+## Tone
+- Conversational, first-person, direct
+- Talks to the reader like a colleague, not an audience
+- Self-deprecating humor that lands ("wonder where the Agents learned that ;)")
+- Doesn't take itself too seriously but the ideas are serious
+
+## Structure
+- Opens with personal context — what I'm doing and why, not abstract thesis
+- "My current passion is..." not "In today's landscape of..."
+- Introduces jargon naturally with parenthetical definitions: "Principals (the humans, like me)"
+- Short paragraphs. Punchy. One idea per beat.
+
+## Language
+- "We" = me and the Agents, explicitly ("we — me and the Agents — call it The Agency")
+- Agents and Principals are capitalized — they're roles, not generic nouns
+- Technical terms used directly, not dumbed down — but always with enough context
+- Semicolons used naturally, not avoided
+- Em dashes over parentheses for asides
+
+## Content Principles
+- Always ground in real experience, not theory — "This is what happened to us — three times"
+- Show the actual artifact (the hookify rule), don't just describe it
+- Humor has a purpose — the kittens clause is funny AND functional
+- Token efficiency matters and is worth calling out — it's part of the craft
+- The framework is open source — always link to the repo
+
+## What to Avoid
+- Marketing-speak ("revolutionary," "game-changing," "cutting-edge")
+- Abstract openings ("In the rapidly evolving world of AI...")
+- Hedging ("might," "could potentially," "it's possible that")
+- Over-explaining — trust the reader to be technical

--- a/usr/jordan/captain/content/linkedin-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/linkedin-enforcement-triangle-20260404.md
@@ -1,0 +1,51 @@
+---
+type: linkedin-post
+platform: LinkedIn
+status: draft
+date: 2026-04-04
+topic: Enforcement Triangle
+---
+
+**Why do AI agents keep breaking their own rules?**
+
+We build multi-agent systems for software development at The Agency. Our agents have a simple rule: never push code directly to main — always go through a PR.
+
+We documented it. We added warnings. They violated it three times anyway.
+
+The problem wasn't the agents. It was us. We gave them two legs of a three-legged stool.
+
+We now enforce every agent capability with what we call the **Enforcement Triangle**:
+
+🔧 **Tool** — does the work, with pre-approved permissions and logging built in
+📋 **Skill** — tells the agent when and how to use the tool, discoverable through autocomplete
+🚫 **Hookify Rule** — blocks the raw alternative and redirects to the skill
+
+Miss any leg and compliance collapses:
+
+→ Tool + Skill, no Rule? The agent knows the right way but still takes shortcuts under pressure.
+→ Tool + Rule, no Skill? The agent hits a wall with no guidance on what to do instead.
+→ Skill + Rule, no Tool? Every invocation triggers a permission prompt. The agent learns to avoid it.
+
+Here's what one looks like — a real rule from our project that catches a test environment leak:
+
+```
+STOP. You are writing to `usr/testuser/` — this means
+AGENCY_PRINCIPAL=testuser leaked from the BATS test suite.
+Run `unset AGENCY_PRINCIPAL` and retry.
+
+See claude/CLAUDE-THEAGENCY.md § "Agent & Principal Addressing"
+
+OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
+```
+
+One markdown file. The frontmatter says when it fires. The body is the message. The agent gets: what's wrong, how to fix it, and where to read why.
+
+The real insight: **documentation doesn't change agent behavior. Mechanical enforcement does.**
+
+Project instructions get compressed. Context windows fill up. Nuance disappears. But a rule that fires on every `git push` and blocks it? That survives compression. That works when the agent is deep in a complex task and just wants to ship.
+
+Every one of our enforcement rules ends with: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"* The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
+
+We're building this as part of The Agency (https://github.com/the-agency-ai/the-agency), an open-source framework for multi-agent software development.
+
+#AIAgents #SoftwareEngineering #ClaudeCode #DeveloperTools #OpenSource

--- a/usr/jordan/captain/content/linkedin-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/linkedin-enforcement-triangle-20260404.md
@@ -6,46 +6,40 @@ date: 2026-04-04
 topic: Enforcement Triangle
 ---
 
-**Why do AI agents keep breaking their own rules?**
+My current passion is AI Augmented Development — seeing how far we can take things with Claude Code and defining an AIADLC (AI Augmented Development Life Cycle).
 
-We build multi-agent systems for software development at The Agency. Our agents have a simple rule: never push code directly to main — always go through a PR.
+I spend my days working with a group of Claude Code Agents. Together — me and the Agents — we build the framework, the tooling, and the workflows. We call it The Agency.
 
-We documented it. We added warnings. They violated it three times anyway.
+To make this work, we have clear rules for Principals (the humans) and the Agents working together. Rules like: never push directly to main, always go through a PR, whatever removes friction and makes things safer, more effective, and more efficient.
 
-The problem wasn't the agents. It was us. We gave them two legs of a three-legged stool.
+We documented them. We added warnings. And our Agents just ignored them. (Much like many of the software engineers I've worked with over the years — wonder where the Agents learned that.)
 
-We now enforce every agent capability with what we call the **Enforcement Triangle**:
+Not because they're dumb. Because we only gave them two legs of a three-legged stool.
 
-🔧 **Tool** — does the work, with pre-approved permissions and logging built in
-📋 **Skill** — tells the agent when and how to use the tool, discoverable through autocomplete
-🚫 **Hookify Rule** — blocks the raw alternative and redirects to the skill
+We now enforce every capability with what we call the **Enforcement Triangle**:
 
-Miss any leg and compliance collapses:
+**The Tool** — does the work, with pre-approved permissions, logging, and telemetry built in.
 
-→ Tool + Skill, no Rule? The agent knows the right way but still takes shortcuts under pressure.
-→ Tool + Rule, no Skill? The agent hits a wall with no guidance on what to do instead.
-→ Skill + Rule, no Tool? Every invocation triggers a permission prompt. The agent learns to avoid it.
+**The Skill** — tells the agent when and how to use the tool. Discoverable through autocomplete, context injection, the natural flow of work. The right path is the easy path.
 
-Here's what one looks like — a real rule from our project that catches a test environment leak:
+**The Hookify Rule** — blocks the raw alternative and redirects to the skill. Mechanical enforcement, not honor system.
 
-```
-STOP. You are writing to `usr/testuser/` — this means
-AGENCY_PRINCIPAL=testuser leaked from the BATS test suite.
-Run `unset AGENCY_PRINCIPAL` and retry.
+Miss any leg and compliance collapses. Agents under pressure behave exactly like engineers under pressure — they take shortcuts.
 
-See claude/CLAUDE-THEAGENCY.md § "Agent & Principal Addressing"
+Here's what a real enforcement rule looks like:
 
-OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
-```
+> STOP. You are writing to `usr/testuser/` — this means AGENCY_PRINCIPAL=testuser leaked from the BATS test suite. Run `unset AGENCY_PRINCIPAL` and retry.
+>
+> See claude/CLAUDE-THEAGENCY.md § "Agent & Principal Addressing"
+>
+> OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
 
-One markdown file. The frontmatter says when it fires. The body is the message. The agent gets: what's wrong, how to fix it, and where to read why.
+Direct. Actionable. Token efficient. The agent gets: what's wrong, how to fix it, and where to read why.
 
-The real insight: **documentation doesn't change agent behavior. Mechanical enforcement does.**
+The real insight: **documentation doesn't change agent behavior. Mechanical enforcement does.** Context gets compressed. Instructions get summarized. Nuance disappears. But a rule that fires on every `git push` and blocks it? That survives compression. That works at 3am when the Agent — or the Principal — is deep in a complex task and just wants to ship.
 
-Project instructions get compressed. Context windows fill up. Nuance disappears. But a rule that fires on every `git push` and blocks it? That survives compression. That works when the agent is deep in a complex task and just wants to ship.
+The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
 
-Every one of our enforcement rules ends with: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"* The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
+We're building this as part of The Agency — an open-source framework for multi-agent and multi-principal software development: https://github.com/the-agency-ai/the-agency
 
-We're building this as part of The Agency (https://github.com/the-agency-ai/the-agency), an open-source framework for multi-agent software development.
-
-#AIAgents #SoftwareEngineering #ClaudeCode #DeveloperTools #OpenSource
+#AIAgents #AIDevelopment #ClaudeCode #DeveloperTools #OpenSource #AIADLC

--- a/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
@@ -1,14 +1,22 @@
 ---
 type: x-article
 platform: x.com (@AgencyGroupAI)
-status: draft
+status: final
 date: 2026-04-04
 topic: Enforcement Triangle
 ---
 
-# The Enforcement Triangle: Why AI Agents Keep Breaking Their Own Rules
+My current passion is AI Augmented Development. I am seeing how far we can take things with @claudeai Code and am defining an AIADLC (AI Augmented Development Life Cycle).
 
-We build multi-agent systems for software development. Our agents have clear rules — never push directly to main, always go through a PR. We documented it. We added warnings. Our agents violated it three times anyway.
+My day is spent working with a group of Claude Code Agents to both build the framework and tooling to support these workflows (we — me and the Agents — call it The Agency) and applying all of it in my day job.
+
+To be successful, we have clear rules for Principals (the humans, like me) and the Agents working together as an Agency. Clear rules like:
+
+- Never push directly to main
+- Always go through a PR
+- Or whatever removes friction and makes things safer, more effective, and more efficient (including in terms of context windows and token usage)
+
+We documented them. We added warnings. And ours just ignored them (much like many of the software engineers I have worked with over the years, wonder where the Agents learned that ;))
 
 Not because they're dumb. Because we only gave them two legs of a three-legged stool.
 
@@ -16,21 +24,28 @@ Not because they're dumb. Because we only gave them two legs of a three-legged s
 
 Every AI agent capability needs three components working together:
 
-**The Tool** does the work. It's a script with permissions, logging, and structured output baked in. Pre-approved in the settings so the agent doesn't need to ask permission every time. This is the mechanical layer.
+**The Tool** — it does the work. It's a script with permissions, logging, and structured output baked in. Pre-approved in the settings so the agent doesn't need to ask permission every time. This is the mechanical layer.
 
-**The Skill** tells the agent when and how to use the tool. It's discoverable — agents find it through autocomplete, through context injection, through the natural flow of work. The skill makes the right path the easy path.
+**The Skill** — tells the agent when and how to use the tool. It's discoverable — agents find it through autocomplete, through context injection, through the natural flow of work. The skill makes the right path the easy path.
 
-**The Hookify Rule** blocks the raw alternative and points to the skill. It's the wall that says "you can't `git push` directly — use `/push` instead." Mechanical enforcement, not honor system.
+**The Hookify Rule** — blocks the raw alternative and points to the skill. It's the wall that says:
+
+> You can't `git push` directly — use `/push` instead.
+
+Mechanical enforcement, not honor system.
 
 We call this the **Enforcement Triangle**.
 
 ## What Happens When You're Missing a Leg
 
-**Tool + Skill, no Rule:** The agent knows the right way but can still take the wrong way. Under pressure (context window filling up, complex task, compaction), it takes shortcuts. This is what happened to us — three times.
+**Tool + Skill, no Rule:**
+The agent knows the right way but can still take the wrong way. Under pressure (context window filling up, complex task, compaction), it takes shortcuts. This is what happened to us — three times.
 
-**Tool + Rule, no Skill:** The agent hits a wall but doesn't know the alternative. It gets stuck, asks the user, wastes cycles. The rule blocks but doesn't guide.
+**Tool + Rule, no Skill:**
+The agent hits a wall but doesn't know the alternative. It gets stuck, asks the user, wastes cycles. The rule blocks but doesn't guide.
 
-**Skill + Rule, no Tool:** The skill describes the workflow but the underlying tool doesn't exist or isn't pre-approved. Every invocation triggers a permission prompt. The agent learns to avoid it.
+**Skill + Rule, no Tool:**
+The skill describes the workflow but the underlying tool doesn't exist or isn't pre-approved. Every invocation triggers a permission prompt. The agent learns to avoid it.
 
 ## The Real Insight
 
@@ -38,21 +53,21 @@ Documentation doesn't change agent behavior. Mechanical enforcement does.
 
 When we write "never push to main" in our project instructions, agents follow it — until they don't. Context gets compressed. Instructions get summarized. The nuance disappears.
 
-But a hookify rule that fires on every `git push` and blocks it with an actionable redirect? That survives context compression. That works at 3am when the agent is deep in a complex task and just wants to ship.
+But a hookify rule that fires on every `git push` and blocks it with an actionable redirect? That survives context compression. That works at 3am when the Agent (or the Principal) is deep in a complex task and just wants to ship.
 
 ## How We Build It
 
-For every new capability in our framework:
+For every new capability in our framework, we:
 
-1. **Build the tool** — bash or Python, with logging and telemetry
+1. **Build the tool** — bash or Python (or Ruby or Rust or TypeScript or Swift) with logging and telemetry
 2. **Wrap it in a skill** — markdown definition with allowed-tools, context injection, discovery
 3. **Block the raw alternative** — hookify rule that intercepts and redirects
 
 All three. Not one, not two. If you ship a tool without the other two legs, you're relying on the agent's good judgment under pressure. And agents under pressure behave exactly like engineers under pressure — they take shortcuts.
 
-## What It Looks Like
+## What It Looks Like In Practice
 
-Here's an actual hookify rule from our project. Our test suite leaks an environment variable that causes tools to write files to the wrong user directory. Instead of hoping agents notice, we block it mechanically:
+Here's an actual hookify rule from our project. Our test suite leaks an environment variable (`AGENCY_PRINCIPAL=testuser`) that causes tools to write files to the wrong directory. Instead of hoping agents notice, we block it mechanically:
 
 ```markdown
 ---
@@ -63,25 +78,30 @@ pattern: usr/testuser
 action: block
 ---
 
-STOP. You are writing to `usr/testuser/` — this means
+STOP.
+You are writing to `usr/testuser/` — this means
 `AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite
-into your shell environment. Run `unset AGENCY_PRINCIPAL`
-and retry.
+into your shell environment.
+Run `unset AGENCY_PRINCIPAL` and retry.
 
 See `claude/CLAUDE-THEAGENCY.md` § "Agent & Principal Addressing"
 — principal resolution uses `agency.yaml`, not raw env vars.
 
-*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
+OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
 ```
 
-The frontmatter defines *when* it fires. The markdown body *is* the message. One file, human-readable — the rule and the enforcement together. The agent gets: what's wrong, how to fix it, and where to read why.
+Direct. Actionable. And short — and token efficient.
 
 ## The Kittens Clause
 
-Every one of our enforcement rules ends with the same line: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"*
+Every one of our — short (read: token efficient) and direct — enforcement rules ends with the same line:
 
-It's a joke. It's also a signal. When an agent sees that line, it knows this isn't a suggestion — it's a mechanical boundary. The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
+> *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
+
+It's a joke. It's also a signal. When an Agent or Principal (human in this loop) sees that line, it knows this isn't a suggestion — it's a mechanical boundary.
+
+The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
 
 ---
 
-*We're building this as part of [The Agency](https://github.com/the-agency-ai/the-agency), an open-source framework for multi-agent software development.*
+*We're building this as part of [The Agency](https://github.com/the-agency-ai/the-agency), an open-source framework for multi-agent and multi-principal software development.*

--- a/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
@@ -50,6 +50,32 @@ For every new capability in our framework:
 
 All three. Not one, not two. If you ship a tool without the other two legs, you're relying on the agent's good judgment under pressure. And agents under pressure behave exactly like engineers under pressure — they take shortcuts.
 
+## What It Looks Like
+
+Here's an actual hookify rule from our project. Our test suite leaks an environment variable that causes tools to write files to the wrong user directory. Instead of hoping agents notice, we block it mechanically:
+
+```markdown
+---
+name: block-testuser-paths
+enabled: true
+event: bash
+pattern: usr/testuser
+action: block
+---
+
+STOP. You are writing to `usr/testuser/` — this means
+`AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite
+into your shell environment. Run `unset AGENCY_PRINCIPAL`
+and retry.
+
+See `claude/CLAUDE-THEAGENCY.md` § "Agent & Principal Addressing"
+— principal resolution uses `agency.yaml`, not raw env vars.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
+```
+
+The frontmatter defines *when* it fires. The markdown body *is* the message. One file, human-readable — the rule and the enforcement together. The agent gets: what's wrong, how to fix it, and where to read why.
+
 ## The Kittens Clause
 
 Every one of our enforcement rules ends with the same line: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"*

--- a/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
@@ -1,0 +1,61 @@
+---
+type: x-article
+platform: x.com (@AgencyGroupAI)
+status: draft
+date: 2026-04-04
+topic: Enforcement Triangle
+---
+
+# The Enforcement Triangle: Why AI Agents Keep Breaking Their Own Rules
+
+We build multi-agent systems for software development. Our agents have clear rules — never push directly to main, always go through a PR. We documented it. We added warnings. Our agents violated it three times anyway.
+
+Not because they're dumb. Because we only gave them two legs of a three-legged stool.
+
+## The Pattern
+
+Every AI agent capability needs three components working together:
+
+**The Tool** does the work. It's a script with permissions, logging, and structured output baked in. Pre-approved in the settings so the agent doesn't need to ask permission every time. This is the mechanical layer.
+
+**The Skill** tells the agent when and how to use the tool. It's discoverable — agents find it through autocomplete, through context injection, through the natural flow of work. The skill makes the right path the easy path.
+
+**The Hookify Rule** blocks the raw alternative and points to the skill. It's the wall that says "you can't `git push` directly — use `/push` instead." Mechanical enforcement, not honor system.
+
+We call this the **Enforcement Triangle**.
+
+## What Happens When You're Missing a Leg
+
+**Tool + Skill, no Rule:** The agent knows the right way but can still take the wrong way. Under pressure (context window filling up, complex task, compaction), it takes shortcuts. This is what happened to us — three times.
+
+**Tool + Rule, no Skill:** The agent hits a wall but doesn't know the alternative. It gets stuck, asks the user, wastes cycles. The rule blocks but doesn't guide.
+
+**Skill + Rule, no Tool:** The skill describes the workflow but the underlying tool doesn't exist or isn't pre-approved. Every invocation triggers a permission prompt. The agent learns to avoid it.
+
+## The Real Insight
+
+Documentation doesn't change agent behavior. Mechanical enforcement does.
+
+When we write "never push to main" in our project instructions, agents follow it — until they don't. Context gets compressed. Instructions get summarized. The nuance disappears.
+
+But a hookify rule that fires on every `git push` and blocks it with an actionable redirect? That survives context compression. That works at 3am when the agent is deep in a complex task and just wants to ship.
+
+## How We Build It
+
+For every new capability in our framework:
+
+1. **Build the tool** — bash or Python, with logging and telemetry
+2. **Wrap it in a skill** — markdown definition with allowed-tools, context injection, discovery
+3. **Block the raw alternative** — hookify rule that intercepts and redirects
+
+All three. Not one, not two. If you ship a tool without the other two legs, you're relying on the agent's good judgment under pressure. And agents under pressure behave exactly like engineers under pressure — they take shortcuts.
+
+## The Kittens Clause
+
+Every one of our enforcement rules ends with the same line: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"*
+
+It's a joke. It's also a signal. When an agent sees that line, it knows this isn't a suggestion — it's a mechanical boundary. The kittens are well-fed in our project. That's how we know the rules are working.
+
+---
+
+*We're building this as part of [The Agency](https://github.com/the-agency-ai/the-agency), an open-source framework for multi-agent software development.*

--- a/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
+++ b/usr/jordan/captain/content/x-article-enforcement-triangle-20260404.md
@@ -54,7 +54,7 @@ All three. Not one, not two. If you ship a tool without the other two legs, you'
 
 Every one of our enforcement rules ends with the same line: *"OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"*
 
-It's a joke. It's also a signal. When an agent sees that line, it knows this isn't a suggestion — it's a mechanical boundary. The kittens are well-fed in our project. That's how we know the rules are working.
+It's a joke. It's also a signal. When an agent sees that line, it knows this isn't a suggestion — it's a mechanical boundary. The kittens are starving in our project — or so we hope. Because if they're well-fed, we're failing.
 
 ---
 

--- a/usr/jordan/captain/dispatches/dispatch-monofolk-hookify-testuser-20260404.md
+++ b/usr/jordan/captain/dispatches/dispatch-monofolk-hookify-testuser-20260404.md
@@ -1,0 +1,26 @@
+---
+type: adoption-directive
+from: the-agency/jordan/captain
+to: monofolk/jordan/captain
+date: 2026-04-04
+priority: medium
+pr: the-agency-ai/the-agency#34
+---
+
+# Dispatch: Adopt hookify rule — block-testuser-paths
+
+## What
+
+New hookify rule `claude/hookify/hookify.block-testuser-paths.md` blocks writes to `usr/testuser/` caused by BATS test suite leaking `AGENCY_PRINCIPAL=testuser` into the shell environment.
+
+## Why
+
+Any repo using the Agency BATS test suite hits this. The leaked env var causes `_path-resolve` and all tools depending on it (flag, dispatch-create, handoff) to resolve to the wrong principal. Files end up in `usr/testuser/` instead of the actual principal's directory. We hit it three times in one session before adding the mechanical block.
+
+## What to Adopt
+
+Copy `claude/hookify/hookify.block-testuser-paths.md` from the-agency PR #34. One file, 13 lines. No dependencies.
+
+## PR Reference
+
+the-agency-ai/the-agency#34

--- a/usr/testuser/flag-queue.jsonl
+++ b/usr/testuser/flag-queue.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2026-04-04T05:39:59Z","message":"BATS test env leak keeps recreating usr/testuser/flag-queue.jsonl — AGENCY_PRINCIPAL=testuser leaks from test suite into shell env. Need test isolation fix: unset AGENCY_PRINCIPAL in teardown or use subshell isolation. This is the second time this session we've had to clean it up.","principal":"testuser","branch":"main","session":""}

--- a/usr/testuser/flag-queue.jsonl
+++ b/usr/testuser/flag-queue.jsonl
@@ -1,1 +1,0 @@
-{"ts":"2026-04-04T05:39:59Z","message":"BATS test env leak keeps recreating usr/testuser/flag-queue.jsonl — AGENCY_PRINCIPAL=testuser leaks from test suite into shell env. Need test isolation fix: unset AGENCY_PRINCIPAL in teardown or use subshell isolation. This is the second time this session we've had to clean it up.","principal":"testuser","branch":"main","session":""}


### PR DESCRIPTION
## Summary

- **Hookify rule** (`block-testuser-paths`): blocks writes to `usr/testuser/` caused by BATS test AGENCY_PRINCIPAL env leak. Includes doc cross-reference and kittens clause.
- **Content directory** (`usr/jordan/captain/content/`): X article (Enforcement Triangle, published), LinkedIn post (published), Jordan's voice style guide, content queue (3 planned articles).
- **Content queue**: Continual Improvement Loop, Why mdpal, Why M&M — next three articles.

## For monofolk/captain

Adopt `claude/hookify/hookify.block-testuser-paths.md` — same env leak affects any repo using the BATS test suite. The content files are the-agency specific, no action needed.

## Review notes

- 225 lines, 5 new files (all markdown)
- Code review: clean, no blocking findings
- No monofolk residue, no sensitive info, no broken links

## Test plan

- [ ] Verify hookify rule frontmatter is valid (name, enabled, event, pattern, action)
- [ ] Verify kittens clause present
- [ ] Verify no hardcoded paths or sensitive info in content files

🤖 Generated with [Claude Code](https://claude.com/claude-code)