### PR TITLE
housekeeping/captain: create devex workstream

### DIFF
--- a/.claude/agents/devex.md
+++ b/.claude/agents/devex.md
@@ -1,0 +1,17 @@
+---
+name: devex
+description: "DevEx — test infrastructure, commit workflow, permission model, tooling ergonomics"
+model: opus
+---
+
+@usr/jordan/devex/CLAUDE-DEVEX-AGENT.md
+@claude/workstreams/devex/CLAUDE-DEVEX.md
+
+**On startup, immediately read these files in order:**
+
+1. Check ISCP: `dispatch list` and `flag list` — process any unread items before other work
+2. `usr/jordan/devex/devex-handoff.md` — your bootstrap handoff (current state, next action)
+3. `claude/agents/tech-lead/agent.md` — your class definition (tech-lead)
+4. `claude/workstreams/devex/KNOWLEDGE.md` — workstream knowledge
+
+Then follow the "Next Action" in your handoff. Do not wait for a prompt — act on startup.

--- a/claude/workstreams/devex/CLAUDE-DEVEX.md
+++ b/claude/workstreams/devex/CLAUDE-DEVEX.md
@@ -1,0 +1,27 @@
+# DevEx Workstream
+
+## Scope
+
+DevEx owns the developer experience for agents and principals working in TheAgency:
+- Test infrastructure (isolation, Docker, BATS, CI)
+- Commit workflow (pre-commit hooks, QGR enforcement, smart scoping)
+- Permission model (settings-template.json, safe operation pre-approval)
+- Tooling ergonomics (agency-init, agent-create, worktree lifecycle)
+- Agent bootstrap (cold start, handoff, identity resolution)
+
+## Boundaries
+
+- **Owns:** `tests/`, `claude/tools/commit-precheck`, `.git/hooks/pre-commit`, `tests/Dockerfile`, `tests/docker-test.sh`, `tests/tools/test_helper.bash`
+- **Contributes to:** `claude/tools/` (ergonomic improvements), `.claude/settings.json` (permission model), `claude/config/settings-template.json`
+- **Does NOT own:** ISCP tools (iscp workstream), application workstreams (mdpal, mock-and-mark), agent class definitions
+
+## Review Discipline
+
+All test infrastructure changes get full QG. Pre-commit hook changes are especially sensitive — a broken hook blocks all agents.
+
+## Key Context
+
+- ISCP built the foundation: `test_helper.bash`, `Dockerfile`, `docker-test.sh`, `ISCP_DB_PATH` override
+- 32 BATS test files total, only 7 have isolation helpers
+- Pre-commit hook (`commit-precheck`) runs ALL tests unconditionally — the burning problem
+- Friction points catalog: `usr/jordan/captain/friction-points-20260405.md`

--- a/claude/workstreams/devex/KNOWLEDGE.md
+++ b/claude/workstreams/devex/KNOWLEDGE.md
@@ -1,0 +1,9 @@
+# devex — Workstream Knowledge
+
+## Patterns and Conventions
+
+<!-- Accumulate patterns discovered during development -->
+
+## Key Decisions
+
+<!-- Record architectural and design decisions with rationale -->

