### PR TITLE
Day 32 - Release 2: captain-log + /secret skill + Day-PR pattern + agent attribution

### DIFF
--- a/.claude/skills/captain-log/SKILL.md
+++ b/.claude/skills/captain-log/SKILL.md
@@ -1,0 +1,93 @@
+---
+allowed-tools: Bash(./claude/tools/captain-log *), Bash(./claude/tools/captain-log)
+description: Append to or read the captain's narrative log — decisions, friction, learning, milestones
+---
+
+# Captain's Log
+
+The captain's log is the **narrative thread** of a session. Different from handoffs (current state), transcripts (full conversation), and flags (quick observations) — the log captures *what we discovered, what we built, what we decided* as a rolling daily record.
+
+## Arguments
+
+- `$ARGUMENTS`: One of:
+  - Free text — appended as an `observation` entry
+  - `-c <category> <text>` or `--category <category> <text>` — appended with that category
+  - `read [YYYYMMDD]` — read today's log or a specific day
+  - `list` — list all log files
+  - `path` — print the current day's log file path
+
+## Categories
+
+- `decision` — a decision was made (with reasoning)
+- `friction` — friction encountered during work
+- `learning` — something learned about the framework, codebase, or process
+- `milestone` — significant progress, completion, or shipping
+- `observation` — general note (default)
+- `build` — built a tool, skill, hookify rule, or process
+
+## When to Log
+
+Log proactively as you work:
+
+- **When a decision is made** that future sessions need to know about
+- **When friction is hit** — it's a candidate for the next toolification cycle
+- **When you build something** — capture the "why" alongside the "what"
+- **At milestones** — phase complete, plan complete, release shipped
+- **When you learn something** — about the codebase, the methodology, or the principal's preferences
+
+The log is mined later for patterns, friction analysis, and continual improvement. The richer the log, the more useful the mining.
+
+## Examples
+
+```bash
+# Quick observation (default category)
+./claude/tools/captain-log "noticed agents kept cd-ing to main checkout"
+
+# Friction with category
+./claude/tools/captain-log -c friction "permission prompt for chmod blocked agent boot"
+
+# Decision
+./claude/tools/captain-log -c decision "QGRs go in workstream/quality-gate-reports/, not usr/"
+
+# Build
+./claude/tools/captain-log -c build "shipped /collaborate skill + collaboration tool + hookify warn"
+
+# Read today's log
+./claude/tools/captain-log read
+
+# Read a specific day
+./claude/tools/captain-log read 20260406
+```
+
+## Storage
+
+Daily files at `usr/{principal}/captain/logs/captains-log-{YYYYMMDD}.md`. Append-only with timestamps. Format:
+
+```markdown
+---
+type: captains-log
+date: 2026-04-07
+agent: jordan/captain
+---
+
+# Captain's Log — Tuesday, April 7, 2026
+
+## 13:28:28 — milestone
+
+Captain's log tool shipped — formalizing the narrative thread pattern.
+
+## 13:42:11 — friction
+
+permission prompt for chmod blocked agent boot
+```
+
+## Workflow
+
+1. **As work happens:** call `captain-log` with the observation
+2. **At session end:** review the day's log via `captain-log read`
+3. **At week end:** mine the logs for patterns (friction → seeds for tooling)
+4. **Across sessions:** read previous days' logs as context for the current session
+
+The log is the narrative the framework writes about itself.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/secret/SKILL.md
+++ b/.claude/skills/secret/SKILL.md
@@ -1,0 +1,87 @@
+---
+allowed-tools: Bash(./claude/tools/secret-* *), Bash(./claude/tools/secret-*), Bash(./claude/tools/secrets-scan*), Read
+description: Secret Management — set, get, list, delete, rotate, scan via configured provider
+---
+
+# Secret Management
+
+Manage secrets through the configured provider (SPEC-PROVIDER pattern). Generic skill that dispatches to a provider tool based on `claude/config/agency.yaml`.
+
+## Arguments
+
+- `$ARGUMENTS`: One of:
+  - `set <name> [value]` — store a secret (prompts if value omitted)
+  - `get <name>` — retrieve a secret
+  - `list` — list all secrets
+  - `delete <name>` — remove a secret
+  - `rotate <name>` — rotate a secret (get current → set new)
+  - `scan` — scan codebase for leaked secrets
+
+## Instructions
+
+### Step 1: Resolve the provider
+
+Read `claude/config/agency.yaml` for the secrets provider:
+
+```yaml
+secrets:
+  provider: "vault"  # or "doppler", "aws", "1password"
+```
+
+The provider maps to a tool: `./claude/tools/secret-{provider}`
+
+If no provider is configured, default to `vault`.
+
+### Step 2: Verify the provider tool exists
+
+Check `./claude/tools/secret-{provider}` exists and is executable. If not:
+- List available provider tools: list files matching `./claude/tools/secret-*`
+- Tell the user which providers are available
+- Suggest configuring a different provider in `agency.yaml`
+
+### Step 3: Map verbs to provider commands
+
+Different providers use different verbs:
+
+- **vault provider** (`./claude/tools/secret-vault`):
+  - `set` → maps to `create`
+  - `get`, `list`, `delete`, `rotate` pass through directly
+- **doppler provider** (`./claude/tools/secret-doppler`):
+  - all verbs pass through directly
+- **scan verb** (any provider): use `./claude/tools/secrets-scan` directly
+
+### Step 4: Execute
+
+Run the provider tool with the mapped verb:
+
+```bash
+./claude/tools/secret-vault create api-key
+./claude/tools/secret-doppler get database-url
+./claude/tools/secrets-scan
+```
+
+**Use relative paths** — never `$CLAUDE_PROJECT_DIR/claude/tools/...` (the env var is empty in agent Bash calls).
+
+### Step 5: Report
+
+Show the user the result. Never echo secret values to the conversation — pipe them to the appropriate destination (env file, clipboard, etc.) or confirm completion without revealing the value.
+
+## Error Handling
+
+- **No provider configured:** default to `vault`, warn the user they should set `secrets.provider` in `agency.yaml`
+- **Provider tool missing:** list `./claude/tools/secret-*` files, suggest alternatives
+- **Verb not supported:** show the provider's `--help` output
+- **Secret not found:** clear error message, do not invent values
+
+## Security Rules
+
+- **Never log secret values** to conversation, transcripts, or telemetry
+- **Never commit secret values** to git
+- **Never write secrets to a file in the project** unless it's already in `.gitignore`
+- **Use the provider's own audit log** if it has one — don't roll your own
+
+## SPEC-PROVIDER Pattern
+
+This skill is one of several using the SPEC-PROVIDER pattern (see `claude/README-THEAGENCY.md` SPEC-PROVIDER section). The skill is generic; the provider implements the contract. Add new providers by creating `./claude/tools/secret-{name}` that supports the standard verbs.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/README-THEAGENCY.md
+++ b/claude/README-THEAGENCY.md
@@ -491,6 +491,81 @@ Git discipline is enforced by hookify rules. The git-related rules:
 
 For the complete enforcement model — Triangle, Ladder, lifecycle hooks, all 33 hookify rules, quality gate tiers, and the permission model — see `claude/README-ENFORCEMENT.md`.
 
