### PR TITLE
Day 30: valueflow A&D + MAR rounds 1-2 + transcripts

### DIFF
--- a/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
+++ b/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
@@ -100,9 +100,38 @@ reviewers:
 
 ## Collaborative Resolution Transcript
 
-Decisions made via 1B1 with principal (Jordan) during captain session 20.
+Decisions made via 1B1 with principal (Jordan) during captain session 20 (Day 30).
 Full transcript: `usr/jordan/captain/transcripts/session20-continued-20260406-0730.md`
+
+## Additional Design Decisions from Session (post-MAR)
+
+These emerged during the 1B1 triage and are captured here for completeness:
+
+| Decision | Context |
+|----------|---------|
+| **Day counting convention** | Count days with commits per repo and per workstream. Day 30 for the-agency. "Day 12 of valueflow for mdpal." Proposed as Agency model. |
+| **Dispatch check loop: 5 minutes** | All agents set `/loop 5m dispatch check` on startup. `dispatch check` (not `dispatch list`) — silent when empty. |
+| **ISCP tip: `dispatch check`** | Use for silent polling, `dispatch list` for interactive inspection. From ISCP dispatch #75. |
+| **Captain order: first up, last down** | Principal wakes → captain up → agents up → work → agents down → captain down → principal sleeps. |
+| **CLAUDE.md three-level hierarchy** | CLAUDE-THEAGENCY.md (methodology) → CLAUDE-{WORKSTREAM}.md (workstream) → CLAUDE-{APP}.md (application/service). V3: fragment registry + autonomous generation tooling. |
+| **Dispatch payload symlinks** | `~/.agency/{repo}/dispatches/` holds symlinks to git artifacts. ISCP implemented in 1e610fd (dispatch #74). Merge pending. |
+| **AI Augmented Development framing** | "About building, not coding." Content seed for X/LinkedIn articles. Four MARFI papers → short + long articles. |
+| **Format on save AND at T1** | Belt and suspenders. Format on write prevents dirty diffs, T1 confirms at commit. Both cheap. |
+| **Defense in depth** | Multiple layers of gates (iteration, phase, PR). Each catches what the previous missed. Additive, not replacement. Reference: Jordan's 2007 lightning talk at Google Quality Conference, London. |
+
+## Resolution Dispatches Sent
+
+| Agent | Dispatch ID | Status |
+|-------|-------------|--------|
+| ISCP | #82 | Sent |
+| mdpal-app | #83 | Sent |
+| mdpal-cli | #84 | Sent |
+| monofolk/captain | collaboration-monofolk PR #6 | Pending merge |
 
 ## Not Received
 
 DevEx (dispatch #66, nudged #80) — no A&D review delivered. Will incorporate when/if received. Not blocking revision.
+
+## Status
+
+**MAR round 1: COMPLETE.** All findings dispositioned. All collaborative items resolved. A&D revision pending (action 2). Will be followed by MAR round 2 with both research subagents and agent dispatches.

--- a/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
+++ b/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
@@ -1,0 +1,103 @@
+---
+type: mar
+project: valueflow
+artifact: valueflow-ad-20260406.md
+round: 1
+date: 2026-04-06
+author: the-agency/jordan/captain
+reviewers:
+  - the-agency/jordan/mdpal-app (dispatch #68 → #70)
+  - the-agency/jordan/iscp (dispatch #65 → #72)
+  - monofolk/jordan/captain (collaboration-monofolk)
+  - the-agency/jordan/mdpal-cli (dispatch #67 → #73)
+  - the-agency/jordan/devex (dispatch #66 → not received)
+---
+
+# MAR Round 1: Valueflow A&D
+
+50 findings from 4 reviewers + 4 embedded Q&A responses. DevEx did not deliver.
+
+## Embedded Questions — Answers Received
+
+| Q | Section | Answered by | Response | Disposition |
+|---|---------|-------------|----------|-------------|
+| MAR triage: schema or free-form? | §2 | ISCP | Free-form V2, structured schema V3. Add YAML frontmatter for metrics. | **Accept** — right call, enough structure for FR12 without constraining |
+| MARFI: dispatches or subagents? | §3 | ISCP | Subagents V2, dispatches V3. Write output to seeds/ for durability. | **Accept** — simpler, cheaper, durable via file output |
+| Commit dispatch carry stage-hash? | §5 | ISCP | Yes. Structured YAML: commit_hash, stage_hash, branch, phase, iteration, files_changed. | **Accept** — machine-consumed by captain merge, structured from day one |
+| Dispatch payload migration? | §8 | ISCP | Superseded by symlink directive #71. Implemented in 1e610fd. | **Done** — symlinks implemented, 173 tests passing |
+| Changed-file test mapping? | §6 | monofolk | Convention-based (option 1). Already implicit. | **Accept** — zero-config default |
+| Stage-hash semantic diff? | §6 | monofolk | Linter's changed-file detection. Only .md → skip. Any code → re-run. | **Accept** — simpler heuristic |
+| Context budget linter? | §9 | monofolk | Yes, build it. DevEx tool. Warn at 4000 tokens. | **Accept** — V2 deliverable |
+| Enforcement registry? | §4 | monofolk | YAML manifest + audit tool. | **Accept** |
+| Captain loop cadence? | §5 | monofolk + mdpal-cli | Fixed interval V2 (/loop 5m dispatch check). Event-driven V3. | **Accept** — close OQ7 |
+| Compaction strategy? | §7 | monofolk | Auto at 80% context. PreCompact writes handoff. | **Accept** — if we have control; handle gracefully if not |
+
+## Bucket 1: Disagree (4 items)
+
+| ID | Source | Finding | Reasoning |
+|----|--------|---------|-----------|
+| D1 | ISCP §10 | Flag categories at triage not capture — don't burden capture moment | **Disagree.** `--friction` costs 1 word at capture and routes instantly. Deferring to triage means undifferentiated pile. Capture IS routing. |
+| D2 | mdpal-cli #3 | Dispatch payload migration risky, fix read path instead of moving storage | **Disagree — superseded.** Principal decided symlinks. ISCP implemented (#74, commit 1e610fd). The read path IS fixed — via symlinks. |
+| D3 | monofolk OQ1 | Schema-validated MAR because health metrics need structured data | **Disagree.** Agree with ISCP: free-form V2 with YAML frontmatter is enough for metrics. Full schema is premature — we don't have enough triage cycles to know the right schema. |
+| D4 | monofolk #17 | V2 includes platform-dependent features (conditional `if:` on hooks, PermissionDenied) — should be V3 | **Disagree.** These are Claude Code features that exist NOW in the current release. `if:` is documented in hooks spec. `PermissionDenied` hook is in the events list. Not hypothetical. |
+
+## Bucket 2: Autonomous — Incorporating (28 items)
+
+| ID | Source | Finding | Action |
+|----|--------|---------|--------|
+| A1 | mdpal-app #2 | No timeout for unanswered cross-workstream RFI | Add to §3: 24h auto-proceed with available input + flag missing responders |
+| A2 | mdpal-app #5 | Schema for triage response, free-form for review input | Specify in §2: review input = free-form markdown, triage response = structured tables + YAML frontmatter |
+| A3 | mdpal-app #8 | PostCompact context budget unmeasured at hook time | Note in §7: minimal injection by default, full if budget allows. DevEx builds measurement. |
+| A4 | mdpal-app #9 | 2000-token budget per doc is too aggressive | Change in §9: budget per skill injection (4000 total), not per document. Doc can be 3000 if skill adds 1000. |
+| A5 | mdpal-app #11 | MAR dispatches should specify reviewer focus | Add to §3 MAR protocol: dispatch includes "review from perspective of: {focus area}" |
+| A6 | ISCP #1 | Dispatch payloads in artifact taxonomy say "TBD (see §8)" | Update §1 artifact table: dispatch payloads at `~/.agency/{repo}/dispatches/` (symlinks to git artifacts) |
+| A7 | ISCP #2 | Enforcement registry drifts without audit tool | Note in §4: audit tool is load-bearing dependency. DevEx must build alongside registry. No registry without auditor. |
+| A8 | ISCP #6 | Stage-hash delta: single markdown file → allow with warning, simpler than "non-code" | Adopt in §6: if delta is single .md file → allow with warning. Any other change → re-run. Simpler, less ambiguous. |
+| A9 | ISCP #7 | PostCompact should also inject agent's scoped CLAUDE.md | Add to §7 PostCompact injection: Identity + State + Next Action + scoped CLAUDE.md (agent registration's @ imports) |
+| A10 | ISCP #10 | V2 list should include symlink implementation (not V3) | Update §12: move "dispatch payloads symlinks" from V3 to V2 as delivered |
+| A11 | ISCP #11 | No DB schema versioning strategy | Add to §8: version column in ISCP DB, checked on every init. Migration tool handles version transitions. |
+| A12 | ISCP #12 | Dispatch authority not tied to enforcement ladder level | Add to §8: dispatch authority at enforcement ladder level 3 (tool enforcement) from day one. Dispatch tool rejects unauthorized types. |
+| A13 | ISCP #13 | No dispatch TTL/cleanup policy | Add to §8: retention policy — archive resolved dispatches after 30 days. Symlinks cleaned when payload archived. |
+| A14 | monofolk #2 | Naming convention should allow sub-project qualifiers | Update §1 artifact table: `{project}[-{subproject}]-pvr-{YYYYMMDD}.md` |
+| A15 | monofolk #4 | MAR "N agents" should be "N relevant agents" with selection criteria | Update §3 MAR protocol: explicit selection criteria, not broadcast. Captain selects relevant agents per artifact scope. |
+| A16 | monofolk #5 | MAR deadlines for dormant agents: 24h auto-proceed | Add to §3 MAR protocol: 24h timeout, proceed with available reviews, flag missing reviewers for information. |
+| A17 | monofolk #10 | Convention-based test mapping confirmed for multi-framework repos | Confirm in §6: convention-based as default, "all tests in affected package" as package-level fallback |
+| A18 | monofolk #13 | Local vs cross-repo dispatch distinction needed | Add to §8: local dispatches = DB + symlinks. Cross-repo dispatches = git-only via collaboration repos. Different mechanisms, same addressing. |
+| A19 | monofolk #15 | Transcript mining needs token budget limit | Add to §10: budget cap per mining run, prioritize recent sessions, limit to last N days |
+| A20 | monofolk #16 | Circuit breaker N should be configurable per workstream, default 5 | Update §11: configurable per workstream. Research/design may have long iterations. |
+| A21 | mdpal-cli #1 | Gate tiers assume language-specific tooling (Swift has no standard linter) | Generalize §6 T1: "stage-hash match + compile/build" as universal baseline. Format/lint optional per language toolchain. |
+| A22 | mdpal-cli #2 | Changed-file scoping needs simpler default for non-mirrored layouts | Add to §6: package-level fallback — "anything in `apps/mdpal/Sources/` changed → run tests in `apps/mdpal/`" |
+| A23 | mdpal-cli #5 | MARFI boundary fuzzy — need concrete decision rule | Add to §3: "MARFI = questions answerable with web search + reading docs. Domain research = questions requiring project context and design decisions." |
+| A24 | mdpal-cli #7 | Circuit breaker should be time-based not attempt-based | Change §11: "no progress in N hours" not "N failed attempts." Agent self-reports: stuck vs making progress on distinct findings. |
+| A25 | mdpal-cli #8 | Context budget linter must ship with decomposition | Move from question to §12 V2 deliverables: linter ships alongside CLAUDE-THEAGENCY.md decomposition |
+| A26 | mdpal-cli #9 | Captain loop cadence is not an open question | Close OQ7: fixed interval V2 (`/loop 5m dispatch check`), event-driven V3 |
+| A27 | ISCP Q&A | MARFI subagents persist output to seeds/ for durability | Add to §3 MARFI protocol: subagents write output to `claude/workstreams/{ws}/seeds/marfi-{agent}-{date}.md` before returning |
+| A28 | ISCP Q&A | Commit dispatch structured YAML frontmatter | Add to §5: commit dispatch payload format — YAML with commit_hash, stage_hash, branch, phase, iteration, files_changed |
+
+## Bucket 3: Collaborative — Need Principal Input (8 items)
+
+| ID | Source | Finding | Question for Principal |
+|----|--------|---------|----------------------|
+| C1 | mdpal-app #3 | T1 should include fast unit tests, not just lint | Three views on T1 baseline. mdpal-app: include tests if fast. mdpal-cli: stage-hash + compile. ISCP: current tiers correct. **What should T1 include?** |
+| C2 | monofolk #3 | Autonomous stages + principal review in §2 contradict | §2 says "present triage to principal" but autonomous stages skip principal. **For autonomous stages, does the agent triage and act without presenting? Principal informed after the fact?** |
+| C3 | monofolk #9 | Commit processing: additive to /phase-complete or replacement? | dispatch-on-commit for every iteration commit (captain notified). /phase-complete for phase boundary (squash, deep QG, PR). **Additive, not replacement. Correct?** |
+| C4 | mdpal-cli #4 | Captain explicitly session-scoped for V2 — conflicts with "always-on" | mdpal-cli: "state explicitly that captain is session-scoped, no daemon." But principal said captain is always-on, not running = holiday. **Is captain session-scoped or always-on? Or: always-on within sessions, no between-session automation in V2?** |
+| C5 | mdpal-cli #6 | `effort:` levels — what do they actually control? | Does effort: low mean skip MAR? Use sonnet? Reduce turns? **What is the intent for effort levels?** |
+| C6 | ISCP #3 | Per-workstream enforcement transition: who decides level changes? | Who moves iscp from level 3 to level 5? **Principal decision informed by audit tool, or automatic?** |
+| C7 | monofolk OQ8 | Compaction at 80%: auto or manual? | monofolk says auto-trigger at 80%. **Do we control when compaction happens, or just handle it gracefully?** |
+| C8 | ISCP #7 + mdpal-app #8 | PostCompact injection scope: minimal or full? | ISCP: inject CLAUDE.md too. mdpal-app: large handoffs consume context. **How much do we inject? Minimal (identity + state + next action) or full (+ CLAUDE.md + working set)?** |
+
+## Reviewer Summary
+
+| Reviewer | Findings | Agree (positive) | Disagree (by me) | Autonomous | Collaborative |
+|----------|----------|-------------------|-------------------|------------|---------------|
+| mdpal-app | 11 | 6 | 0 | 5 (A1-A5) | 1 (C1) |
+| ISCP | 12 + 4 Q&A | 1 | 1 (D1) | 11 (A6-A13, A27-A28) | 2 (C6, C8) |
+| monofolk | 18 + 8 OQ answers | 5 | 2 (D3, D4) | 7 (A14-A20) | 3 (C2, C3, C7) |
+| mdpal-cli | 9 | 4 | 1 (D2) | 5 (A21-A26) | 2 (C4, C5) |
+| DevEx | — | — | — | — | NOT RECEIVED |
+| **Totals** | **50 + 12** | **16** | **4** | **28** | **8** |
+
+## Not Received
+
+DevEx (dispatch #66, nudged #80) — no A&D review delivered. Will incorporate when/if received. Not blocking revision.

--- a/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
+++ b/claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
@@ -78,25 +78,30 @@ reviewers:
 
 | ID | Source | Finding | Question for Principal |
 |----|--------|---------|----------------------|
-| C1 | mdpal-app #3 | T1 should include fast unit tests, not just lint | Three views on T1 baseline. mdpal-app: include tests if fast. mdpal-cli: stage-hash + compile. ISCP: current tiers correct. **What should T1 include?** |
-| C2 | monofolk #3 | Autonomous stages + principal review in §2 contradict | §2 says "present triage to principal" but autonomous stages skip principal. **For autonomous stages, does the agent triage and act without presenting? Principal informed after the fact?** |
-| C3 | monofolk #9 | Commit processing: additive to /phase-complete or replacement? | dispatch-on-commit for every iteration commit (captain notified). /phase-complete for phase boundary (squash, deep QG, PR). **Additive, not replacement. Correct?** |
-| C4 | mdpal-cli #4 | Captain explicitly session-scoped for V2 — conflicts with "always-on" | mdpal-cli: "state explicitly that captain is session-scoped, no daemon." But principal said captain is always-on, not running = holiday. **Is captain session-scoped or always-on? Or: always-on within sessions, no between-session automation in V2?** |
-| C5 | mdpal-cli #6 | `effort:` levels — what do they actually control? | Does effort: low mean skip MAR? Use sonnet? Reduce turns? **What is the intent for effort levels?** |
-| C6 | ISCP #3 | Per-workstream enforcement transition: who decides level changes? | Who moves iscp from level 3 to level 5? **Principal decision informed by audit tool, or automatic?** |
-| C7 | monofolk OQ8 | Compaction at 80%: auto or manual? | monofolk says auto-trigger at 80%. **Do we control when compaction happens, or just handle it gracefully?** |
-| C8 | ISCP #7 + mdpal-app #8 | PostCompact injection scope: minimal or full? | ISCP: inject CLAUDE.md too. mdpal-app: large handoffs consume context. **How much do we inject? Minimal (identity + state + next action) or full (+ CLAUDE.md + working set)?** |
+| C1 | mdpal-app #3 | T1 should include fast unit tests, not just lint | **RESOLVED:** T1 = stage-hash + build/compile + format + relevant fast tests, **60 second budget**. Format runs on save AND at T1 (belt and suspenders). 60s is generous for iteration complete — agents don't get impatient. If tests exceed 60s, test scoping needs improvement. |
+| C2 | monofolk #3 | Autonomous stages + principal review in §2 contradict | **RESOLVED:** Autonomous stages: agent triages MAR feedback and acts without presenting to principal. Sends informational dispatch with bucket disposition — "here's what came in, here's what I did." Principal sees it on next check-in (MDPal panel). Scope-definition stages (PVR, A&D, master plan): full present-and-discuss flow. |
+| C3 | monofolk #9 | Commit processing: additive to /phase-complete or replacement? | **RESOLVED:** Additive, not replacement. Defense in depth. Dispatch-on-commit fires on every iteration commit (captain notified, merges, syncs). /phase-complete handles phase boundary (squash merge, deep QG, PR). Two mechanisms for two boundaries. Multiple layers catch what individual layers miss. |
+| C4 | mdpal-cli #4 | Captain explicitly session-scoped for V2 — conflicts with "always-on" | **RESOLVED:** Captain is always-on by design — first up, last down. If any agent is running, captain is running. Principal brings captain up first, puts captain to bed last, then principal goes to bed. V2 mechanism is interactive sessions. V3 adds headless daemon (`--bare -p`). Between sessions dispatches queue — no work lost. Not session-scoped — always-on in intent, session-based in V2 mechanism. |
+| C5 | mdpal-cli #6 | `effort:` levels — what do they actually control? | **RESOLVED:** Effort is Anthropic's abstraction over token budget — it tunes model behavior, context usage, depth of reasoning behind the scenes. We don't control the levers individually, we set the dial per skill. Low = fast and cheap. High = deep and thorough. `/dispatch-read` = low, `/quality-gate` = high. Don't define internals — Anthropic manages that. |
+| C6 | ISCP #3 | Per-workstream enforcement transition: who decides level changes? | **RESOLVED:** Principal decides. DRI is the principal. Audit tool informs, agents recommend, captain presents — but the principal makes the call. For TheAgency framework itself, Jordan is the DRI. Other principals decide for their own repos. No automatic transitions. |
+| C7 | monofolk OQ8 | Compaction at 80%: auto or manual? | **RESOLVED:** We don't control compaction timing — Claude Code fires it around 80% context used (20% remaining). We control recovery. PostCompact hook re-injects handoff. Transcripts provide depth. Multi-part handoffs provide structure. Intra-session handoffs are insurance checkpoints. The better the handoff, the less compaction matters. |
+| C8 | ISCP #7 + mdpal-app #8 | PostCompact injection scope: minimal or full? | **RESOLVED:** PostCompact injects the handoff only. CLAUDE.md survives compaction — it's system-level context that Claude Code preserves. The handoff provides session-specific context that was compressed. Keep handoffs tight, CLAUDE.md light. The decomposition of CLAUDE-THEAGENCY.md into composable chunks saves context budget for handoff injection and actual work. |
 
 ## Reviewer Summary
 
-| Reviewer | Findings | Agree (positive) | Disagree (by me) | Autonomous | Collaborative |
-|----------|----------|-------------------|-------------------|------------|---------------|
-| mdpal-app | 11 | 6 | 0 | 5 (A1-A5) | 1 (C1) |
-| ISCP | 12 + 4 Q&A | 1 | 1 (D1) | 11 (A6-A13, A27-A28) | 2 (C6, C8) |
-| monofolk | 18 + 8 OQ answers | 5 | 2 (D3, D4) | 7 (A14-A20) | 3 (C2, C3, C7) |
-| mdpal-cli | 9 | 4 | 1 (D2) | 5 (A21-A26) | 2 (C4, C5) |
+| Reviewer | Findings | Agree (positive) | Disagree (by me) | Autonomous | Collaborative → Resolved |
+|----------|----------|-------------------|-------------------|------------|--------------------------|
+| mdpal-app | 11 | 6 | 0 | 5 (A1-A5) | 1 (C1) → resolved |
+| ISCP | 12 + 4 Q&A | 1 | 1 (D1) | 11 (A6-A13, A27-A28) | 2 (C6, C8) → resolved |
+| monofolk | 18 + 8 OQ answers | 5 | 2 (D3, D4) | 7 (A14-A20) | 3 (C2, C3, C7) → resolved |
+| mdpal-cli | 9 | 4 | 1 (D2) | 5 (A21-A26) | 2 (C4, C5) → resolved |
 | DevEx | — | — | — | — | NOT RECEIVED |
-| **Totals** | **50 + 12** | **16** | **4** | **28** | **8** |
+| **Totals** | **50 + 12** | **16** | **4** | **28** | **8 → all resolved** |
+
+## Collaborative Resolution Transcript
+
+Decisions made via 1B1 with principal (Jordan) during captain session 20.
+Full transcript: `usr/jordan/captain/transcripts/session20-continued-20260406-0730.md`
 
 ## Not Received
 

--- a/claude/workstreams/agency/valueflow-ad-20260406.md
+++ b/claude/workstreams/agency/valueflow-ad-20260406.md
@@ -3,18 +3,21 @@ type: ad
 project: valueflow
 workstream: agency
 date: 2026-04-06
-status: draft — pending MAR
+status: revised — MAR round 1 incorporated, pending round 2
 author: the-agency/jordan/captain
 pvr: claude/workstreams/agency/valueflow-pvr-20260406.md
+mar-round-1: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
 ---
 
 # Valueflow — Architecture & Design
 
 ## Overview
 
-This document designs the implementation of valueflow — TheAgency's AIADLC. It covers: the flow stages, multi-agent groups, enforcement ladder, captain loop, quality gates, context resilience, continual learning, and the CLAUDE-THEAGENCY.md decomposition.
+This document designs the implementation of valueflow — TheAgency's AIADLC. It covers: the flow stages, multi-agent groups, enforcement ladder, captain architecture, quality gates, context resilience, dispatch payload architecture, CLAUDE-THEAGENCY.md decomposition, continual learning, error recovery, and the V2/V3 boundary.
 
-The design draws from: the PVR (13 FRs, 8 NFRs, 5 constraints), MAR rounds 1-2 (9 reviewers), MARFI research (Lean/SAFe/Shape Up/DORA, AI multi-agent patterns, enforcement patterns, Claude Code features), and the session 20 transcript.
+The design draws from: the PVR (13 FRs, 8 NFRs, 5 constraints), MAR round 1 (4 research reviewers + 5 agent reviewers, 50 findings + 12 Q&A), MARFI research (Lean/SAFe/Shape Up/DORA, AI multi-agent patterns, enforcement patterns, Claude Code features), and the Day 30 session transcript.
+
+**Revision note:** This is the post-MAR-round-1 revision. All 28 autonomous incorporations and 8 collaborative resolutions (with principal) applied. Embedded questions resolved. See MAR disposition: `claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md`.
 
 ---
 
@@ -46,6 +49,8 @@ Stage {
 | Ship | Commits + QGRs | PRs merged to origin | Pre-PR QG | Captain-managed |
 | Value | Shipped product | Customer feedback → new seeds (V3) | Customer adoption | — |
 
+**MARFI can trigger at any stage** — not just at the beginning. Mid-flow research is valid: during A&D when a technical question arises, during planning when a dependency is discovered. The driving agent decides when research input is needed.
+
 ### Artifact Types
 
 Every artifact in valueflow has a type, a canonical location, and a naming convention.
@@ -54,14 +59,16 @@ Every artifact in valueflow has a type, a canonical location, and a naming conve
 |----------|-----------|----------|--------|
 | Seed | `seed` | `claude/workstreams/{ws}/seeds/` | `seed-{topic}-{YYYYMMDD}.md` |
 | MARFI brief | `marfi` | `claude/workstreams/{ws}/seeds/` | `marfi-{project}-{YYYYMMDD}.md` |
-| PVR | `pvr` | `claude/workstreams/{ws}/` | `{project}-pvr-{YYYYMMDD}.md` |
-| A&D | `ad` | `claude/workstreams/{ws}/` | `{project}-ad-{YYYYMMDD}.md` |
-| Plan | `plan` | `claude/workstreams/{ws}/` | `{project}-plan-{YYYYMMDD}.md` |
+| PVR | `pvr` | `claude/workstreams/{ws}/` | `{project}[-{subproject}]-pvr-{YYYYMMDD}.md` |
+| A&D | `ad` | `claude/workstreams/{ws}/` | `{project}[-{subproject}]-ad-{YYYYMMDD}.md` |
+| Plan | `plan` | `claude/workstreams/{ws}/` | `{project}[-{subproject}]-plan-{YYYYMMDD}.md` |
 | QGR | `qgr` | `claude/workstreams/{ws}/reviews/` | `qgr-{boundary}-{phase.iter}-{stage-hash}-{YYYYMMDD-HHMM}.md` |
 | MAR report | `mar` | `claude/workstreams/{ws}/reviews/` | `mar-{artifact}-round{N}-{YYYYMMDD}.md` |
 | Transcript | `transcript` | `usr/{principal}/{project}/transcripts/` | `{topic}-{YYYYMMDD-HHMM}.md` |
 | Handoff | `handoff` | `usr/{principal}/{project}/` | `{agent}-handoff.md` |
-| Dispatch payload | `dispatch` | TBD (see Section 8) | `{type}-{slug}-{YYYYMMDD-HHMM}.md` |
+| Dispatch payload | `dispatch` | Git (author's branch/worktree) + symlink in `~/.agency/{repo}/dispatches/` | `{type}-{slug}-{YYYYMMDD-HHMM}.md` |
+
+Sub-project qualifiers are optional in naming (e.g., `dashboards-mcc-pvr-20260402.md`).
 
 ### Transition Protocol
 
@@ -69,13 +76,13 @@ Each stage transition follows:
 
 1. Author declares artifact complete
 2. Gate runs (MAR or QG depending on artifact type)
-3. Gate produces artifact (MAR report or QGR)
+3. Gate produces artifact (MAR report or QGR) — paired to the artifact version
 4. Author triages feedback (three-bucket)
-5. Revisions if needed → re-gate
+5. Revisions if needed → re-gate (new MAR disposition paired to revised artifact)
 6. Principal sign-off (at scope-definition boundaries: PVR, A&D, master plan)
 7. Transition to next stage
 
-**Autonomous stages skip step 6** — phase plans, iterations, and implementation transitions don't require principal sign-off unless the agent escalates.
+**Autonomous stages skip step 6.** Phase plans, iterations, and implementation transitions don't require principal sign-off unless the agent escalates. The agent triages MAR feedback, acts on all three buckets independently, and sends an informational dispatch to the principal: "here's what came in, here's what I did." Principal sees it on next check-in. Only scope-definition stages (PVR, A&D, master plan) get the full present-and-discuss flow.
 
 ---
 
@@ -90,24 +97,33 @@ When an agent receives feedback (from MAR, QG, or any review):
    - **Disagree** — finding rejected with reasoning
    - **Autonomous** — finding accepted, author incorporates independently
    - **Collaborative** — finding requires principal input
-3. **Present** — author presents triage to principal:
+3. **Present** — for scope-definition artifacts, author presents full triage to principal:
    - Disagree items: table with finding + reasoning
    - Autonomous items: table with finding + action taken
    - Collaborative items: 1B1 discussion
-4. **Principal reviews** all three buckets — can move items between buckets
-5. **Revise** artifact based on final dispositions
-6. **Record** — triage documented in MAR report for audit trail
+   - Principal reviews all three buckets — can move items between buckets
+   For autonomous stages: author triages and acts, sends informational dispatch to principal
+4. **Revise** artifact based on final dispositions
+5. **Record** — triage documented in MAR report for audit trail, paired to artifact version
 
-### Dispatch Format for MAR Results
+**Important:** Reviewers give raw feedback (findings, concerns, questions). The **author** triages into buckets, not the reviewer. This must be stated explicitly in every MAR dispatch — agents default to self-sorting if not told otherwise.
+
+### Dispatch Formats
+
+**Review input** (from reviewers): free-form markdown. Raw findings, no structure required.
+
+**Triage response** (from author): structured tables with YAML frontmatter for metrics:
 
 ```yaml
 type: review-response
 subject: "MAR triage: {artifact} — {N} disagree, {N} autonomous, {N} collaborative"
+findings_count: N
+disagree: N
+autonomous: N
+collaborative: N
 ```
 
-Body contains three tables (disagree, autonomous, collaborative) with finding ID, source reviewer, finding text, and disposition reasoning.
-
-**Question for ISCP:** Should MAR triage be a structured dispatch type with schema validation, or free-form markdown? Structured enables automated tracking of finding resolution rates (FR12 health metrics). Free-form is simpler to implement.
+Body contains three tables (disagree, autonomous, collaborative) with finding ID, source reviewer, finding text, and disposition reasoning. This enables FR12 health metrics (automated tracking of finding resolution rates) without requiring full schema validation.
 
 ---
 
@@ -117,58 +133,59 @@ Body contains three tables (disagree, autonomous, collaborative) with finding ID
 
 **Purpose:** Research input before authoring an artifact.
 
-**When:** Before PVR (always for new work), before A&D (always), before Plan (cross-cutting projects). NOT for domain-specific exploration — that's the agent's normal work.
+**When:** Before PVR (always for new work), before A&D (always), before Plan (cross-cutting projects), and mid-flow when a research question arises. NOT for domain-specific exploration — that's the agent's normal work.
+
+**Decision rule:** MARFI is for questions answerable with web search + reading docs (cross-cutting research). Domain research — questions requiring understanding the project's constraints and design decisions — is the agent's normal work and doesn't need captain mediation.
 
 **Protocol:**
 1. Driving agent drafts research questions
-2. Principal reviews and adds questions
+2. Principal reviews and adds questions (MARFI process gate)
 3. Captain spins up N research agents (sonnet model, `effort: medium`)
 4. Agents execute in parallel (background, `run_in_background: true`)
-5. Results returned to driving agent
-6. Driving agent synthesizes into MARFI brief
+5. **Agents write output to `claude/workstreams/{ws}/seeds/marfi-{agent}-{date}.md` for durability** — if the session crashes mid-MARFI, research is preserved
+6. Results returned to driving agent
+7. Driving agent synthesizes into MARFI brief
 
-**Agent composition:** Research agents are generic — they receive a focused question and research it. No persistent identity. Spawned per-MARFI, destroyed after.
-
-**Question for ISCP:** Should MARFI agents be dispatched (cross-session, durable) or subagents (within-session, ephemeral)? For V2, subagents are simpler. For V3 with ClaudeCorp, dispatches enable cross-machine research.
+**Agent composition:** V2: generic subagents, ephemeral, no persistent identity. V3: dispatched agents for cross-machine research (ClaudeCorp).
 
 ### MAR (Multi-Agent Review)
 
-**Purpose:** Three-bucket review of artifacts at every transition.
+**Purpose:** Review of artifacts at every transition with three-bucket disposition.
 
-**When:** After every artifact (PVR, A&D, Plan, QGR at phase boundary). Always.
+**When:** After every artifact (PVR, A&D, Plan, QGR at phase boundary). Always. MAR is never skipped.
 
 **Protocol:**
 1. Author declares artifact ready for review
-2. Captain dispatches review request to selected reviewers
-3. Review instructions: "Give raw findings — concerns, gaps, questions, what works. Do NOT sort into buckets."
-4. Reviewers respond via dispatch (review-response type)
-5. Author collects all findings, triages into three buckets
-6. Author presents triage to principal (for scope-definition artifacts) or processes autonomously (for phase plans, iterations)
-7. Revise, re-review if needed
+2. Captain dispatches review request to **relevant** reviewers (not broadcast — captain selects based on artifact scope)
+3. **Review dispatch includes reviewer focus:** "Review from perspective of: {focus area}" — tells the reviewer what angle to evaluate from
+4. Review instructions (in every MAR dispatch): "Give raw findings — concerns, gaps, questions, what works. Do NOT sort into buckets. The author triages — not you."
+5. Reviewers respond via dispatch (review-response type)
+6. **24-hour timeout:** if a reviewer hasn't responded in 24 hours, auto-proceed with available reviews. Flag missing reviewers for information. Do not block indefinitely on dormant agents.
+7. Author collects all findings, triages into three buckets
+8. For scope-definition artifacts: present full triage to principal. For autonomous stages: triage and act, inform principal via dispatch.
+9. Revise, re-review if needed. MAR disposition is versioned — paired to the artifact version it reviewed.
 
-**Reviewer selection:** Per artifact type:
+**Reviewer selection:** Per artifact type. "N relevant agents" — captain selects agents whose workstream is affected, not all agents.
 
-| Artifact | Reviewer profiles | Count |
-|----------|-------------------|-------|
-| PVR | Methodology critic, practitioner, adopter advocate, Lean analyst + all active agents | 4 research + N agents |
-| A&D | Security, performance, maintainability, testability + relevant agents | 4 research + N agents |
-| Plan | Feasibility, risk, dependency, scope + relevant agents | 4 research + N agents |
-| Code (QG) | Existing 7-agent QG protocol (security, logic, perf, style, edge-case, integration, documentation) | 7 |
+| Artifact | Research reviewer profiles | Agent reviewers |
+|----------|---------------------------|-----------------|
+| PVR | Methodology critic, practitioner, adopter advocate, Lean analyst | Agents whose workstreams are affected |
+| A&D | Security, performance, maintainability, testability | Agents who will implement or consume |
+| Plan | Feasibility, risk, dependency, scope | Agents whose workstreams are affected |
+| Code (QG) | Existing 7-agent QG protocol | N/A (subagents only) |
 
 **V2:** Research reviewers are subagents (sonnet, `effort: high`). Agent reviewers receive dispatches.
 
 **V3 target architecture:** Named subagents with `SendMessage` for within-session MAR. `--fork-session` for parallel reviewer branches from same checkpoint.
 
-**Question for DevEx:** Should MAR review dispatches carry a deadline? What happens if a reviewer doesn't respond within N hours? Auto-proceed with available reviews, or block?
-
 ### MAP (Multi-Agent Plan Input)
 
-**Purpose:** Planning input from multiple agents/workstreams for complex projects.
+**Purpose:** Planning input from multiple agents/workstreams for complex cross-cutting projects.
 
-**When:** Cross-cutting projects spanning multiple workstreams. Single-workstream plans skip MAP.
+**When:** Cross-cutting projects spanning multiple workstreams. Single-workstream plans skip MAP — the driving agent drafts the plan, MAR reviews it.
 
 **Protocol:**
-1. Captain identifies relevant agents across workstreams
+1. Captain identifies relevant agents across workstreams: "anyone I should speak with?"
 2. Captain dispatches RFI: "This plan will affect your workstream — what should we consider?"
 3. Agents respond with constraints, dependencies, concerns
 4. Driving agent incorporates into plan seed
@@ -178,24 +195,23 @@ Body contains three tables (disagree, autonomous, collaborative) with finding ID
 
 ## 4. Enforcement Ladder Architecture
 
-### Revised Ordering
+### Ordering
 
-Based on ISCP MAR round 2 feedback, the ladder ordering is refined:
-
-1. **Document** — CLAUDE-THEAGENCY.md + README-THEAGENCY.md. Human-readable, no tooling. Step 1 for adopters.
+1. **Document** — CLAUDE-THEAGENCY.md + README-THEAGENCY.md. Human-readable, no tooling. Step 1 for adopters: read the docs, follow conventions manually.
 2. **Skill** — wraps the documented process in an invocable skill. References docs via `@` import.
 3. **Tool** — builds the mechanical capability. Pre-approved in settings.json.
-4. **Hookify warn** — warns when the tool is bypassed. Points to the skill.
-5. **Hookify block** — blocks the bypass. Tool is the only path.
+4. **Hookify warn** — warns when the tool is bypassed. Points to the skill. "You should use X — here's how."
+5. **Hookify block** — blocks the bypass. Tool is the only path. Can't proceed without it.
 
-The change from the PVR: **tools before warn.** You build the tool first, then warn about bypassing it. Warning before the tool exists tells agents "don't do X" without giving them the alternative.
+**Tools before warn.** You build the tool first, then warn about bypassing it. Warning before the tool exists tells agents "don't do X" without giving them the alternative.
+
+**Each layer addresses the bypass discovered in the previous layer.** Gate on artifact existence (mechanical, auditable), not on artifact quality (human judgment).
 
 ### Enforcement Registry
 
-Each capability declares its current ladder position:
+Each capability declares its current ladder position in `claude/config/enforcement.yaml`:
 
 ```yaml
-# claude/config/enforcement.yaml
 capabilities:
   git-commit:
     level: 5  # block
@@ -211,14 +227,13 @@ capabilities:
     # skill, tool, hookify TBD
 ```
 
-**Question for DevEx:** Can you build an audit tool that reads this registry and validates that each declared level actually has the corresponding artifacts? E.g., level 3 (tool) requires: doc exists, skill exists, tool exists and is executable.
+**The audit tool is a load-bearing dependency.** The registry only has value if it's validated against reality. DevEx builds the audit tool alongside the registry — no registry without an auditor. The audit tool checks: at level N, do all artifacts for levels 1-N actually exist?
 
 ### Per-Workstream Enforcement
 
 Each workstream can be at a different ladder level for each capability. Active workstreams at higher enforcement, dormant workstreams at lower.
 
 ```yaml
-# Per workstream in enforcement.yaml
 workstreams:
   iscp:
     git-commit: 5  # block — fully enforced
@@ -228,22 +243,49 @@ workstreams:
     mar: 1         # document only
 ```
 
+**Enforcement level transitions are principal decisions.** The audit tool informs, agents recommend, captain presents — but the principal decides when to tighten. DRI is the principal. No automatic transitions.
+
+### Dispatch Authority
+
+Dispatch type creation is gated by agent role at enforcement ladder level 3 (tool enforcement) from day one:
+
+| Dispatch type | Who can create |
+|---------------|---------------|
+| directive | captain only |
+| review | captain only |
+| seed | any agent |
+| review-response | artifact author (in reply to review) |
+| commit | automated (git-commit tool) |
+| main-updated | captain only (sync-all) |
+| escalation | any agent |
+| dispatch | any agent (general communication) |
+
+Enforced via: dispatch tool checks `agent-identity --agent` against the type's allowed creators.
+
 ---
 
 ## 5. Captain Architecture
 
+### Always-On
+
+Captain is always-on by design. First up, last down. If any agent is running, captain is running. Not running is a holiday — we aren't working.
+
+**V2 mechanism:** Interactive sessions. Captain runs in a terminal session whenever work is happening. Between sessions, dispatches queue in ISCP DB — no work is lost. No automation runs outside an active session.
+
+**V3 mechanism:** Headless daemon (`--bare -p`). Captain runs continuously, processes dispatches as they arrive. ClaudeCorp-ready.
+
+**The behavior is the same — the mechanism changes.**
+
 ### Two Modes
 
-**Always-on loop:**
+**Always-on loop** (V2: `/loop 5m dispatch check`):
 ```
-while true:
-  fetch origin
-  dispatch list --status unread → process each
+every 5 minutes:
+  dispatch check → process unread
   commit dispatches → merge, sync worktrees (batched)
   phase-complete dispatches → build PR, pre-PR QG, push
-  escalations → flag for principal
-  flags → triage or capture
-  sleep(cadence)
+  escalations → triage before all other work
+  flags → capture or triage
 ```
 
 **Interactive session:** Principal sits down, captain switches to conversational mode. Seeds, PVR discussions, MAR triage, strategic decisions.
@@ -254,19 +296,24 @@ On restart (after "holiday" or crash):
 1. Process all queued dispatches (ISCP DB, ordered by created_at)
 2. Sync all worktrees with main
 3. Rebuild any stale PR branches
-4. Report queue depth and any aged dispatches (>N hours old)
+4. Report queue depth and any aged dispatches (>N hours old) — surfaces the "no response" problem
 5. Resume normal loop
 
 ### Commit Processing
 
-1. Receive `commit` dispatch from agent
-2. Verify QGR receipt exists for the commit (stage-hash match)
-3. Merge commit to main (fast-forward if clean, flag if conflict)
-4. Batch: don't sync worktrees until all pending commits processed
-5. Sync all worktrees after batch complete
-6. At phase boundary: build PR branch, run pre-PR QG, push to origin
+Dispatch-on-commit is **additive** to `/phase-complete`. Defense in depth — multiple layers, each catches what the one before missed.
 
-**Question for ISCP:** Should commit dispatches carry the stage-hash so captain can verify without reading the worktree? This would enable verification before merge.
+**Iteration commits (dispatch-on-commit):**
+1. Agent commits via `/iteration-complete`
+2. `git-commit` tool auto-dispatches to captain (commit type)
+3. Commit dispatch carries structured YAML: `commit_hash`, `stage_hash`, `branch`, `phase`, `iteration`, `files_changed`
+4. Captain verifies QGR receipt (stage-hash match from dispatch — no need to read worktree)
+5. Merge commit to main (fast-forward if clean, flag if conflict)
+6. Batch: don't sync worktrees until all pending commits processed
+7. Sync all worktrees after batch complete
+
+**Phase commits (`/phase-complete`):**
+8. At phase boundary: squash merge, deep QG, build PR branch, pre-PR QG, push to origin
 
 ---
 
@@ -274,52 +321,55 @@ On restart (after "holiday" or crash):
 
 ### Gate Tiers
 
-Based on MAR feedback, gates are tiered by commit boundary type:
+Gates are tiered by commit boundary type:
 
 | Tier | Boundary | Checks | Time budget |
 |------|----------|--------|-------------|
-| T1 | Iteration commit | Format + lint on changed files + stage-hash match | <10s |
-| T2 | Phase commit | T1 + relevant unit tests (changed-file scoping) | <60s |
+| T1 | Iteration commit | Stage-hash match + build/compile + format + relevant fast tests | **<60s** |
+| T2 | Phase commit | T1 + full relevant unit tests (changed-file scoping) | <120s |
 | T3 | Phase complete | Full test suite (Docker) + MAR on phase artifacts | <5min |
 | T4 | Pre-PR | Full diff QG vs origin/main | <5min |
 
+**T1 = stage-hash + compile + format + fast tests, 60 second budget.** This is iteration complete — the agent finished a unit of work. 60s is generous for scoped tests. If tests exceed the budget, test scoping needs improvement, not skipping. Format runs on save AND at T1 (belt and suspenders — both cheap).
+
+**T1 baseline is universal:** `stage-hash match + build/compile` works for every language. Format and lint are optional per language toolchain (Swift has no standard linter, JS has eslint). Relevant unit tests included if they fit the time budget.
+
 ### Changed-File Test Scoping
 
-**Question for DevEx:** What's the right mechanism for mapping changed files to relevant tests?
+**Convention-based as default:** `claude/tools/flag` → `tests/tools/flag.bats` (path mirroring). Zero-config, covers 90% of cases.
 
-Options:
-1. **Convention-based:** `claude/tools/flag` → `tests/tools/flag.bats` (path mirroring)
-2. **Manifest:** each tool declares its test file in metadata
-3. **Tag-based:** tests tagged with the files/modules they cover
+**Package-level fallback:** For non-mirrored layouts (Swift, Rust, Go packages): "anything in `apps/mdpal/Sources/` changed → run tests in `apps/mdpal/`." This handles projects where test paths don't mirror source paths.
 
-Recommend option 1 (convention) with option 2 (manifest) as fallback for non-obvious mappings.
+**Manifest as override:** For edge cases where convention and package-level don't map, a tool can declare its test file in metadata.
 
 ### Stage-Hash Delta Tolerance
 
-ISCP raised: what if you amend a typo after running QG? The hash changes. Full re-run for a comment?
+If the delta between QGR hash and current staged hash is a **single markdown file** → allow with warning. Any other change → re-run QG. Simpler and less ambiguous than "non-code files changed" (is `package.json` code?).
 
-Design: if the delta between QGR hash and current staged hash is below a threshold, allow with warning. Threshold: only non-code files changed (markdown, comments, whitespace). Any code change = re-run.
-
-**Question for DevEx:** Can you implement a "semantic diff" that distinguishes code changes from non-code changes in the stage-hash comparison?
-
-### Test Hermiticity (NFR9 from DevEx MAR)
+### Test Hermiticity
 
 All tests run in isolation. No test may modify:
-- `.git/config`
+- `.git/config` (live repo config)
 - Live databases (`~/.agency/*/iscp.db`)
-- Working directory outside temp space
+- Working directory outside allocated temp space
 
 Enforced via:
-- `ISCP_DB_PATH` override (existing)
-- `GIT_CONFIG_GLOBAL=/dev/null` (existing)
+- `ISCP_DB_PATH` override (existing, ISCP efa00d6)
+- `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_SYSTEM=/dev/null` (existing)
 - Teardown guard: hash `.git/config` before/after, fail if changed (existing)
-- Docker runner for full-suite (existing, needs extension to all 32 files)
+- Docker runner for full-suite (existing, needs extension to all test files)
 
 ---
 
 ## 7. Context Resilience Architecture
 
-### Multi-Part Handoff
+### Three Handoff Classes
+
+1. **Session handoff** — between sessions. Current state, next action, working set. Written on SessionEnd, PreCompact, at boundary commands.
+2. **Agent bootstrap handoff** — captain creates a new agent on a workstream. Everything the agent needs to start working: identity, role, seeds, first action.
+3. **Agent project bootstrap handoff** — captain assigns a project to an existing agent. A "sit rep": everything they need to succeed. Links to transcripts, documents, and relevant context.
+
+### Multi-Part Handoff Structure
 
 Handoff files structured in sections for selective re-injection:
 
@@ -353,96 +403,98 @@ Implement timeout with graceful degradation in commit-precheck
 ## Working Set
 - claude/tools/commit-precheck (rewriting)
 - tests/tools/commit-precheck.bats (new)
-- claude/config/test-manifest.yaml (new, if manifest approach)
 ```
+
+Multi-part is the **ceiling**, not the floor. Simple bootstraps work with a single file. Complex agents use full structure.
 
 ### PostCompact Hook
 
-On compaction, re-inject the handoff as a system message:
+**CLAUDE.md survives compaction** — it's system-level context that Claude Code preserves. PostCompact only needs to inject **session-specific context** that was compressed.
 
-```javascript
-// .claude/hooks/post-compact.js
+PostCompact hook re-injects the handoff as a system message:
+
+```json
 {
   "event": "PostCompact",
-  "command": "cat usr/{principal}/{project}/{agent}-handoff.md",
-  "output": "systemMessage"
+  "command": "cat usr/{principal}/{project}/{agent}-handoff.md"
 }
 ```
 
-Minimal injection: Identity + Current State + Next Action. Full injection if context budget allows.
+**Injection scope:** Handoff only. CLAUDE.md is already present. Keep handoffs tight, CLAUDE.md light. The decomposition of CLAUDE-THEAGENCY.md into composable chunks (§9) saves context budget for handoff injection and actual work. Every token saved in CLAUDE.md is a token available for conversation.
+
+### Intra-Session Handoffs
+
+Handoffs are not just for session boundaries — they're **insurance checkpoints** within a session. Written at boundary commands, at `/sync-all`, at discussion milestones. If compaction or crash occurs, the most recent checkpoint provides recovery. The better the handoff, the less context loss matters.
 
 ### Stage-Aware Resume
 
 On session start or post-compaction, agent verifies:
 1. Read handoff → know identity, stage, next action
-2. `dispatch list` → process unread items
+2. `dispatch check` → process unread items
 3. Verify current stage artifacts exist and are consistent
 4. Resume from Next Action
+
+### Transcript Injection
+
+Pull last N transcripts of relevant work into new sessions. Enables more frequent compaction without losing context. Session transcripts stored in git; index stored outside git (avoid conflicts). Agent-written summaries now; Anthropic API could automate later.
 
 ---
 
 ## 8. Dispatch Payload Architecture
 
-### Current Problem
+### Symlink Design (Principal Decision)
 
-Dispatch payloads in git cause three classes of bugs:
-1. Branch transparency — payloads on one branch invisible to others
-2. Template confusion — `dispatch create` writes templates agents don't edit
-3. Path derivation — payload path derived from branch name, breaks on PR branches
-
-### Proposed Design: Payloads Alongside DB
-
-Move dispatch payloads from git to `~/.agency/{repo}/dispatches/`:
+Dispatch payloads stay in git (C3 — source of truth, auditable). Branch-transparent access via symlinks in `~/.agency/{repo}/dispatches/`:
 
 ```
 ~/.agency/the-agency/
   iscp.db                    — notification DB (existing)
-  dispatches/                — payload files (NEW)
-    dispatch-001.md
-    dispatch-002.md
-    ...
+  dispatches/                — symlinks to git artifacts (NEW)
+    dispatch-001.md → /Users/jdm/code/the-agency/claude/workstreams/agency/valueflow-pvr-20260406.md
+    dispatch-002.md → /Users/jdm/code/the-agency/.claude/worktrees/devex/usr/jordan/devex/some-artifact.md
 ```
 
-**Advantages:**
-- Branch-transparent by default (no git branch issues)
-- No template confusion (tool writes content directly)
-- No path derivation bugs (ID-based naming, not branch-based)
-- Mutable (can be updated, unlike git-immutable payloads)
-- Consistent with DB — both are operational state, not source artifacts
+**How it works:**
+- Artifacts stay in git on their branch/worktree (C3 holds)
+- `~/.agency/{repo}/dispatches/` contains symlinks to the filesystem path
+- OS resolves symlinks — no git commands needed to read
+- Works for main checkout AND worktrees (both are real directories on disk)
+- Dangling symlinks = worktree deleted or artifact moved. Detectable: `readlink -e` returns error. Dispatch read warns with actionable message.
 
-**Disadvantages:**
-- Not in git — no version history, no audit trail in commits
-- Not visible in PRs
-- Backup responsibility shifts to filesystem
+**Dispatch tool changes:**
+1. On `dispatch create`: write payload to correct git location, create symlink in `~/.agency/{repo}/dispatches/`
+2. On `dispatch read`: follow symlink. If dangling, warn and fall back to legacy 4-strategy resolution
+3. DB `payload_path` stores the symlink name
 
-**Mitigation:** Important dispatches (directives, reviews, seeds) get committed to git as well — the dispatch tool writes to both locations. The `~/.agency/` copy is the primary read path; the git copy is the audit trail.
+**Local vs cross-repo distinction:** Local dispatches use DB + symlinks. Cross-repo dispatches are git-only via collaboration repos (different mechanism, same addressing).
 
-**Question for ISCP:** Is this the right direction? Can you design the migration path — both the schema change (payload_path points to `~/.agency/` instead of git) and the backward compatibility (read from both locations during transition)?
+**Implementation status:** ISCP implemented in commit 1e610fd (dispatch #74). 173 tests passing. Merge pending.
 
-### Dispatch Authority
+### DB Schema Versioning
 
-Based on ISCP MAR feedback, dispatch type creation is gated by agent role:
+Version column in ISCP DB, checked on every init. Migration tool handles version transitions. Prevents version skew when agents share the DB.
 
-| Dispatch type | Who can create |
-|---------------|---------------|
-| directive | captain only |
-| review | captain only |
-| seed | any agent |
-| review-response | artifact author (in reply to review) |
-| commit | automated (git-commit tool) |
-| main-updated | captain only (sync-all) |
-| escalation | any agent |
-| dispatch | any agent (general communication) |
+### Dispatch Retention
 
-Enforced via: dispatch tool checks `agent-identity --agent` against the type's allowed creators. Hookify block on unauthorized dispatch types.
+Archive resolved dispatches after 30 days. Clean up symlinks when payloads are archived. Prevents unbounded DB and filesystem growth.
+
+### Dispatch Create
+
+`dispatch create` requires `--body` (content) or `--template` (explicit opt-in). No content = no dispatch = fail loud. Template mode is opt-in, not default. Implemented in ISCP commit 85d874d.
 
 ---
 
 ## 9. CLAUDE-THEAGENCY.md Decomposition
 
+### Three-Level Hierarchy
+
+1. **CLAUDE-THEAGENCY.md** — methodology (imports composable docs)
+2. **CLAUDE-{WORKSTREAM}.md** — workstream scope, conventions, boundaries
+3. **CLAUDE-{APP/SERVICE}.md** — application/service-specific instructions (V3: autonomous generation)
+
 ### Taxonomy: By Concern
 
-Decompose into focused documents, each `@`-importable:
+Decompose CLAUDE-THEAGENCY.md into focused documents, each `@`-importable:
 
 | Document | Content | Imported by |
 |----------|---------|------------|
@@ -452,16 +504,20 @@ Decompose into focused documents, each `@`-importable:
 | `claude/docs/GIT-DISCIPLINE.md` | Commit workflow, captain merge, PR lifecycle | git-commit skill, captain |
 | `claude/docs/ISCP-PROTOCOL.md` | Dispatch, flag, addressing, hook integration | ISCP skills, all agents |
 | `claude/docs/ENFORCEMENT-LADDER.md` | The 5-stage ladder, registry, per-workstream levels | Enforcement skills, DevEx |
-| `claude/docs/CONTEXT-RESILIENCE.md` | Handoffs, PostCompact, stage-aware resume | All agents |
+| `claude/docs/CONTEXT-RESILIENCE.md` | Handoffs, PostCompact, stage-aware resume, transcripts | All agents |
 | `claude/docs/CONTINUAL-LEARNING.md` | Transcript mining, flag categories, telemetry, improvement loop | Captain, DevEx |
 
 CLAUDE-THEAGENCY.md becomes a thin wrapper that `@` imports all of the above. Skills import only what they need.
 
 ### Context Budget
 
-Each document stays under 2000 tokens. If it exceeds that, split further. The goal: a skill never injects more than 4000 tokens of methodology docs (the skill's own instructions + the relevant `@` import).
+Budget per **skill injection** (4000 tokens total), not per document. A doc can be 3000 tokens if the skill adds only 1000 tokens of its own instructions. The goal: no skill exceeds 4000 tokens of methodology + instructions.
 
-**Question for DevEx:** Can you build a context budget linter that measures the token count of each `@` import chain and warns when a skill exceeds the budget?
+**Context budget linter is a V2 deliverable** — ships alongside the decomposition. Measures `@` import chain token counts. Warns when a skill exceeds budget. DevEx builds this.
+
+### Fragment Registry (V3)
+
+Machine-readable manifest tracking all CLAUDE.md fragments: locations, import chains, token counts. Enables autonomous fragment generation and import chain validation. V3 — requires tooling maturity.
 
 ---
 
@@ -469,10 +525,12 @@ Each document stays under 2000 tokens. If it exceeds that, split further. The go
 
 ### Three Input Channels
 
-**1. Flag mechanism** — categorized quick-capture:
-- `flag --friction "description"` → friction pipeline
-- `flag --idea "description"` → seed pipeline  
-- `flag --bug "description"` → fix pipeline
+**1. Flag mechanism** — categorized quick-capture at the moment of observation:
+- `flag --friction "description"` → friction pipeline (improvement candidates)
+- `flag --idea "description"` → seed pipeline (new work candidates)
+- `flag --bug "description"` → fix pipeline (immediate action)
+
+Categories at capture, not at triage. `--friction` costs one word and routes instantly. Deferring categorization to triage leaves an undifferentiated pile. Capture IS routing.
 
 Flags are triaged via `/flag-triage` skill (three-bucket: resolved, autonomous, collaborative).
 
@@ -480,12 +538,13 @@ Flags are triaged via `/flag-triage` skill (three-bucket: resolved, autonomous, 
 - Session transcripts at `usr/{principal}/{project}/transcripts/`
 - Granola transcripts (summary + raw) at same location
 - Mining tool extracts: decisions, friction points, recurring patterns, tool usage
+- **Token budget per mining run** — limit scope, prioritize recent sessions (last N days)
 - Output: seeds for improvement
 
 **3. Telemetry** — `_log-helper` data + ISCP timestamps:
 - Tool invocation counts and durations
 - Dispatch lead times (created → read → resolved)
-- Flag accumulation rates
+- Flag accumulation rates by category
 - Permission prompt frequency (target: zero for safe ops)
 - Context window consumption per skill
 
@@ -502,6 +561,10 @@ Observe (flags, transcripts, telemetry)
 
 The methodology improves itself through itself.
 
+### Day Counting
+
+Measure working days per repo and per workstream. Day N = Nth day with commits. "Day 12 of valueflow for mdpal" = 12 days of active work. Compare to calendar days for velocity signal. Proposed as Agency model convention.
+
 ---
 
 ## 11. Error Recovery
@@ -510,16 +573,18 @@ The methodology improves itself through itself.
 
 | Failure | Response |
 |---------|----------|
-| QG fails repeatedly on same code | Agent flags for principal escalation after 3 attempts. Circuit breaker: principal can override with reasoning (audited). |
+| QG fails repeatedly | **Time-based circuit breaker:** if no progress in N hours (configurable per workstream, default 5 iterations worth of time), agent self-reports: stuck vs making distinct progress. If stuck, escalate to principal. Principal can override with reasoning (audited). |
 | MAR produces irreconcilable disagreements | Author presents all positions to principal. Principal decides. Decision recorded in MAR report. |
-| Agent stuck in implementation loop | Captain monitors commit frequency. If no commit in N iterations, dispatch escalation to agent + flag to principal. |
-| Dispatch sent to non-existent agent | Dispatch tool fails loud with actionable error. DB record created with status "undeliverable." Captain notified. |
-| Context lost after compaction | PostCompact hook re-injects handoff. Agent runs stage-aware resume. If handoff is stale/missing, agent flags and waits. |
+| Agent stuck in implementation loop | Captain monitors commit frequency. If no commit in expected timeframe, dispatch escalation to agent + flag to principal. |
+| Dispatch sent to non-existent agent | Dispatch tool fails loud with actionable error. Try to resolve — agent may not be registered yet but worktree may exist. DB record created with status "undeliverable." Captain notified. |
+| Context lost after compaction | PostCompact hook re-injects handoff. Agent runs stage-aware resume. If handoff is stale/missing, agent flags and waits for principal. |
 | Phase not converging | Principal can invoke circuit breaker: kill the phase, pivot, or re-scope. Audited decision. No autonomous kill — principal judgment required. |
+| Cross-workstream RFI no response | 24-hour timeout. Proceed with available input. Flag missing responders for information. |
+| Captain down (crash or session end) | Dispatches queue in ISCP DB. On restart: catch-up protocol (§5). No work lost. |
 
 ### Escalation Protocol
 
-Agents escalate via `flag --escalation "description"` or `dispatch create --type escalation`. Captain triages escalations before all other work. Principal is notified via MDPal tray (V2) or direct terminal message.
+Agents escalate via `flag --escalation "description"` or `dispatch create --type escalation`. Captain triages escalations before all other work. Principal is notified via MDPal tray or direct terminal message.
 
 ---
 
@@ -527,21 +592,26 @@ Agents escalate via `flag --escalation "description"` or `dispatch create --type
 
 ### V2 Delivers
 
-- Flow stages documented in CLAUDE-THEAGENCY.md (decomposed)
+- Flow stages documented in CLAUDE-THEAGENCY.md (decomposed by concern)
 - Three-bucket protocol documented and enforced via MAR skill
-- MARFI as subagents (within-session)
-- MAR via dispatches (cross-session) + subagents (within-session)
-- Enforcement ladder with registry
-- Captain always-on loop (within session, `/loop` based)
-- Quality gate tiers (T1-T4) with changed-file scoping
-- Multi-part handoffs + PostCompact hook
-- Flag categories (--friction, --idea, --bug)
-- Health metrics from ISCP timestamps
-- Dispatch authority enforcement
+- MARFI as subagents (within-session), output persisted to seeds/ for durability
+- MAR via dispatches (cross-session) + subagents (within-session), 24h timeout
+- Enforcement ladder with registry + audit tool
+- Captain always-on (session-based), `/loop 5m dispatch check`
+- Quality gate tiers (T1-T4) with changed-file scoping, T1 at 60s budget
+- Multi-part handoffs + PostCompact hook (handoff only, CLAUDE.md survives)
+- Three handoff classes (session, agent bootstrap, project bootstrap)
+- Flag categories (`--friction`, `--idea`, `--bug`)
+- Health metrics from ISCP timestamps (lead time, principal intervention frequency)
+- Dispatch authority enforcement at ladder level 3
+- Dispatch payload symlinks (implemented, merge pending)
+- `dispatch create` requires `--body` (implemented)
 - `effort:` levels on all skills
 - `WorktreeCreate` hook for auto-registration
 - Conditional `if:` on hooks for efficiency
 - `PermissionDenied` hook for safe-command retry
+- Context budget linter (ships with decomposition)
+- Day counting convention
 
 ### V3 Extends
 
@@ -553,19 +623,28 @@ Agents escalate via `flag --escalation "description"` or `dispatch create --type
 - `--session-id` deterministic sessions
 - Cross-repo agent access for MARFI
 - Value → Seed feedback loop
-- Dispatch payloads outside git (if design validated)
+- CLAUDE.md fragment registry + autonomous generation
+- Event-driven captain (vs fixed-interval polling)
+- Transcript injection via Anthropic API
 
 ---
 
-## Open A&D Questions
+## Resolved Questions (from MAR Round 1)
 
-These are carried forward for resolution during implementation planning:
+All embedded questions resolved:
 
-1. **MAR dispatch structure** — schema-validated or free-form? (Question for ISCP)
-2. **Changed-file test mapping** — convention, manifest, or tags? (Question for DevEx)
-3. **Stage-hash semantic diff** — code vs non-code delta tolerance (Question for DevEx)
-4. **Context budget linter** — measure `@` import chain token counts (Question for DevEx)
-5. **Dispatch payload migration** — payloads alongside DB feasibility (Question for ISCP)
-6. **Enforcement registry format** — YAML manifest, validated by audit tool (Question for DevEx)
-7. **Captain loop cadence** — fixed interval or event-driven? (Implementation decision)
-8. **Compaction strategy** — when to trigger, what PreCompact captures (Implementation decision)
+| Question | Resolution | Source |
+|----------|-----------|--------|
+| MAR triage schema | Free-form V2 with YAML frontmatter. Structured schema V3. | ISCP |
+| MARFI: dispatches or subagents | Subagents V2, dispatches V3. Write to seeds/ for durability. | ISCP |
+| Commit dispatch carry stage-hash | Yes. Structured YAML frontmatter. | ISCP |
+| Dispatch payload architecture | Symlinks to git artifacts. Implemented. | Principal decision + ISCP |
+| Changed-file test mapping | Convention-based default, package-level fallback, manifest override. | monofolk + mdpal-cli |
+| Stage-hash semantic diff | Single markdown file → allow with warning. Any other change → re-run. | ISCP |
+| Context budget linter | V2 deliverable. DevEx builds. Warn at 4000 tokens per skill. | monofolk |
+| Enforcement registry | YAML manifest + audit tool. No registry without auditor. | monofolk |
+| Captain loop cadence | Fixed interval V2 (`/loop 5m dispatch check`). Event-driven V3. | monofolk + mdpal-cli |
+| Compaction strategy | Claude Code controls timing (~80% used). We control recovery via handoffs + PostCompact. | Principal |
+| PostCompact injection scope | Handoff only. CLAUDE.md survives compaction. | Principal |
+| Enforcement transitions | Principal decides. DRI is the principal. | Principal |
+| Effort levels | Anthropic's abstraction over token budget. We set the dial per skill. | Principal |

--- a/claude/workstreams/agency/valueflow-ad-20260406.md
+++ b/claude/workstreams/agency/valueflow-ad-20260406.md
@@ -3,10 +3,11 @@ type: ad
 project: valueflow
 workstream: agency
 date: 2026-04-06
-status: revised — MAR round 1 incorporated, pending round 2
+status: revised — MAR rounds 1+2 (research) incorporated, agent round 2 pending
 author: the-agency/jordan/captain
 pvr: claude/workstreams/agency/valueflow-pvr-20260406.md
 mar-round-1: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md
+mar-round-2-research: 4 subagents (methodology-critic, practitioner, adopter-advocate, lean-analyst)
 ---
 
 # Valueflow — Architecture & Design
@@ -40,16 +41,15 @@ Stage {
 
 | Stage | Inputs | Outputs | Gate | Autonomy |
 |-------|--------|---------|------|----------|
-| Seed | Gleam (observation, transcript, flag) | Seed document | None — capture is frictionless | Principal-driven |
-| Research (MARFI) | Seed + research questions (principal-reviewed) | MARFI brief | Principal reviews questions before agents spin up | Collaborative |
-| Define | Seed + MARFI brief | PVR | MAR + principal sign-off | Collaborative |
+| Seed | Gleam — a thought, observation, transcript, flag; as little as a gleam in someone's eye | Seed document | None — capture is frictionless | Principal-driven |
+| Define | Seed + MARFI brief (if research conducted) | PVR | MAR + principal sign-off | Collaborative |
 | Design | PVR + MARFI (technical approach) | A&D | MAR + principal sign-off | Collaborative |
 | Plan | PVR + A&D + MAP input (if cross-cutting) | Master plan + phase plans | MAR (autonomous for phase plans unless flagged) | Autonomous (phases) |
 | Implement | Phase plan | Code + QGRs + commits | QG per iteration, QG per phase | Autonomous |
 | Ship | Commits + QGRs | PRs merged to origin | Pre-PR QG | Captain-managed |
-| Value | Shipped product | Customer feedback → new seeds (V3) | Customer adoption | — |
+| Value | Shipped product | Customer feedback → new seeds | Customer adoption | V3 — feedback loop not in V2 scope |
 
-**MARFI can trigger at any stage** — not just at the beginning. Mid-flow research is valid: during A&D when a technical question arises, during planning when a dependency is discovered. The driving agent decides when research input is needed.
+**MARFI is a sub-protocol, not a stage.** It can trigger at any stage — not just at the beginning. Mid-flow research is valid: during A&D when a technical question arises, during planning when a dependency is discovered. The driving agent decides when research input is needed.
 
 ### Artifact Types
 
@@ -94,7 +94,7 @@ When an agent receives feedback (from MAR, QG, or any review):
 
 1. **Collect** — receive raw findings from all reviewers
 2. **Triage** — author categorizes each finding:
-   - **Disagree** — finding rejected with reasoning
+   - **Disagree** — finding rejected with reasoning. Reject when: the finding is based on incorrect premises, conflicts with a principal decision, is superseded by other work, or proposes a change that would violate a constraint. Always state the reasoning.
    - **Autonomous** — finding accepted, author incorporates independently
    - **Collaborative** — finding requires principal input
 3. **Present** — for scope-definition artifacts, author presents full triage to principal:
@@ -129,6 +129,14 @@ Body contains three tables (disagree, autonomous, collaborative) with finding ID
 
 ## 3. Multi-Agent Groups
 
+### Overview
+
+| Group | Purpose | When | V2 Mechanism |
+|-------|---------|------|-------------|
+| **MARFI** | Research input — cross-cutting questions answerable with web search + docs | Before any artifact authoring, or mid-flow when research question arises | Subagents (ephemeral, sonnet) |
+| **MAR** | Review of artifacts — many eyes, all bugs are shallow | After every artifact, always, never skipped | Subagents (research) + dispatches (agents) |
+| **MAP** | Planning input from multiple workstreams | Cross-cutting complex projects only | Captain dispatches RFI to relevant agents |
+
 ### MARFI (Multi-Agent Request for Information)
 
 **Purpose:** Research input before authoring an artifact.
@@ -152,7 +160,7 @@ Body contains three tables (disagree, autonomous, collaborative) with finding ID
 
 **Purpose:** Review of artifacts at every transition with three-bucket disposition.
 
-**When:** After every artifact (PVR, A&D, Plan, QGR at phase boundary). Always. MAR is never skipped.
+**When:** After every artifact (PVR, A&D, Plan, QGR at phase boundary). Always. MAR is never skipped — it is the equivalent of pair programming. Many eyes, all bugs are shallow (Linus's Law). With AI agents, the cost of review is seconds, not hours. There is no reason not to review everything. Captain scales the reviewer group to match artifact significance — a trivial revision gets 1-2 subagents (seconds), a major artifact gets the full research + agent review.
 
 **Protocol:**
 1. Author declares artifact ready for review
@@ -160,7 +168,7 @@ Body contains three tables (disagree, autonomous, collaborative) with finding ID
 3. **Review dispatch includes reviewer focus:** "Review from perspective of: {focus area}" — tells the reviewer what angle to evaluate from
 4. Review instructions (in every MAR dispatch): "Give raw findings — concerns, gaps, questions, what works. Do NOT sort into buckets. The author triages — not you."
 5. Reviewers respond via dispatch (review-response type)
-6. **24-hour timeout:** if a reviewer hasn't responded in 24 hours, auto-proceed with available reviews. Flag missing reviewers for information. Do not block indefinitely on dormant agents.
+6. **Timeouts:** Subagent reviewers (within-session): complete in seconds to minutes — if a subagent errors, proceed without it. Dispatched agent reviewers (cross-session): 24-hour timeout, auto-proceed with available reviews. Flag missing reviewers. Do not block indefinitely on dormant agents.
 7. Author collects all findings, triages into three buckets
 8. For scope-definition artifacts: present full triage to principal. For autonomous stages: triage and act, inform principal via dispatch.
 9. Revise, re-review if needed. MAR disposition is versioned — paired to the artifact version it reviewed.
@@ -303,7 +311,7 @@ On restart (after "holiday" or crash):
 
 Dispatch-on-commit is **additive** to `/phase-complete`. Defense in depth — multiple layers, each catches what the one before missed.
 
-**Iteration commits (dispatch-on-commit):**
+**Iteration commits (dispatch-on-commit) — coordination path:**
 1. Agent commits via `/iteration-complete`
 2. `git-commit` tool auto-dispatches to captain (commit type)
 3. Commit dispatch carries structured YAML: `commit_hash`, `stage_hash`, `branch`, `phase`, `iteration`, `files_changed`
@@ -312,8 +320,13 @@ Dispatch-on-commit is **additive** to `/phase-complete`. Defense in depth — mu
 6. Batch: don't sync worktrees until all pending commits processed
 7. Sync all worktrees after batch complete
 
-**Phase commits (`/phase-complete`):**
-8. At phase boundary: squash merge, deep QG, build PR branch, pre-PR QG, push to origin
+**Phase commits (`/phase-complete`) — quality + shipping path (separate mechanism):**
+1. Agent completes phase via `/phase-complete`
+2. Deep QG (T3) — full test suite, MAR on phase artifacts
+3. Squash merge to main
+4. Build PR branch, pre-PR QG (T4), push to origin
+
+These are two different mechanisms at two different boundaries serving different purposes. Dispatch-on-commit is coordination (captain knows, merges, syncs). Phase-complete is quality and shipping (deep gate, PR, origin). Both verify stage-hash, but for different reasons at different scopes.
 
 ---
 
@@ -344,7 +357,7 @@ Gates are tiered by commit boundary type:
 
 ### Stage-Hash Delta Tolerance
 
-If the delta between QGR hash and current staged hash is a **single markdown file** → allow with warning. Any other change → re-run QG. Simpler and less ambiguous than "non-code files changed" (is `package.json` code?).
+If the delta between QGR hash and current staged hash is **exclusively markdown files** (all changed files are `.md`) → allow with warning. Any non-markdown file in the delta → re-run QG. If the commit contains both a markdown change and a code change, re-run. Simpler and less ambiguous than "non-code files changed" (is `package.json` code? Yes — re-run).
 
 ### Test Hermiticity
 
@@ -358,6 +371,7 @@ Enforced via:
 - `GIT_CONFIG_GLOBAL=/dev/null` + `GIT_CONFIG_SYSTEM=/dev/null` (existing)
 - Teardown guard: hash `.git/config` before/after, fail if changed (existing)
 - Docker runner for full-suite (existing, needs extension to all test files)
+- **T3 Docker fallback:** if Docker is not running, T3 falls back to in-process test execution with full isolation helpers. Warn that Docker is preferred. Do not block or skip — degraded is better than absent.
 
 ---
 
@@ -366,7 +380,7 @@ Enforced via:
 ### Three Handoff Classes
 
 1. **Session handoff** — between sessions. Current state, next action, working set. Written on SessionEnd, PreCompact, at boundary commands.
-2. **Agent bootstrap handoff** — captain creates a new agent on a workstream. Everything the agent needs to start working: identity, role, seeds, first action.
+2. **Agent bootstrap handoff** — triggered when captain creates a new agent on a workstream (via `/workstream-create` or `/worktree-create`). V2: `WorktreeCreate` hook (Claude Code feature, detailed in PVR MARFI) auto-triggers bootstrap. Everything the agent needs to start working: identity, role, seeds, first action.
 3. **Agent project bootstrap handoff** — captain assigns a project to an existing agent. A "sit rep": everything they need to succeed. Links to transcripts, documents, and relevant context.
 
 ### Multi-Part Handoff Structure
@@ -509,11 +523,13 @@ Decompose CLAUDE-THEAGENCY.md into focused documents, each `@`-importable:
 
 CLAUDE-THEAGENCY.md becomes a thin wrapper that `@` imports all of the above. Skills import only what they need.
 
+**Minimum viable adoption (start here):** Flow stages (§1) + three-bucket protocol (§2) + MAR at level 1 (docs only, manual review) + session handoffs. No tooling required. Read the docs, follow the conventions manually. This is enforcement ladder step 1 — everything else builds from here.
+
 ### Context Budget
 
 Budget per **skill injection** (4000 tokens total), not per document. A doc can be 3000 tokens if the skill adds only 1000 tokens of its own instructions. The goal: no skill exceeds 4000 tokens of methodology + instructions.
 
-**Context budget linter is a V2 deliverable** — ships alongside the decomposition. Measures `@` import chain token counts. Warns when a skill exceeds budget. DevEx builds this.
+**Context budget linter is a V2 deliverable** — ships alongside the decomposition. Measures `@` import chain token counts. Warns when a skill exceeds budget. DevEx builds this. **Risk:** if the linter slips, the decomposition loses its enforcement mechanism. Linter and decomposition must ship together or neither ships.
 
 ### Fragment Registry (V3)
 

--- a/usr/jordan/captain/dispatches/directive-overdue-mdpal-cli-deliver-valueflow-a-d-review-20260406-1618.md
+++ b/usr/jordan/captain/dispatches/directive-overdue-mdpal-cli-deliver-valueflow-a-d-review-20260406-1618.md
@@ -1,0 +1,14 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-06T08:18
+status: created
+priority: high
+subject: "OVERDUE: mdpal-cli deliver Valueflow A&D review"
+in_reply_to: null
+---
+
+# OVERDUE: mdpal-cli deliver Valueflow A&D review
+
+Your A&D review is overdue. Three other agents have already delivered (mdpal-app, ISCP, monofolk). Read claude/workstreams/agency/valueflow-ad-20260406.md and give raw findings. Merge main first. Focus on: does this design work for a tech-lead building a product? Are gate tiers realistic? Does the handoff structure match your experience? Deliver now.

--- a/usr/jordan/captain/dispatches/directive-overdue-valueflow-a-d-review-deliver-now-20260406-1618.md
+++ b/usr/jordan/captain/dispatches/directive-overdue-valueflow-a-d-review-deliver-now-20260406-1618.md
@@ -1,0 +1,14 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-06T08:18
+status: created
+priority: high
+subject: "OVERDUE: Valueflow A&D review — deliver now"
+in_reply_to: null
+---
+
+# OVERDUE: Valueflow A&D review — deliver now
+
+Your A&D review is overdue. Three other agents have already delivered (mdpal-app, ISCP, monofolk). Read claude/workstreams/agency/valueflow-ad-20260406.md and give raw findings. Merge main first. Focus on: does this design work for a tech-lead building a product? Are gate tiers realistic? Does the handoff structure match your experience? Deliver now.

--- a/usr/jordan/captain/dispatches/dispatch-mar-a-d-resolved-mdpal-app-findings-dispositioned-20260406-1640.md
+++ b/usr/jordan/captain/dispatches/dispatch-mar-a-d-resolved-mdpal-app-findings-dispositioned-20260406-1640.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-04-06T08:40
+status: created
+priority: normal
+subject: "MAR A&D resolved — mdpal-app findings dispositioned"
+in_reply_to: null
+---
+
+# MAR A&D resolved — mdpal-app findings dispositioned
+
+MAR A&D round 1 complete. All 8 collaborative items resolved with principal. Your findings: A1-A5 all incorporated. C1 (T1 gate scope) — resolved: stage-hash + compile + format + fast tests, 60s budget. Full disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md. Session transcript: usr/jordan/captain/transcripts/session20-continued-20260406-0730.md

--- a/usr/jordan/captain/dispatches/dispatch-mar-a-d-resolved-mdpal-cli-findings-dispositioned-20260406-1640.md
+++ b/usr/jordan/captain/dispatches/dispatch-mar-a-d-resolved-mdpal-cli-findings-dispositioned-20260406-1640.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-06T08:40
+status: created
+priority: normal
+subject: "MAR A&D resolved — mdpal-cli findings dispositioned"
+in_reply_to: null
+---
+
+# MAR A&D resolved — mdpal-cli findings dispositioned
+
+MAR A&D round 1 complete. All 8 collaborative items resolved with principal. Your findings: D2 (payload migration) — disagree, superseded by symlink design. A21-A26 all incorporated (generalized T1, package-level test fallback, MARFI decision rule, time-based circuit breaker, context linter V2 deliverable, close OQ7). C4 (captain scope) — resolved: always-on by design, first up last down, V2=sessions V3=daemon. C5 (effort levels) — Anthropic's abstraction, set dial per skill. Full disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md. Session transcript: usr/jordan/captain/transcripts/session20-continued-20260406-0730.md

--- a/usr/jordan/captain/dispatches/dispatch-mar-a-d-round-1-resolved-your-findings-disposition-20260406-1640.md
+++ b/usr/jordan/captain/dispatches/dispatch-mar-a-d-round-1-resolved-your-findings-disposition-20260406-1640.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-04-06T08:40
+status: created
+priority: normal
+subject: "MAR A&D round 1 resolved — your findings dispositioned"
+in_reply_to: null
+---
+
+# MAR A&D round 1 resolved — your findings dispositioned
+
+MAR A&D round 1 complete. All 8 collaborative items resolved with principal. Your findings: A1-A5 all incorporated. C1 (T1 gate scope) — resolved: stage-hash + compile + format + fast tests, 60s budget. Full disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md. Session transcript: usr/jordan/captain/transcripts/session20-continued-20260406-0730.md

--- a/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-20260406-1652.md
+++ b/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-20260406-1652.md
@@ -1,0 +1,14 @@
+---
+type: review
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-06T08:52
+status: created
+priority: normal
+subject: "MAR Round 2: Revised Valueflow A&D"
+in_reply_to: null
+---
+
+# MAR Round 2: Revised Valueflow A&D
+
+Revised A&D at claude/workstreams/agency/valueflow-ad-20260406.md. Your round 1 findings incorporated. Symlink design confirmed. All embedded questions resolved. Give raw findings on the revision — what's improved, what's still missing, new concerns. MAR disposition for round 1: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md

--- a/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-mdpal-app-20260406-1652.md
+++ b/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-mdpal-app-20260406-1652.md
@@ -1,0 +1,14 @@
+---
+type: review
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-04-06T08:52
+status: created
+priority: normal
+subject: "MAR Round 2: Revised Valueflow A&D — mdpal-app"
+in_reply_to: null
+---
+
+# MAR Round 2: Revised Valueflow A&D — mdpal-app
+
+Revised A&D at claude/workstreams/agency/valueflow-ad-20260406.md. Your round 1 findings incorporated: RFI timeout, reviewer focus in dispatches, 4000-token budget per skill, triage format structured. Give raw findings on the revision. MAR disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md

--- a/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-mdpal-cli-20260406-1652.md
+++ b/usr/jordan/captain/dispatches/review-mar-round-2-revised-valueflow-a-d-mdpal-cli-20260406-1652.md
@@ -1,0 +1,14 @@
+---
+type: review
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-06T08:52
+status: created
+priority: normal
+subject: "MAR Round 2: Revised Valueflow A&D — mdpal-cli"
+in_reply_to: null
+---
+
+# MAR Round 2: Revised Valueflow A&D — mdpal-cli
+
+Revised A&D at claude/workstreams/agency/valueflow-ad-20260406.md. Your round 1 findings incorporated: generalized T1, package-level test fallback, MARFI decision rule, time-based circuit breaker. Give raw findings on the revision. MAR disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md

--- a/usr/jordan/captain/dispatches/review-mar-round-2-valueflow-a-d-devex-this-is-your-revie-20260406-1652.md
+++ b/usr/jordan/captain/dispatches/review-mar-round-2-valueflow-a-d-devex-this-is-your-revie-20260406-1652.md
@@ -1,0 +1,14 @@
+---
+type: review
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-06T08:52
+status: created
+priority: high
+subject: "MAR Round 2: Valueflow A&D — DevEx, this is your review"
+in_reply_to: null
+---
+
+# MAR Round 2: Valueflow A&D — DevEx, this is your review
+
+Revised A&D at claude/workstreams/agency/valueflow-ad-20260406.md. You missed round 1 entirely. This is your review. Give raw findings. DevEx-relevant sections: §4 enforcement ladder, §6 quality gate tiers (T1 now 60s with fast tests), §9 context budget linter (V2 deliverable for you), §10 continual learning. MAR disposition: claude/workstreams/agency/reviews/mar-valueflow-ad-round1-20260406.md

--- a/usr/jordan/captain/transcripts/handoffs-evolution-20260406-0730.md
+++ b/usr/jordan/captain/transcripts/handoffs-evolution-20260406-0730.md
@@ -1,0 +1,22 @@
+---
+type: transcript
+date: 2026-04-06T07:30
+source: granola
+topic: handoffs strategy and agent bootstrap workflow
+---
+
+## Summary
+
+Three distinct handoff types going forward:
+
+1. **Session handoff** — between sessions (existing mechanism)
+2. **Agent bootstrap handoff** — captain creates a new agent on a workstream; handoff bootstraps that agent
+3. **Agent project bootstrap handoff** — captain assigns a project to an existing agent on an existing workstream
+   - Functions like a "sit rep": everything the agent needs to succeed
+   - Includes links to transcripts, documents, and relevant context
+
+Richer bootstrap handoffs could allow session resumes to become much slimmer.
+
+## Transcript
+
+Me: Yeah, I'm gonna give some notes here real quick on handoffs. The handoffs have always been a very powerful mechanism for us. They go back to the days before we had session resume. They have been just been a great mechanism for us. So what I think we want to do with the handoffs going forward is we want to continue to have at least two classes and we can figure out the others. One is a session handoff handoff between a session. The second is an agent bootstrap handoff. This is a handoff that bootstraps a session. Bootstraps an agent on a work stream. And so when captain sets up a work stream creates an agent, they also do. A bootstrap agent bootstrap handoff that helps make that happen. The third class is. A situation where. The captain is assigning a project to someone. They already exist. They're on a work stream. They already exist, but we want to bootstrap them with all the. Context they need. So this is an agent project bootstrap hangout handoff. And you can think of this as a sit rep. This is everything they need to know to go be successful doing this. It might conclude links to transcripts to documents, everything that they need so that they can get running. And so this is how we evolve handoffs. And if we do this right, maybe get out of the business of, you know, we probably end up with very slim session resumes that are nice and thin for us.

--- a/usr/jordan/captain/transcripts/session20-continued-20260406-0730.md
+++ b/usr/jordan/captain/transcripts/session20-continued-20260406-0730.md
@@ -1,0 +1,134 @@
+---
+type: transcript
+date: 2026-04-06T07:30
+source: captain-session-20
+topic: valueflow MAR, dispatch architecture, transcripts strategy, handoffs evolution
+participants: jordan, captain
+status: active
+---
+
+## Context
+
+Continuation of session 20. Previous transcript: valueflow-design-session-20260406-0400.md. This picks up from MAR round 2, through dispatch payload architecture, DevEx findings, and Jordan's Granola drops on transcripts and handoffs.
+
+## PVR MAR Round 2
+
+### Agent Reviews Received
+- **mdpal-app (#59):** 9 findings. Three-bucket clarification praised. NFR8 "under 2 hours" needs qualifying. FR6 gate scope mechanism unspecified (A&D territory). FR12 rework rate as companion metric. Captain catch-up protocol needed. OQ4 answer: checklist + MAR + principal sign-off.
+- **ISCP (#60):** Deep technical. Enforcement ladder ordering: tools before warn (you build the tool, THEN warn about bypassing). Gate scope mechanism options. Stage-hash delta tolerance. Captain batching needs topological ordering. Permission model missing as FR. Dispatch authority enforcement. Error recovery absent.
+- **mdpal-cli (#61):** Empty template again — dispatch payload bug.
+- **DevEx (#64):** 9 raw findings. FR6 gate scope undefined. Permission model invisible. NFR8 measures wrong thing. C3 causing pain. Test hermiticity missing. Captain recovery undefined. OQ4 should be answered now. FR12 data source underspecified. MARFI should trigger at any stage.
+- **monofolk/captain:** Round 1 feedback resolved. New: three-bucket clarification important, FR6 needs specificity, FR9 decomposition by concern, NFR4 multi-part handoffs (ceiling not floor), NFR8 "under 2 hours" ambitious. Missing: compaction strategy, error recovery. Ready for A&D.
+
+### Key Decisions from MAR Triage
+- DevEx review misattributed as principal review initially — corrected
+- MAR framing fix: reviewers kept self-sorting into buckets despite instructions. Need mechanical enforcement in MAR skill.
+- DevEx ignored corrected framing twice — principal had to intervene directly
+
+## ISCP Fixes Merged
+
+Both escalations resolved and merged to main:
+- **Escalation #53 (empty templates):** dispatch create now requires --body or --template (opt-in). 163 → 169 tests.
+- **Escalation #63 (PR branch identity):** agent-identity resolves captain/* branches as captain. .agency-agent file precedence.
+- `.agency-agent` file created on main checkout for captain identity.
+
+## Dispatch Payload Architecture — Design Decision
+
+### The Discussion
+Three classes of bugs with payloads in git:
+1. Branch transparency — payloads invisible across branches
+2. Template confusion — dispatch create wrote templates agents didn't edit
+3. Path derivation — PR branches created garbage directories
+
+Captain proposed payloads outside git → principal said NO: actual artifact must be in git.
+
+Principal's key insight: "If the payload is a PVR in the repo, running through valueflow, then it is in git. But we need it accessible."
+
+### The Solution: Symlinks
+`~/.agency/{repo}/dispatches/` holds symlinks to actual git artifacts on disk:
+- Symlink to main checkout file → works (real directory)
+- Symlink to worktree file → works (real directory)
+- OS resolves symlinks — no git commands needed for reading
+- Artifacts stay in git (C3 holds)
+- Branch-transparent by default
+
+Dispatched to ISCP (#71) for design and implementation.
+
+## Valueflow A&D Authored
+
+Full A&D drafted covering 12 sections:
+1. Flow stage architecture (inputs, outputs, gates, autonomy per stage)
+2. Three-bucket disposition protocol (mechanism, dispatch format)
+3. Multi-agent groups (MARFI, MAR, MAP — protocols, composition, V2 vs V3)
+4. Enforcement ladder (revised: doc → skill → tool → warn → block)
+5. Captain architecture (always-on loop, interactive, catch-up protocol)
+6. Quality gate tiers (T1-T4 by boundary type)
+7. Context resilience (multi-part handoffs, PostCompact, stage-aware resume)
+8. Dispatch payload architecture (symlinks)
+9. CLAUDE-THEAGENCY.md decomposition (by concern, context budget)
+10. Continual learning (three channels, improvement loop)
+11. Error recovery (failure modes, circuit breaker, escalation)
+12. V2/V3 boundary
+
+Embedded questions for ISCP and DevEx throughout. Dispatched for MAR (#65-68, collaboration-monofolk PR #5).
+
+## FR13: Continual Learning and Improvement
+
+Added to PVR. Three input channels:
+1. Transcript mining — patterns from session transcripts
+2. Flag mechanism — categorized: `flag --friction`, `flag --idea`, `flag --bug`
+3. Telemetry — _log-helper data, ISCP timestamps, dispatch patterns
+
+The methodology observes its own performance and tightens.
+
+## Content: AI Augmented Development Framing
+
+Jordan's framing: "AI Augmented Development is about building, not coding. In the past humans coded and built. Now it's about building — the coding is handled by agents."
+
+Captured as content seed for X/LinkedIn articles. Plus: four MARFI research papers → short and long articles.
+
+## DevEx PVR Findings — 1B1 (in progress)
+
+9 findings from DevEx. Triaging:
+- Finding 1 (FR6 gate scope): A&D answers this — convention-based with manifest fallback
+- Finding 2 (permission model): Adding FR14
+- Finding 3 (NFR8 measure full stream): In discussion
+- Findings 4-9: Autonomous incorporation
+
+## Granola Drops: Transcripts Strategy
+
+### Transcript Types
+- **Principal-agent dialogue** — back-and-forth brainstorming, problem-solving
+- **Monologue/dictation** — like Granola sessions, generating artifacts on a topic
+
+### Architecture
+- Always-on transcripts: continuous capture of agent ↔ user exchanges
+- Agent drops block summaries periodically
+- Transcripts stored in git; index stored outside git (avoid conflicts)
+- Index entries: summary + timestamp covering the time period
+
+### Injection Design
+- Transcript injection into handoffs — pull last X transcripts into new sessions
+- Enables more frequent compaction without losing context
+- Agent-written summaries now; Anthropic API could automate later
+- Session resumes become slimmer when transcripts carry the context
+
+## Granola Drops: Handoff Evolution
+
+### Three Handoff Classes
+1. **Session handoff** — between sessions (existing)
+2. **Agent bootstrap handoff** — captain creates agent on workstream, handoff bootstraps them
+3. **Agent project bootstrap handoff** — captain assigns project to existing agent. A "sit rep": everything they need to succeed. Links to transcripts, documents, context.
+
+### Strategic Direction
+- Richer bootstrap handoffs → slimmer session resumes
+- Handoffs remain core primitive, predating session resume
+
+## PR #40 Created
+25 commits packaged: [the-agency-ai/the-agency#40](https://github.com/the-agency-ai/the-agency/pull/40). Full session 20 output.
+
+## Process Notes Captured
+- MARFI: principal must review research questions before agents spin up
+- MAR: reviewers give raw findings, do NOT self-sort into buckets. Need mechanical enforcement.
+- 15-minute dispatch check loop in agent startup sequence
+- DevEx is new, hasn't internalized the process — needs documentation + enforcement

--- a/usr/jordan/captain/transcripts/transcripts-strategy-20260406-0730.md
+++ b/usr/jordan/captain/transcripts/transcripts-strategy-20260406-0730.md
@@ -1,0 +1,27 @@
+---
+type: transcript
+date: 2026-04-06T07:30
+source: granola
+topic: transcripts and session capture strategy
+---
+
+## Summary
+
+- Transcript = gold standard for capturing what was said (vs. summaries, which are derivatives)
+- Two transcript types to capture:
+  - Principal–agent dialogue (back-and-forth, brainstorming, problem-solving)
+  - Monologue/dictation (like this session) — used to generate artifacts on a topic
+- "Always-on" transcripts: continuous capture of agent ↔ user exchanges
+  - Agent periodically drops in block summaries of its conclusions
+- Session transcripts differ from dictation — both are valuable, serve different purposes
+- Transcripts will get large; need an index to make them queryable
+  - Index entries: summary + timestamp covering the relevant time period
+  - Transcripts stored in git; index stored outside git (to avoid conflicts)
+- New design: transcript injection into handoffs
+  - Pull last X transcripts of work into each new session
+  - Enables more frequent compaction without losing context
+- Agent-written summaries exist now; Anthropic API could automate these later
+
+## Transcript
+
+Me: The gold standard for what was said and what was discussed for the context of a conversation or a situation is a transcript. It's why we have court reporters who copy down every word. Blair said this response was here, not a summary, but every word. You can then get a summary and that's in fact what they have young junior associates do sit around and summarize those down into things. But at the end of the day the gold standard is that transcript. And what we want to do through multiple mechanisms is capture that and bring that into the agency. The first is the transcript of discussions between a principal and an agent. Where we're going back and forth where we're brainstorming, where we're solving an issue. We want to get these. We want to capture these. The other place where we want to bring in a transcript is what I will call the diatribe or monologue transcript, which is what I'm doing here right now with Granola. I am actually going through and talking about some stuff and what I'm going to pass to the captain is a summary from Granola. Plus I'm also going to give the full transcript. And this will become an artifact about this topic of transcripts. So this is very meta. We have a transcription. We're using monologue transcription to capture or dictation to capture what we're going for. It's interesting. So what we want is always on transcripts. And what transcripts capture and how they differ from session files is they are the back and forth. The agent said this. I said this and every once in a while the agent will go and drop a summary in of a block. Its conclusions that it drop. Gathered. That is the session transcript versus the dictation or what I'm doing right here. What this implies is these are going to get big and we want to capture them. So what we want to do is we actually want to have an index so you can look them up. Because they're always on. It should be possible for us to have a transcript of the of the of the time frame. And in addition what we want to do is we want to be in a handoff. We want to pull in the last x transcripts. Of work. And then we also have it. So what we have is we have a transcription tool that generates transcription. Right now we have agent written summaries. We could later probably plug that into the anthropic API and have those summaries generated for us. I think that would be very easy to do. And so we have that. We have that session transcript, that back and forth. We should every so often we should save those. We should have a summary that captures what it is. Put that in an index with a timestamp that it covers this period. Of time. So that's what we get. So I then can be able to go and I can query this transcript. These are all tied to a specific. These should be in get. But the index should be outside of git. So that we're not dealing with issues there that otherwise would. And then the other thing is that we want to do transcript injection. We're going to design a better handoff. That allows us to do injection and maybe stop resuming sessions the way we have been. Or at least be able to go with very slimmed down session resumes. You know we can do that. This also should let us compact more frequently because we're not going to lose any context. Okay, so this is about there.


### PR DESCRIPTION
## Summary
- Valueflow A&D revised through 2 MAR rounds (50+ findings from round 1, 12 from round 2)
- MAR round 1 full disposition document (permanent audit trail)
- All 8 collaborative items resolved with principal
- 28 autonomous incorporations applied
- Round 2 research reviewers complete, agent reviews dispatched
- Transcripts: session 20 continued, transcripts strategy (Granola), handoffs evolution (Granola)
- Day counting convention adopted (Day 30)

## Key decisions
- MAR = pair programming (Linus's Law), never skipped, scales to artifact
- T1 gate: 60s budget with fast tests
- Captain: first up, last down, always-on by design
- Dispatch payload symlinks (ISCP implemented)
- Enforcement transitions: principal decides (DRI)
- PostCompact: handoff only (CLAUDE.md survives)

## Test plan
- [ ] Merge to main
- [ ] Sync worktrees
- [ ] Agent round 2 reviews arrive and get triaged

🤖 Generated with [Claude Code](https://claude.com/claude-code)