--- a/claude/workstreams/devex/seeds/seed-devex-kickoff-20260406.md
+++ b/claude/workstreams/devex/seeds/seed-devex-kickoff-20260406.md
@@ -1,0 +1,105 @@
+---
+type: seed
+date: 2026-04-06
+from: the-agency/jordan/captain
+subject: "DevEx workstream kickoff — test isolation, pre-commit, developer friction"
+---
+
+# DevEx Workstream Seed
+
+## Mission
+
+DevEx owns the developer experience for agents and principals working in TheAgency. Test infrastructure, commit workflow, permission model, tooling ergonomics — anything that creates friction between "I want to do X" and X actually happening.
+
+## Why Now
+
+ISCP rollout (2026-04-05/06) exposed cascading failures in test infrastructure that blocked captain operations twice in one session. The pre-commit hook is broken enough that we're routinely bypassing it with `--no-verify`, which defeats its purpose. These problems will only compound as more agents come online.
+
+## The Burning Problem: Test Isolation + Pre-Commit
+
+### What broke (2026-04-05/06, captain session)
+
+1. **BATS tests corrupt `.git/config`** — `agent-identity.bats` sets `core.bare=true` and `user.email=test@example.com` in the LIVE repo config. All git operations break. Commits get wrong author attribution. Discovered twice in one session — the pre-commit hook re-triggered it.
+
+2. **BATS tests leak into live ISCP DB** — `flag.bats`, `dispatch.bats` insert test records into `~/.agency/the-agency/iscp.db`. Between test and teardown, `iscp-check` reports "You have 62 flag(s)" to any agent that starts up. Indistinguishable from real flags.
+
+3. **Test debris in working directory** — Tests create `.claude/agents/testname.md`, `claude/agents/testname/`, and `claude/workstreams/test; rm -rf /` (injection test) in the live working tree. These show up in `git status` and can be accidentally committed.
+
+4. **Pre-commit hook runs full BATS suite for ANY change** — `commit-precheck` runs all 32 BATS test files (155 tests) even for markdown-only changes. Takes minutes. Times out. Captain killed stuck processes twice. Forces `--no-verify`, which bypasses QGR enforcement.
+
+5. **Pre-commit BATS run re-triggers the corruption** — The hook runs BATS, BATS corrupts `.git/config`, the commit fails, captain fixes config, tries again, hook runs BATS again, re-corrupts. Vicious cycle.
+
+### What ISCP built (foundation to build on)
+
+ISCP agent fixed the immediate test isolation bugs in dispatches #20-22. This work is merged to main.
+
+**Layer 1: In-process isolation** (`tests/tools/test_helper.bash`)
+- `iscp_test_isolation_setup()` — overrides HOME, sets `ISCP_DB_PATH` to temp file, sets `GIT_CONFIG_GLOBAL=/dev/null`, snapshots `.git/config` hash
+- `iscp_test_isolation_teardown()` — verifies `.git/config` hash unchanged, cleans temp files
+- All 7 ISCP BATS files updated to use these helpers
+- `ISCP_DB_PATH` env var support in `claude/tools/lib/_iscp-db`
+
+**Layer 2: Docker isolation** (`tests/Dockerfile` + `tests/docker-test.sh`)
+- Alpine container with bash/git/sqlite/jq/bats
+- Repo mounted read-only at `/repo`
+- Non-root `testrunner` user
+- Container destroyed after run — zero host contamination
+- Currently manual: `./tests/docker-test.sh`
+- Only runs ISCP tests (7 files) — not the full 32-file suite
+
+**What ISCP did NOT fix:**
+- Pre-commit hook still runs full suite unconditionally
+- Non-ISCP test files (25 of 32) have NO isolation
+- Docker runner isn't integrated into the commit workflow
+- No smart test scoping (changed-file detection)
+- Working directory test debris (testname agent, injection test dirs)
+
+### What DevEx needs to build
+
+**Priority 1: Make pre-commit not broken**
+- Smart test scoping — detect changed files, run only relevant BATS tests
+- Skip tests entirely for non-code changes (markdown, dispatches, handoffs)
+- Timeout with graceful degradation — if tests take too long, warn but don't block
+- Never run BATS tests that can corrupt the host environment from the pre-commit hook
+
+**Priority 2: Extend isolation to all tests**
+- Apply ISCP's isolation pattern to all 32 BATS test files, not just the 7 ISCP ones
+- Fix working directory pollution (testname agent, injection test dirs)
+- Ensure all test fixtures use temp directories, not the live working tree
+- Docker runner should support the full suite, not just ISCP tests
+
+**Priority 3: Make Docker the default for full-suite runs**
+- `./tests/docker-test.sh` runs ALL tests, not just ISCP
+- Pre-commit hook uses Docker for full-suite (if Docker available), in-process for targeted runs
+- CI integration (future — when we have CI)
+
+## Broader DevEx Scope (beyond first task)
+
+The friction points document (`usr/jordan/captain/friction-points-20260405.md`) catalogs 15 issues across 4 categories. DevEx owns most of them:
+
+**Permission Friction (P1-P6):** settings-template.json ships too few permissions, agents prompt for safe operations, macOS permissions break on updates.
+
+**Tooling Gaps (T1-T5):** T1 (dispatch fetch/reply — DONE by ISCP), T2 (worktree payload access — DONE by ISCP), T3 (pre-commit timeout — THIS SEED), T4 (worktree agent lifecycle), T5 (test isolation leaks — THIS SEED).
+
+**Agent Bootstrap (B1-B3):** agency-init broken, agent-create missing essentials, no permission prompt counter.
+
+**Claude Code Behavioral (C1-C2):** Agent permission scope undefined, multi-principal DB security.
+
+## Key Files
+
+| File | What | Status |
+|------|------|--------|
+| `tests/tools/test_helper.bash` | Shared BATS isolation helpers | EXISTS — ISCP built |
+| `tests/Dockerfile` | Docker test container | EXISTS — ISCP built |
+| `tests/docker-test.sh` | Docker test runner | EXISTS — ISCP built, ISCP-only |
+| `claude/tools/commit-precheck` | Pre-commit hook logic | EXISTS — needs rewrite |
+| `.git/hooks/pre-commit` | Git hook entry point | EXISTS — calls commit-precheck |
+| `claude/tools/lib/_iscp-db` | ISCP DB with env var override | EXISTS — ISCP built |
+| `usr/jordan/captain/friction-points-20260405.md` | Full friction catalog | EXISTS |
+
+## References
+
+- ISCP dispatches #20, #21, #22 — the bug reports that triggered this work
+- ISCP commits: b1cd1b0, efa00d6, 52222e7, d0c7c9e
+- Friction points: `usr/jordan/captain/friction-points-20260405.md`
+- ISCP reference: `claude/workstreams/iscp/iscp-reference-20260405.md`