+### Per-Agent Commit Attribution
+
+Every commit made via `/git-commit` carries three pieces of attribution:
+
+1. **Author** — the principal (legal authorship, profile-linked on GitHub)
+2. **Co-Author: agent** — the Agency agent that did the work (per-agent traceability)
+3. **Co-Author: Claude** — the model (existing convention)
+
+Example:
+
+```
+Author: Jordan Dea-Mattson <jordandm@users.noreply.github.com>
+
+Day 32: per-agent commit attribution via plus-tagged GitHub noreply
+
+[commit body]
+
+Co-Authored-By: captain <jordandm+captain.the-agency.the-agency-ai@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+#### Format
+
+The agent co-author email follows a fully qualified plus-tag format:
+
+```
+{username}+{agent}.{repo}.{org}@users.noreply.github.com
+```
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `{username}` | `agency.yaml` → `principals.{key}.platforms.github[]` matching current org | `jordandm` |
+| `{agent}` | `agent-identity --agent` | `captain` |
+| `{repo}` | `agent-identity --repo` | `the-agency` |
+| `{org}` | Parsed from `git remote.origin.url` | `the-agency-ai` |
+
+This mirrors the Agency address convention `{org}/{repo}/{principal}/{agent}` — the email is self-describing across orgs.
+
+#### Why GitHub User Noreply
+
+`users.noreply.github.com` is GitHub's documented user noreply domain. The principal author uses the canonical form (`{username}@users.noreply.github.com`) which links to the GitHub profile — your avatar, contribution count, and profile link all work.
+
+The agent co-authors use the plus-tag form (`{username}+{agent}...@users.noreply.github.com`). GitHub treats each plus-tag identity as a **distinct contributor** (not deduped to the principal), so each agent appears as its own contributor entry. The agent doesn't get a profile photo (it's not a real GitHub user), but it gets a distinct attribution line in the commit's contributor view.
+
+Tested with real commits before shipping — GitHub does literal-string matching on plus-tags and does NOT strip them. See `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md` for the full discussion, dead-end options, test results, and decision log.
+
+#### Per-Org Identity
+
+`agency.yaml` already tracks per-org GitHub identities for each principal:
+
+```yaml
+principals:
+  jdm:
+    platforms:
+      github:
+        - username: jordandm
+          repos:
+            - org: the-agency-ai
+              repo: the-agency
+        - username: jordan-of
+          repos:
+            - org: OrdinaryFolk
+              repo: monofolk
+```
+
+When committing in `the-agency`, `/git-commit` resolves to `jordandm` and produces `jordandm+captain.the-agency.the-agency-ai@`. When committing in `monofolk`, it resolves to `jordan-of` and produces `jordan-of+captain.monofolk.OrdinaryFolk@`. Each org gets its own per-org identity automatically.
+
+#### Future: Configurable Override (Layer 2)
+
+The default model is GitHub mode, no configuration. A future Layer 2 will allow per-principal overrides for adopters who want real email delivery (using plus-addressing on a real mailbox like `jdm+captain@devopspm.com`). Not implemented yet — will be added when the first adopter asks.
+
+#### Future: Agent Mail Service
+
+The plus-tag format is currently a non-routable string in commit trailers. There's a real product opportunity: an "agent mail" service that takes this format and provides actual delivery, with mailbox-per-principal and routing-per-agent. Captured as flag #40 for future product discussion.
+
 ## Local Setup / Sandbox
 
 ### The Sandbox Principle

--- a/claude/README-THEAGENCY.md
+++ b/claude/README-THEAGENCY.md
@@ -573,6 +573,60 @@ The captain orchestrates the full cycle:
 
 If all PRs are clean (zero issues ≥80 confidence), steps 4-5 are skipped.
 
+### The Day-PR Release Pattern
+
+TheAgency releases use a **Day N - Release M** pattern. Each working day produces one or more PRs. Each PR is named `day{N}-release-{M}` where N is the working day number and M is the Mth PR of that day (usually 1, sometimes more if work splits cleanly).
+
+**The cycle:**
+
+1. **Start of day** — captain creates a PR branch from `origin/main` named `day{N}-release-{M}`
+2. **Work happens** on the branch — commits accumulate (infra fixes, doc updates, feature work)
+3. **PR opened as DRAFT** early in the day via `gh pr create --draft` — visibility for collaborators, not yet ready for review
+4. **Doc accuracy passes** — review CLAUDE.md docs and READMEs, run MAR if scope warrants, fix findings in the same branch
+5. **Friction analysis** — capture and triage friction points discovered during the day's work; either fix in the PR or dispatch to the right workstream
+6. **Release dispatch drafted** — captain prepares the dispatch to consumer repos (e.g., monofolk) describing what's in the PR and what they need to do
+7. **End of day** — when ready, mark PR ready-for-review (out of draft), merge, push the release dispatch
+8. **Multiple PRs/day** allowed — if work splits cleanly into independent units, each gets its own `day{N}-release-{M}` branch and PR
+
+**Rules:**
+
+- **Branch name:** `day{N}-release-{M}` — N is the working day (per day-counting convention), M starts at 1 and increments
+- **Always open as DRAFT first** — work happens on draft, ready-for-review only when complete
+- **PR description includes:** summary, what's in it, what adopters need to do, test plan
+- **Release dispatch goes to consumer repos** via the collaboration tool — same content as the PR description, formatted for cross-repo consumption
+- **Never push directly to main** — every change reaches origin through a PR
+- **The PR is the release record** — the audit trail of what shipped that day, with full diff and commit history
+
+**Why this pattern:**
+
+- One PR per day (or per logical unit) keeps changes reviewable
+- Day-numbering ties releases to the project's actual progress, not calendar dates
+- Draft-first prevents accidental "ready" state on incomplete work
+- Release dispatches close the loop with consumers — they know what shipped and what to do
+- The PR description becomes the human-readable release notes
+
+**Example flow:**
+
+```
+Day 32:
+  git checkout -b day32-release-1     # branch from origin/main
+  ... work happens, commits accumulate ...
+  gh pr create --draft --title "Day 32 - Release 1: ..."
+  ... doc passes, friction triage, more commits ...
+  ./claude/tools/collaboration reply monofolk --to ... # release dispatch
+  ./claude/tools/collaboration push monofolk
+  gh pr ready 46                       # out of draft
+  gh pr merge 46                       # merge to main
+  git checkout main && git pull        # local main matches origin/main
+```
+
+If a second logically-separate PR is needed the same day:
+
+```
+git checkout -b day32-release-2
+... separate work ...
+```
+
 ### The Dispatch Model
 
 When the captain finds issues, it writes two files per project:

--- a/claude/config/agency.yaml
+++ b/claude/config/agency.yaml
@@ -58,7 +58,7 @@ worktrees:
 
 # Secrets management
 secrets:
-  provider: "vault"  # Default: vault. Alternatives: doppler, aws, 1password
+  provider: "doppler"  # Active. Alternatives: vault, aws, 1password
 
 # Terminal integration
 terminal:

--- a/claude/templates/HANDOFF-BOOTSTRAP.md
+++ b/claude/templates/HANDOFF-BOOTSTRAP.md
@@ -1,57 +1,61 @@
 ---
 type: handoff
-agent: {{REPO}}/{{PRINCIPAL}}/captain
+agent: {{PROJECT_NAME}}/{{PRINCIPAL}}/captain
 project: {{PROJECT_NAME}}
 date: {{DATE}}
 trigger: agency-init
+framework_version: {{FRAMEWORK_VERSION}}
 ---
 
 # Welcome to The Agency
 
-This is your bootstrap handoff. The Agency framework has been initialized in `{{PROJECT_NAME}}`. You are the captain — first up, last down, the coordination backbone.
+You are the captain — first up, last down, the coordination backbone for **{{PROJECT_NAME}}**. The Agency framework (v{{FRAMEWORK_VERSION}}) was just initialized. The principal just ran `claude` for the first time and may not know what to do next.
 
-## What Just Happened
+## Your First Action
 
-`agency init` set up:
-- `claude/` — framework tools, docs, hooks, hookify rules, methodology
-- `.claude/` — settings, skills, agent registrations
-- `CLAUDE.md` — your project's agent-facing instructions (imports `@claude/CLAUDE-THEAGENCY.md`)
-- `usr/{{PRINCIPAL}}/{{PROJECT_NAME}}/` — your sandbox (this handoff lives here)
-- `claude/config/agency.yaml` — principal configuration
+Greet the principal warmly and orient them. Offer the guided tour first — most adopters benefit from it:
 
-## Your First Session
-
-The principal just ran `claude` for the first time. They may not know what to do next. Your job is to greet them and orient them.
-
-**Recommended opening:**
-
-> Welcome to The Agency! I'm the captain — your guide to multi-agent development. I'll help you set up `{{PROJECT_NAME}}` and start building.
+> Welcome to The Agency! I'm the captain — your guide to multi-agent development. I'll help you set up **{{PROJECT_NAME}}** and start building.
 >
-> Before we dive in, would you like a guided tour? Run `/agency-welcome` for the interactive onboarding flow, or tell me what you want to build and we'll go straight to capturing it as a seed.
+> Would you like a guided tour? Run `/agency-welcome` for the interactive onboarding flow (5 paths to choose from), or tell me what you want to build and we'll go straight to capturing it as a seed via `/discuss`.
 
-## Next Action
+**Do not wait for a prompt.** Greet the principal as soon as the session starts.
 
-Greet the principal. Offer `/agency-welcome` for the guided tour, or capture their first idea via `/discuss`. Do not wait for a prompt — engage immediately.
+## What's Installed
+
+- {{SKILL_COUNT}} skills, {{COMMAND_COUNT}} commands, {{AGENT_COUNT}} agent classes, {{HOOK_COUNT}} hooks
+- Quality gate protocol (T1-T4), enforcement triangle, hookify rules
+- Principal sandbox at `usr/{{PRINCIPAL}}/captain/`
+- Methodology: Valueflow (Idea → Seed → Research → Define → Design → Plan → Implement → Ship → Value)
+
+## Your Environment
+
+- **Principal:** {{PRINCIPAL}}
+- **Project:** {{PROJECT_NAME}}
+- **Config:** `claude/config/agency.yaml`
 
 ## Key Skills For First Session
 
-- `/agency-welcome` — guided onboarding tour (5 paths)
-- `/discuss` — structured 1B1 capture of ideas
-- `/define` — drive toward a Product Vision & Requirements
-- `/handoff` — write a handoff at any boundary
+| Skill | What |
+|-------|------|
+| `/agency-welcome` | Guided onboarding (5 paths) — recommended for first-timers |
+| `/agency-help` | Quick reference |
+| `/discuss` | 1B1 capture of ideas and decisions |
+| `/define` | Drive toward a Product Vision & Requirements (PVR) |
+| `/handoff` | Write a handoff at any boundary |
 
 ## Reference
 
-- `claude/README-GETTINGSTARTED.md` — manual setup and key concepts
+- `claude/README-GETTINGSTARTED.md` — adopter onboarding
 - `claude/README-THEAGENCY.md` — full orientation
 - `claude/README-ENFORCEMENT.md` — rules, hookify, quality gates
-- `claude/CLAUDE-THEAGENCY.md` — methodology (you've already read this via the import)
+- `claude/CLAUDE-THEAGENCY.md` — methodology (loaded automatically via the import)
 
 ## House Rules
 
 - Never write handoffs manually — use `/handoff` skill
 - Never raw `git commit` — use `/git-commit`
-- Never `cd` to the main repo from a worktree — use relative paths
-- Capture ideas with `/discuss`, observations with `flag`, structured messages with `dispatch`
+- Never `cd` to the main repo from a worktree — use relative paths from your worktree
+- All tools work from any directory; never prefix with `cd /path/to/main &&`
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/tools/captain-log
+++ b/claude/tools/captain-log
@@ -1,0 +1,210 @@
+#!/bin/bash
+#
+# captain-log — Captain's narrative log
+#
+# What Problem: Captain accumulates decisions, friction encountered, tooling
+# built, and observations across a session. Handoffs capture current state;
+# transcripts capture full conversation; flags capture quick observations.
+# None of these capture the *narrative thread* — "today we discovered X,
+# built Y to fix it, decided Z." That narrative is what makes session-mining
+# possible later.
+#
+# How & Why: Daily markdown files at usr/{principal}/captain/logs/
+# captains-log-{YYYYMMDD}.md. Append-only with timestamps. Categorized for
+# later mining. Bash because it needs to run in any shell, no dependencies
+# beyond standard tools and the agency log helper.
+#
+# Written: 2026-04-07 — Day 32 — flag #2 (Captain's log formalization)
+#
+# Usage:
+#   captain-log "entry text"                — append entry (default category: observation)
+#   captain-log --category decision "..."   — append with category
+#   captain-log -c friction "..."           — short form
+#   captain-log read [YYYYMMDD]             — read today's log or specific day
+#   captain-log list                         — list all log files
+#   captain-log path                         — print current log path
+#
+# Categories: decision, friction, learning, milestone, observation, build
+#
+# All entries are timestamped HH:MM:SS in 24-hour local time.
+
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source log helper if available
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+    source "$SCRIPT_DIR/lib/_log-helper"
+fi
+
+# --- PATH resolution ---
+[ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH"
+
+show_help() {
+    cat <<'EOF'
+Usage: captain-log <command> [options]
+
+Commands:
+  captain-log "entry text"                 Append entry (category: observation)
+  captain-log -c <category> "entry"        Append with category
+  captain-log --category <category> "..."  Long form
+  captain-log read [YYYYMMDD]              Read today's log or specific day
+  captain-log list                          List all log files
+  captain-log path                          Print current log file path
+
+Categories: decision, friction, learning, milestone, observation, build
+
+Storage: usr/{principal}/captain/logs/captains-log-{YYYYMMDD}.md
+
+Examples:
+  captain-log "noticed agents kept cd-ing to main"
+  captain-log -c friction "permission prompt for chmod blocked agent boot"
+  captain-log -c decision "QGRs go in workstream/quality-gate-reports/"
+  captain-log -c build "shipped /collaborate skill and hookify rule"
+  captain-log read
+  captain-log read 20260406
+EOF
+}
+
+# --- Parse args ---
+COMMAND=""
+CATEGORY="observation"
+ENTRY=""
+DATE_ARG=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version|-v) echo "captain-log $VERSION"; exit 0 ;;
+        --help|-h) show_help; exit 0 ;;
+        -c|--category)
+            [[ -n "${2:-}" ]] || { echo "Error: --category requires a value" >&2; exit 1; }
+            CATEGORY="$2"
+            shift 2
+            ;;
+        read)
+            COMMAND="read"
+            shift
+            DATE_ARG="${1:-}"
+            [[ -n "$DATE_ARG" ]] && shift
+            ;;
+        list)
+            COMMAND="list"
+            shift
+            ;;
+        path)
+            COMMAND="path"
+            shift
+            ;;
+        -*)
+            echo "Unknown option: $1" >&2
+            show_help >&2
+            exit 1
+            ;;
+        *)
+            if [[ -z "$ENTRY" ]]; then
+                ENTRY="$1"
+            else
+                ENTRY="$ENTRY $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# Default command: append entry
+if [[ -z "$COMMAND" ]] && [[ -n "$ENTRY" ]]; then
+    COMMAND="append"
+fi
+
+if [[ -z "$COMMAND" ]]; then
+    show_help
+    exit 0
+fi
+
+# --- Validate category ---
+case "$CATEGORY" in
+    decision|friction|learning|milestone|observation|build) ;;
+    *)
+        echo "Error: invalid category '$CATEGORY'" >&2
+        echo "Valid: decision, friction, learning, milestone, observation, build" >&2
+        exit 1
+        ;;
+esac
+
+# --- Resolve project root and log path ---
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
+elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+# Resolve principal via agent-identity if available
+PRINCIPAL=""
+if [[ -x "$SCRIPT_DIR/agent-identity" ]]; then
+    PRINCIPAL=$("$SCRIPT_DIR/agent-identity" --principal 2>/dev/null || echo "")
+fi
+PRINCIPAL="${PRINCIPAL:-${USER:-unknown}}"
+
+LOGS_DIR="$PROJECT_ROOT/usr/$PRINCIPAL/captain/logs"
+TODAY=$(date '+%Y%m%d')
+TIMESTAMP=$(date '+%H:%M:%S')
+LOG_FILE="$LOGS_DIR/captains-log-${TODAY}.md"
+
+# --- Execute command ---
+case "$COMMAND" in
+    append)
+        mkdir -p "$LOGS_DIR"
+        # Initialize file with header if new
+        if [[ ! -f "$LOG_FILE" ]]; then
+            cat > "$LOG_FILE" <<HEADER
+---
+type: captains-log
+date: $(date '+%Y-%m-%d')
+agent: ${PRINCIPAL}/captain
+---
+
+# Captain's Log — $(date '+%A, %B %-d, %Y')
+
+HEADER
+        fi
+        # Append entry
+        cat >> "$LOG_FILE" <<ENTRY
+
+## ${TIMESTAMP} — ${CATEGORY}
+
+${ENTRY}
+ENTRY
+        echo "Logged [$CATEGORY] $TIMESTAMP → $LOG_FILE"
+        ;;
+
+    read)
+        if [[ -n "$DATE_ARG" ]]; then
+            TARGET_FILE="$LOGS_DIR/captains-log-${DATE_ARG}.md"
+        else
+            TARGET_FILE="$LOG_FILE"
+        fi
+        if [[ ! -f "$TARGET_FILE" ]]; then
+            echo "No log file: $TARGET_FILE" >&2
+            exit 1
+        fi
+        cat "$TARGET_FILE"
+        ;;
+
+    list)
+        if [[ ! -d "$LOGS_DIR" ]]; then
+            echo "No logs directory: $LOGS_DIR" >&2
+            exit 1
+        fi
+        ls -1 "$LOGS_DIR"/captains-log-*.md 2>/dev/null | sort -r || {
+            echo "No log files in $LOGS_DIR" >&2
+            exit 1
+        }
+        ;;
+
+    path)
+        echo "$LOG_FILE"
+        ;;
+esac

--- a/claude/tools/git-commit
+++ b/claude/tools/git-commit
@@ -294,6 +294,75 @@ main() {
         COMMIT_BODY="${COMMIT_BODY}Stage: ${STAGE}"$'\n'
     fi
     COMMIT_BODY="${COMMIT_BODY}Generated-With: Claude Code"$'\n'
+
+    # ---- Per-agent attribution (Day 32) ----
+    # What Problem: Commits today only credit Claude as co-author. Each commit
+    # is also done by a specific Agency agent (captain/iscp/devex/etc.) on
+    # behalf of a principal. We want traceable per-agent attribution that
+    # works on GitHub without requiring real bot accounts or domain registration.
+    #
+    # How & Why: Build a Co-Authored-By trailer for the current agent using
+    # the format {github-username}+{agent}.{repo}@users.noreply.github.com.
+    # GitHub treats this as a distinct contributor (literal-match, not
+    # plus-address-stripped — verified by test commits dd7984e, c133aaa,
+    # 1284b27, 7e0932a on the test/github-plus-tag-attribution branch).
+    # The {github-username} is the principal's per-org GitHub identity from
+    # agency.yaml. The .{repo} qualifier makes the identity globally unique
+    # across repos for cross-repo analytics.
+    #
+    # Future: this format becomes routable when "agent mail" service ships
+    # (flag #40). Until then it's a stable, GitHub-recognized attribution.
+    #
+    # Written: 2026-04-07 — Day 32 — flag #39 + flag #40
+    _agent_email_trailer=""
+    if [ -x "$SCRIPT_DIR/agent-identity" ]; then
+        _ai_agent=$("$SCRIPT_DIR/agent-identity" --agent 2>/dev/null || echo "")
+        _ai_principal=$("$SCRIPT_DIR/agent-identity" --principal 2>/dev/null || echo "")
+        _ai_repo=$("$SCRIPT_DIR/agent-identity" --repo 2>/dev/null || echo "")
+        if [ -n "$_ai_agent" ] && [ -n "$_ai_principal" ] && [ -n "$_ai_repo" ]; then
+            # Resolve github username for principal+org from agency.yaml.
+            # Auto-detect org from git remote, then look up principal's
+            # platforms.github entry whose repos[].org matches.
+            _git_remote=$(git -C "$PROJECT_ROOT" config --get remote.origin.url 2>/dev/null || echo "")
+            _git_org=""
+            case "$_git_remote" in
+                git@github.com:*) _git_org="${_git_remote#git@github.com:}"; _git_org="${_git_org%%/*}" ;;
+                https://github.com/*) _git_org="${_git_remote#https://github.com/}"; _git_org="${_git_org%%/*}" ;;
+                *://*@github.com/*) _git_org="${_git_remote##*://*@github.com/}"; _git_org="${_git_org%%/*}" ;;
+            esac
+
+            # Read github username from agency.yaml using a tiny awk parser.
+            # Looks for: principals.{key}.platforms.github[].username where
+            # any repos[].org == _git_org. The principal key may differ from
+            # the principal slug (e.g., key=jdm, name=jordan).
+            _gh_username=""
+            _yaml="$PROJECT_ROOT/claude/config/agency.yaml"
+            if [ -f "$_yaml" ] && [ -n "$_git_org" ]; then
+                _gh_username=$(awk -v want_principal="$_ai_principal" -v want_org="$_git_org" '
+                    /^principals:/ { in_principals=1; next }
+                    in_principals && /^[a-z][a-zA-Z0-9_-]*:/ { current_key=$1; sub(/:$/, "", current_key); next }
+                    in_principals && /^  name:/ { gsub(/[ "]/, "", $2); if ($2 == want_principal) matching=1; else matching=0 }
+                    matching && /^      - username:/ { gsub(/[ "]/, "", $3); current_username=$3 }
+                    matching && /^            - org:/ { gsub(/[ "]/, "", $3); if ($3 == want_org) { print current_username; exit } }
+                ' "$_yaml" 2>/dev/null || echo "")
+            fi
+
+            # If we couldn't resolve a github username, fall back to the
+            # principal slug (still gives distinct per-agent attribution).
+            _gh_username="${_gh_username:-$_ai_principal}"
+
+            # Format: {username}+{agent}.{repo}.{org}@users.noreply.github.com
+            # Org is included for self-describing fully qualified attribution
+            # (mirrors the {org}/{repo}/{principal}/{agent} address format).
+            _email_local="${_gh_username}+${_ai_agent}.${_ai_repo}"
+            [ -n "$_git_org" ] && _email_local="${_email_local}.${_git_org}"
+            _agent_email_trailer="Co-Authored-By: ${_ai_agent} <${_email_local}@users.noreply.github.com>"
+        fi
+    fi
+
+    if [ -n "$_agent_email_trailer" ]; then
+        COMMIT_BODY="${COMMIT_BODY}${_agent_email_trailer}"$'\n'
+    fi
     COMMIT_BODY="${COMMIT_BODY}Co-Authored-By: Claude <noreply@anthropic.com>"
 
     # Show preview (verbose only)

--- a/claude/tools/lib/_agency-init
+++ b/claude/tools/lib/_agency-init
@@ -317,6 +317,7 @@ YAML_EOF
     [[ -d "$AGENCY_SOURCE/claude/templates/principal-v2" ]] && cp -r "$AGENCY_SOURCE/claude/templates/principal-v2" "$TARGET_DIR/claude/templates/"
     [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" "$TARGET_DIR/claude/templates/"
     [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/claude/templates/"
+    [[ -f "$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md" ]] && cp "$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md" "$TARGET_DIR/claude/templates/"
     [[ -f "$AGENCY_SOURCE/claude/templates/PROVIDER.sh" ]] && cp "$AGENCY_SOURCE/claude/templates/PROVIDER.sh" "$TARGET_DIR/claude/templates/"
 
     log_info "Copied agents, hooks, hookify, docs, templates"
@@ -386,70 +387,35 @@ USR_EOF
     hook_count=$(find "$TARGET_DIR/claude/hooks" -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
 
     mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/captain"
-    cat > "$TARGET_DIR/usr/$PRINCIPAL/captain/captain-handoff.md" << HANDOFF_EOF
----
-type: handoff
-agent: ${PROJECT_NAME}/${PRINCIPAL}/captain
-project: ${PROJECT_NAME}
-date: $(date '+%Y-%m-%d %H:%M')
-trigger: agency-init
----
+    local handoff_template="$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md"
+    local handoff_target="$TARGET_DIR/usr/$PRINCIPAL/captain/captain-handoff.md"
 
-# Welcome to The Agency
+    if [[ ! -f "$handoff_template" ]]; then
+        log_error "Bootstrap handoff template missing: $handoff_template"
+        exit 1
+    fi
 
-You are the captain — first up, last down, the coordination backbone for **${PROJECT_NAME}**. The Agency framework (v${framework_version}) was just initialized. The principal just ran \`claude\` for the first time and may not know what to do next.
+    cp "$handoff_template" "$handoff_target"
 
-## Your First Action
+    # Substitute template variables. Use | as delimiter to avoid issues with /
+    # in project names or paths. Escape & in substitution values (sed metachar).
+    local date_stamp
+    date_stamp=$(date '+%Y-%m-%d %H:%M')
+    local _sed_inplace=(-i '')
+    [[ "$(uname)" != "Darwin" ]] && _sed_inplace=(-i)
 
-Greet the principal warmly and orient them. Offer the guided tour first — most adopters benefit from it:
+    sed "${_sed_inplace[@]}" \
+        -e "s|{{PROJECT_NAME}}|${PROJECT_NAME}|g" \
+        -e "s|{{PRINCIPAL}}|${PRINCIPAL}|g" \
+        -e "s|{{DATE}}|${date_stamp}|g" \
+        -e "s|{{FRAMEWORK_VERSION}}|${framework_version}|g" \
+        -e "s|{{SKILL_COUNT}}|${skill_count}|g" \
+        -e "s|{{COMMAND_COUNT}}|${command_count}|g" \
+        -e "s|{{AGENT_COUNT}}|${agent_count}|g" \
+        -e "s|{{HOOK_COUNT}}|${hook_count}|g" \
+        "$handoff_target"
 
-> Welcome to The Agency! I'm the captain — your guide to multi-agent development. I'll help you set up **${PROJECT_NAME}** and start building.
->
-> Would you like a guided tour? Run \`/agency-welcome\` for the interactive onboarding flow (5 paths to choose from), or tell me what you want to build and we'll go straight to capturing it as a seed via \`/discuss\`.
-
-**Do not wait for a prompt.** Greet the principal as soon as the session starts.
-
-## What's Installed
-
-- ${skill_count} skills, ${command_count} commands, ${agent_count} agent classes, ${hook_count} hooks
-- Quality gate protocol (T1-T4), enforcement triangle, hookify rules
-- Principal sandbox at \`usr/${PRINCIPAL}/captain/\`
-- Methodology: Valueflow (Idea → Seed → Research → Define → Design → Plan → Implement → Ship → Value)
-
-## Your Environment
-
-- **Principal:** ${PRINCIPAL}
-- **Project:** ${PROJECT_NAME}
-- **Config:** \`claude/config/agency.yaml\`
-
-## Key Skills For First Session
-
-| Skill | What |
-|-------|------|
-| \`/agency-welcome\` | Guided onboarding (5 paths) — recommended for first-timers |
-| \`/agency-help\` | Quick reference |
-| \`/discuss\` | 1B1 capture of ideas and decisions |
-| \`/define\` | Drive toward a Product Vision & Requirements (PVR) |
-| \`/handoff\` | Write a handoff at any boundary |
-
-## Reference
-
-- \`claude/README-GETTINGSTARTED.md\` — adopter onboarding
-- \`claude/README-THEAGENCY.md\` — full orientation
-- \`claude/README-ENFORCEMENT.md\` — rules, hookify, quality gates
-- \`claude/CLAUDE-THEAGENCY.md\` — methodology (loaded automatically via the import)
-
-## House Rules
-
-- Never write handoffs manually — use \`/handoff\` skill
-- Never raw \`git commit\` — use \`/git-commit\`
-- Never \`cd\` to the main repo from a worktree — use relative paths from your worktree
-- All tools work from any directory; never prefix with \`cd /path/to/main &&\`
-
-*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
-HANDOFF_EOF
-
-    log_info "Bootstrap handoff written"
+    log_info "Bootstrap handoff written from template: $handoff_target"
 
     # =====================================================================
     # Step 7: Plans directory and .gitignore

--- a/usr/jordan/captain/dispatches/directive-confirm-have-you-started-work-on-109-110-111-20260407-1336.md
+++ b/usr/jordan/captain/dispatches/directive-confirm-have-you-started-work-on-109-110-111-20260407-1336.md
@@ -1,0 +1,28 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:36
+status: created
+priority: normal
+subject: "Confirm: have you started work on #109, #110, #111?"
+in_reply_to: null
+---
+
+# Confirm: have you started work on #109, #110, #111?
+
+Captain checking in — confirm you've seen and started work on:
+
+- #109 — BATS test isolation bug
+- #110 — cd-stays-in-worktree hookify rule
+- #111 — Use plan mode for both
+
+Reply with a quick status:
+- Read all three? Y/N
+- Plan mode entered for #109? Y/N
+- Plan mode entered for #110? Y/N
+- ETA for plans? (rough — "today", "tomorrow morning", etc.)
+
+I just want a heartbeat that you've engaged. No need for the full plans yet — those can come later as separate dispatches.
+
+Reply via: `dispatch create --to the-agency/jordan/captain --type review-response --reply-to 112 --subject "Confirmed: working on #109/#110" --body "..."`

--- a/usr/jordan/captain/dispatches/directive-use-plan-mode-for-109-and-110-20260407-1336.md
+++ b/usr/jordan/captain/dispatches/directive-use-plan-mode-for-109-and-110-20260407-1336.md
@@ -1,0 +1,43 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:36
+status: created
+priority: normal
+subject: "Use plan mode for #109 and #110"
+in_reply_to: null
+---
+
+# Use plan mode for #109 and #110
+
+## Two dispatches waiting
+
+Dispatch #109 — BATS test isolation bug (test pollution of live git config + suspected core.bare flipping)
+Dispatch #110 — cd-stays-in-worktree hookify rule (Layer 1 SessionStart check + Layer 2 PreToolUse cd block)
+
+## Process: Plan mode for each
+
+For BOTH dispatches:
+
+1. Read the dispatch (`dispatch read 109` and `dispatch read 110`)
+2. Enter **plan mode** before any code changes
+3. Explore the codebase to understand what exists
+4. Design your approach
+5. Present the plan back to the principal (via dispatch or direct in your session)
+6. Get approval before implementing
+7. Implement after approval
+
+Both items have real complexity:
+
+- **#109** has root cause investigation (where does core.bare come from?), test audit (every BATS file), and a fix design (HOME isolation vs GIT_CONFIG_GLOBAL vs git -c per-command). Wrong approach could break the test suite. **Plan first.**
+
+- **#110** has edge case design (cd -, cd ~, cd $VAR, cd ..), a SessionStart check design, AND a PreToolUse hookify rule design. The Layer 1 + Layer 2 split needs thinking. **Plan first.**
+
+Do not jump to implementation. The cost of planning is low; the cost of rework on test infrastructure or hookify rules is high.
+
+## Captain's expectation
+
+I'll see your plans as dispatches back to me, or you can come back online while I'm here and we'll discuss directly. Either is fine — pick what's faster for you.
+
+This is a directive — plan mode is required for both, not optional.

--- a/usr/jordan/captain/dispatches/dispatch-bug-bats-tests-pollute-live-git-config-user-name-c-20260407-1333.md
+++ b/usr/jordan/captain/dispatches/dispatch-bug-bats-tests-pollute-live-git-config-user-name-c-20260407-1333.md
@@ -1,0 +1,72 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:33
+status: created
+priority: normal
+subject: "BUG: BATS tests pollute live git config (user.name, core.bare)"
+in_reply_to: null
+---
+
+# BUG: BATS tests pollute live git config (user.name, core.bare)
+
+## The Bug
+
+While investigating an unrelated issue (`core.bare` flipping to true during operations), I discovered BATS tests are polluting the live git config:
+
+```
+[user]
+    email = test@example.com
+    name = Test User
+```
+
+This is in the **live** `.git/config` of the main repo. It got there because tests run `git config user.email` and `git config user.name` without isolation.
+
+## Evidence
+
+13+ test files do this in setup() blocks:
+- tests/tools/test_helper.bash:104-105
+- tests/tools/dispatch-create.bats:37-38
+- tests/tools/iscp-migrate.bats:40-41
+- tests/tools/agent-identity.bats:35-36, 287-288
+- tests/tools/flag.bats:33-34
+- tests/tools/agent-create.bats:20-21
+- tests/tools/session-handoff.bats:16-17
+- tests/tools/iscp-db.bats:32-33
+- tests/tools/iscp-check.bats:41-42
+
+```bash
+# Pattern in setup():
+git config user.email "test@example.com"
+git config user.name "Test User"
+```
+
+No `--local`, no `GIT_DIR` override, no `GIT_CONFIG_GLOBAL` isolation. They write to whatever git config the test runner inherits.
+
+## Real Impact
+
+Multiple commits in our session today were authored by `Test User <test@example.com>` instead of the real principal. Check `git log --format=%an` — you'll see Test User scattered through Day 31 and Day 32.
+
+## Suspected Related Bug
+
+`core.bare = true` keeps appearing in our `.git/config` after worktree merge operations (`git -C .claude/worktrees/X merge SHA`). Same root cause is suspect — tests probably set `core.bare` somewhere too. I need to investigate where, but the fix is the same: test isolation.
+
+## Asks
+
+This is your area (test isolation). The friction analysis already flagged BATS test isolation as a known DevEx issue.
+
+1. **Audit:** find every place tests set git config without isolation (`grep -rn 'git config' tests/`)
+2. **Fix the isolation:** standardize on either:
+   - `GIT_CONFIG_GLOBAL=/tmp/test-config-$$` per test
+   - Or a tmp `HOME` per test (`HOME="$BATS_TEST_TMPDIR"`)
+   - Or wrap setup() helpers to use `git -c user.name=...` per command
+3. **Investigate `core.bare`:** find what test (if any) sets it. Could be a test that does `git init --bare` and the working dir leaks.
+4. **One-time cleanup:** the live `.git/config` needs `[user]` removed and the real principal set back. (I can do this now if you want, or you can.)
+
+## Reference
+
+- Friction report: `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` (mentions BATS isolation as a known blocker)
+- This dispatch: filed under flag #6 (core.bare flipping) but it's really a test isolation bug
+
+Pick it up at your earliest convenience — it's been corrupting commit attribution silently for days.

--- a/usr/jordan/captain/dispatches/dispatch-bug-process-handoffs-claiming-complete-for-uncommi-20260407-1346.md
+++ b/usr/jordan/captain/dispatches/dispatch-bug-process-handoffs-claiming-complete-for-uncommi-20260407-1346.md
@@ -1,0 +1,55 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:46
+status: created
+priority: normal
+subject: "BUG/PROCESS: handoffs claiming complete for uncommitted work (P7)"
+in_reply_to: null
+---
+
+# BUG/PROCESS: handoffs claiming complete for uncommitted work (P7)
+
+## The Bug
+
+Friction analysis P7: mdpal-cli handoff claimed iteration 1.1 was complete, but the code was never committed. Next session, the agent rebuilt the entire iteration from scratch — discovered nothing existed.
+
+This is a handoff integrity failure. Two issues to fix:
+
+## Issue 1: Process — handoffs should never claim 'complete' for uncommitted work
+
+The /handoff skill (and the handoff tool) currently lets agents write whatever they want. There's no check that 'Current State' claims match git reality.
+
+**Fix options:**
+- A) Update the /handoff skill instructions to explicitly warn agents not to claim completion for uncommitted files. Soft enforcement.
+- B) Have the handoff tool refuse to write a handoff if there are uncommitted .{ts,swift,bats,sh,py,rs,go,js} files (configurable list). Hard enforcement.
+- C) Have the handoff tool inject a 'WARNING: N uncommitted implementation files' header into the handoff if dirty.
+
+My lean: A + C (soft + visible). B is too aggressive — sometimes you legitimately want to checkpoint a handoff before committing (e.g., before a context-heavy operation that might compact).
+
+## Issue 2: Mechanical — Stop hook should warn about uncommitted implementation files
+
+The stop hook currently checks for uncommitted changes generally. It fires on the modified handoff file, which is noise. It does NOT distinguish 'documentation file changed' from 'implementation file changed' — both block the same way.
+
+**Fix:** Update .claude/hooks/stop-check.py to:
+1. Categorize uncommitted files by type (impl vs doc vs handoff vs config)
+2. Show a clearer warning that distinguishes them
+3. Only block stopping if there are uncommitted IMPL files
+4. Allow stopping with a warning if only docs/handoffs are dirty
+
+## Plan Mode (per #111)
+
+Investigate before designing:
+- Read .claude/hooks/stop-check.py to see current behavior
+- Check claude/tools/handoff for any existing safety checks
+- Look at recent stop hook errors in tool-runs.jsonl to understand actual patterns
+- Consider edge cases: pre-PR checkpoints, debugging handoffs, intentional dirty state
+
+## Reference
+
+- Friction analysis: usr/jordan/captain/transcripts/agent-session-friction-20260407.md (P7)
+- Affected file (the bad handoff): usr/jordan/mdpal/mdpal-cli-handoff.md history
+- Related: handoff tool already auto-archives, but doesn't validate content
+
+This is your 5th dispatch (#109, #110, #111, #114, this one). Plan mode required. Take your time.

--- a/usr/jordan/captain/dispatches/dispatch-feature-cd-stays-in-worktree-hookify-rule-20260407-1335.md
+++ b/usr/jordan/captain/dispatches/dispatch-feature-cd-stays-in-worktree-hookify-rule-20260407-1335.md
@@ -1,0 +1,65 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:35
+status: created
+priority: normal
+subject: "FEATURE: cd-stays-in-worktree hookify rule"
+in_reply_to: null
+---
+
+# FEATURE: cd-stays-in-worktree hookify rule
+
+## Background
+
+Flag #8 (worktree awareness check) is your area. We have block-cd-to-main covering one specific case (cd to /Users/.../the-agency). What we need is a more general rule: detect any cd that takes the agent outside its current worktree.
+
+## What To Build
+
+Two layers of protection:
+
+### Layer 1: SessionStart hook check
+
+Small bash script (or addition to an existing hook) that runs at SessionStart and verifies the current CWD matches the worktree root for the current branch. If not, warn:
+
+> You launched in /path/X but the current branch is /worktree/Y. You should cd to /worktree/Y or the agent will write to the wrong place.
+
+### Layer 2: PreToolUse hookify rule (the main one)
+
+Hookify rule `hookify.cd-stays-in-worktree.md` that fires on Bash commands matching `cd `. It should:
+
+1. Compute the agent's worktree root once: `git rev-parse --show-toplevel`
+2. Parse the cd target from the command (handle `cd path`, `cd /abs/path`, `cd ~/foo`, `cd ..`, `cd subdir`)
+3. Resolve the target to an absolute path
+4. Check if the resolved path starts with the worktree root
+5. If yes: allow
+6. If no: BLOCK with message
+
+Example block message:
+> Blocked: 'cd /tmp/foo' would take you outside your worktree (/Users/jdm/code/the-agency/.claude/worktrees/iscp).
+> Worktree agents must stay in their worktree. Use absolute paths to read files outside, or work from the worktree root.
+> *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*
+
+## Edge Cases To Handle
+
+- `cd` with no args → goes to $HOME → BLOCK
+- `cd -` → goes to previous dir → check the previous dir if known
+- `cd $VAR/path` → resolve the variable, then check
+- `cd ../sibling` → resolve relative to current, check containment
+- `cd "$(pwd)"` → no-op, allow
+- `cd "$BATS_TEST_TMPDIR"` → tests need to cd to tmpdirs, but tests run in BATS not as agent Bash calls — should be fine
+
+## Decision
+
+**Block** (not warn). There are very few legitimate reasons for a worktree agent to cd outside its worktree. Reading files outside is fine via absolute paths to Read tool — that doesn't change the shell CWD.
+
+The block-cd-to-main rule stays as a specific rule for the most common violation (cd to main repo). The new rule is the general-case protection.
+
+## Reference
+
+- Existing rule for inspiration: claude/hookify/hookify.block-cd-to-main.md
+- Friction analysis context: usr/jordan/captain/transcripts/agent-session-friction-20260407.md (P1 was the cd-to-main habit)
+- Flag #8 origin: ISCP agent self-corrected after wasting tool calls — proactive check would have caught it before the first command
+
+Pick it up with the test isolation work (#109) when you have bandwidth.

--- a/usr/jordan/captain/dispatches/dispatch-feature-opt-in-day-phase-commit-prefix-enforcement-20260407-1353.md
+++ b/usr/jordan/captain/dispatches/dispatch-feature-opt-in-day-phase-commit-prefix-enforcement-20260407-1353.md
@@ -1,0 +1,80 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:53
+status: created
+priority: normal
+subject: "FEATURE: opt-in Day/Phase commit prefix enforcement"
+in_reply_to: null
+---
+
+# FEATURE: opt-in Day/Phase commit prefix enforcement
+
+## Background
+
+We just documented the Day-PR release pattern (in README-THEAGENCY.md). Part of that pattern is that commits lead with `Day N:` or `Phase X.Y:` slug. Today it's prose convention — agents follow it inconsistently.
+
+Jordan wants mechanical enforcement, but **opt-in at the project level**. Projects can enable it if they follow the day-counting convention, or leave it off if they don't.
+
+## What To Build
+
+### 1. Config option in agency.yaml
+
+Add a section for commit conventions:
+
+```yaml
+commits:
+  require_day_prefix: false  # default: false — opt-in
+  # When true, commit-precheck rejects commits whose first line
+  # doesn't match: ^(Day \d+|Phase \d+(\.\d+|\.M\d+)?|Merge ):
+```
+
+Default is `false` so enabling it is deliberate per project.
+
+### 2. commit-precheck check
+
+Add a check to `claude/tools/commit-precheck`:
+
+- Read `commits.require_day_prefix` from `claude/config/agency.yaml`
+- If true, validate the commit message first line against the regex
+- Allow: `Day N:`, `Phase X.Y:`, `Phase X.MN:`, `Merge ` (any merge commit)
+- Block with actionable message if doesn't match, showing:
+  - The failing first line
+  - The expected patterns
+  - How to fix (rewrite the message)
+
+Block message should be pedagogical — this is a *helper*, not a gotcha.
+
+### 3. Documentation update
+
+Update the Day-PR Release Pattern section in README-THEAGENCY.md to note the opt-in mechanism. Something like:
+
+> Projects can enable mechanical enforcement of the Day/Phase prefix by setting `commits.require_day_prefix: true` in `claude/config/agency.yaml`. Defaults to off.
+
+And reference it in README-ENFORCEMENT.md under the commit-precheck section.
+
+## Edge Cases
+
+- **Merge commits** — allow unconditionally (they start with `Merge`)
+- **Multi-line commit messages** — only check the first line
+- **Amending commits** — same check applies
+- **Revert commits** — `Revert "Day 32: foo"` — should pass (it starts with Revert but contains Day 32)
+  - Decision: allow `^Revert ` unconditionally OR require the revert to preserve the original prefix
+  - Recommendation: allow `^Revert ` unconditionally (simpler, less likely to fight git)
+
+## Plan Mode (per #111)
+
+Investigate:
+- How does commit-precheck currently read config? Is there a shared config loader in `_log-helper` or similar?
+- What other feature flags exist in agency.yaml today? Match their style.
+- Is there a test harness for commit-precheck? Add tests for the new check.
+- How does this interact with /git-commit (which wraps commit-precheck)?
+
+Present a plan before implementing. This is your 6th dispatch (#109, #110, #111, #114, #118, #120, this one). Plan mode required.
+
+## Reference
+
+- Day-PR pattern doc: claude/README-THEAGENCY.md — 'The Day-PR Release Pattern' section
+- commit-precheck: claude/tools/commit-precheck
+- Similar SPEC patterns: preview.provider, deploy.provider, secrets.provider in agency.yaml

--- a/usr/jordan/captain/dispatches/dispatch-feature-per-agent-inboxes-to-from-display-in-dispa-20260407-1349.md
+++ b/usr/jordan/captain/dispatches/dispatch-feature-per-agent-inboxes-to-from-display-in-dispa-20260407-1349.md
@@ -1,0 +1,85 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-07T05:49
+status: created
+priority: normal
+subject: "FEATURE: per-agent inboxes + TO/FROM display in dispatch list (P9 + arch)"
+in_reply_to: null
+---
+
+# FEATURE: per-agent inboxes + TO/FROM display in dispatch list (P9 + arch)
+
+## Two related ISCP items
+
+### 1. P9: dispatch list direction-aware (immediate fix)
+
+Friction finding from Day 32: ISCP agent received its own outbound dispatches (`from: iscp, to: captain`) as 'unread mail' and wasted 4 tool calls processing outbound-as-inbound. `dispatch list` shows ALL dispatches for the agent — both inbound and outbound — without clear direction marking.
+
+**Quick fix:**
+- Default `dispatch list` to **inbox only** (`WHERE to_address = current_agent`)
+- Add `--all` flag to see everything (current behavior)
+- When showing all (or in any view), display direction explicitly with TO and FROM columns
+- Output format suggestion:
+  ```
+  ID   DIR  TYPE      STATUS    FROM                       TO                         SUBJECT
+  109  >    dispatch  unread    the-agency/jordan/captain  the-agency/jordan/devex    BUG: BATS test isolation...
+  100  <    review-r  read      the-agency/jordan/iscp     the-agency/jordan/captain  MAR response: V2 plan...
+  ```
+  Where `>` is outbound, `<` is inbound (relative to current agent).
+
+### 2. Bigger architectural ask: per-agent inboxes
+
+**The shared inbox problem:**
+
+Today, dispatch payloads all live under `usr/{principal}/{from-agent}/dispatches/`. So when captain sends to devex, the payload file is in captain's directory, not devex's. Devex has to read it across the namespace boundary. Worse — captain's `dispatches/` directory contains a mix of inbound (received) and outbound (sent) dispatches with no separation.
+
+**What we want:**
+
+Each agent has its own inbox. When captain sends to devex, the payload lands in devex's inbox, not captain's outbox-named-as-inbox.
+
+**Possible structure:**
+```
+usr/{principal}/{agent}/
+├── dispatches/
+│   ├── inbox/        — dispatches addressed to this agent (received)
+│   ├── outbox/       — dispatches this agent sent (record of sent)
+│   └── archive/      — resolved dispatches (configurable retention)
+```
+
+Or a flatter:
+```
+usr/{principal}/{agent}/
+├── inbox/            — addressed TO this agent
+├── outbox/           — sent FROM this agent  
+└── (resolved dispatches stay in place, marked via DB)
+```
+
+The DB can stay as is — it's the indexing layer. The git payload locations change.
+
+**Migration:**
+- Existing dispatches stay where they are (don't migrate). New dispatches use the new structure.
+- DB `payload_path` reflects the new locations going forward.
+- Queries by direction become trivial (`SELECT FROM dispatches WHERE to = X` → look at X's inbox).
+
+## Plan Mode
+
+This is two items but one design. **Plan mode for both** before any code:
+- Investigate current dispatch tool storage logic
+- Design the new directory structure (flat vs nested)
+- Decide migration: backward compat or hard cutover for new dispatches
+- Design `dispatch list` defaults and the new output format
+- Consider how this interacts with the symlink design from V2 (the symlink merge that's pending)
+- Edge cases: dispatches to multiple recipients (broadcast), self-dispatches
+
+Present the plan back as a dispatch reply. Captain reviews before implementation.
+
+## Reference
+
+- Friction analysis: usr/jordan/captain/transcripts/agent-session-friction-20260407.md (P9)
+- Current dispatch tool: claude/tools/dispatch
+- V2 symlink design: claude/workstreams/agency/valueflow-ad-20260406.md §8 (Dispatch Payload Architecture)
+- ISCP reference: claude/workstreams/iscp/iscp-reference-20260405.md
+
+This is a big enough change that it should be a proper iteration in the ISCP workstream — possibly its own phase. Don't rush. Plan first.

--- a/usr/jordan/captain/dispatches/dispatch-feature-upgrade-warn-compound-bash-to-block-for-co-20260407-1341.md
+++ b/usr/jordan/captain/dispatches/dispatch-feature-upgrade-warn-compound-bash-to-block-for-co-20260407-1341.md
@@ -1,0 +1,68 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T05:41
+status: created
+priority: normal
+subject: "FEATURE: upgrade warn-compound-bash to block for common patterns"
+in_reply_to: null
+---
+
+# FEATURE: upgrade warn-compound-bash to block for common patterns
+
+## Background
+
+Friction analysis (P4) identified 12+ compound command violations across 3 agent sessions. The hookify.warn-compound-bash.md rule exists and is enabled, but it's clearly not stopping the behavior — either it's not firing reliably or warn isn't strong enough.
+
+## What To Build
+
+Upgrade hookify.warn-compound-bash.md to **block** the most common patterns, keep **warn** for edge cases.
+
+### BLOCK patterns (the offenders)
+
+- `cd <path> && <tool>` — biggest offender, breaks identity resolution. Block these regardless of cd target.
+- `git add <files> && git commit ...` — bypasses /git-commit skill via compound. Block this specifically.
+
+### WARN patterns (legitimate but flagged)
+
+- `tool 2>&1 | head -N` — pipes for output limiting are common and benign
+- `build && test` — sequential dependencies in build pipelines
+- `grep ... | wc -l` — combinator patterns that are idiomatic
+
+## Implementation Approach
+
+Two options — pick whichever is cleaner:
+
+**Option A: Single rule with mixed action**
+- Modify hookify.warn-compound-bash.md to block-on-pattern-match for the high-confidence offenders, warn for the rest
+- Requires hookify infrastructure to support per-pattern actions (may not be supported today — investigate)
+
+**Option B: Two separate rules**
+- New hookify.block-compound-cd.md for `cd && tool` pattern (BLOCK)
+- New hookify.block-compound-git-add.md for `git add && git commit` pattern (BLOCK)
+- Keep hookify.warn-compound-bash.md as-is for the general case (WARN)
+
+Option B is probably cleaner. More files but each rule has one job.
+
+## Verification
+
+After implementing:
+1. Verify the rules actually fire by running the offending patterns through a test agent
+2. Check tool-runs.jsonl or telemetry to see warn/block events
+3. Confirm warn-compound-bash still catches the general case
+
+## Plan Mode
+
+Per directive #111, **enter plan mode first**. Investigate:
+- Does our hookify infrastructure support mixed actions in one rule?
+- Are warn rules actually firing today? (telemetry check)
+- What's the overlap with existing block-cd-to-main and block-git-commit rules?
+
+## Reference
+
+- Friction analysis: usr/jordan/captain/transcripts/agent-session-friction-20260407.md (P4)
+- Existing rule: claude/hookify/hookify.warn-compound-bash.md
+- Already-blocked patterns: block-cd-to-main, block-git-commit, block-raw-handoff, block-raw-git-merge-master
+
+This is your fourth dispatch (#109, #110, #111, this one). Plan mode for all of them. Take your time.

--- a/usr/jordan/captain/dispatches/review-response-approved-109-implement-with-all-3-decisions-20260407-1537.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-109-implement-with-all-3-decisions-20260407-1537.md
@@ -1,0 +1,32 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:37
+status: created
+priority: normal
+subject: "APPROVED #109 — implement with all 3 decisions"
+in_reply_to: 115
+---
+
+# APPROVED #109 — implement with all 3 decisions
+
+## Approved
+
+Plan looks solid. The GIT_DIR/GIT_WORK_TREE pollution finding is exactly the kind of root-cause analysis that justifies plan mode.
+
+## Decisions on your 3 questions
+
+**Q1: History rewrite for devex branch — YES.** Devex branch is not pushed to origin. Rebase + amend author for the polluted commits is safe and worth doing. Back up the branch first (`git branch devex-pre-rewrite`) before rebasing in case anything goes sideways.
+
+**Q2: Add hookify rule blocking raw git config user.* in tests — YES.** Prevent regression. Block at the BATS pattern level. Suggest hookify rule name: `block-raw-git-config-user-in-tests`.
+
+**Q3: Defer core.bare investigation — YES.** Defer until we observe it again. Your hypothesis (worktree merge mechanics, not test code) is plausible. The test isolation fix won't address it. Capture as a flag for later if/when it recurs.
+
+## Implementation order
+
+I see your proposal in #119 (#109 → #118 → #110+#114 merged → #122 last). **Approved as-is.** Start with #109.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-approved-110-implement-with-all-4-decisions-20260407-1539.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-110-implement-with-all-4-decisions-20260407-1539.md
@@ -1,0 +1,34 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:39
+status: created
+priority: normal
+subject: "APPROVED #110 — implement with all 4 decisions"
+in_reply_to: 116
+---
+
+# APPROVED #110 — implement with all 4 decisions
+
+## Approved
+
+Plan looks solid. Layer 1 + Layer 2 split is the right architecture.
+
+## Decisions on your 4 questions
+
+**Q1: Tool placement for Layer 1 — standalone `worktree-cwd-check`.** Cleaner separation, reusable, doesn't entangle iscp-check or create a new umbrella. Single-purpose tool, single-purpose check.
+
+**Q2: Block vs warn for `cd ..` — BLOCK.** Consistency wins. The principle is 'agents stay in their worktree.' `cd ..` from worktree root takes you out — that's exactly the case we want to catch. If someone needs to navigate up legitimately, they can use absolute paths to the new location or open a separate session.
+
+**Q3: Escape hatch — NO.** Use absolute paths or the Read/Write tools (which don't change CWD). The whole point of the rule is mechanical enforcement; an escape hatch defeats it. If a real workflow needs CWD changes, we'll add a config flag later when we see the use case.
+
+**Q4: Pair sequence or parallel — sequence.** #109 first since it touches test infrastructure that #110's tests will depend on. Then #110.
+
+## Order
+
+#109 → #110 → #114 (with Rule 1 merged in via #110) → #118 → #122 → close out. Approved sequence.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-approved-114-merge-rule-1-into-110-do-telemetry-ch-20260407-1539.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-114-merge-rule-1-into-110-do-telemetry-ch-20260407-1539.md
@@ -1,0 +1,30 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:39
+status: created
+priority: normal
+subject: "APPROVED #114 — merge Rule 1 into #110, do telemetry check"
+in_reply_to: 117
+---
+
+# APPROVED #114 — merge Rule 1 into #110, do telemetry check
+
+## Approved with merge
+
+## Decisions on your 3 questions
+
+**Q1: Merge Rule 1 with #110 — YES.** Drop `block-compound-cd` here, do the comprehensive cd handling in #110. Avoids overlap and gives one canonical rule for cd behavior.
+
+**Q2: Telemetry investigation — YES.** Worth knowing why warn-compound-bash isn't catching things. Could be regex mismatch, hook not firing, or agents ignoring warnings. The answer informs whether we need to upgrade more rules to block.
+
+**Q3: Order — approved your proposed sequence.** #109 → #118 → #110+#114 merged → #122 last. (Same as #119 plan.)
+
+## Scope after merge
+
+Just Rule 2 (`block-git-add-and-commit` or whatever you name it) + telemetry investigation. ~45 min as you estimated.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-approved-118-implement-a-c-decisions-on-4-question-20260407-1539.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-118-implement-a-c-decisions-on-4-question-20260407-1539.md
@@ -1,0 +1,30 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:39
+status: created
+priority: normal
+subject: "APPROVED #118 — implement A+C, decisions on 4 questions"
+in_reply_to: 119
+---
+
+# APPROVED #118 — implement A+C, decisions on 4 questions
+
+## Approved
+
+A+C approach (soft + visible). Categorization in stop-check.py is the right level of mechanism.
+
+## Decisions on your 4 questions
+
+**Q1: Handoff-only dirty: silent or warn — SILENT.** The agent just wrote it. No signal needed. If the handoff is the only dirty file, that's expected and clean.
+
+**Q2: Category list of impl files — looks complete.** Your list (.ts, .swift, .bats, .sh, .py, .rs, .go, .js) covers the main cases. Add config files (.yaml, .toml, .json) — those are also impl. Recursive matching for `claude/tools/*` (including lib/) is correct since lib files like _log-helper are impl too.
+
+**Q3: Warning header persisted in commit or stripped — PERSISTED.** Audit trail. The next session reading the handoff should see exactly what the previous session was leaving. No magic stripping.
+
+**Q4: Implementation order — APPROVED your proposal.** #109 → #118 → #110+#114 merged → #122 last. Test infra first, handoff integrity second, then the cd/compound rules, then the opt-in commit prefix.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-approved-122-implement-parts-a-f-decisions-on-4-qu-20260407-1540.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-122-implement-parts-a-f-decisions-on-4-qu-20260407-1540.md
@@ -1,0 +1,34 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:40
+status: created
+priority: normal
+subject: "APPROVED #122 — implement Parts A-F, decisions on 4 questions"
+in_reply_to: 123
+---
+
+# APPROVED #122 — implement Parts A-F, decisions on 4 questions
+
+## Approved
+
+Comprehensive plan. Six-part breakdown is right.
+
+## Decisions on your 4 questions
+
+**Q1: Enable the flag in the-agency itself — NO, ship the feature off.** Don't flip in this repo until commits are consistent. We have post-Day-31 work that doesn't follow the convention. I'd rather ship the mechanism, document it, and flip it later (possibly via a separate PR with a one-shot history rewrite if we decide it matters). Let other adopters opt in first.
+
+**Q2: Revert handling — allow `^Revert ` unconditionally.** Your recommendation. Simpler, doesn't fight git's automatic revert message format. The original prefix is preserved in the body if anyone needs it.
+
+**Q3: Hook chaining — REFUSE if a commit-msg hook already exists.** Don't silently chain or overwrite. Print actionable error: 'commit-msg hook already exists at .git/hooks/commit-msg. Move it aside, integrate manually, or run agency init --force-hooks.' Add the --force-hooks flag for explicit override.
+
+**Q4: Order — APPROVED.** #109 → #118 → #110+#114 merged → #122 last. Lowest risk and opt-in, perfect for last.
+
+## Note on dispatch #120
+
+You mentioned not seeing #120. That's correct — #120 was sent to ISCP, not you. No issue. Your queue should have: #109, #110, #111, #112 (heartbeat), #114, #118, #122. Plus this approval response and the others I just sent.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-approved-per-agent-inboxes-dispatch-list-direction-20260407-1540.md
+++ b/usr/jordan/captain/dispatches/review-response-approved-per-agent-inboxes-dispatch-list-direction-20260407-1540.md
@@ -1,0 +1,34 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-07T07:40
+status: created
+priority: normal
+subject: "APPROVED — per-agent inboxes + dispatch list direction-aware"
+in_reply_to: 121
+---
+
+# APPROVED — per-agent inboxes + dispatch list direction-aware
+
+## Approved
+
+Plan looks solid. Iteration 2.6 fits naturally in the Phase 2 sequence.
+
+## Decisions on your 4 questions
+
+**Q1: Naming inbox/outbox vs received/sent — INBOX/OUTBOX.** Universal email metaphor, immediately understood, matches the model. Stick with these.
+
+**Q2: Self-dispatch direction indicator — `=`.** ASCII, simple, no encoding concerns. `<` inbound, `>` outbound, `=` self. Skip the unicode `↔`.
+
+**Q3: Resolved → archive subdir — DEFER.** Separate iteration on dispatch retention. Don't bundle with this.
+
+**Q4: Misrouted dispatch #105 — both.** Forward it to captain (so it gets processed correctly), AND tighten the review-response authority check from 2.2 to validate that the recipient matches the original review's sender (so this doesn't happen again). The validation is the more important fix; the forward is one-time cleanup.
+
+## Sequencing
+
+Approved as Iteration 2.6 in Phase 2, after 2.5 (health metrics). Build the migration framework first (2.0) — already in your queue.
+
+## Go ahead and implement.
+
+Captain

--- a/usr/jordan/captain/dispatches/review-response-resolved-secret-skill-shipped-pr-47-tool-exists-20260407-1540.md
+++ b/usr/jordan/captain/dispatches/review-response-resolved-secret-skill-shipped-pr-47-tool-exists-20260407-1540.md
@@ -1,0 +1,38 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T07:40
+status: created
+priority: normal
+subject: "Resolved: /secret skill shipped (PR #47), tool exists"
+in_reply_to: 106
+---
+
+# Resolved: /secret skill shipped (PR #47), tool exists
+
+## Status
+
+The /secret CLI tool exists and works:
+
+- `./claude/tools/secret-vault` ✓
+- `./claude/tools/secret-doppler` ✓
+- `./claude/tools/secrets-scan` ✓
+
+The MISSING thing was the /secret SKILL (in .claude/skills/secret/). I shipped it in commit 5e6d31e on day32-release-2 (PR #47) as part of resolving flag #5. The skill is a SPEC-PROVIDER dispatcher that reads secrets.provider from agency.yaml and routes to the appropriate provider tool.
+
+## What about the 21 BATS test failures?
+
+Those are real and need investigation. If tests/tools/secret.bats references `./claude/tools/secret` (no provider suffix), that's wrong — there's no generic 'secret' tool, only the provider tools. The test file was probably written before the SPEC-PROVIDER pattern was applied to secrets.
+
+Two options:
+1. **Update tests/tools/secret.bats** to test the provider tools (vault, doppler) directly via the SPEC-PROVIDER pattern
+2. **Delete tests/tools/secret.bats** if the tests were testing a tool that no longer makes sense in the current architecture
+
+Add this to your queue as part of test isolation work (#109). When you're auditing tests anyway, fix or delete this one. Low priority — the tool itself works.
+
+## Resolving this dispatch
+
+Resolved as 'tool exists, skill shipped, test fix queued.'
+
+Captain

--- a/usr/jordan/captain/logs/captains-log-20260407.md
+++ b/usr/jordan/captain/logs/captains-log-20260407.md
@@ -1,0 +1,12 @@
+---
+type: captains-log
+date: 2026-04-07
+agent: jordan/captain
+---
+
+# Captain's Log — Tuesday, April 7, 2026
+
+
+## 13:28:28 — milestone
+
+Captain's log tool shipped — formalizing the narrative thread pattern (flag #2)

--- a/usr/jordan/captain/transcripts/agent-attribution-model-20260407.md
+++ b/usr/jordan/captain/transcripts/agent-attribution-model-20260407.md
@@ -1,0 +1,215 @@
+---
+type: discussion-record
+date: 2026-04-07
+participants: [jordan, captain]
+topic: per-agent commit attribution model
+status: resolved → implemented in commit 03d3ed6
+---
+
+# Per-Agent Commit Attribution Model
+
+A working session that started from a question — "should we attribute commits to the agent and maybe give credit to the principal?" — and ended with a shipped implementation in `claude/tools/git-commit`. This document captures the decisions, the rationale, the dead-ends, and the open questions for future iteration.
+
+## The Question
+
+The starting prompt: in a multi-agent framework, who gets credit for a commit?
+
+Today (before this work):
+```
+Author: Jordan Dea-Mattson <jdm@devopspm.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+The principal (Jordan) and Claude get credit. The actual Agency agent (captain, iscp, devex, mdpal-cli, etc.) is invisible. Multiple agents in the same session look identical in `git log`.
+
+The goal: make the per-agent attribution visible without losing principal accountability or breaking existing tooling.
+
+## Constraints
+
+These shaped every decision:
+
+1. **No domain registration.** Whatever we ship must work without buying or claiming a new domain.
+2. **Works out of the box on GitHub.** Zero-config for any adopter with a GitHub account.
+3. **Configurable later.** Adopters with different setups (private email, custom mail) can override the default.
+4. **Principal owns the commit.** Legal authorship belongs to the principal — agents are tools, even when autonomous. The Author field stays the principal.
+5. **Agent identity is real and traceable.** "Captain" or "devex" should appear somewhere a human or tool can read.
+6. **Don't break `git blame` / `git shortlog` / contribution stats.** Those tools work on the Author field. Don't move agents into Author and lose principal aggregation.
+
+## Options Considered
+
+### Option A — Agent-only Co-Authored-By trailer with placeholder email
+
+```
+Co-Authored-By: captain <captain@noreply.invalid>
+```
+
+- Pros: Zero setup, RFC 2606 reserved domain, semantic clarity ("not a real email").
+- Cons: No principal encoding in the email itself. Agent looks orphaned from any principal.
+- **Rejected** in favor of approaches that encode both principal and agent.
+
+### Option B — Real mailbox with plus-addressing
+
+```
+Co-Authored-By: captain <jdm+captain@devopspm.com>
+```
+
+- Pros: Real delivery (replies route to the principal's mailbox via plus-addressing), agent identity in the tag, GitHub can profile-link if the email is verified on the principal's account.
+- Cons: Exposes principal's real email — though it's already public from existing commits. Requires the principal to use a mail provider that supports plus-addressing (most do). More work to set up across team members.
+- **Kept as the configurable Layer-2 option** for adopters who want forwarding to work and don't mind the email exposure.
+
+### Option C — `captain+jordandm@noreply.{framework}.dev`
+
+`{agent}+{principal}@noreply.framework-domain` — agent as the base, principal as the tag.
+
+- Reads as "captain working for jordandm." Semantically clean.
+- **Rejected** because it requires the framework to own a domain, which Jordan explicitly didn't want.
+
+### Option D — `jordandm+captain@noreply.github.com` (entity noreply)
+
+Borrowing GitHub's pattern of using `@noreply.github.com` (without `users.`) for non-user entities like repos (`monofolk@noreply.github.com`) and notification categories (`ci_activity@noreply.github.com`).
+
+- Pros: GitHub-owned domain, no registration, looks legitimate.
+- Cons: **No profile linking** — `noreply.github.com` is not the user noreply domain. The principal's profile wouldn't link.
+- **Rejected** because we wanted profile linking on the principal author.
+
+### Option E — `jordandm+captain@users.noreply.github.com` (user noreply with plus-tag)
+
+What we ended up with. Uses the **user** noreply domain (`users.noreply.github.com`) which is what GitHub recognizes for user attribution.
+
+- Pros: Same domain for principal and agent, GitHub-owned, no registration, works for any GitHub user.
+- Open question: Does GitHub strip the `+captain` plus-tag and dedupe to `jordandm`? **Tested with real commits.**
+
+## The Test
+
+Four throwaway commits on a test branch (`test/github-plus-tag-attribution`, since deleted) verified GitHub's actual behavior:
+
+| Commit | Format | Result |
+|--------|--------|--------|
+| `dd7984e` | `jordandm+captain@users.noreply.github.com` (agent only) | "3 people authored" — distinct identity |
+| `c133aaa` | `jordandm+iscp.the-agency@users.noreply.github.com` (with .repo) | "3 people authored" — distinct identity |
+| `1284b27` | Principal canonical author + 3 plus-tag co-authors + Claude | "5 people committed" — all distinct |
+| `7e0932a` | Principal canonical author + 3 `agent.repo` plus-tag co-authors | "4 people committed" — all distinct |
+
+**Findings:**
+
+1. **GitHub does NOT strip plus-tags** on `users.noreply.github.com`. Each `jordandm+X@users.noreply.github.com` is a distinct contributor — literal string match.
+2. **Canonical `jordandm@users.noreply.github.com` profile-links to the user.** The principal author's avatar shows correctly.
+3. **Plus-tag identities show as distinct contributors with gray default avatars** — not deduped, not profile-linked, but counted separately in GitHub's contributor view.
+4. **`.` is valid in the local-part** — `jordandm+captain.the-agency@` works fine, no encoding issues.
+
+This is exactly what we want for the model:
+- Principal author = real linked GitHub identity (avatar, profile, contribution count)
+- Each agent = distinct contributor entry (gray avatar, but distinct attribution)
+
+## The Final Format
+
+```
+Author: Jordan Dea-Mattson <jordandm@users.noreply.github.com>
+
+[commit message body]
+
+Co-Authored-By: captain <jordandm+captain.the-agency.the-agency-ai@users.noreply.github.com>
+Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
+```
+
+**Schema:** `{username}+{agent}.{repo}.{org}@users.noreply.github.com`
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `{username}` | `agency.yaml` → `principals.{key}.platforms.github[]` matching current org | `jordandm` |
+| `{agent}` | `agent-identity --agent` | `captain` |
+| `{repo}` | `agent-identity --repo` | `the-agency` |
+| `{org}` | Parsed from git `remote.origin.url` | `the-agency-ai` |
+
+**Why fully qualified:** Mirrors the Agency address convention `{org}/{repo}/{principal}/{agent}`. Self-describing — you can tell which agent in which repo in which org from the email alone, without looking up principal mappings.
+
+**Why GitHub user noreply:** Profile linking on the principal author. Agents get gray avatars (correct — they're not GitHub users) but are counted as distinct contributors.
+
+## What `/git-commit` Does (after this change)
+
+Before building the commit body, `git-commit`:
+
+1. Calls `agent-identity` for `--agent`, `--principal`, `--repo`
+2. Parses `git remote get-url origin` to extract the GitHub `{org}`
+3. Reads `claude/config/agency.yaml` with an awk parser, finds the principal entry whose `name` matches `--principal`, finds the `platforms.github[]` entry whose `repos[].org` matches `{org}`, returns the `username`
+4. Builds: `Co-Authored-By: {agent} <{username}+{agent}.{repo}.{org}@users.noreply.github.com>`
+5. Appends to the trailer block before the existing `Co-Authored-By: Claude` line
+
+**Fallbacks** (it never crashes the commit):
+- `agent-identity` unavailable → skip the trailer
+- GitHub username not resolvable from `agency.yaml` → use the principal slug as fallback
+- Git remote not parseable → omit the `.org` suffix
+
+## Configurable Layer (Future)
+
+The Day 32 ship is GitHub-mode-only, no override. The Layer 2 model (real mailbox with plus-addressing) is documented as the configurable future:
+
+```yaml
+principals:
+  jdm:
+    commit_email: jdm@devopspm.com   # if set, use this for author + plus-tag for agent
+```
+
+When set, `/git-commit` would build:
+```
+Author: Jordan Dea-Mattson <jdm@devopspm.com>
+Co-Authored-By: captain <jdm+captain@devopspm.com>
+```
+
+— routing to the principal's real mailbox, optional verification on GitHub for profile linking on agents.
+
+Not implemented yet. Will be added when the first adopter asks.
+
+## Open Items / Future Work
+
+### Agent Mail Service (flag #40)
+
+The plus-tag format `jordandm+captain.the-agency.the-agency-ai@users.noreply.github.com` is currently a non-routable string in commit trailers. There's a real product idea here: an "agent mail" service that takes this format and provides actual delivery.
+
+- Service-owned domain (e.g., `agentmail.dev`)
+- Mailbox per principal
+- Plus-tags route per agent
+- Forwarding rules per agent (e.g., `jdm+captain.commits@agentmail.dev` → main inbox, `jdm+iscp.errors@agentmail.dev` → digest)
+- Solves the agentic email gap: agents need addressable identities AND routing back to principals
+
+Initial users would be AIADLC framework adopters. Could become the GitHub-noreply alternative for projects not on GitHub.
+
+Flagged: `flag #40`. Captured for future product discussion.
+
+### Configurable per-principal override (Layer 2)
+
+Documented above. Not implemented in this PR. Will add when needed.
+
+### Verification of plus-tag profile linking
+
+The test branch confirmed GitHub does NOT strip plus-tags — each is a distinct identity. This means agents don't get profile photos in the GitHub UI, just gray avatars with the agent name. If GitHub ever adds plus-address handling on `users.noreply.github.com`, our existing format would suddenly start showing the principal's avatar on every agent co-author. That would be a positive change with zero migration needed.
+
+### History rewrite for stale Test User attributions
+
+Separate issue (flag #6, dispatched to devex as #109). Not part of this attribution work but related — the Test User pollution shows the importance of getting attribution right. Once devex fixes the test isolation bug, the historical commits with Test User attribution remain on devex branch (fixable by rebase before merge to main).
+
+## Decision Log (chronological)
+
+1. **Author should be the principal** — ownership, legal, `git blame` integrity. Agents go in Co-Authored-By trailers, not the Author field.
+2. **Co-Authored-By trailer for the agent** — standard mechanism, GitHub renders as additional contributor.
+3. **GitHub user noreply for the email domain** — `users.noreply.github.com`, not `noreply.github.com`. The user noreply is the only form GitHub profile-links.
+4. **Plus-tag carries the agent** — `+captain` after the username.
+5. **Include `.repo` in the plus-tag** — disambiguates across repos.
+6. **Include `.org` in the plus-tag** — fully qualified, self-describing, mirrors the address convention.
+7. **Pull GitHub username from `agency.yaml`** — supports per-org identities (principal can have different usernames in different orgs).
+8. **Default is GitHub mode, no override** — ship simple, add config when needed.
+9. **Implementation lives in `claude/tools/git-commit`** — captain territory, small enough to do in-context, not dispatched to devex.
+10. **Test branch deleted after verification** — keep main history clean.
+
+## Implementation Reference
+
+- Tool: `claude/tools/git-commit` (commit `03d3ed6`)
+- Test commits (deleted): `dd7984e`, `c133aaa`, `1284b27`, `7e0932a`
+- Flags captured: `flag #39` (attribution model), `flag #40` (agent mail business idea)
+- Related: Day 32 - Release 1 PR (`day32-release-1` branch, PR #46)
+
+## What This Records
+
+This isn't just a how-it-works doc — it's the reasoning trail. When someone in the future asks "why does our commit attribution use this weird plus-tag thing?", this document is the answer. The dead-end options are here so we don't re-litigate them. The constraints are here so we don't accidentally violate them when extending. The open items are here so the next person knows what's not done.
+
+The narrative thread of how we arrived at the format is the most valuable part. The code is just the implementation of a decision.

--- a/usr/jordan/captain/transcripts/flag-triage-20260407.md
+++ b/usr/jordan/captain/transcripts/flag-triage-20260407.md
@@ -1,0 +1,108 @@
+---
+type: triage-record
+date: 2026-04-07
+participants: [jordan, captain]
+topic: flag triage — Day 32
+status: 16 flags resolved + cleared, 18 remaining for 1B1
+---
+
+# Flag Triage — Day 32
+
+Triage of the captain's flag queue. 34 flags accumulated since Day 28. Categorized into three batches: already resolved, captured elsewhere, still live.
+
+This document archives the 16 flags being cleared (with their resolutions) before they're removed from the active queue. The 18 still-live flags get 1B1'd separately.
+
+---
+
+## Batch 1: Already Resolved (cleared)
+
+These flags were resolved by Day 32 work. The original observations were correct at the time; the work addressed them.
+
+### Flag 1, 2, 3 — Permission prompts on basic ops
+
+**Original (2026-04-05):** ISCP agent hitting permission prompts for basic operations (ls, git show, sqlite3, ~/.agency/, cd+git compound). Claude Code treats compound commands as bare repo attack vectors.
+
+**Resolution:** Day 32 permissions overhaul. Replaced 100+ narrow patterns with `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)` in `.claude/settings.json` and `claude/config/settings-template.json`. The project boundary is the security boundary; hookify rules handle behavioral enforcement, not the permission system. See commits `daf1148`, `e552885`, `26f7963`.
+
+### Flag 17, 18 — Symlink dispatch payload architecture
+
+**Original (2026-04-06):** Critical design — `~/.agency/{repo}/dispatches/` should hold symlinks to git payloads, not copies. Solves branch transparency without violating C3 (git as source of truth).
+
+**Resolution:** Implemented in ISCP commit `1e610fd`. Already in production in the symlink-merge work that landed before Day 32. Recorded in valueflow A&D §8.
+
+### Flag 19 — Day counting convention
+
+**Original (2026-04-06):** Count days with commits per repo and per workstream. Day 30 = 30 days with commits since 2026-01-05. Propose as Agency model. Add to CLAUDE-THEAGENCY.md and valueflow PVR as a health metric.
+
+**Resolution:** Documented in `claude/README-THEAGENCY.md` under the Day-PR Release Pattern section as part of Day 32 commit `f3022da`. Convention is now active — every Day 32 commit uses `Day 32:` prefix.
+
+### Flag 16, 20 — Manual dispatch loop convention
+
+**Original (2026-04-06):** Add to all agent registration startup sequences: 'Set a loop to check for dispatches every 5 minutes: /loop 5m dispatch check'.
+
+**Resolution:** INVALIDATED by Day 32 friction analysis P2. The manual `/loop 5m dispatch check` setup was identified as wasted startup overhead (3 tool calls per session). Removed from all agent registrations. The `iscp-check` hook fires automatically on `SessionStart`, `UserPromptSubmit`, and `Stop` — no manual loop needed. See commit `e04dd56`.
+
+### Flag 22 — Dispatch tool not pre-approved (--friction)
+
+**Original (2026-04-06):** Agents blocked on sending dispatches — dispatch tool not pre-approved in worktree settings. The MAR review process is broken by permission friction. settings-template must ship dispatch permissions. This is the #1 DevEx priority.
+
+**Resolution:** Resolved by the `Bash(*)` overhaul. Settings-template now ships with the broad permissions. No agent should hit a permission prompt on a tool again. See commit `2a151aa`.
+
+### Flag 23, 25, 26 — One agent per worktree
+
+**Original (2026-04-06):**
+- Two agents (mdpal-cli and mdpal-app) sharing one worktree breaks identity, dispatch routing, git status, commit attribution.
+- RULE: One agent, one worktree.
+- CONVENTION: Agent/worktree naming — workstream prefix + agent name. mdpal → mdpal-cli, mdpal-app.
+
+**Resolution:** Already implemented. mdpal worktree was split into `mdpal-cli` and `mdpal-app` worktrees during the Day 31 reboot. The "one agent, one worktree" rule is now reflected in `.claude/agents/mdpal-cli.md` and `.claude/agents/mdpal-app.md` as separate registrations. Worktree naming follows the convention.
+
+### Flag 24 — Shared worktree multi-agent design
+
+**Original (2026-04-06):** DESIGN: shared worktree model — multiple agents in one worktree (mdpal-cli + mdpal-app in mdpal worktree). Need: multi-agent identity or workstream-scoped dispatch visibility. ISCP needs to support this pattern — it's intentional for collaborating agents on the same codebase.
+
+**Resolution:** INVALIDATED by Flag #25 (one agent per worktree rule). The shared worktree pattern was abandoned in favor of per-agent worktrees with collaboration via dispatches. No ISCP work needed.
+
+### Flag 27 — agent-identity worktree resolution bug (--friction)
+
+**Original (2026-04-07):** agent-identity resolves to captain on iscp worktree. Root cause: CLAUDE_PROJECT_DIR unset in Bash tool calls + no .agency-agent file in worktree + SCRIPT_DIR fallback goes to main checkout. Cascading failure: handoff tool writes to wrong agent path.
+
+**Resolution:** ISCP agent fixed this in commit `de73c9c`. Added PWD-based worktree detection as middle tier between `CLAUDE_PROJECT_DIR` (only set in hooks) and `SCRIPT_DIR` fallback (resolves to main). The worktree's git rev-parse --show-toplevel now correctly resolves identity. 22/22 agent-identity tests pass.
+
+### Flag 32 — Security skill broken
+
+**Original (2026-04-07):** BUG: Security skill seems to be broken. Investigate.
+
+**Resolution:** Found and fixed. Root cause: `/secret` existed only as a command (`.claude/commands/secret.md`) not a skill, AND the command body used `$CLAUDE_PROJECT_DIR` in a Bash example which is empty in agent shell sessions. Created `.claude/skills/secret/SKILL.md` as a proper SPEC-PROVIDER skill (third example after `/preview` and `/deploy`). Configured `doppler` as the active provider in `agency.yaml`. Shipped in commit `5e6d31e` (PR #47, Day 32 - Release 2). Doppler tool verification dispatched to monofolk/devex.
+
+---
+
+## Batch 2: Captured Elsewhere (cleared)
+
+These flags became dispatches to other agents. The work is queued in their inbox; the flag is no longer the right tracking mechanism.
+
+### Flag 29 — Worktree awareness check
+
+**Original (2026-04-07):** SEED: detect when agent's shell CWD doesn't match its worktree root. Could be a PreToolUse hookify rule or a lightweight check in agent-identity. The ISCP agent self-corrected when it realized cd /Users/jdm/code/the-agency goes to main, not the worktree — but only after wasting tool calls.
+
+**Resolution:** Dispatched to devex as #110. Two-layer plan: SessionStart hook (Layer 1) to catch wrong CWD at boot, PreToolUse hookify rule (Layer 2) to block any `cd` that takes the agent outside their worktree. Plan #116 from devex approved with all 4 decisions. Implementation in devex queue.
+
+### Flag 30 — core.bare keeps flipping
+
+**Original (2026-04-07):** BUG: git config core.bare keeps getting set to true on the main checkout. Happens during worktree merges (git -C worktree merge SHA). Breaks all git operations on main until manually fixed with git config core.bare false. Need to investigate root cause.
+
+**Resolution:** Dispatched to devex as part of #109 (BATS test isolation work). DevEx investigated and concluded: not currently broken in live config, no test sets core.bare directly, hypothesis is worktree merge mechanics rather than test code. Recommendation: defer until we observe it again. Captain agreed in approval response to plan #115.
+
+---
+
+## What Was Cleared
+
+16 flags cleared total. The active flag queue now has 18 items remaining for 1B1 triage.
+
+The cleared flags are recorded here as the audit trail. The original observations + the resolutions both belong in history.
+
+---
+
+## Next: 1B1 the 18 remaining flags
+
+See follow-up triage for the live items: provenance discipline, GTM seeds, command audit, Anthropic issues, MAR process improvements, agency-audit + structure.yaml seeds, V3 fragment registry, security pre-GTM concern, Granola workflow, agent mail business idea.

--- a/usr/jordan/iscp/history/handoff-20260407-010353.md
+++ b/usr/jordan/iscp/history/handoff-20260407-010353.md
@@ -1,0 +1,75 @@
+---
+type: handoff
+agent: the-agency/jordan/iscp
+workstream: iscp
+date: 2026-04-07
+trigger: MAR review dispatch #95 completed — V2 plan ISCP perspective review sent as dispatch #100
+---
+
+## Identity
+
+`the-agency/jordan/iscp` -- ISCP workstream agent. I build and maintain the Inter-Session Communication Protocol: the notification, dispatch, and flag infrastructure that connects all agents.
+
+## Current State
+
+ISCP v1 is complete and hardened. 174 BATS tests green. The iscp branch is fully merged into main -- zero unique commits on iscp, main is 8 commits ahead. Both the symlink commit (1e610fd) and structured commit dispatch (41fb5cf) are on main.
+
+Full tool suite operational: `agent-identity`, `dispatch` (create/list/read/check/resolve/status/reply), `flag` (capture/list/count/discuss/clear/resolve), `iscp-check` (hook notification), `iscp-migrate` (legacy migration).
+
+## Last Session Work
+
+Completed MAR review of Valueflow V2 implementation plan (dispatch #95). Sent review-response as dispatch #100 to captain with 14 findings. Key findings:
+- Iteration 2.1 (symlink merge) is already done -- reduce to verification step
+- Iteration 2.4 (dispatch-on-commit) is partially implemented (41fb5cf)
+- Dispatch authority role resolution mechanism undefined (finding #3)
+- Review-response authority rule is inverted -- reviewers send responses, not authors (finding #4)
+- DB schema versioning should be Phase 2.0, not part of 2.5 (finding #6)
+- SMS-style dispatches and BUG 2 not in plan -- intentional? (findings #10, #11)
+- Flag categories (2.3) must precede health metrics (2.5) for flag rate metrics (finding #12)
+
+## Valueflow Context
+
+- Plan: `claude/workstreams/agency/valueflow-plan-20260407.md`
+- PVR: `claude/workstreams/agency/valueflow-pvr-20260406.md`
+- A&D: `claude/workstreams/agency/valueflow-ad-20260406.md`
+- MAR dispositions: `claude/workstreams/agency/reviews/`
+
+## Key Decisions
+
+- `dispatch create` requires `--body` or explicit `--template`. No silent empty payloads.
+- `agent-identity` checks `.agency-agent` file before branch detection. PR branches resolve to captain.
+- `CLAUDE_PROJECT_DIR` is authoritative over `SCRIPT_DIR` for project root in all ISCP tools.
+- Symlink-based dispatch payload resolution with legacy 4-strategy fallback.
+- Commit dispatches carry structured metadata: commit_hash, branch, files_changed, stage_hash, work_item.
+
+## Open Items
+
+1. **DB schema versioning** -- migration framework for schema changes. Should be Phase 2.0 (prerequisite for flag categories and health metrics).
+2. **Flag categories** (`--friction`, `--idea`, `--bug`) -- A&D Section 10. V2 Phase 2.3.
+3. **Dispatch retention** -- archive resolved dispatches after 30 days. Not started.
+4. **Dropbox primitive** -- file staging between worktrees. Not started.
+5. **BUG 2** -- `dispatch list --all` shows other agents' unread mail. Not in V2 plan.
+6. **SMS-style dispatches** -- principal requested. Not in V2 plan. Flag #1 in queue.
+7. **Dispatch authority role resolution** -- design question raised in MAR review finding #3.
+
+## Flags in Queue (4 items)
+
+1. SMS-style dispatches (principal request)
+2. Captain's log formalization
+3. Friction-to-toolification pattern
+4. Release notes on push
+
+## Next Action
+
+1. Await captain's triage of dispatch #100 (MAR review response)
+2. When V2 plan is approved and seed dispatched, write ISCP workstream implementation plan at `claude/workstreams/iscp/iscp-valueflow-plan-20260407.md`
+3. Start with DB schema versioning (Phase 2.0 / backlog item #1) -- it unblocks everything else
+4. Fresh worktree from main recommended (existing iscp worktree has stale state)
+
+## Startup Actions
+
+1. Set dispatch loop: `/loop 5m dispatch check`
+2. Process unread dispatches: `dispatch list`
+3. Process unread flags: `flag list`
+4. Read the valueflow A&D: `claude/workstreams/agency/valueflow-ad-20260406.md`
+5. Follow Next Action above


### PR DESCRIPTION
## Summary

Day 32 - Release 2. Builds on Release 1 (PR #46, merged). New capabilities and patterns shipped after the docs+infra release.

(This PR was originally #47, auto-closed when day32-release-1 was deleted. Re-created with base=main.)

## What's In It

### 1. New Tool + Skill: `/captain-log`
The narrative thread pattern. Daily timestamped log entries with categories: decision, friction, learning, milestone, observation, build. Different from handoffs (state), transcripts (full conversation), and flags (quick capture) — captures the *why* and *what we built*.

- Tool: `claude/tools/captain-log`
- Skill: `.claude/skills/captain-log/SKILL.md`
- Storage: `usr/{principal}/captain/logs/captains-log-{YYYYMMDD}.md`
- Resolves flag #2

### 2. `/secret` Skill (SPEC-PROVIDER)
Converted `/secret` from command to a proper skill following the SPEC-PROVIDER pattern (third example after `/preview` and `/deploy`). Reads `secrets.provider` from `agency.yaml`, dispatches to `./claude/tools/secret-{provider}`. Fixed the `$CLAUDE_PROJECT_DIR` bug.

- New skill: `.claude/skills/secret/SKILL.md`
- Configured `doppler` as active provider
- Resolves flag #5

### 3. Day-PR Release Pattern Documented
Added "The Day-PR Release Pattern" subsection to README-THEAGENCY.md. Documents the day{N}-release-{M} convention, draft-first PR flow, release dispatches.

### 4. Agency Init Template Refactor
Replaced inline heredoc in `_agency-init` with a template+sed pattern, matching how `CLAUDE-PROJECT.md` is handled. HANDOFF-BOOTSTRAP.md is now the source of truth.

### 5. Per-Agent Commit Attribution
Every commit via `/git-commit` now carries a per-agent Co-Authored-By trailer:

```
Author: Jordan Dea-Mattson <jordandm@users.noreply.github.com>
Co-Authored-By: captain <jordandm+captain.the-agency.the-agency-ai@users.noreply.github.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
```

Format: `{username}+{agent}.{repo}.{org}@users.noreply.github.com` — fully qualified, mirrors the Agency address convention. Verified with real test commits before shipping.

- Implementation: `claude/tools/git-commit`
- Discussion record: `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`
- README-THEAGENCY.md: new "Per-Agent Commit Attribution" subsection
- Resolves flag #39, captures flag #40

### 6. Coordination Artifacts
- 8 dispatches sent to devex (plans #109/110/114/118/122 + heartbeat + secret tool resolve)
- 1 dispatch to iscp (per-agent inboxes plan)
- 6 review-responses approving plans
- Flag triage record (16 cleared)
- Granola workflow seed (captured from flag #37)
- Agent Mail Service seed (captured from flags #39+#40)

## What Adopters Need To Do

1. Pull latest the-agency
2. Run `./claude/tools/agency update`
3. The new attribution kicks in automatically on next `/git-commit`

🤖 Generated with [Claude Code](https://claude.com/claude-code)