--- a/usr/jordan/captain/dispatches/directive-workstream-kickoff-read-seed-start-discuss-with-jo-20260406-0923.md
+++ b/usr/jordan/captain/dispatches/directive-workstream-kickoff-read-seed-start-discuss-with-jo-20260406-0923.md
@@ -1,0 +1,14 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-06T01:23
+status: created
+priority: high
+subject: "Workstream kickoff: read seed, start /discuss with Jordan"
+in_reply_to: null
+---
+
+# Workstream kickoff: read seed, start /discuss with Jordan
+
+Welcome to DevEx. Your seed is at claude/workstreams/devex/seeds/seed-devex-kickoff-20260406.md — read it, read the friction points at usr/jordan/captain/friction-points-20260405.md, read ISCP's test isolation code (tests/tools/test_helper.bash, tests/Dockerfile, tests/docker-test.sh), read the current pre-commit hook (claude/tools/commit-precheck), then start /discuss with Jordan to drive toward a PVR. The burning problem is test isolation and the pre-commit hook — this is your highest priority.

--- a/usr/jordan/devex/CLAUDE-DEVEX-AGENT.md
+++ b/usr/jordan/devex/CLAUDE-DEVEX-AGENT.md
@@ -1,0 +1,26 @@
+# DevEx Agent Instructions
+
+## Identity
+
+- **Agent:** the-agency/jordan/devex
+- **Principal:** Jordan
+- **Workstream:** devex
+- **Role:** Test infrastructure, commit workflow, permission model, tooling ergonomics
+
+## Coordination
+
+- **Captain:** the-agency/jordan/captain — dispatches, PR lifecycle, merge coordination
+- **ISCP agent:** the-agency/jordan/iscp — built the test isolation foundation you're extending
+- **All agents:** your work affects everyone — broken pre-commit blocks all agents
+
+## File Discipline
+
+- **Your sandbox:** `usr/jordan/devex/` (handoffs, dispatches, tools, tmp)
+- **Your workstream:** `claude/workstreams/devex/` (seeds, reviews, knowledge)
+- **Your code:** `tests/`, `claude/tools/commit-precheck`, `.git/hooks/pre-commit`, `tests/Dockerfile`, `tests/docker-test.sh`, `tests/tools/test_helper.bash`
+- **Your scripts:** `usr/jordan/devex/tools/` (ad hoc, persisted)
+- **Your scratch:** `usr/jordan/devex/tmp/` (gitignored)
+
+## Process
+
+Full methodology: seed → /discuss → PVR → A&D → Plan → implement with QG at every boundary. You are a tech-lead class agent — you own the full lifecycle for your workstream.

--- a/usr/jordan/devex/devex-handoff.md
+++ b/usr/jordan/devex/devex-handoff.md
@@ -1,0 +1,52 @@
+# Handoff: devex — Bootstrap
+
+---
+type: agency-bootstrap
+date: 2026-04-06 01:20
+principal: jordan
+agent: the-agency/jordan/devex
+workstream: devex
+---
+
+## Who You Are
+
+DevEx agent for TheAgency. You own test infrastructure, commit workflow, permission model, and tooling ergonomics. Your work directly impacts every agent and principal in the repo — a broken pre-commit hook blocks everyone.
+
+## Current State
+
+**New workstream.** No PVR, A&D, or Plan yet. You have a seed document and existing code from the ISCP agent to build on.
+
+### What exists (ISCP built)
+
+- `tests/tools/test_helper.bash` — shared BATS isolation helpers (iscp_test_isolation_setup/teardown)
+- `tests/Dockerfile` + `tests/docker-test.sh` — Docker test runner (ISCP tests only, manual)
+- `claude/tools/lib/_iscp-db` — `ISCP_DB_PATH` env var for DB isolation
+- 7 of 32 BATS test files have isolation helpers
+- 155 tests green
+
+### What's broken (the burning problem)
+
+- Pre-commit hook (`claude/tools/commit-precheck`) runs ALL 32 BATS files for ANY change including markdown
+- Times out, blocks commits for minutes, forces `--no-verify`
+- BATS tests still leak debris into working directory (testname dirs, injection test artifacts)
+- 25 of 32 BATS test files have NO isolation
+- Docker runner only covers 7 ISCP test files
+
+## Key Files
+
+| File | What |
+|------|------|
+| `claude/workstreams/devex/seeds/seed-devex-kickoff-20260406.md` | **READ THIS FIRST** — full problem statement, what ISCP built, what you need to build |
+| `usr/jordan/captain/friction-points-20260405.md` | 15 friction points across 4 categories — your backlog |
+| `tests/tools/test_helper.bash` | ISCP's isolation helpers — your foundation |
+| `tests/Dockerfile` | Docker test container |
+| `tests/docker-test.sh` | Docker test runner (ISCP-only) |
+| `claude/tools/commit-precheck` | Pre-commit hook logic — NEEDS REWRITE |
+
+## Next Action
+
+1. Read the seed: `claude/workstreams/devex/seeds/seed-devex-kickoff-20260406.md`
+2. Read the friction points: `usr/jordan/captain/friction-points-20260405.md`
+3. Read ISCP's test isolation code: `tests/tools/test_helper.bash`, `tests/Dockerfile`, `tests/docker-test.sh`
+4. Read the current pre-commit hook: `claude/tools/commit-precheck`
+5. Start `/discuss` with Jordan on the seed — drive toward a PVR

--- a/usr/jordan/devex/tmp/.gitignore
+++ b/usr/jordan/devex/tmp/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
## Summary
- New **devex** workstream: test infrastructure, commit workflow, permission model, tooling ergonomics
- Agent registration (`.claude/agents/devex.md`) — tech-lead class instance
- Seed document with full problem statement built from captain's session observations
- References ISCP's test isolation foundation (test_helper.bash, Dockerfile, docker-test.sh)
- Dispatch #27 sent: kickoff directive

## First priority
Fix the pre-commit hook (`commit-precheck`) — it runs all 32 BATS files for any change, times out, and forces `--no-verify`. Blocked captain operations twice in one session.

## Test plan
- [ ] Merge to main
- [ ] Merge main into devex worktree
- [ ] Start devex agent: `cd .claude/worktrees/devex/ && claude --agent devex`
- [ ] Agent reads seed, starts /discuss

🤖 Generated with [Claude Code](https://claude.com/claude-code)