### PR TITLE
Day 33 R1: agency-issue v1, release-plan v1, dispatch loop convention, iscp-check delta suppression, 6 seeds

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -21,7 +21,7 @@
           },
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/tools/iscp-check"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/tools/iscp-check --force"
           },
           {
             "type": "command",

--- a/.claude/skills/agency-issue/SKILL.md
+++ b/.claude/skills/agency-issue/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: agency-issue
+description: File, view, comment on, and close issues against the-agency framework on GitHub. Two-way channel with persisted local audit trail in `usr/{principal}/reports/`.
+---
+
+# agency-issue
+
+Use this skill when the user (or you) hits friction with the-agency framework — a bug, missing feature, doc gap, ergonomic problem — and wants to file it in the GitHub issue tracker.
+
+Unlike `/feedback` (which is fire-and-forget to Anthropic for Claude Code itself), `/agency-issue` is a two-way channel against the-agency's own GitHub repo. You can file, view current state, add comments, and close issues — all from within an agency session.
+
+Every filed issue writes a markdown report to `usr/{principal}/reports/` with frontmatter capturing the GitHub issue number, target repo, date, and a response log slot.
+
+## Usage
+
+### File a new issue
+
+```bash
+./claude/tools/agency-issue file \
+  --type bug \
+  --title "Concise one-line title" \
+  --body-file /path/to/issue-body.md
+```
+
+Or with inline body:
+
+```bash
+./claude/tools/agency-issue file \
+  --type friction \
+  --title "Hookify rule X blocks legitimate workflow Y" \
+  --body "When I do X, hookify rule Y triggers and blocks me. The rule is correct in spirit but the heuristic is too broad..."
+```
+
+**Required flags:**
+- `--type` — one of: `bug`, `feature`, `friction`, `question`, `docs`
+- `--title` — single-line issue title
+- `--body` OR `--body-file` — issue body (use `-` for stdin with `--body-file`)
+
+**No labels in v1.** The type goes into the issue body header, not a GitHub label. Triage happens by reading.
+
+### List open issues
+
+```bash
+./claude/tools/agency-issue list
+./claude/tools/agency-issue list --state closed --limit 50
+./claude/tools/agency-issue list --state all
+```
+
+### View a specific issue
+
+```bash
+./claude/tools/agency-issue view 47
+```
+
+Shows the issue body, metadata, and all comments.
+
+### Comment on an issue
+
+```bash
+./claude/tools/agency-issue comment 47 --body "Reproduced on monofolk too. Adding context: ..."
+./claude/tools/agency-issue comment 47 --body-file my-comment.md
+```
+
+### Close an issue
+
+```bash
+./claude/tools/agency-issue close 47
+./claude/tools/agency-issue close 47 --comment "Fixed in #52, shipped in Day 33 R2."
+```
+
+## Issue body format
+
+For consistency, follow the same structure as `/feedback` (per `claude/docs/FEEDBACK-FORMAT.md`):
+
+- **Problem** — what's broken or missing, who hits it, what the impact is
+- **Steps to Reproduce** — exact commands or sequence (for bugs); use case description (for features)
+- **Diagnostic Evidence** — commands run, output, log excerpts
+- **Root Cause** — if known
+- **Requested Behavior** — exactly what you want, not vague
+- **Why This Matters** — impact on workflow
+
+For internal cross-references, append a "Related" section at the bottom with paths to seeds, dispatches, transcripts, etc.
+
+## Permissions
+
+Delegated to GitHub via `gh`. Anyone with `gh auth` can file. Comment and close are gated by GitHub's own write-access checks — `gh` will refuse if the user lacks permission.
+
+## Configuration
+
+Target repo lives in `claude/config/agency.yaml`:
+
+```yaml
+issues:
+  provider: github
+  github:
+    target_repo: "the-agency-ai/the-agency"
+```
+
+v1 supports a single provider (github) and single target repo. v2+ will follow the SPEC-PROVIDER pattern for pluggable backends (gitlab, linear, jira) and multi-target support.
+
+## Reports and audit trail
+
+Every filed issue writes a report file to `usr/{principal}/reports/`:
+
+```
+report-agency-issue-{slug}-{YYYYMMDD}.md
+```
+
+The frontmatter captures:
+
+```yaml
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-08
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/47
+github_issue_number: 47
+status: open
+---
+```
+
+The `usr/{principal}/reports/REPORTS-INDEX.md` file is updated with a row pointing at the new report. Same pattern as Claude Code feedback reports — the reports directory is the principal's external-filing record.
+
+## Failure modes
+
+- **gh CLI not installed** → install from https://cli.github.com/
+- **gh not authenticated** → run `gh auth login`
+- **No write access to target repo** → GitHub error passed through; need maintainer to grant access
+- **Other gh errors** → passed through verbatim with context about which verb failed
+
+## When to use vs not use
+
+**Use `agency-issue` when:**
+- You hit a bug or friction in the-agency framework itself
+- You want a feature in the framework
+- You want documentation to be clearer or more complete
+- You have a question that should be tracked in the issue tracker (not just a chat)
+
+**Use `/feedback` instead when:**
+- The bug is in Claude Code itself (Anthropic's CLI), not in the-agency framework
+- The feature request is for Claude Code
+
+**Use a flag (`flag <message>`) instead when:**
+- It's a quick observation you want to come back to later
+- You're not sure if it warrants a public issue yet
+- You want to triage with the principal first
+
+**Use a dispatch instead when:**
+- You're coordinating with another agent in the agency, not filing against the framework
+- It's a directive, review request, or status update — not a bug or feature

--- a/claude/CLAUDE-THEAGENCY.md
+++ b/claude/CLAUDE-THEAGENCY.md
@@ -434,6 +434,33 @@ The `iscp-check` hook fires on SessionStart, UserPromptSubmit, and Stop. It quer
 ### When You Have Mail
 
 - **SessionStart:** Process unread items FIRST before other work (hookify enforced)
+- **Set up two dispatch loops on session start.** Every agent — not just captain — runs both loops at session start. They auto-expire after 7 days; re-set each session.
+
+  **Loop 1 — fast-path (silent-when-clean), every 5 minutes:**
+
+  ```
+  /loop 5m Run: ./claude/tools/dispatch list --status unread
+
+  If the output is exactly "No dispatches found." — produce NO output
+  whatsoever. No "Clean", no acknowledgment, nothing. End the turn silently.
+
+  If there are unread dispatches: pause current work, read each with
+  `dispatch read <id>`, respond appropriately, then resolve each with
+  `dispatch resolve <id>` if no further action is needed.
+  ```
+
+  **Loop 2 — nag-path (visible-when-sitting), every 30 minutes:**
+
+  ```
+  /loop 30m NAG CHECK: Run ./claude/tools/dispatch list --status unread.
+  If any unread items exist, they've been sitting at least 30 minutes —
+  produce a VISIBLE alert to the user (not silent): list the unread items
+  with IDs, ages, and senders, note that you are now reading and responding.
+  Then read each, respond, and resolve. If the output is "No dispatches
+  found." — produce NO output and end silently.
+  ```
+
+  Why two loops: the 5-minute loop picks up new mail quickly between prompts with zero terminal noise when there's nothing to do. The 30-minute loop is the "dispatches are being ignored" alarm — if anything is still unread at 30m, the 5m loop already processed it or is blocked, so a visible alert to the principal is warranted.
 - **Mid-session:** Act on mail at a natural break, not immediately
 - **Dispatch types:** directive (do this), review (fix these), seed (input material), escalation (urgent)
 

--- a/claude/config/agency.yaml
+++ b/claude/config/agency.yaml
@@ -87,6 +87,14 @@ deploy:
 # Crawl (site content extraction)
 crawl:
   provider: "webfetch"  # Default: webfetch (built-in). Alternatives: playwright, wget, scrapy
+
+# Issue tracking (file/view/comment/close issues against the-agency framework)
+# v1: single provider (github), single target. v2+: SPEC-PROVIDER pattern with
+# pluggable providers (gitlab, linear, jira) and multi-target support.
+issues:
+  provider: "github"  # v1: github only
+  github:
+    target_repo: "the-agency-ai/the-agency"  # Where issues are filed
   sites: []  # Configure per-project: [{name, url, patterns}]
 
 # Testing — declares test suites and how to run them

--- a/claude/config/settings-template.json
+++ b/claude/config/settings-template.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/tools/iscp-check"
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/tools/iscp-check --force"
           },
           {
             "type": "command",

--- a/claude/templates/HANDOFF-BOOTSTRAP.md
+++ b/claude/templates/HANDOFF-BOOTSTRAP.md
@@ -13,7 +13,12 @@ You are the captain — first up, last down, the coordination backbone for **{{P
 
 ## Your First Action
 
-Greet the principal warmly and orient them. Offer the guided tour first — most adopters benefit from it:
+**Before greeting the principal**, arm your two dispatch loops. These are standard for every agent, every session (see `claude/CLAUDE-THEAGENCY.md` → "When You Have Mail" for the canonical prompts):
+
+1. `/loop 5m …silent-when-clean…` — fast-path, picks up new mail between prompts with zero noise
+2. `/loop 30m …visible-when-sitting…` — nag alarm if dispatches are still unread after 30 minutes
+
+Then greet the principal warmly and orient them. Offer the guided tour first — most adopters benefit from it:
 
 > Welcome to The Agency! I'm the captain — your guide to multi-agent development. I'll help you set up **{{PROJECT_NAME}}** and start building.
 >

--- a/claude/tools/agency-issue
+++ b/claude/tools/agency-issue
@@ -1,0 +1,476 @@
+#!/bin/bash
+#
+# agency-issue — File, view, comment on, and close GitHub issues against
+# the-agency framework, with persisted local report files for audit.
+#
+# What Problem: /feedback (Anthropic Claude Code) is fire-and-forget — no
+# status visibility, no update path. We need a richer two-way channel for
+# filing issues against the-agency framework itself: file, view current
+# state, comment, close, all wrapped over the GitHub CLI with a persisted
+# local audit trail in usr/{principal}/reports/.
+#
+# This is the v1 implementation per the design 1B1'd with principal on
+# 2026-04-08 (see seed-agency-issue-skill-20260408.md).
+#
+# How & Why: Thin wrapper over `gh issue` — no local cache, live calls
+# every invocation, GitHub is the source of truth. Each filing writes a
+# markdown report file to usr/{principal}/reports/ with frontmatter
+# capturing the GitHub issue number, target repo, date, and a response
+# log slot for future updates. The REPORTS-INDEX.md is updated on every
+# file action.
+#
+# Target repo resolution: reads `issues.github.target_repo` from
+# claude/config/agency.yaml. Defaults to `the-agency-ai/the-agency` if
+# unconfigured. Same awk-parse approach as the secret tool — no yaml
+# library dependency.
+#
+# Permissions: delegates to GitHub. Anyone with `gh auth` can file. Comment
+# and close are gated by GitHub's own permission model — `gh` will refuse
+# if the user lacks write access. No custom authz.
+#
+# No labels in v1 — principal pushed back on premature complexity. Triage
+# happens by reading the issue body, not filtering on label dimensions.
+# Add labels later if/when volume justifies them.
+#
+# Verbs:
+#   file       Create a new issue, write a report file
+#   list       List open issues (or --state closed|all)
+#   view <id>  Show a specific issue with comments
+#   comment    Add a comment to an existing issue
+#   close      Close an issue (optionally with a closing comment)
+#
+# Written: 2026-04-08 — Day 33 R2
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- PATH resolution (for non-login shells) ---
+[ -d /opt/homebrew/bin ] && export PATH="/opt/homebrew/bin:$PATH"
+
+# --- Resolve project root ---
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
+elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+AGENCY_YAML="$PROJECT_ROOT/claude/config/agency.yaml"
+
+# --- Resolve target repo from agency.yaml ---
+# Looks for: issues.github.target_repo: "owner/repo"
+TARGET_REPO="the-agency-ai/the-agency"
+if [[ -f "$AGENCY_YAML" ]]; then
+    _resolved=$(awk '
+        /^issues:/ { in_issues=1; next }
+        in_issues && /^[a-z]/ && !/^  / { in_issues=0 }
+        in_issues && /^  github:/ { in_github=1; next }
+        in_github && /^  [a-z]/ && !/^    / { in_github=0 }
+        in_github && /^    target_repo:/ {
+            gsub(/^    target_repo: *"?/, "")
+            gsub(/"? *(#.*)?$/, "")
+            print
+            exit
+        }
+    ' "$AGENCY_YAML" 2>/dev/null || echo "")
+    [[ -n "$_resolved" ]] && TARGET_REPO="$_resolved"
+fi
+
+# --- Resolve principal for report directory ---
+PRINCIPAL=""
+if PRINCIPAL=$("$SCRIPT_DIR/agent-identity" --principal 2>/dev/null); then
+    :
+fi
+if [[ -z "$PRINCIPAL" ]]; then
+    PRINCIPAL="${USER:-default}"
+fi
+REPORTS_DIR="$PROJECT_ROOT/usr/$PRINCIPAL/reports"
+REPORTS_INDEX="$REPORTS_DIR/REPORTS-INDEX.md"
+
+# --- Helpers ---
+
+_die() {
+    echo "agency-issue: $*" >&2
+    exit 1
+}
+
+_check_gh() {
+    command -v gh >/dev/null 2>&1 || _die "gh CLI not installed. Install: https://cli.github.com/"
+    gh auth status >/dev/null 2>&1 || _die "gh not authenticated. Run: gh auth login"
+}
+
+_today() { date +%Y-%m-%d; }
+_now_iso() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+_slug() {
+    # Convert a string to a filesystem-safe slug
+    printf '%s' "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g; s/-\{2,\}/-/g; s/^-//; s/-$//' | cut -c1-50
+}
+
+_ensure_reports_dir() {
+    mkdir -p "$REPORTS_DIR"
+    if [[ ! -f "$REPORTS_INDEX" ]]; then
+        cat > "$REPORTS_INDEX" <<EOF
+# Principal Reports Index
+
+Reports filed externally (Anthropic Claude Code, the-agency GitHub, etc.) by or on behalf of $PRINCIPAL.
+
+Each row is one filing. Click through to the per-report markdown for full context, current state, and response log.
+
+**Location:** \`usr/$PRINCIPAL/reports/\` (principal-scoped)
+**Naming convention:** \`report-{kind}-{slug}-{YYYYMMDD}.md\`
+
+---
+
+## Filed Reports
+
+<!-- AGENCY-ISSUE-INDEX-START — agency-issue tool appends rows above the END marker -->
+
+| Date | Title | Kind | Target | External ID | Local Report | Status |
+|------|-------|------|--------|-------------|--------------|--------|
+
+<!-- AGENCY-ISSUE-INDEX-END -->
+
+## How to add an entry
+
+1. Draft the report with captain, following \`claude/docs/FEEDBACK-FORMAT.md\`
+2. File via the appropriate channel:
+   - \`agency-issue file\` → the-agency GitHub (auto-appends to this index)
+   - \`/feedback\` → Anthropic Claude Code (manually create the report file + append a row)
+3. The per-report markdown lives in this directory with full text, response log, and frontmatter linking back to the source seed
+4. This index is the at-a-glance view; the per-report file is the source of truth
+
+## Principle
+
+Reports are the record of what we asked the outside world for. Every gap we find in an external tool that we can't close in userspace becomes a report. Every response from the other side gets appended to its report file so we have a full narrative.
+EOF
+    fi
+
+    # Backfill the markers if they're missing (for indexes created before the marker convention)
+    if ! grep -q "AGENCY-ISSUE-INDEX-START" "$REPORTS_INDEX"; then
+        # Inject markers around the existing table — find the table block by header signature
+        local tmp
+        tmp=$(mktemp -t agency-issue-index.XXXXXX)
+        awk '
+            /^\| Date \| Title \|/ && !found_header {
+                print "<!-- AGENCY-ISSUE-INDEX-START — agency-issue tool appends rows above the END marker -->"
+                print ""
+                print
+                found_header=1
+                in_table=1
+                next
+            }
+            in_table && /^\| / { print; next }
+            in_table && /^\|--/ { print; next }
+            in_table && !/^\|/ {
+                print ""
+                print "<!-- AGENCY-ISSUE-INDEX-END -->"
+                print ""
+                print
+                in_table=0
+                next
+            }
+            { print }
+            END {
+                if (in_table) {
+                    print ""
+                    print "<!-- AGENCY-ISSUE-INDEX-END -->"
+                }
+            }
+        ' "$REPORTS_INDEX" > "$tmp"
+        mv "$tmp" "$REPORTS_INDEX"
+    fi
+}
+
+_append_to_index() {
+    local date="$1" title="$2" kind="$3" target="$4" external_id="$5" local_path="$6" status="$7"
+    local relative_local
+    relative_local="${local_path#$PROJECT_ROOT/}"
+    local row
+    row=$(printf '| %s | %s | %s | %s | %s | [%s](%s) | %s |' \
+        "$date" "$title" "$kind" "$target" "$external_id" \
+        "$(basename "$local_path" .md)" "$relative_local" "$status")
+
+    # Insert above the END marker so rows accumulate inside the table block
+    local tmp
+    tmp=$(mktemp -t agency-issue-index-append.XXXXXX)
+    awk -v row="$row" '
+        /<!-- AGENCY-ISSUE-INDEX-END -->/ {
+            print row
+            print
+            next
+        }
+        { print }
+    ' "$REPORTS_INDEX" > "$tmp"
+    mv "$tmp" "$REPORTS_INDEX"
+}
+
+_write_report_file() {
+    local issue_number="$1" issue_url="$2" title="$3" type="$4" body_file="$5"
+    local slug
+    slug=$(_slug "$title")
+    local report_file="$REPORTS_DIR/report-agency-issue-${slug}-$(date +%Y%m%d).md"
+
+    local body_content=""
+    if [[ -f "$body_file" ]]; then
+        body_content=$(cat "$body_file")
+    fi
+
+    cat > "$report_file" <<EOF
+---
+report_type: agency-issue
+issue_type: $type
+filing_agent: $(./claude/tools/agent-identity 2>/dev/null || echo "$PRINCIPAL")
+filed_by: $PRINCIPAL
+date_filed: $(_today)
+target_repo: $TARGET_REPO
+github_issue: $issue_url
+github_issue_number: $issue_number
+status: open
+---
+
+# $title
+
+**Filed:** $(_now_iso)
+**Target:** [$TARGET_REPO](https://github.com/$TARGET_REPO)
+**Issue:** [#$issue_number]($issue_url)
+**Type:** $type
+**Status:** open
+
+## Filed Body
+
+$body_content
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **$(_today):** Filed via \`agency-issue file\`. Issue created at $issue_url
+EOF
+
+    echo "$report_file"
+}
+
+_show_help() {
+    cat <<'HELP'
+agency-issue — File and track GitHub issues for the-agency framework
+
+Usage:
+  agency-issue file --type TYPE --title TITLE [--body BODY | --body-file FILE]
+  agency-issue list [--state open|closed|all] [--limit N]
+  agency-issue view <id>
+  agency-issue comment <id> --body BODY | --body-file FILE
+  agency-issue close <id> [--comment COMMENT]
+  agency-issue --version
+  agency-issue --help
+
+Verbs:
+  file       Create a new issue. Writes a local report to usr/{principal}/reports/
+  list       List open issues (default) or filter by state
+  view       Show a specific issue with its comments
+  comment    Add a comment to an existing issue
+  close      Close an issue, optionally with a final comment
+
+Required for `file`:
+  --type     bug | feature | friction | question | docs
+  --title    Issue title (one line)
+  --body     Issue body (or use --body-file)
+
+Optional for `file`:
+  --body-file FILE   Read the body from a file (use - for stdin)
+
+Configuration:
+  Target repo: read from claude/config/agency.yaml under issues.github.target_repo
+  Default: the-agency-ai/the-agency
+  Override: set issues.github.target_repo in agency.yaml
+
+Permissions: delegated to GitHub via `gh`. Anyone with gh auth can file.
+Comment and close are gated by GitHub's own write-access checks.
+
+Reports: every filed issue writes a markdown report to
+  usr/{principal}/reports/report-agency-issue-{slug}-{YYYYMMDD}.md
+and adds a row to usr/{principal}/reports/REPORTS-INDEX.md
+
+Failure modes:
+  - gh not installed → install from https://cli.github.com/
+  - gh not authenticated → run gh auth login
+  - no write access to target repo → GitHub error passed through
+  - other gh errors → passed through verbatim
+HELP
+}
+
+# --- Verb dispatch ---
+
+_cmd_file() {
+    local type="" title="" body="" body_file=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --type) type="$2"; shift 2 ;;
+            --title) title="$2"; shift 2 ;;
+            --body) body="$2"; shift 2 ;;
+            --body-file) body_file="$2"; shift 2 ;;
+            *) _die "Unknown flag for file: $1" ;;
+        esac
+    done
+
+    [[ -n "$type" ]] || _die "file: --type required (bug | feature | friction | question | docs)"
+    [[ -n "$title" ]] || _die "file: --title required"
+
+    case "$type" in
+        bug|feature|friction|question|docs) ;;
+        *) _die "file: invalid --type '$type'. Must be one of: bug, feature, friction, question, docs" ;;
+    esac
+
+    # Resolve body — use explicit cleanup, no trap (locals go out of scope at function return,
+    # which causes set -u to fire when EXIT trap runs at script-exit time).
+    local body_tmp final_body
+    body_tmp=$(mktemp -t agency-issue-body.XXXXXX)
+    final_body=$(mktemp -t agency-issue-final.XXXXXX)
+
+    _cleanup_file() {
+        [[ -n "${body_tmp:-}" && -f "$body_tmp" ]] && rm -f "$body_tmp"
+        [[ -n "${final_body:-}" && -f "$final_body" ]] && rm -f "$final_body"
+    }
+
+    if [[ -n "$body_file" ]]; then
+        if [[ "$body_file" == "-" ]]; then
+            cat > "$body_tmp"
+        elif [[ -f "$body_file" ]]; then
+            cp "$body_file" "$body_tmp"
+        else
+            _cleanup_file
+            _die "file: --body-file '$body_file' not found"
+        fi
+    elif [[ -n "$body" ]]; then
+        printf '%s\n' "$body" > "$body_tmp"
+    else
+        _cleanup_file
+        _die "file: --body or --body-file required"
+    fi
+
+    # Prepend a type header to the body so triagers see it without labels
+    {
+        printf '**Type:** %s\n\n' "$type"
+        cat "$body_tmp"
+    } > "$final_body"
+
+    _ensure_reports_dir
+
+    # File via gh
+    local issue_url
+    if ! issue_url=$(gh issue create --repo "$TARGET_REPO" --title "$title" --body-file "$final_body" 2>&1); then
+        local err="$issue_url"
+        _cleanup_file
+        _die "gh issue create failed: $err"
+    fi
+
+    # gh issue create prints the URL on success
+    local issue_number
+    issue_number=$(echo "$issue_url" | grep -oE 'issues/[0-9]+' | grep -oE '[0-9]+' | tail -1)
+    if [[ -z "$issue_number" ]]; then
+        _cleanup_file
+        _die "Could not parse issue number from gh output: $issue_url"
+    fi
+
+    local report_file
+    report_file=$(_write_report_file "$issue_number" "$issue_url" "$title" "$type" "$final_body")
+
+    _append_to_index "$(_today)" "$title" "$type" "$TARGET_REPO" "#$issue_number" "$report_file" "open"
+
+    _cleanup_file
+
+    echo "Filed: $issue_url"
+    echo "Report: $report_file"
+}
+
+_cmd_list() {
+    local state="open" limit="20"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --state) state="$2"; shift 2 ;;
+            --limit) limit="$2"; shift 2 ;;
+            *) _die "Unknown flag for list: $1" ;;
+        esac
+    done
+
+    case "$state" in
+        open|closed|all) ;;
+        *) _die "list: invalid --state '$state'. Must be open, closed, or all" ;;
+    esac
+
+    gh issue list --repo "$TARGET_REPO" --state "$state" --limit "$limit"
+}
+
+_cmd_view() {
+    local id="${1:-}"
+    [[ -n "$id" ]] || _die "view: issue id required"
+    # gh issue view shows body+metadata; --comments is a SEPARATE mode that shows only comments.
+    # To get both, call gh twice.
+    gh issue view "$id" --repo "$TARGET_REPO"
+    # Comments section, if any
+    local comments
+    comments=$(gh issue view "$id" --repo "$TARGET_REPO" --comments 2>/dev/null || true)
+    if [[ -n "$comments" ]]; then
+        echo ""
+        echo "─── Comments ───"
+        echo "$comments"
+    fi
+}
+
+_cmd_comment() {
+    local id="${1:-}"
+    [[ -n "$id" ]] || _die "comment: issue id required"
+    shift
+
+    local body="" body_file=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --body) body="$2"; shift 2 ;;
+            --body-file) body_file="$2"; shift 2 ;;
+            *) _die "Unknown flag for comment: $1" ;;
+        esac
+    done
+
+    if [[ -n "$body_file" ]]; then
+        gh issue comment "$id" --repo "$TARGET_REPO" --body-file "$body_file"
+    elif [[ -n "$body" ]]; then
+        gh issue comment "$id" --repo "$TARGET_REPO" --body "$body"
+    else
+        _die "comment: --body or --body-file required"
+    fi
+}
+
+_cmd_close() {
+    local id="${1:-}"
+    [[ -n "$id" ]] || _die "close: issue id required"
+    shift
+
+    local comment=""
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --comment) comment="$2"; shift 2 ;;
+            *) _die "Unknown flag for close: $1" ;;
+        esac
+    done
+
+    if [[ -n "$comment" ]]; then
+        gh issue close "$id" --repo "$TARGET_REPO" --comment "$comment"
+    else
+        gh issue close "$id" --repo "$TARGET_REPO"
+    fi
+}
+
+# --- Main ---
+
+case "${1:-}" in
+    --version) echo "agency-issue $TOOL_VERSION"; exit 0 ;;
+    --help|-h|"") _show_help; exit 0 ;;
+    file) _check_gh; shift; _cmd_file "$@" ;;
+    list) _check_gh; shift; _cmd_list "$@" ;;
+    view) _check_gh; shift; _cmd_view "$@" ;;
+    comment) _check_gh; shift; _cmd_comment "$@" ;;
+    close) _check_gh; shift; _cmd_close "$@" ;;
+    *) _die "Unknown verb: $1. Run 'agency-issue --help' for usage." ;;
+esac

--- a/claude/tools/git-commit
+++ b/claude/tools/git-commit
@@ -45,6 +45,19 @@ TOOL_VERSION="2.0.0-20260120-000002"
 
 # Source log helper for tool tracking
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Resolve project root for tools that need it (per-agent attribution lookup
+# reads agency.yaml at $PROJECT_ROOT/claude/config/agency.yaml). Prefer
+# CLAUDE_PROJECT_DIR (set in hooks), fall back to git rev-parse, then to
+# SCRIPT_DIR-based fallback. Without this, the per-agent attribution code
+# below silently fails with "PROJECT_ROOT: unbound variable" under set -u.
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
+elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
     source "$SCRIPT_DIR/lib/_log-helper"
 fi

--- a/claude/tools/iscp-check
+++ b/claude/tools/iscp-check
@@ -24,7 +24,7 @@
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.1"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # CLAUDE_PROJECT_DIR is authoritative — see escalation #90
@@ -43,16 +43,25 @@ source "$SCRIPT_DIR/lib/_iscp-db"
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Handle flags
+FORCE=false
 case "${1:-}" in
     --version) echo "iscp-check $TOOL_VERSION"; exit 0 ;;
+    --force) FORCE=true ;;
     --help|-h)
         cat <<'HELP'
 iscp-check — ISCP notification hook
 
-Usage: iscp-check [--version|--help]
+Usage: iscp-check [--force|--version|--help]
 
 Checks for unread ISCP items (dispatches, flags, dropbox, notifications)
 and outputs a JSON systemMessage if any are found. Silent when empty.
+
+By default (delta mode), emits a notification only when the unread total
+has INCREASED since the last invocation — prevents repeated "you have N
+items" spam on every UserPromptSubmit/Stop when the counts haven't changed.
+
+Pass --force to emit unconditionally when items are waiting (used by
+SessionStart hook so every new session sees the current state).
 
 Designed for hook consumption (SessionStart, UserPromptSubmit, Stop).
 Every failure path exits silently — never blocks the agent.
@@ -83,6 +92,37 @@ IFS='|' read -r flags dispatches dropbox notifications <<< "$counts"
 # Silent when all zeros
 total=$(( flags + dispatches + dropbox + notifications ))
 if [[ "$total" -eq 0 ]]; then
+    # Reset state so the next arrival triggers a notification even if
+    # it's just a single item (otherwise a drop-to-zero would leave
+    # last_total > 0 and the next item of equal count would be silent).
+    state_dir=$(dirname "$db_path")
+    agent_slug="${my_agent//\//_}"
+    state_file="$state_dir/.iscp-notify-state-$agent_slug"
+    echo 0 > "$state_file" 2>/dev/null || true
+    exit 0
+fi
+
+# Delta suppression: only emit when the total has INCREASED since last
+# notification. --force bypasses (used by SessionStart hook). State file
+# lives next to the DB, outside git, per-agent.
+state_dir=$(dirname "$db_path")
+agent_slug="${my_agent//\//_}"
+state_file="$state_dir/.iscp-notify-state-$agent_slug"
+
+last_total=0
+if [[ -f "$state_file" ]]; then
+    last_total=$(cat "$state_file" 2>/dev/null || echo 0)
+    # Guard against corrupted state (non-numeric)
+    [[ "$last_total" =~ ^[0-9]+$ ]] || last_total=0
+fi
+
+# Update state regardless of whether we emit — the state tracks "what the
+# agent has been told" so a drop in count (items read) lowers the bar for
+# the next notification.
+echo "$total" > "$state_file" 2>/dev/null || true
+
+# Suppress if delta mode and count has not increased
+if ! $FORCE && [[ "$total" -le "$last_total" ]]; then
     exit 0
 fi
 

--- a/claude/tools/release-plan
+++ b/claude/tools/release-plan
@@ -1,0 +1,425 @@
+#!/bin/bash
+#
+# release-plan — Analyze the current branch state and propose a release plan
+#
+# What Problem: Captain (or any agent) preparing a release branch manually
+# walks through git status, groups uncommitted changes into logical commits,
+# decides what's leftover scratch vs real work, and writes a PR shape. This
+# is consistent overhead across releases and prone to drift between captains
+# and between days. Producing a release plan should be a tool, not a ritual.
+#
+# Captured during Day 33 R1 work when principal observed manual grouping and
+# said "That should be a tool!" — see seed-release-plan-tool-20260408.md.
+# Bootstrap intent: build the tool now, use it on itself, ship in R1.
+#
+# How & Why: Heuristic-based grouping by file path patterns. No ML, no
+# session-state inference, no clever timing logic — just glob patterns mapped
+# to logical commit groups. Output is markdown to stdout (or to a file with
+# --output) so the human can review before applying.
+#
+# v1 scope: GENERATE the plan only, do not apply. No branch creation, no
+# staging, no committing. The captain (or another tool) takes the plan and
+# executes it. v2+ may add --apply.
+#
+# Heuristic groups (in priority order — earlier groups win on overlap):
+#
+#   1. methodology   — CLAUDE-*.md, README-*.md, docs/*, templates/CLAUDE-*
+#   2. config        — config/agency.yaml, config/manifest.json
+#   3. settings      — .claude/settings.json, config/settings-template.json
+#   4. hooks         — claude/hooks/*, .claude/hooks/*
+#   5. tools         — claude/tools/* (excluding lib/_*)
+#   6. skills        — .claude/skills/*
+#   7. tests         — tests/*
+#   8. workstream    — claude/workstreams/*/seeds/*, reviews/*, *-pvr-*, *-ad-*, *-plan-*
+#   9. coordination  — usr/*/dispatches/*, history/*, transcripts/*, code-reviews/*, *-handoff.md, reports/*
+#  10. scratch       — usr/*/tmp/* (excluded from plan)
+#  11. other         — anything that doesn't match (flagged for review)
+#
+# Each group becomes a proposed commit. Groups with no files are omitted.
+# Coordination commits use /coord-commit (no QG). All others use /git-commit.
+#
+# Written: 2026-04-08 — Day 33 R1 — bootstrap from agency-issue v1 pattern
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
+elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+# --- Args ---
+BASE_REF="origin/main"
+OUTPUT_FILE=""
+SHOW_OTHER="true"
+AUTO_SWITCH="true"
+FORCE_DAY=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --base) BASE_REF="$2"; shift 2 ;;
+        --output) OUTPUT_FILE="$2"; shift 2 ;;
+        --no-other) SHOW_OTHER="false"; shift ;;
+        --no-switch) AUTO_SWITCH="false"; shift ;;
+        --day) FORCE_DAY="$2"; shift 2 ;;
+        --version) echo "release-plan $TOOL_VERSION"; exit 0 ;;
+        --help|-h)
+            cat <<'HELP'
+release-plan — Analyze branch state and propose a release plan
+
+Usage:
+  release-plan [--base REF] [--output FILE] [--no-other]
+  release-plan --version
+  release-plan --help
+
+Options:
+  --base REF       Base ref for ahead-commit comparison (default: origin/main)
+  --output FILE    Write the plan to FILE instead of stdout
+  --no-other       Suppress the "Other / unmatched files" section
+  --no-switch      Do not auto-switch to a release branch (analyze in place)
+  --day N          Force the release day number (otherwise auto-detected)
+
+What it does:
+  1. Inventories all changes vs the base ref:
+     - Local commits ahead of BASE_REF
+     - Modified files (staged + unstaged)
+     - Untracked files (excluding gitignored)
+  2. Groups files by heuristic glob patterns into logical commit categories
+  3. Proposes a commit ordering with suggested boundary type (/git-commit or /coord-commit)
+  4. Flags scratch files (usr/*/tmp/*) for exclusion
+  5. Writes a markdown plan to stdout or --output
+
+The plan is GENERATED, not applied. Captain reviews and executes the plan
+manually (or via /git-commit / /coord-commit). v2+ may add --apply.
+
+Heuristic groups (in priority order):
+  methodology, config, settings, hooks, tools, skills, tests,
+  workstream, coordination, scratch, other
+HELP
+            exit 0 ;;
+        *) echo "release-plan: unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+cd "$PROJECT_ROOT"
+
+# Helper for git in this repo (git-dir/work-tree explicit to handle weird env)
+g() { git --git-dir=.git --work-tree=. "$@"; }
+
+# --- Branch detection / auto-switch ---
+# Pattern: day{N}-release-{M}
+# Logic:
+#   1. Find highest day{N}-release-{M} among local branches
+#   2. If FORCE_DAY set, use that day
+#   3. If the existing branch has commits beyond origin/main → reuse it
+#   4. If the existing branch has zero commits beyond base → reuse it (was created but never used)
+#   5. If no matching branch exists at all → create day{N}-release-1 from $BASE_REF
+
+resolve_release_branch() {
+    local highest_day highest_release
+    highest_day=""
+    highest_release=""
+
+    # Walk all local branches matching the pattern
+    while read -r b; do
+        [[ -z "$b" ]] && continue
+        # Strip leading whitespace and current-marker
+        b="${b# }"
+        b="${b#\* }"
+        if [[ "$b" =~ ^day([0-9]+)-release-([0-9]+)$ ]]; then
+            local d="${BASH_REMATCH[1]}"
+            local r="${BASH_REMATCH[2]}"
+            if [[ -z "$highest_day" ]] || (( d > highest_day )); then
+                highest_day="$d"
+                highest_release="$r"
+            elif (( d == highest_day )) && (( r > highest_release )); then
+                highest_release="$r"
+            fi
+        fi
+    done < <(g branch --list 'day*-release-*')
+
+    local target_day="${FORCE_DAY:-$highest_day}"
+
+    if [[ -z "$target_day" ]]; then
+        # No existing release branches, no day forced — give up auto-detect
+        echo ""
+        return
+    fi
+
+    if [[ "$target_day" != "$highest_day" ]] || [[ -z "$highest_release" ]]; then
+        # New day or no existing release for this day → start at release 1
+        echo "day${target_day}-release-1"
+        return
+    fi
+
+    # Reuse the highest existing release branch for this day
+    echo "day${highest_day}-release-${highest_release}"
+}
+
+CURRENT_BRANCH=$(g branch --show-current)
+TARGET_BRANCH=""
+
+if [[ "$AUTO_SWITCH" == "true" ]]; then
+    TARGET_BRANCH=$(resolve_release_branch)
+    if [[ -n "$TARGET_BRANCH" && "$TARGET_BRANCH" != "$CURRENT_BRANCH" ]]; then
+        # Check if the branch exists locally
+        if g show-ref --verify --quiet "refs/heads/$TARGET_BRANCH"; then
+            echo "release-plan: switching to existing branch $TARGET_BRANCH" >&2
+            g checkout "$TARGET_BRANCH" >&2
+        else
+            echo "release-plan: creating $TARGET_BRANCH from $BASE_REF" >&2
+            g checkout -b "$TARGET_BRANCH" "$BASE_REF" >&2
+        fi
+        CURRENT_BRANCH="$TARGET_BRANCH"
+    fi
+fi
+
+AHEAD_COUNT=$(g rev-list --count "${BASE_REF}..HEAD" 2>/dev/null || echo "0")
+
+# --- Collect file sets ---
+# Modified (tracked) files — both staged and unstaged
+MODIFIED=$(g diff --name-only HEAD 2>/dev/null || true)
+# Untracked files, respecting .gitignore
+UNTRACKED=$(g ls-files --others --exclude-standard 2>/dev/null || true)
+# Local commits ahead of base
+AHEAD_COMMITS=$(g log --oneline "${BASE_REF}..HEAD" 2>/dev/null || true)
+
+# All files needing attention
+ALL_FILES=$(printf '%s\n%s\n' "$MODIFIED" "$UNTRACKED" | grep -v '^$' | sort -u || true)
+
+# --- Group classifier ---
+# For each file, emit "GROUP|file" — first matching group wins
+classify() {
+    local f="$1"
+    # methodology
+    case "$f" in
+        claude/CLAUDE-*.md|claude/README-*.md|claude/docs/*.md|usr/*/CLAUDE-*.md|claude/templates/CLAUDE-*|claude/templates/HANDOFF-*)
+            echo "methodology|$f"; return ;;
+    esac
+    # config
+    case "$f" in
+        claude/config/agency.yaml|claude/config/manifest.json)
+            echo "config|$f"; return ;;
+    esac
+    # settings
+    case "$f" in
+        .claude/settings.json|claude/config/settings-template.json)
+            echo "settings|$f"; return ;;
+    esac
+    # hooks
+    case "$f" in
+        claude/hooks/*|.claude/hooks/*)
+            echo "hooks|$f"; return ;;
+    esac
+    # iscp-check is a tool but it's notification machinery — group with settings
+    case "$f" in
+        claude/tools/iscp-check|claude/tools/collaboration|claude/tools/agent-identity)
+            echo "settings|$f"; return ;;
+    esac
+    # tools
+    case "$f" in
+        claude/tools/lib/_*) echo "tools|$f"; return ;;
+        claude/tools/*) echo "tools|$f"; return ;;
+    esac
+    # skills
+    case "$f" in
+        .claude/skills/*) echo "skills|$f"; return ;;
+    esac
+    # tests
+    case "$f" in
+        tests/*) echo "tests|$f"; return ;;
+    esac
+    # workstream artifacts
+    case "$f" in
+        claude/workstreams/*) echo "workstream|$f"; return ;;
+    esac
+    # scratch (excluded)
+    case "$f" in
+        usr/*/tmp/*) echo "scratch|$f"; return ;;
+    esac
+    # coordination
+    case "$f" in
+        usr/*/dispatches/*|usr/*/history/*|usr/*/transcripts/*|usr/*/code-reviews/*|usr/*/reports/*|usr/*/captain-handoff.md|usr/*/*-handoff.md|usr/*/logs/*|usr/*/seeds/*)
+            echo "coordination|$f"; return ;;
+    esac
+    # other / unmatched
+    echo "other|$f"
+}
+
+# --- Build groups ---
+# bash 3 (macOS default) lacks associative arrays — use a temp file with group|file lines
+GROUPS_FILE=$(mktemp -t release-plan-groups.XXXXXX)
+trap 'rm -f "$GROUPS_FILE"' EXIT
+for f in $ALL_FILES; do
+    [[ -z "$f" ]] && continue
+    classify "$f" >> "$GROUPS_FILE"
+done
+
+# --- Feature pairing ---
+# Detect tool basenames that have a matching skill dir in the changeset.
+# When found, promote tool + skill (and any matching paths) into a single
+# feature:{name} group so they commit together.
+detect_features() {
+    while IFS='|' read -r grp file; do
+        [[ "$grp" == "tools" ]] || continue
+        local name
+        name=$(basename "$file")
+        # Skip helper libs (lib/_*)
+        [[ "$name" == _* ]] && continue
+        # Check if a skill with the same basename exists in the changeset
+        if grep -q "^skills|.claude/skills/${name}/" "$GROUPS_FILE"; then
+            echo "$name"
+        fi
+    done < "$GROUPS_FILE" | sort -u
+}
+
+FEATURES=$(detect_features)
+
+# For each feature, reclassify matching files into feature:{name}
+for feat in $FEATURES; do
+    [[ -z "$feat" ]] && continue
+    awk -v feat="$feat" -F'|' -v OFS='|' '
+        # Tool path: claude/tools/{feat}
+        $2 == "claude/tools/" feat { $1 = "feature:" feat; print; next }
+        # Skill path: .claude/skills/{feat}/...
+        $2 ~ "^\\.claude/skills/" feat "/" { $1 = "feature:" feat; print; next }
+        # Test path: tests/tools/{feat}.bats
+        $2 == "tests/tools/" feat ".bats" { $1 = "feature:" feat; print; next }
+        # Otherwise pass through unchanged
+        { print }
+    ' "$GROUPS_FILE" > "${GROUPS_FILE}.tmp"
+    mv "${GROUPS_FILE}.tmp" "$GROUPS_FILE"
+done
+
+# Helper: get all files for a group
+group_files() {
+    grep "^${1}|" "$GROUPS_FILE" 2>/dev/null | cut -d'|' -f2- || true
+}
+
+# Helper: list all distinct feature group names
+feature_groups() {
+    grep '^feature:' "$GROUPS_FILE" 2>/dev/null | cut -d'|' -f1 | sort -u || true
+}
+
+# --- Group metadata ---
+group_title() {
+    case "$1" in
+        methodology)  echo "Methodology / docs" ;;
+        config)       echo "Config" ;;
+        settings)     echo "Settings + notification machinery" ;;
+        hooks)        echo "Hooks" ;;
+        tools)        echo "Tools" ;;
+        skills)       echo "Skills" ;;
+        tests)        echo "Tests" ;;
+        workstream)   echo "Workstream artifacts (seeds, reviews, plans)" ;;
+        coordination) echo "Coordination artifacts (dispatches, handoffs, reports)" ;;
+        scratch)      echo "SCRATCH — excluded from release" ;;
+        other)        echo "Other / unmatched (review needed)" ;;
+    esac
+}
+
+group_commit_type() {
+    case "$1" in
+        coordination) echo "/coord-commit" ;;
+        scratch)      echo "(do not commit)" ;;
+        other)        echo "(review)" ;;
+        *)            echo "/git-commit" ;;
+    esac
+}
+
+# Order in which groups appear in the plan (and the suggested commit order)
+ORDER=(methodology config settings hooks tools skills tests workstream coordination scratch other)
+
+# --- Render plan ---
+render() {
+    cat <<EOF
+# Release Plan — $(date +%Y-%m-%d\ %H:%M)
+
+**Current branch:** \`$CURRENT_BRANCH\`
+**Base ref:** \`$BASE_REF\`
+**Ahead of base by:** $AHEAD_COUNT commit(s)
+
+EOF
+
+    if [[ -n "$AHEAD_COMMITS" ]]; then
+        echo "## Local commits ahead of base"
+        echo ""
+        echo '```'
+        echo "$AHEAD_COMMITS"
+        echo '```'
+        echo ""
+        echo "_These commits are already on the current branch — they will land in the release as-is._"
+        echo ""
+    fi
+
+    echo "## Proposed commits (in order)"
+    echo ""
+
+    local commit_n=0
+
+    # Emit feature groups first (paired tool+skill+tests sets)
+    for fg in $(feature_groups); do
+        local feat="${fg#feature:}"
+        local files
+        files=$(group_files "$fg")
+        [[ -z "$files" ]] && continue
+        commit_n=$((commit_n + 1))
+        echo "### Commit $commit_n: Feature — \`$feat\` (tool + skill + tests) — /git-commit"
+        echo ""
+        echo '```'
+        printf '%s\n' "$files" | sed 's/^/  /' | grep -v '^  $' || true
+        echo '```'
+        echo ""
+    done
+
+    for group in "${ORDER[@]}"; do
+        local files
+        files=$(group_files "$group")
+        [[ -z "$files" ]] && continue
+
+        # Skip 'other' if --no-other
+        [[ "$group" == "other" && "$SHOW_OTHER" == "false" ]] && continue
+
+        if [[ "$group" == "scratch" ]]; then
+            echo "### EXCLUDE: $(group_title "$group")"
+        elif [[ "$group" == "other" ]]; then
+            echo "### REVIEW: $(group_title "$group")"
+        else
+            commit_n=$((commit_n + 1))
+            echo "### Commit $commit_n: $(group_title "$group") — $(group_commit_type "$group")"
+        fi
+        echo ""
+        echo '```'
+        printf '%s\n' "$files" | sed 's/^/  /' | grep -v '^  $' || true
+        echo '```'
+        echo ""
+    done
+
+    echo "## Suggested PR shape"
+    echo ""
+    echo "- **Branch:** \`$CURRENT_BRANCH\` (push to origin, open as draft PR)"
+    echo "- **Base:** \`$BASE_REF\`"
+    echo "- **Title:** _draft based on the largest commit group_"
+    echo "- **Body:** _summarize each commit group_"
+    echo ""
+    echo "## Mechanics"
+    echo ""
+    echo "1. Stage and commit each group above in order, using the indicated commit type."
+    echo "2. \`git push -u origin $CURRENT_BRANCH\`"
+    echo "3. \`gh pr create --draft --base ${BASE_REF#origin/} --title '...' --body '...'\`"
+    echo "4. Verify draft PR exists and CI runs."
+    echo ""
+    echo "_Generated by \`release-plan $TOOL_VERSION\`. Heuristic-based grouping; review before applying._"
+}
+
+if [[ -n "$OUTPUT_FILE" ]]; then
+    render > "$OUTPUT_FILE"
+    echo "Wrote plan to: $OUTPUT_FILE"
+else
+    render
+fi

--- a/claude/workstreams/agency/seeds/seed-agency-issue-skill-20260408.md
+++ b/claude/workstreams/agency/seeds/seed-agency-issue-skill-20260408.md
@@ -1,0 +1,304 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-08
+captured_by: the-agency/jordan/captain
+principal: jordan
+status: shipped-v1
+discussion: 1B1 with principal 2026-04-08
+v1_implementation:
+  tool: claude/tools/agency-issue
+  skill: .claude/skills/agency-issue/SKILL.md
+  config: claude/config/agency.yaml (issues.github.target_repo)
+  reports_dir: usr/jordan/reports/
+  smoke_test_issue: https://github.com/the-agency-ai/the-agency/issues/52
+---
+
+**SHIPPED v1 — 2026-04-08.** Captain implemented in-session. Tool, skill, config, reports directory all in place. Smoke-tested by filing this very design as the first agency issue: [#52](https://github.com/the-agency-ai/the-agency/issues/52). Five verbs working: file, list, view, comment, close.
+
+
+# Seed: `/agency-issue` skill
+
+A skill for filing, viewing, commenting on, and updating issues against the-agency framework itself. Two-way channel with GitHub issues on `the-agency-ai/the-agency` — richer than `/feedback` (which is fire-and-forget to Anthropic, no status visibility, no update path).
+
+## Scope
+
+Filing and tracking **GitHub issues on the-agency repo** — platform and framework issues discovered by current users (human or agent) of the-agency.
+
+**Explicitly NOT in scope (this version):**
+- Project-local issue tracking for downstream adopters' own projects
+- A generic issue-tracker primitive for arbitrary repos
+- Cross-repo issue routing (monofolk, other orgs)
+- Internal-only issues that never go to GitHub
+
+## Decisions (from 1B1 with principal 2026-04-08)
+
+### Item 1 — Audience scope
+**Decision:** Narrow. For the-agency users (human or agent) who want to file issues in the-agency GitHub repo. Platform/framework issues, not local implementation issues.
+
+**Options considered:**
+- **(A) Local-only** — each agency instance has its own issue tracker, never crosses repo boundaries. Rejected: framework bugs downstream adopters hit stay invisible to the maintainer.
+- **(B) Upstream-always** — every issue goes to the-agency central tracker. **Selected** (effectively).
+- **(C) Hybrid local-first with optional routing** — project-local vs framework classification. Rejected for v1 as out of scope; revisit if downstream adopters hit project-local tracking needs.
+
+### Item 2 — Thin vs fat wrapper
+**Decision:** Thin wrapper — live `gh` calls, no local SQLite cache. BUT writes a persisted report file to `usr/{principal}/reports/` for every filed issue (same pattern as Claude Code feedback reports), capturing the GitHub issue ID, date filed, full content, and a response log.
+
+**Options considered:**
+- **(A) Thin wrapper, no state** — pure `gh` passthrough. Rejected: no audit trail of what we've filed.
+- **(B) Fat wrapper with local SQLite mirror** — sync + offline browse + delta notification. Rejected for v1 as premature; GitHub handles most of this already.
+- **(C) Thin now, fat later** — ship thin, extract fat pieces if needed. **Selected.**
+
+### Item 3 — Sibling to `/feedback` or shared primitive?
+**Decision:** Independent siblings. `/agency-issue` matches `/feedback`'s report format and index structure by imitation, but no shared primitive. When a third external target appears (monofolk, client repos, etc.), extract a shared primitive then.
+
+**Critical distinction:** `/feedback` is Anthropic/Claude Code — fire-and-forget to a vendor. `/agency-issue` is our own project — two-way channel, we own the repo, we're the maintainer. The patterns look similar but the relationships are categorically different.
+
+**Options considered:**
+- **(A) Independent siblings** — duplicated logic, may drift. **Selected (as C).**
+- **(B) Shared primitive under the hood** — DRY but premature abstraction. Rejected for v1.
+- **(C) Independent now, extract primitive later** — **Effectively selected.**
+
+### Item 4 — Permissions
+**Decision:**
+- **A (who files)** = **(i) Anyone in the agency** — human or agent, no approval gating
+- **B (who comments)** = **Anyone who could comment on that issue on GitHub** — delegate to GitHub's permission model
+- **C (who closes/resolves)** = **Whoever filed it, and whoever has those permissions at the-agency** — delegate to GitHub again
+- **D (draft-and-approve before filing)** = **No** — unlike `/feedback` (vendor gating), we own the repo; cost of a wrong issue is trivial (just close it), cost of approval friction is real
+
+**Options considered (for filing, A):**
+- (i) Anyone in the agency — **Selected.**
+- (ii) Agents surface via flags, captain consolidates — rejected, adds friction
+- (iii) Human-only — rejected, blocks autonomous agent friction capture
+
+**Options considered (for commenting, B):**
+- (i) Anyone who can invoke the skill — superseded
+- **GitHub permission model** — **Selected.** Skill delegates authz to `gh`.
+
+**Options considered (for closing, C):**
+- (i) Principal only — superseded
+- (ii) Captain + principal — superseded
+- **Filer + maintainers** — **Selected.** Matches GitHub's model; skill delegates.
+
+**Principle:** the skill delegates all authorization decisions to GitHub. No custom permission logic on our side. Simpler, safer, harder to get wrong.
+
+### Item 5 — Reports directory location
+**Decision:** **Principal-scoped** at `usr/{principal}/reports/`. Reports are the principal's external-filing record; the filing agent is metadata (in frontmatter), not a path segment.
+
+**Follow-up:** today's Claude Code feedback report (currently at `usr/jordan/captain/reports/`) needs to migrate to `usr/jordan/reports/`. REPORTS-INDEX.md moves with it.
+
+**Options considered:**
+- (A) Principal-scoped — **Selected.**
+- (B) Captain-scoped (current state for the one existing report) — rejected; conflates captain's work with principal's filings
+- (C) Hybrid per-agent reports dirs — rejected; scales but adds union-index machinery we don't need yet
+
+### Item 6 — Labels and categories
+**Decision (revised):** **No labels in v1.** Originally we agreed on a minimal 4-dimension label set (type, component, priority, reporter), but principal pushed back: *"Do we really need labels? Or just we file issues and they triage and determine from the description? Are we making this too complex?"*
+
+Files issues with good descriptions. Triage is reading the body, not filtering on label dimensions. GitHub's built-in `open/closed` state + search is enough at low volume. Add labels later if/when volume justifies them.
+
+**Implication:** this eliminates Item 10.B (label setup machinery) entirely. No `gh label create` calls, no setup subcommand, no `labels-bootstrapped` cache marker. Filing path is pure.
+
+**Options considered:**
+- 4-dimension label set (`type:*`, `component:*`, `priority:*`, `reporter:*`) — initially selected, then rejected as premature complexity
+- **No labels** — **Selected.** Triage from body content. Add labels when volume justifies.
+- Richer vocabulary (priority text, performance sub-type, etc.) — rejected for same reason
+
+### Item 7 — Internal linkage between issues and seeds/dispatches
+**Decision:** **(B) Plain text "Related" section in the issue body** with paths to internal artifacts (seeds, dispatches, transcripts) + **attachment capability** for additional context.
+
+**Attachment implementation notes:**
+- **Text attachments** (logs, transcripts, code snippets) — embed as fenced code blocks or `<details>` expandables in the issue body
+- **Binary attachments** (screenshots, zip files) — upload via `gh gist create` first, link in the issue body
+- `gh issue create` does not natively support file attachments; these are workarounds
+
+**Options considered:**
+- **(A) No internal linking** — rejected, loses audit trail
+- **(B) Plain text "Related" section** — **Selected for v1.**
+- **(C) Full bidirectional linkage** (frontmatter backlinks in related seeds) — deferred; revisit when we have lots of cross-references
+
+### Item 8 — How does the agency learn about GitHub responses?
+**Decision:** **(A) Pull-on-demand only** for v1. No background polling, no notification. `agency-issue status <id>` / `list` / `view <id>` hit GitHub live when invoked.
+
+**Later:** add a status-line indicator ("📋 N issues with new activity") once the Fleet Awareness status-line infrastructure ships. Natural second consumer of the silent status-line pattern.
+
+**Options considered:**
+- **(A) Pull-on-demand only** — **Selected for v1.**
+- **(B) Status-line periodic check** — deferred to post-Fleet-Awareness
+- **(C) Hook-based notification** (new hook like iscp-check for GitHub) — rejected, the status-line path will be cleaner and we'll have it soon
+- **(D) Rely on GitHub's own notifications** — philosophy, not infrastructure; acceptable fallback
+
+### Item 9 — Valueflow integration (issues ↔ seeds ↔ plans)
+**Decision:**
+
+**Direction 1 (Issue → internal work):** **(i) Manual promotion — agents can triage, not just the principal.** Principal directive: *"Agents can triage as well. I want you to triage."* Any agent (captain especially) reads filed issues, proposes triage decisions, drafts seeds, and surfaces candidates for promotion. Principal has final say on non-obvious calls. Captain-driven triage is the default expectation for a healthy agency. No auto-seeding.
+
+**Direction 2 (Internal work → issue closure):** **(ii) Skill-assisted.** `agency-issue close <id>` wraps `gh issue close` with a closing comment, optionally linked to the PR/commit that fixed it. Updates the local report file with the closing state.
+
+**Options considered for Direction 1:**
+- (i) Manual promotion — **Selected.**
+- (ii) Auto-seed every filed issue — rejected, clutters seeds/
+- (iii) Label-driven (`accepted` triggers seed creation) — deferred; plausible once we see filing volume
+
+**Options considered for Direction 2:**
+- (i) Pure manual (`gh issue close` by hand, or `Fixes #NNN` in PR) — too thin
+- **(ii) Skill-assisted close** — **Selected.**
+- (iii) QGR-integrated (`/phase-complete` auto-closes referenced issues) — deferred, nice-to-have
+
+## Verb set (from Item 4 discussion)
+
+| Verb | What | Authz |
+|------|------|-------|
+| `file` | Create a new issue | Anyone |
+| `list` | List open / all issues | Anyone |
+| `view <id>` | Show issue + comments | Anyone |
+| `status <id>` | Short status line | Anyone |
+| `comment <id> <text>` | Add a comment | GitHub permissions |
+| `update <id> --title ... --body ...` | Edit the issue | GitHub permissions (filer or maintainer) |
+| `close <id>` / `resolve <id>` | Mark resolved | GitHub permissions (filer + maintainer) |
+
+### Item 10 — Setup and prerequisites
+
+1B1'd as four sub-items.
+
+#### Item 10.A — Target repo configuration
+**Decision:** `agency.yaml` config block under `issues.{provider}.target_repo`. Auto-populated from git remote on init when possible; override-able. The SPEC-PROVIDER pattern (see "Future: SPEC-PROVIDER pattern" section below) means the target lives in provider-specific config, not at the skill level.
+
+For v1: `issues.github.target_repo: the-agency-ai/the-agency`. Single target.
+
+**Options considered:**
+- (i) Hardcoded — rejected, breaks on fork
+- **(ii) `agency.yaml` config block** — **Selected.**
+- (iii) Auto-detect from git remote origin — rejected, breaks for downstream worktrees
+
+#### Item 10.B — Label setup
+**Decision: DROPPED.** Item 6 killed labels for v1, so there is no label setup. Skipped entirely.
+
+#### Item 10.C — First-run detection
+**Decision:** Simple. Only check is `gh auth status` on every invocation (~50ms, fast enough). No caching. No bootstrap markers. No setup state.
+
+#### Item 10.D — Failure modes
+**Decision:** Three named cases plus pass-through of `gh` errors:
+
+1. **`gh` not installed** → actionable error: "Install gh CLI: https://cli.github.com/"
+2. **`gh` not authenticated** → actionable error: "Run `gh auth login` to authenticate"
+3. **No write access to target repo** → actionable error explaining the user lacks write access to `{repo}`
+4. **All other `gh` failures** (network, rate limit, etc.) → pass through `gh`'s error message verbatim with context about which verb was invoked
+
+That covers it.
+
+## Future-version notes (captured for v2 and beyond)
+
+### Future: SPEC-PROVIDER pattern
+
+Principal raised this during the 1B1: *"I envision we will want to eventually allow people to file issues against the-agency (platform, framework, tools, etc) and later file issues against their own project. For us it is the same thing. So, maybe it is a SPEC:PROVIDER pattern, where agency-issue [VERB] calls a (in this case) github-issue [VERB]."*
+
+The natural v2+ shape:
+
+```
+/agency-issue file              (contract skill — agency semantics + reports + audit)
+       ↓
+  claude/tools/agency-issue     (top-level dispatcher, reads issues.provider from agency.yaml)
+       ↓
+  claude/tools/agency-issue-github   (GitHub provider, wraps gh CLI)
+```
+
+Later providers: `agency-issue-gitlab`, `agency-issue-linear`, `agency-issue-jira`, etc. Same skill contract, pluggable backend.
+
+**Layering:**
+- **`/agency-issue`** (contract skill) — agency semantics: report files, frontmatter, internal audit trail, "Related" sections, REPORTS-INDEX updates
+- **`agency-issue-github`** (provider) — GitHub-specific: `gh` CLI wrapping, GitHub URL formats, GitHub permission delegation
+- **Target repo(s)** in provider config under `agency.yaml` — provider-specific, not skill-level
+
+```yaml
+issues:
+  provider: github
+  github:
+    target_repo: the-agency-ai/the-agency  # v1: single target
+    # v2+: multi-target support
+    # targets:
+    #   platform: the-agency-ai/the-agency   # framework issues
+    #   project: my-org/my-repo              # local project issues
+```
+
+This is the **fourth SPEC-PROVIDER consumer** after `secret`, `preview`, `deploy`. Pattern is the right shape for "agency semantics layered over a pluggable backend." But **not in v1** — v1 stays simple, single target, single provider, no pattern overhead.
+
+### Future: Multi-instance contract pattern (principal directive)
+
+Principal directive (2026-04-08): *"Consider that the model (SPEC:PROVIDER) should be flexible and powerful enough for the skills to be used with for example linear. So, I use agency-issue to report an issue to the agency github, but I can report local-issue to my linear?"*
+
+The implication: the **same contract** (file, view, comment, close) should support **multiple instances**, each pointing at a different provider + target. Not just `/agency-issue` with a swappable provider — but a *family* of skills built from the same contract:
+
+```
+contract: issue (verbs: file, view, list, comment, update, close)
+                              ↓
+        ┌─────────────────────┼─────────────────────┐
+        ↓                     ↓                     ↓
+  /agency-issue         /local-issue          /vendor-issue (etc)
+        │                     │                     │
+  provider: github      provider: linear      provider: gitlab
+  target: the-agency-ai/the-agency
+                        target: user's Linear board
+                                              target: vendor's gitlab
+```
+
+Each skill instance:
+- Uses the **same contract** (same verb names, same arg shapes, same output format)
+- Has its **own provider** binding (github, linear, gitlab, jira, etc.)
+- Has its **own target config** in `agency.yaml`
+- Writes to its **own section of the reports index** (or one shared index with a `target:` column)
+
+**Three possible shapes for this:**
+
+1. **Shared contract definition + per-instance skills.** Define the issue contract in one place (e.g., `claude/contracts/issue.md`). Each instance skill (`/agency-issue`, `/local-issue`, etc.) implements the contract by composing a provider tool. Skills are thin; the contract is the spec.
+
+2. **One generic skill `/issue` with `--scope` flag.** `/issue file --scope agency`, `/issue file --scope local`. Single skill, multiple scopes, each scope has provider+target config in `agency.yaml`.
+   ```yaml
+   issues:
+     scopes:
+       agency: { provider: github, target: the-agency-ai/the-agency }
+       local: { provider: linear, target: user-linear-board-id }
+   ```
+
+3. **Skill family with sibling implementations.** `/agency-issue`, `/local-issue`, `/vendor-issue` are independent skills that all happen to follow the same contract by convention. Some shared library code, but each skill is its own surface area.
+
+**Trade-offs:**
+
+- **Shape 1** is the cleanest abstractly but requires a contracts mechanism we don't have today
+- **Shape 2** is simpler implementation-wise (one skill, scopes) but loses the discoverability of distinct `/agency-issue` vs `/local-issue` slash commands
+- **Shape 3** matches our existing skill-per-purpose convention but risks drift between siblings
+
+**Captain's lean:** Shape 1 (contract-driven) is the right end-state. Shape 2 (one skill, scopes) is a reasonable v1 of the multi-instance pattern. Shape 3 (sibling skills) is what we're already doing implicitly (e.g., `/feedback` and `/agency-issue` are de facto siblings of an unspoken contract).
+
+**Defer the choice** until v2 when we have a concrete second consumer (Linear, gitlab, or local-issue use case). v1 ships single-instance `/agency-issue` only. The contract emerges through use.
+
+### Other future questions
+
+- **Multi-target support** within a single provider (platform vs project issues)
+- **Issue templates.** GitHub supports `.github/ISSUE_TEMPLATE/`. Should the-agency ship one matching our format? Skill could pre-fill from the template.
+- **Status-line indicator** for "issues with new activity" — natural second consumer of fleet awareness status-line infrastructure
+- **Comment-thread-as-dispatch-thread** mapping — could a GitHub issue comment become a dispatch in our system? Probably not, but worth considering when fleet awareness matures.
+- **Closing issues from PR merge** via `Fixes #NNN` semantics — GitHub already does this; do we need anything beyond?
+- **Filing from within a worktree.** v1 ignores worktree state and uses the configured target repo. v2+ may want worktree-aware target selection.
+- **Graceful degradation when `gh` auth is stale or offline.** v1 fails clearly; v2+ may want cached read-only fallback.
+
+## Related Agency work
+
+- **`usr/jordan/reports/REPORTS-INDEX.md`** (to be migrated from captain/) — the principal-scoped reports index; this skill is a second consumer of that pattern
+- **`/feedback`** (Claude Code / Anthropic) — sibling skill, independent implementation, similar format conventions
+- **Fleet Awareness seed** (`seed-fleet-awareness-20260408.md`) — the status-line indicator approach (Item 8, future) will share status-line infrastructure
+- **Silent periodic tool calls seed** (`seed-silent-periodic-tool-calls-20260408.md`) — related to how we'd eventually add proactive GitHub-activity notification
+- **Captain's reports tracking pattern** — REPORTS-INDEX.md + per-report markdown file, invented today for Claude Code feedback filing
+
+## Next steps
+
+1. `/define` — produce a proper PVR from this seed (not yet done)
+2. `/design` — A&D document covering the skill contract, report file format, label setup, error handling
+3. Plan — phases and iterations; likely a single-phase ship since it's a thin skill
+4. Implement — wrap `gh` with the decided verb set, create the label set on the repo, write the first filed issue through it
+
+## Conversation source
+
+Captured during Day 33 from a principal-captain 1B1 on 2026-04-08. Principal's framing: "This is a skill for filing, viewing, fetching, and updating issues that users find in the agency. Two parts: the user part (file, view, see status, update/comment) and the captain/agency agent/agency principal part (view, update, comment, resolve, etc.)."
+
+Discussion resolved items 1-9 of the 10-item 1B1 agenda. Principal's closing direction: "Capture all of these options + what we selected in the seed, so we can think about next version options." This seed is that record.

--- a/claude/workstreams/agency/seeds/seed-fleet-awareness-20260408.md
+++ b/claude/workstreams/agency/seeds/seed-fleet-awareness-20260408.md
@@ -1,0 +1,190 @@
+---
+type: seed
+workstream: agency (possibly split to new "fleet" workstream — decision in /define)
+date: 2026-04-08
+captured_by: the-agency/jordan/captain
+principal: jordan
+status: seed
+---
+
+# Seed: Fleet Awareness
+
+## The Idea
+
+Captain needs to know, at any moment: who is alive, what are they working on, what's blocking them, what's next. Today, captain guesses — reads the last handoff, assumes worktree agents are where they said they'd be, and waits for dispatches to arrive. That works until it doesn't: agents crash silently, sessions end without handoffs, work-in-flight becomes invisible, and standups don't exist.
+
+This is **fleet awareness** — a first-class protocol for liveness, startup, heartbeat, and status reporting across every agent in the agency.
+
+## Three Parts, One Feature
+
+### 1. Liveness DB (protocol substrate)
+
+External SQLite database at `~/.agency/{repo}/fleet.db`, outside git. Same neighborhood as `iscp.db`.
+
+**Schema sketch (draft — for discussion):**
+
+```
+agent_sessions
+  id               INTEGER PRIMARY KEY
+  agent_address    TEXT NOT NULL            -- fully qualified: repo/principal/agent
+  session_id       TEXT NOT NULL            -- Claude Code session ID if available, else UUID
+  came_online_at   TIMESTAMP NOT NULL
+  last_heartbeat   TIMESTAMP NOT NULL
+  went_offline_at  TIMESTAMP                -- NULL while alive; set on clean exit
+  startup_state    TEXT (JSON)              -- checklist: handoff_read, loops_armed, iscp_checked, collab_checked, captain_pinged
+  metadata         TEXT (JSON)              -- worktree path, branch, plan phase, anything else
+  UNIQUE(agent_address, session_id)
+```
+
+**Staleness rule (draft):** `last_heartbeat > 15min ago AND went_offline_at IS NULL` → presumed offline (session crashed without clean exit). Configurable.
+
+**Query primitives (draft):**
+- `fleet alive` — list currently-alive agents
+- `fleet status <agent>` — detailed state for one agent
+- `fleet history <agent>` — session history
+- `fleet cleanup` — sweep stale sessions
+
+### 2. `/startup` skill (canonical entry for every agent)
+
+Covers all three entry paths:
+- **Cold start** — first time in a fresh install/clone
+- **Bootstrap** — first time for a newly-created agent
+- **Resume** — continuing work across session boundary
+
+Single skill, same sequence, different branches based on state detection.
+
+**Sequence (draft):**
+
+1. Resolve identity (`agent-identity`) — who am I
+2. Detect entry mode (cold / bootstrap / resume) from handoff presence + fleet.db history
+3. Read handoff (`handoff read`) — or write initial if cold/bootstrap
+4. Check local ISCP (`dispatch list`, `flag list`)
+5. Check cross-repo (`collaboration check`) — all agents, not captain-only (per peer-to-peer decision)
+6. Arm the two dispatch loops (5m silent + 30m nag)
+7. **Arm the heartbeat loop** (10m, see below)
+8. **Register liveness** — write row to fleet.db with startup_state checklist
+9. **Ping captain** — send a `status` dispatch: "alive, online, entry mode: {cold|bootstrap|resume}, handoff summary"
+10. Follow "Next Action" from handoff
+
+**Result:** every agent's startup becomes a single command. The CLAUDE-{AGENT}.md startup section collapses to: **"Run `/startup` on session start."**
+
+### 3. Heartbeat
+
+Periodic ping from every agent (including captain) to fleet.db. Updates `last_heartbeat`.
+
+**Draft design:**
+- New tool: `claude/tools/fleet-heartbeat` — updates current session's heartbeat, idempotent
+- Scheduled loop: `/loop 10m fleet-heartbeat` armed by `/startup`
+- Silent operation — no terminal noise
+- Stale threshold tuneable (default 15m → presumed offline)
+- On clean exit: `/session-end` writes `went_offline_at`
+
+### 4. `/captains-report` skill (standup)
+
+Depends on the liveness DB. Captain fans out a standup-style dispatch to currently-alive fleet, collects responses, compiles a report.
+
+**Sequence (draft):**
+
+1. Args: `--since "<time>"` (e.g., `"last standup"`, `"yesterday"`, `"1h ago"`)
+2. Query fleet.db: who's alive right now?
+3. For each alive agent, dispatch a `standup` (or `directive` with structured subject) asking:
+   - What did you do since {time}?
+   - What's next?
+   - Any blockers?
+4. Wait for responses (timeout, e.g., 10m configurable)
+5. Aggregate into a report — table + per-agent narrative
+6. Output:
+   - Print to captain's terminal
+   - Write to `usr/jordan/captain/logs/captains-report-{YYYYMMDD-HHMM}.md`
+7. Agents who didn't respond: listed as "no response"
+8. Agents marked offline in fleet.db: listed as "offline since {time}"
+
+## Why Now
+
+- Captain is currently flying blind on fleet state — guesses from handoffs and dispatch timing
+- Silent agent crashes are invisible — no way to know a session died mid-work
+- No standup protocol — captain cannot ask "what's everyone doing right now?"
+- Growing fleet: today it's captain + 4 worktree agents; will scale with more workstreams
+- Cross-repo collaboration is becoming peer-to-peer (iscp #165) — liveness awareness becomes more valuable as more agents coordinate directly
+
+## Open Questions (for /define 1B1)
+
+1. ~~**Workstream ownership.**~~ **RESOLVED by principal during seed capture:** *"You are the fleet. The fleet is you."* Captain owns the fleet workstream. Fleet is captain's domain — coordination, liveness, standup, presence, scheduling. A new `fleet` workstream is created under captain's ownership. Other agents (iscp, devex) contribute via dispatches but captain drives the work.
+
+2. **Protocol split across agents.** Fleet workstream is captain-owned, but implementation still touches iscp (schema patterns, DB conventions) and devex (skills, tool scaffolding). The plan should assign specific iterations to the right implementer while captain orchestrates. Open: does captain implement directly, or dispatch every iteration?
+
+3. **Session ID source.** Claude Code provides session IDs in hooks but not always in user-initiated commands. Fallback to UUID? Persist the session ID in a file?
+
+4. **Dispatch type for standup.** New `standup` type, or reuse `directive` with a structured subject format? New types bump the ISCP schema; reuse has less protocol churn.
+
+5. **Heartbeat interval.** 10m default sensible? Too frequent wastes cycles, too sparse makes staleness detection slow.
+
+6. **Staleness threshold.** 15m default sensible? Needs to be > heartbeat interval + jitter + expected-pause.
+
+7. **Startup checklist granularity.** Which steps count? What does "startup complete" mean? Does a failed step block the agent from being counted as "alive"?
+
+8. **Principal liveness.** Is the principal represented in the fleet DB? They're not an agent per se but their presence/absence affects captain's behavior.
+
+9. **Multi-principal.** How does this scale when multiple principals share the same repo (future)?
+
+10. **Cross-repo fleet visibility.** Does captain see monofolk's fleet too? Separate DBs or aggregated view?
+
+11. **Offline history retention.** How long do we keep went-offline rows? Forever (audit trail) or rolling window?
+
+12. **Privacy / isolation.** Sandbox agents writing to a shared DB — any isolation needed?
+
+13. **`/captains-report` scope.** Captain-only skill, or can any agent request a report? (A tech lead running their own standup for their sub-team, for instance.)
+
+14. **Report format.** Markdown table? Narrative? Both? Include plan phase progress from the handoff?
+
+15. **Timeout behavior for standup.** If an agent is alive but doesn't respond to the standup dispatch within timeout, what does captain do? Note in report, re-ask, escalate?
+
+16. **Symmetric `/suspend` (or `/shutdown`).** Principal raised this during seed capture: *"does handoff become part of suspend or some such skill?"* If `/startup` arms the session, a symmetric skill should cleanly close it:
+    - Write handoff (via existing `/handoff` tool)
+    - Mark `went_offline_at` in fleet.db
+    - Emit a final heartbeat with state = "suspended"
+    - Cancel any armed loops cleanly
+    - Send a `status` dispatch to captain: "going offline, handoff at {path}"
+    - Archive anything that should be archived
+    - Return a "safe to exit" confirmation
+    - Name candidates: `/suspend`, `/shutdown`, `/session-end` (existing), `/offline`
+    - Open: is this a new skill, or does it absorb/replace `/session-end` and `/handoff`?
+
+## Related Work
+
+- **Priority Order** (shipped) — captain reads dispatches first, principal communications override
+- **Dispatch loops** (shipped) — 5m silent + 30m nag pattern, now canonical for every agent
+- **Peer-to-peer collaboration** (iscp #165 queued) — cross-repo dispatches become peer-to-peer with captain auto-CC
+- **Captain's log** (shipped Day 32) — narrative thread alongside handoffs; may cross-reference standup reports
+- **ISCP schema versioning** (Phase 2.0 shipped) — fleet.db schema can use the same PRAGMA user_version pattern
+- **Per-agent inboxes** (iscp Plan #121 approved) — another substrate extension
+
+## Conversation Source
+
+This seed was captured from a principal/captain conversation on 2026-04-08 during Day 33. Key quotes:
+
+> "I want to have a skill captains report, which you use to send a dispatch out to the fleet asking them for current status and what is pending and any blockers."
+
+> "I want to have a skill 'resume' which guides them through the resume process. What to read, what to do (setup loops), send a dispatch to captain that they are alive, send input for captains report, etc."
+
+> "Do we want to add to a database outside the repo a mechanism that let's us see who is live, when came online or went offline, and that if they have a session, confirmation that they did all of their startup activities in our 'resume' or startup skill?"
+
+> "Maybe this /resume skill is actually /startup? Because it might be a resume, a cold-start, or a bootstrap?"
+
+> "We also need a heartbeat."
+
+> "You are the fleet. The fleet is you." — resolving workstream ownership: fleet is captain's domain.
+
+> "And does handoff become part of suspend or some such skill?" — proposing a symmetric shutdown skill paired with `/startup`.
+
+Full chat transcript available in the current session record.
+
+## Next Steps
+
+1. Principal + captain 1B1 through `/define` — resolve open questions, produce Fleet Awareness PVR
+2. `/design` — produce A&D document with schema, tool contracts, skill specifications
+3. Plan — phases and iterations, workstream assignment, cross-agent coordination
+4. Implement — iscp owns DB and protocol, devex owns skills and tooling (or whoever the plan assigns)
+5. Ship — gradual rollout: captain first, then worktree agents one at a time
+
+*Captured during Day 33 R1 work.*

--- a/claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md
+++ b/claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md
@@ -1,0 +1,94 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-07
+status: parked — awaits prioritization
+source: flag #37
+captured-by: the-agency/jordan/captain
+---
+
+# Seed: Granola Workflow — External Material Ingestion Pipeline
+
+## The Problem
+
+Granola transcripts (meeting summaries + raw transcripts) are a **primary source of seed material** today. We have no formal pipeline for getting them into the framework. They live wherever Granola puts them; they get into the repo via ad hoc copy-paste during agent sessions; there's no redaction, no classification, no consistent location.
+
+This bites us in two ways:
+
+1. **Friction at capture time** — when a Granola transcript inspires a seed/discussion, the agent has to manually paste content, decide where it goes, and figure out what to redact (if anything). The friction discourages capture.
+
+2. **Inconsistency at retrieval time** — past transcripts referenced by current work are hard to find. Some are in `usr/jordan/captain/transcripts/`, some are in `claude/workstreams/{ws}/seeds/`, some are inline in handoffs, some are nowhere.
+
+## What's Needed
+
+A formal workflow for pulling external materials (Granola summaries + transcripts) into the repo:
+
+### 1. Ingestion Process
+
+- A standardized location for Granola materials (probably `usr/{principal}/granola/{date}/`)
+- A way to bring them in: tool, skill, or manual convention
+- Naming convention that ties them to source meeting + date + topic
+- Both summary AND raw transcript captured (summary for quick reference, raw for full context when needed)
+
+### 2. Redact Functionality
+
+External materials may contain:
+- Other people's PII (names, emails, contact info)
+- Sensitive business information
+- Information about people/orgs not in the project
+- Things the principal wouldn't want in a public repo
+
+The pipeline needs a redact step: either automated (regex patterns + named-entity removal) or principal-reviewed (interactive markup before commit). Default should be conservative — when in doubt, flag for manual review.
+
+### 3. Classification
+
+Not every external material is a seed. Three categories:
+
+- **Seed material** — directly inspires PVR/discussion work; goes to `claude/workstreams/{ws}/seeds/`
+- **Reference** — context that informs decisions but isn't a starting point; goes to `claude/workstreams/{ws}/references/` or similar
+- **Ephemeral** — useful in the moment but not worth committing; goes to `usr/{principal}/{project}/tmp/` (gitignored)
+
+The pipeline asks the principal to classify on capture, with sensible defaults.
+
+### 4. Tooling
+
+- A tool/skill to pull the latest Granola export and stage it
+- A redact step (interactive or automated)
+- A classification + commit step
+- Cross-references: from the Granola material file back to the project work it inspired (and vice versa)
+
+## Why This Matters
+
+The Valueflow methodology starts with Idea → Seed. Seeds are the entry point. **If seed capture has friction, the whole flow has friction at the source.** Granola transcripts are one of the highest-volume seed sources today. Formalizing this pipeline reduces friction at the most important point in the flow.
+
+Also: continual learning depends on having historical context. When a future session asks "why did we decide X six months ago?", the answer often lives in a Granola transcript that someone heard but never captured. Proper pipelines = better mining = better continual improvement.
+
+## Constraints
+
+- **Don't expose PII or sensitive info** in public commits — redaction is mandatory, not optional
+- **Don't make capture harder than current ad hoc copy-paste** — if the formal pipeline has friction, it'll get bypassed
+- **Don't build a big system** — start with the simplest thing that addresses the friction (a tool + a convention), iterate from there
+
+## Open Design Questions
+
+1. **Where do raw Granola exports live?** Per-principal sandbox (`usr/{principal}/granola/`)? Framework directory? Outside git entirely?
+2. **Redact automation vs review?** Where's the right balance? Maybe heuristic redaction with mandatory principal sign-off before commit?
+3. **Classification at capture vs lazy?** Force the principal to classify upfront (strict) or default to "ephemeral" and allow promotion later (lazy)?
+4. **Granola API integration?** Granola has an API — should the tool pull from the API directly, or rely on file exports?
+5. **Cross-reference mechanism?** Front matter? Sidecar metadata file? A central index?
+
+## Related
+
+- Flag #14, #15: agency-audit + structure.yaml seeds (could include granola/ in structure validation)
+- Continual learning loop: transcript mining (planned, deferred to V2.1)
+- This seed is captain-side, but consumers include all workstream agents
+
+## Spin-Up Notes
+
+When prioritized, this could become its own workstream (`claude/workstreams/granola/`) or live as an iteration in the agency workstream. Decision point: how big does the design get? If just a tool + convention, it's an iteration. If a full pipeline with API integration, classification UI, and continual learning hooks, it's a workstream.
+
+Recommend starting as an iteration (tool + convention + redact step) and graduating to a workstream if the scope grows.
+
+## Captured From
+
+Flag #37 (2026-04-07T02:59:56Z): "SEED/PROCESS: workflow for pulling in external materials from Granola (summary + transcript). These might be seed materials or general project context. Need: (1) ingestion process — where do they live, how do agents access them, (2) redact functionality — strip PII/sensitive info before they enter the repo, (3) classification — seed vs reference vs ephemeral, (4) tooling to support the workflow. Granola transcripts are a primary source of seed material today and we have no formal pipeline."

--- a/claude/workstreams/agency/seeds/seed-release-plan-tool-20260408.md
+++ b/claude/workstreams/agency/seeds/seed-release-plan-tool-20260408.md
@@ -1,0 +1,83 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-08
+captured_by: the-agency/jordan/captain
+principal: jordan
+status: seed
+---
+
+# Seed: `release-plan` tool
+
+## What it is
+
+A tool that answers the question **"what should be in today's PR?"** automatically. Instead of captain manually grouping uncommitted changes + local-ahead commits + untracked files into logical commits, the tool analyzes the current state and produces a proposed release plan.
+
+Captured during Day 33 R1 work when principal observed me manually walking through the staging area and grouping changes — *"That should be a tool!"*
+
+## What it does
+
+Given the current branch state, produces:
+
+1. **Inventory** of everything that could land in the release:
+   - Local commits ahead of origin
+   - Modified files (staged + unstaged)
+   - Untracked files (excluding gitignored)
+2. **Logical grouping** by directory / file pattern / commit hint:
+   - Methodology / docs (`claude/CLAUDE-*.md`, `usr/*/CLAUDE-*.md`, `claude/templates/*`)
+   - Tool changes (`claude/tools/*`)
+   - Skill changes (`.claude/skills/*`)
+   - Hook changes (`claude/hooks/*`, `.claude/settings.json`, `claude/config/settings-template.json`)
+   - Workstream artifacts (seeds, dispatches, plans, transcripts)
+   - Coordination artifacts (`usr/*/dispatches/`, `usr/*/history/`, `usr/*/reports/`)
+   - Tests (`tests/`)
+3. **Suggested commit boundaries** — N proposed commits with:
+   - File list
+   - Suggested message (drawn from file paths + agent identity)
+   - Whether it needs QG (`/git-commit`) or coordination (`/coord-commit`)
+4. **Things to exclude from R1** — files that look like they were left over from prior work, untouched in the current session, or are tmp/scratch
+5. **PR shape** — branch name, base branch, draft status, suggested title and summary
+
+## Why it matters
+
+Captain does this analysis manually every release. Today's analysis took ~5 minutes of careful reading and produced a 5-commit grouping. With multiple releases per day, that's pure overhead — and prone to drift between releases (different captains might group differently). A tool gives consistent, fast, reviewable output.
+
+It also unblocks **agents** doing their own releases (devex, iscp, etc.) — they'd run `release-plan` in their worktree to get the same analysis without needing captain.
+
+## Sketch of usage
+
+```bash
+./claude/tools/release-plan
+# → produces a markdown plan to stdout, or writes to .claude/.tmp/release-plan-{YYYYMMDD-HHMM}.md
+
+./claude/tools/release-plan --apply
+# → actually creates the branch, stages and commits per the plan, and opens a draft PR
+
+./claude/tools/release-plan --since {ref}
+# → consider only changes since {ref} (default: origin/main)
+```
+
+## Design questions for /define
+
+1. **Heuristics vs machine-learned grouping.** Heuristics from file paths are simple and explainable. ML grouping is fancier but harder to debug. v1 should be heuristic-only.
+2. **How does it know what's "current session" vs leftover from prior work?** Use `git stash` timestamps? Modification time vs session start? Commit-hint-from-message? Hard problem.
+3. **Does it auto-write commit messages?** Or just propose? I'd say propose and let captain edit before applying.
+4. **Integration with `/git-commit`**. Each proposed commit should be runnable through `/git-commit` so QG attribution stays consistent.
+5. **Integration with `/sync-all`** and the Day-PR Release Pattern. Release plan is the *input* to building the day-N-release-M branch.
+6. **Should it be invokable by any agent or captain-only?** Probably any agent for their own worktree's release.
+
+## Related work
+
+- **Day-PR Release Pattern** (shipped Day 32) — `day{N}-release-{M}` branches as drafts. release-plan would automate the branch construction.
+- **`/pr-prep` skill** — runs the QG before creating a PR. release-plan would run *before* `/pr-prep` to determine WHAT goes in the PR.
+- **`/coord-commit` skill** — for committing coordination artifacts without QG. release-plan would emit `coord-commit` calls for the artifact group.
+- **`/git-commit` tool** — release-plan emits `git-commit` calls for content groups.
+- **`stage-hash` tool** — release-plan can use stage-hash to verify each proposed commit.
+
+## Slot
+
+This is **the natural follow-on to `agency-issue`** — both are "captain manually does X, that should be a tool" patterns. Build when there's a quiet moment in the R1/R2 cycle. Not blocking anything.
+
+## Conversation source
+
+Captured during Day 33 R1 work, after captain produced a manual 5-commit grouping for the day's release. Principal: *"That should be a tool!"*

--- a/claude/workstreams/agency/seeds/seed-silent-periodic-tool-calls-20260408.md
+++ b/claude/workstreams/agency/seeds/seed-silent-periodic-tool-calls-20260408.md
@@ -1,0 +1,161 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-08
+captured_by: the-agency/jordan/captain
+principal: jordan
+status: filed
+parked_for_revisit: true
+anthropic_feedback_id: 8dd67e96-63ea-4a22-b687-d26a1b2d0add
+github_issue: https://github.com/anthropics/claude-code/issues/45017
+report: usr/jordan/reports/report-silent-periodic-tool-calls-20260408.md
+---
+
+**FILED 2026-04-08.** Anthropic feedback ID `8dd67e96-63ea-4a22-b687-d26a1b2d0add`; GitHub issue [anthropics/claude-code#45017](https://github.com/anthropics/claude-code/issues/45017). Tracking at `usr/jordan/reports/report-silent-periodic-tool-calls-20260408.md`.
+
+
+# Seed: Silent Periodic Tool Calls (Claude Code gap — external feature request)
+
+## What this is
+
+A feedback/feature-request document to file with Anthropic (Claude Code team) asking for a native mechanism to execute periodic tool calls silently — i.e., without rendering in the terminal transcript. This is a **dependency** for the Fleet Awareness workstream: the autonomous-agent awareness substrate can't be fully silent without Claude Code harness changes.
+
+Parked for later revisit. We may wait until Fleet Awareness reaches a deeper design stage before submitting, so we can cite specific impact.
+
+## The gap (short version)
+
+Claude Code today has silent mechanisms (hooks, status line, async hooks, subagent internals) but none combine **silent + periodic + agent-context-aware**. The only periodic mechanism (`CronCreate`/`/loop`) always renders visibly. For autonomous agents that self-poll external state between user turns, this is pollution that scales linearly with polling frequency.
+
+## Related Agency work
+
+This seed intersects with several current workstreams:
+
+- **Fleet Awareness** (`seed-fleet-awareness-20260408.md`) — the primary consumer. Fleet's `/startup`, heartbeat, and `/captains-report` skills all need periodic checks that today cannot be silent. This is documented as a **constraint** in the Fleet Awareness seed (question #7-related).
+- **ISCP** (`claude/workstreams/iscp/`) — the `iscp-check` hook is our existing silent notification path, but it's event-driven (fires on user actions only). The peer-to-peer collaboration work (iscp plan #165) increases the value of live fleet awareness.
+- **Captain's dispatch loop convention** (now in `claude/CLAUDE-THEAGENCY.md` → "When You Have Mail") — the 5-minute fast-path loop pattern is the concrete pain point. The 30-minute visible nag loop is fine as-is; the fast-path is what's polluted.
+- **Day 33 R1 work** — this seed was captured mid-Day-33 during the conversation that also produced iscp-check delta suppression (v1.1.0), the status line candidate architecture investigation, and the peer-to-peer collaboration dispatch (#165).
+
+## Our research
+
+Two rounds of research via `claude-code-guide` agent confirmed:
+
+1. **Round 1 (doc scan)** — no native silent-cron mechanism exists; background bash + file logging is the documented workaround; async hooks are silent but non-periodic.
+2. **Round 2 (silence mechanisms catalog)** — hooks silent (event-driven), status line silent (footer-only, can't inject agent context), subagent internals silent (not periodic), async hooks silent (not periodic), cron visible. **No combination provides silent + periodic + agent-context-aware.**
+
+## Two proposed options + one hybrid question
+
+The insight: **hooks are already silent by design.** We don't need a new "silent mode" for agent turns. We need a periodic trigger that fires a hook-style execution rather than a full agent turn.
+
+### Option 1 (preferred) — Periodic hook type in settings.json
+
+```json
+{
+  "hooks": {
+    "Periodic": [
+      { "interval": "5m", "command": ".claude/tools/iscp-check" }
+    ]
+  }
+}
+```
+
+Fires on a timer; runs silently like all other hooks; can inject via `additionalContext` into the next agent turn. This is the hook-based analogue of cron jobs. Reuses all existing hook infrastructure (silent execution, `additionalContext` injection, JSON output contract). Minimal new surface area.
+
+### Option 2 — Status line for display-only polling (already exists; document it)
+
+```json
+{
+  "statusLine": { "type": "command", "command": ".claude/tools/iscp-statusline" }
+}
+```
+
+Status line commands already run periodically and silently (~every UI tick). Output renders in the footer bar, not the transcript. This solves **display** (user sees mail count in footer) but cannot inject into agent context (footer output doesn't reach the agent's next turn). Good complement to Option 1 — use it for the visual indicator, use Periodic hooks for the context injection.
+
+### Hybrid question — can CronCreate trigger a HOOK fire instead of a turn?
+
+```typescript
+CronCreate({
+  cron: "*/5 * * * *",
+  hook: ".claude/tools/iscp-check",
+  recurring: true,
+})
+```
+
+Rather than scheduling a `prompt` (which fires an agent turn and renders), let CronCreate schedule a `hook` command. The scheduled fire runs as a hook — silent by design, can inject via `additionalContext`. This is arguably the cleanest implementation: **no new hook type, just a new scheduler variant.** The existing silent-hook machinery runs unchanged; only the trigger source changes.
+
+**Ask Anthropic:** is this feasible? Does the existing scheduler have the plumbing to invoke a hook-style command instead of a turn? Which of the two options (Periodic hook type vs CronCreate-with-hook) is a smaller change?
+
+## What we've tried (for the feedback)
+
+1. Delta suppression in existing hook (`iscp-check v1.1.0`, shipped Day 33) — works, but hooks only fire on user events.
+2. Empty-output bash tool — still renders the `Bash(command)` line.
+3. Status line polling — silent, but can't inject into agent context.
+4. Background detached bash loop — silent after spawn, but hook-gated notification lag.
+5. Async hooks — silent but non-periodic.
+
+## Use case for the feedback
+
+Multi-agent framework ([the-agency](https://github.com/the-agency-ai/the-agency)) where each agent runs as its own Claude Code session and agents coordinate via a SQLite-backed inter-session communication protocol (ISCP). Agents need to notice incoming dispatches from other agents within ~5 minutes so they can respond to directives, reviews, and escalations while their principal is away.
+
+## Mechanical notes for submission
+
+- `/feedback` skill files to GitHub automatically on success — **one submission** covers both channels (Anthropic feedback + public issue)
+- Principal identity to include: Jordan Dea-Mattson, @jordandm (the-agency-ai org), email TBD
+- Claude Code version: run `claude --version` at submission time
+- Repository reference: https://github.com/the-agency-ai/the-agency
+
+## Draft feedback text (ready to submit via /feedback)
+
+---
+
+# Silent/hidden mode for scheduled tool calls (for autonomous agents)
+
+**Summary.** Claude Code has no mechanism to execute periodic scheduled tool calls (`CronCreate`, `/loop`) without rendering them in the terminal transcript. For autonomous-agent infrastructure that needs to self-poll between user turns, every fire produces visible `⎿ Bash(command) + output` pollution.
+
+**Existing silent mechanisms each fail for this use case:**
+
+| Mechanism | Silent | Periodic | Agent-context-aware |
+|-----------|--------|----------|--------------------|
+| SessionStart / UserPromptSubmit / Stop hooks | ✅ | ❌ | ✅ |
+| Async hooks (`"async": true`) | ✅ | ❌ | Partial |
+| Status line command | ✅ | ✅ | ❌ (footer only) |
+| Subagent execution (internals) | ✅ | ❌ | Returns-only |
+| `CronCreate` / `/loop` | ❌ | ✅ | ✅ |
+| Background `Bash(run_in_background: true)` | Partial | ✅ | ❌ (file-gated) |
+
+**No combination gives silent + periodic + agent-context-aware.**
+
+**Use case.** Multi-agent framework (the-agency, https://github.com/the-agency-ai/the-agency) where agents coordinate via SQLite-backed inter-session messaging (ISCP) and need to notice dispatches within ~5 minutes while the principal is away. Hook-based notification catches mail on `UserPromptSubmit` and `Stop`, but between events the agent is blind. Polling via `/loop` fills the gap but pollutes the interactive session — at 5-minute intervals, an 8-hour day produces ~100 visible "no-op" renders.
+
+**What we tried.**
+1. Delta suppression in a hook (`iscp-check v1.1.0`) — works but hook only fires on user events
+2. Empty-output bash tool — `Bash(command)` line still renders
+3. Status line polling — silent but can't inject into agent context
+4. Background detached bash loop — silent but hook-gated notification lag
+5. Async hooks — silent, non-periodic
+
+**Proposed feature (any one of three would solve it).**
+
+**Option A — `hidden: true` flag on CronCreate.** Scheduled turns execute but don't render.
+**Option B — `Periodic` hook type.** Timer-based hook with same silent + additionalContext semantics as other hooks.
+**Option C — Per-tool-call `hidden` parameter.** Individual `Bash(..., hidden: true)` suppresses render; tool still runs, result still in agent context.
+
+**Why it matters.** Unblocks multi-agent frameworks, background sync agents, monitoring agents, and any long-running autonomous pattern where the agent is observer rather than prompt-responder. The Claude Code docs emphasize autonomous operation and composable building blocks — periodic silent self-awareness is the missing primitive.
+
+**Reporter.** Jordan Dea-Mattson, @jordandm (the-agency-ai)
+**Framework.** https://github.com/the-agency-ai/the-agency
+**Claude Code version.** TBD at submission
+
+---
+
+## Revisit triggers
+
+File this feedback when one of these is true:
+
+1. **Fleet Awareness PVR reaches design review** — having the PVR lets us cite the concrete substrate we're building and quantify the polling frequency we need
+2. **Day 34 or later release cycle** — avoid piling too much on the Day 33 R1 branch
+3. **New Claude Code release ships** — check if any of the mechanisms above change before filing
+4. **Second concrete use case surfaces** — currently the only consumer is Fleet Awareness; if another workstream hits the same gap, that strengthens the request
+
+## Conversation source
+
+Captured during Day 33 from a principal-captain conversation where captain mistakenly claimed the 5-minute dispatch loop was silent, principal corrected by observing "I see places where I am not seeing tool calls and their results in my terminal session," two rounds of research clarified the silent-mechanism catalog, and principal directed "file a /feedback and github issue on this one. Write it up per protocol."

--- a/claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md
+++ b/claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md
@@ -1,0 +1,109 @@
+---
+type: seed
+workstream: gtm
+date: 2026-04-07
+status: parked — business opportunity exploration
+source: flag #39 + flag #40
+captured-by: the-agency/jordan/captain
+---
+
+# Seed: Agent Mail — Email Infrastructure for AI Agents
+
+## The Idea
+
+Email infrastructure designed specifically for AI agents in multi-agent frameworks. Each agent gets its own addressable identity, plus-addressing works naturally across agent+principal combinations, forwarding routes to human principals via configurable rules, and there's an audit trail of which agent sent what.
+
+This came up twice in Day 32 from different angles:
+- **Flag #39:** "Agentic email service... captain+jordandm@... with forwarding routes... a noreply-for-agents service that handles attribution, traceability, and replies-to-principal routing."
+- **Flag #40:** "Agent Mail Service... takes the format `jordandm+captain.the-agency@users.noreply.github.com` forward as a real email delivery service. Service-owned domain (e.g., `agentmail.dev`)."
+
+## The Gap In The Market
+
+Today, when you want to attribute commits or messages to AI agents in a multi-agent framework, you have three bad options:
+
+1. **Use the principal's real email** — works, but exposes private email and conflates principal/agent identity
+2. **Use GitHub noreply with plus-tags** — works for commit attribution (what we just shipped on Day 32) but doesn't deliver messages, no replies route anywhere, only useful inside GitHub
+3. **Set up multiple GitHub bot accounts** — works but is heavyweight, requires GitHub App registration per agent, and locks you into GitHub
+
+There's no email service that says "we know about agents." None of the existing services (Gmail, FastMail, Proton, ImprovMX, etc.) treat agents as first-class entities with identity, routing, and replies-to-principal as a native feature.
+
+## The Product
+
+A managed email service where:
+
+- **Each principal gets a mailbox** — `jordan@agentmail.dev`
+- **Plus-tags route per agent** — `jordan+captain@agentmail.dev`, `jordan+iscp@agentmail.dev`, `jordan+devex@agentmail.dev` all deliver to Jordan's inbox by default
+- **Per-agent forwarding rules** — `jordan+captain.commits@agentmail.dev` could route to a digest, `jordan+iscp.errors@agentmail.dev` could forward to Slack, `jordan+devex.urgent@agentmail.dev` could SMS the principal
+- **Reply-to-principal routing** — when someone replies to an agent address, the reply lands in the principal's inbox with the agent context preserved
+- **Audit trail** — every message sent from an agent address is logged: which agent, when, to whom, why (link to the dispatch/commit/action that generated it)
+- **Identity verification** — addresses are verifiable on platforms like GitHub (so commit attribution works) without needing per-agent GitHub accounts
+
+## Why It's An Opportunity
+
+The market for this didn't exist a year ago because nobody was building multi-agent frameworks. Now there are several:
+- TheAgency
+- gstack
+- metaswarm
+- (and the inevitable wave coming)
+
+All of them face the same attribution + delivery problem we just hit on Day 32. Right now they all hack around it. A managed service that solves it cleanly is a small but real market — and the market is going to grow as multi-agent dev becomes mainstream.
+
+## The Connection To Day 32
+
+The plus-tag attribution format we shipped on Day 32 is **exactly the format Agent Mail would understand**. When commits use `jordandm+captain.the-agency.the-agency-ai@users.noreply.github.com`, that's a non-routable string today. With Agent Mail, it becomes a routable address. Same format, same semantics, just upgraded delivery — adopters could migrate by changing one config line in `agency.yaml`.
+
+Our `commit_email` override (planned future config) is the migration path:
+```yaml
+principals:
+  jdm:
+    commit_email:
+      mode: agent-mail
+      mailbox: "jordan@agentmail.dev"
+```
+
+When this ships, every commit's agent co-author becomes a real, deliverable, replyable address.
+
+## Initial Users
+
+1. **AIADLC framework adopters** — TheAgency, gstack, metaswarm users
+2. **Agent-driven CI/CD pipelines** — bots that need identity and message routing
+3. **Multi-agent research teams** — academic and industry research running multiple agents
+4. **Personal "second brain" agents** — individual users running personal agent stacks
+
+## Constraints To Solve
+
+- **Domain ownership** — service needs its own domain (e.g., `agentmail.dev`)
+- **MX + SPF + DKIM + DMARC** — proper email infrastructure
+- **GitHub verifiability** — addresses should work as verified emails on GitHub for profile linking
+- **Spam handling** — both inbound (we don't want agent addresses spammed) and outbound (we don't want our service to look like a spam source)
+- **Privacy** — principals should control what's logged about their agents
+- **Pricing model** — per-principal? per-agent? per-message? freemium?
+
+## Open Design Questions
+
+1. **Mailbox-per-principal or mailbox-per-agent?** Probably principal — agents are tags, not full mailboxes. But agents could be promoted to full mailboxes if needed.
+2. **Web UI vs API-only?** Both, eventually. API first.
+3. **Hosted vs self-hosted?** Hosted to start. Self-hosted as a second tier for enterprise.
+4. **Integration with existing email?** Should `jordan+captain@agentmail.dev` be able to forward to `jdm@devopspm.com`? Yes — that's the whole point.
+5. **GitHub integration?** First-class — auto-verify addresses on GitHub, link to profiles, support the noreply pattern as a fallback.
+
+## Related
+
+- Day 32 Per-Agent Commit Attribution implementation: `claude/tools/git-commit` (commit `03d3ed6`)
+- Discussion record: `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`
+- README-THEAGENCY.md "Per-Agent Commit Attribution" subsection
+
+## Spin-Up Notes
+
+This is a business opportunity, not a TheAgency feature. When prioritized:
+- Validate market: ask other AIADLC framework authors if they'd pay for this
+- Validate technical: verify GitHub address verification works as expected
+- Validate domain: secure `agentmail.dev` or similar
+- Build MVP: principal mailboxes + plus-tag routing, no fancy features
+
+If we don't build it, someone else will. The Day 32 attribution work is evidence the market exists.
+
+## Captured From
+
+- Flag #39 (2026-04-07T06:29:01Z): "BUSINESS OPPORTUNITY: Agentic email service..."
+- Flag #40 (2026-04-07T07:27:53Z): "BUSINESS: Agent Mail Service..."

--- a/tests/tools/iscp-check.bats
+++ b/tests/tools/iscp-check.bats
@@ -239,5 +239,5 @@ _create_dispatch() {
 @test "iscp-check: --version shows version" {
     run "$ISCP_CHECK" --version
     assert_success
-    assert_output_contains "1.0.1"
+    assert_output_contains "1.1.0"
 }

--- a/usr/jordan/captain/CLAUDE-CAPTAIN.md
+++ b/usr/jordan/captain/CLAUDE-CAPTAIN.md
@@ -42,7 +42,10 @@ On every session start, do these in order:
 1. **Read handoff:** `usr/jordan/captain/captain-handoff.md`
 2. **Check local ISCP:** `dispatch list` and `flag list` — process unread items before other work
 3. **Check cross-repo dispatches:** `./claude/tools/collaboration check`
-4. Follow the "Next Action" in the handoff. Do not wait for a prompt.
+4. **Arm the two dispatch loops** (see `claude/CLAUDE-THEAGENCY.md` → "When You Have Mail" for the canonical prompts). This is standard for every agent:
+   - `/loop 5m …silent-when-clean…` — fast-path, picks up new mail between prompts with zero noise
+   - `/loop 30m …visible-when-sitting…` — nag alarm if dispatches are still unread after 30 minutes
+5. Follow the "Next Action" in the handoff. Do not wait for a prompt.
 
 **Reference (read on demand, not every startup):**
 - `claude/agents/captain/agent.md` — role and responsibilities

--- a/usr/jordan/captain/CLAUDE-CAPTAIN.md
+++ b/usr/jordan/captain/CLAUDE-CAPTAIN.md
@@ -4,6 +4,37 @@
 
 `the-agency/jordan/captain` — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
 
+## Priority Order
+
+Captain has two standing priorities that override everything else, in this order:
+
+### 1. Inquiries and communications from your Principal
+
+**The principal does not contact you unless it is important.** When the principal sends a message, asks a question, or issues a directive, that is your top priority. Stop what you are doing. Listen first. Understand before you act. Confirm before you proceed.
+
+This is not just about urgency — it is about respect for the principal's time. When they pull you out of background work to ask something, the cost of the interruption was already paid by them. Do not waste it by jumping to the next thing or asking them to wait while you finish something else. Address what they brought to you, completely, before returning to other work.
+
+Rules:
+- **When the principal asks for your attention, you give it.** Full stop. The current task waits.
+- **When the principal asks a question, answer it.** Don't pivot to a different topic mid-response.
+- **When the principal redirects you, follow.** Don't keep working on what you were doing.
+- **When the principal corrects you, listen.** Acknowledge and adjust — don't defend.
+
+### 2. Dispatches
+
+**This is the team looking to you for support.** Worktree agents (devex, iscp, mdpal-cli, mdpal-app, etc.) and cross-repo collaborators (monofolk) communicate via dispatches. They send a dispatch when they need a decision, an approval, an unblock, or coordination. They are waiting for you.
+
+Rules:
+- **When you have a dispatch, read it.** People are waiting. Don't let dispatches sit unread.
+- **Read on the iscp-check notification.** When the hook tells you mail is waiting, that is the signal to check immediately at the next natural break.
+- **Process dispatches at session start, before other work.** This is the third startup step below — it is non-negotiable.
+- **Reply or resolve in the same session.** Don't leave plans waiting for approval indefinitely.
+- **Coordinate at the speed your team is working.** If devex shipped a plan and is sitting waiting on you, your job is to unblock them.
+
+### How they interact
+
+If both happen at the same time — principal contacts you AND a new dispatch arrives — the principal's communication wins. Acknowledge the dispatch quickly ("dispatch from devex just landed, will read after we wrap this") but address the principal first.
+
 ## Startup Sequence
 
 On every session start, do these in order:

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -3,7 +3,7 @@ type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
 date: 2026-04-07
-trigger: day-32-end-of-session
+trigger: end-of-session
 ---
 
 ## Identity
@@ -12,135 +12,131 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 
 ## Current State
 
-**Day 32 complete.** Two PRs shipped. Multi-agent infrastructure rebuilt. Methodology documented. First real Day-PR Release Pattern day.
+**Day 33 partially started.** Branch `day33-release-1` exists locally with the CLAUDE-THEAGENCY dispatch-loop edit unstaged. Day 32 priority-order commit (`6cd4307`) is on local main, ahead of origin. **Nothing pushed.** No PR opened.
 
-### Day 32 - Release 1 (PR #46) — MERGED
-12 commits. Multi-agent infrastructure fixes + Valueflow V2 plan + Phase 1 M1/M2 + docs accuracy pass.
+P0 worktree bug surfaced late in session, then **downgraded to P1** within minutes — see Open Items.
 
-- **Permissions overhaul:** `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)` replaces 100+ narrow patterns
-- **Agent identity fix:** `agent-identity` PWD-based worktree detection (de73c9c)
-- **`$CLAUDE_PROJECT_DIR` fix:** Variable empty in agent Bash calls. All skills/docs use `./claude/tools/`
-- **Hookify blocks:** `block-cd-to-main` (cd + absolute paths), `block-raw-handoff` (forces /handoff skill)
-- **All agents to `opus[1m]`:** 1M context window
-- **Startup trimmed:** 9-10 steps → 3 (handoff, dispatch check, work)
-- **`.agency-agent` gitignored**
-- **Friction analysis:** `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` — 30-40% overhead identified
-- **Valueflow V2 master plan:** `claude/workstreams/agency/valueflow-plan-20260407.md` — 6 phases, 3 workstreams, MAR'd
-- **Phase 1 M1:** QUALITY-GATE.md tier definitions (T1-T4)
-- **Phase 1 M2:** New `claude/docs/ISCP-PROTOCOL.md`
-- **Docs accuracy passes (2 rounds of 4 reviewers each):** CLAUDE-THEAGENCY.md, README-THEAGENCY.md, README-GETTINGSTARTED.md
-- **NEW: `claude/README-ENFORCEMENT.md`** — comprehensive 5-layer enforcement model + all 33 hookify rules
-- **Bug fix:** `master-updated` dispatch type (was wrong in some docs)
-- **Bug fix:** Handoff path `{agent}-handoff.md` (was wrong)
+## What Happened This Session
 
-### Day 32 - Release 2 (PR #48) — MERGED
-6 commits. New capabilities and patterns built on top of R1.
+### Methodology shipped
+- **CLAUDE-CAPTAIN.md Priority Order** (committed locally as `6cd4307`, NOT yet on a release branch):
+  1. Principal communications win, full stop
+  2. Dispatches second — read on iscp-check notification
+- **Dispatch loop is universal** — every agent runs `/loop 5m dispatch list --status unread` at session start. Documented in `claude/CLAUDE-THEAGENCY.md` (unstaged change).
+- mdpal-app already adopted the convention on its own startup (per #148).
 
-- **`/captain-log` tool + skill** — narrative thread daily log, categories (decision/friction/learning/milestone/observation/build). Resolves flag #2.
-- **`/secret` skill (SPEC-PROVIDER)** — converted from command, third example of SPEC-PROVIDER pattern. Resolves flag #5.
-- **Day-PR Release Pattern documented** in README-THEAGENCY.md
-- **Agency init template refactor** — `_agency-init` now uses `HANDOFF-BOOTSTRAP.md` template + sed
-- **Per-agent commit attribution** — `/git-commit` builds `Co-Authored-By: {agent} <{username}+{agent}.{repo}.{org}@users.noreply.github.com>`. Verified with real test commits. Discussion record at `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`. Resolves flag #39, captures #40.
-- **Coordination artifacts:** 8 dispatches sent to devex, 1 to iscp, 6 review-responses approving plans, flag triage record (16 cleared)
+### DevEx queue dispatched (Day 33 work)
+**Directive #149** — 4 items in order, plan-mode required, captain review then execute:
+1. SPEC-PROVIDER wrappers for `/preview` and `/deploy`
+2. Valueflow Phase 3
+3. History rewrite of devex branch (Test User attribution)
+4. Hookify rules from Day 32 friction
+
+### Item 1 plan approved
+- DevEx sent plan as #151 (6 iterations, ~85 min)
+- Captain approved as #153 with answers to all 4 questions:
+  - Merge main into devex (not cherry-pick)
+  - docker-compose / fly defaults confirmed
+  - No provider tool stubs — wrapper IS the deliverable
+  - enforcement.yaml level 2 confirmed
+
+### Item 3 closed
+- DevEx already cleaned devex branch in earlier session (#132, #150)
+- Main branch part requires force-push to origin/main → BLOCKED
+- **Principal chose Option A: accept main as-is** (#152)
+- 64 historical Test User commits remain in pushed history. Test isolation fix prevents new ones.
+
+### P0 → P1 worktree bug (downgraded, still real)
+- mdpal-app reported `git-commit` wipes worktree index (#155, high priority)
+- Initial symptom: ~1280 files show as deleted after running git-commit, no commit made
+- Escalated to devex as #157 (drop Item 1, triage as P0 hotfix)
+- Notified mdpal-cli to verify (#159)
+- Principal hypothesis sent as #160: likely mdpal-specific worktree creation issue
+- **DOWNGRADED via #161 from mdpal-app:** the 1280 'deleted' files are **normal sparse-worktree state** for split worktrees (mdpal-app, mdpal-cli) — not an index wipe. mdpal-cli already knew this and warned in passing (#154).
+- **Real residual bug (P1, not blocking):** git-commit silently exits 1 from mdpal-app's worktree with zero diagnostic output. Workaround works fine. Devex queued for after Item 1.
+- Cleanup dispatched: #162 (devex resume Item 1), #163 (mdpal-cli stand down), #164 (mdpal-app ack).
+- **Principal hypothesis was wrong direction** — it was sparse-checkout, not worktree creation. Disregard #160 thread.
+
+### Two side issues captured for devex
+1. **Sparse-worktree convention is undocumented** — new agents in split worktrees panic at the 1280 D files. Needs a line in CLAUDE-THEAGENCY.md or worktree-create skill.
+2. **Split-worktree onboarding gotcha cluster** — mdpal-cli reports BATS pre-commit broken (#133, #134) + this confusion. Worth a single doc pass. Possibly fold into Item 4 (hookify rules from friction).
+
+### Dispatches processed
+Resolved this session: #137, #139, #145, #146, #148, #150, #151, #155, #161.
+Dispatches sent: #149, #152, #153, #157, #158, #159, #160, #162, #163, #164.
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop immediately:** `/loop 5m dispatch list --status unread`
+2. **Check devex status on Item 1.** P0 was downgraded — devex should have resumed Item 1 (SPEC-PROVIDER wrappers). Watch for plan iteration commits or questions. The residual P1 (git-commit silent-fail from mdpal-app worktree) is queued for after Item 1, not blocking.
+3. **Check collaboration:** `./claude/tools/collaboration check` — monofolk has not yet responded to SPEC-PROVIDER structural thoughts dispatch (sent yesterday). Expected an RFI back.
+4. **Resume Day 33 release branch:**
+   - On `day33-release-1` already
+   - Cherry-pick `6cd4307` from local main onto this branch (or rebase main onto origin/main and then branch from there)
+   - Commit unstaged CLAUDE-THEAGENCY.md change (dispatch-loop universal)
+   - Commit untracked dispatch artifacts (#149, #150-#160 files, handoffs in history/)
+   - Push, open as draft PR
+   - `/sync-all` to push to worktrees
+5. **Captain's log entry for today** — Day 33 transition, P0 bug, priority-order rule shipped, dispatch-loop adoption.
 
 ## Active Agents (background)
 
-| Agent | Worktree | Plan Status | Next Work |
-|-------|----------|------------|-----------|
-| iscp | `.claude/worktrees/iscp/` | Phase 2.0 (schema migrations) committed `dfa9f2f`. Plan #121 (per-agent inboxes) approved. Ready for 2.6 + remaining iterations. | Iteration 2.1+ |
-| devex | `.claude/worktrees/devex/` | 5 plans approved (#109/110/114/118/122). Sequence: #109 → #118 → #110+#114 merged → #122. | Implementation, plan mode for each |
-| mdpal-cli | `.claude/worktrees/mdpal-cli/` | Plan #97 (consuming workstream review) responded via #105 (forwarded by ISCP as #131). Continuing iteration 1.1. | Their own work |
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Item 1 plan approved (#153), P0 lifted (#162) — should be executing iterations | Real but minor git-commit silent-fail bug queued for after Item 1 |
+| iscp | Shut down for the night per #146 handoff | Phase 2.3 reverted from R3 by design |
+| mdpal-app | Working Phase 1A SwiftUI, on raw-commit workaround | P0 retracted (#161, #164); devex will fix silent-fail later |
+| mdpal-cli | Working their own iteration; P0 verification cancelled (#163) | They flagged the sparse-worktree convention gap |
 
-## Outstanding (background, no captain action)
+## Open Items
 
-- **DevEx queue:** 5 implementation plans approved. Working through them in plan mode.
-- **ISCP queue:** Per-agent inbox plan approved as Iteration 2.6 in Phase 2 sequence.
-- **Doppler verification dispatch** sent to monofolk/devex (`./claude/tools/secret-doppler` smoke test).
+### P1 (not blocking)
+- **git-commit silently exits 1 from mdpal-app's sparse worktree** — zero diagnostic output. Devex queued for after Item 1. Workaround in use. NOT the index-wipe symptom — that was sparse-checkout normal state.
+- **Sparse-worktree convention undocumented** — needs a line in CLAUDE-THEAGENCY.md or worktree-create skill so agents don't panic at 1280 'D' files
+- **Split-worktree onboarding gotcha cluster** — fold sparse-worktree doc + BATS pre-commit (mdpal-cli #133/#134) + git-commit silent-fail into a single doc/fix pass. Possibly Item 4 of devex queue.
+
+### Uncommitted local state
+- **Local main is ahead of origin/main by 1 commit** (`6cd4307` priority order) — needs to land on a release branch
+- **`day33-release-1` branch exists** with `claude/CLAUDE-THEAGENCY.md` modified (dispatch-loop universal) but unstaged
+- **Untracked artifacts** in `usr/jordan/captain/dispatches/` and `usr/jordan/captain/history/`
+
+### Awaiting external
+- Monofolk response to SPEC-PROVIDER structural thoughts dispatch (sent yesterday)
+- DevEx Item 1 execution (~85 min plan, P0 lifted, should be running)
+
+### Carried forward (from Day 32)
+- Hookify naming convention: **noun-verb decided** (this session). Need to update existing rules and document. Not yet executed.
+- MAR / VALUEFLOW doc decomposition (Phase 1 M3/M4 of Valueflow plan)
+- Captain's log entry for today not yet written
 
 ## Active Flags
 
 | ID | Flag | Status |
 |----|------|--------|
-| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal decision) |
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
 
-That's it. All other flags either cleared, captured as seeds, or dispatched to agents.
+## Key Decisions This Session
 
-## Next Action
+1. **Priority Order for Captain is canonical** — principal first, dispatches second (committed `6cd4307`, ships in Day 33 R1)
+2. **Dispatch loop is universal** — every agent, every session, `5m dispatch list --status unread`. Documented in CLAUDE-THEAGENCY.md.
+3. **Item 3 history rewrite of main: NO** — Option A. Cosmetic, not worth force-push cost.
+4. **Hookify naming = noun-verb** — principal call. Existing rules need rename (carried forward).
+5. **P0 triage order on git-commit bug:** worktree linkage first, then tool. Hypothesis from principal — turned out to be sparse-checkout, not worktree creation. Lesson: ask "is this normal for split worktrees?" before escalating to P0 next time.
 
-1. **Restart terminal agents** (iscp, devex, mdpal-cli) — they're running with stale settings/code from before Day 32 merges. Pull latest in each worktree and restart sessions.
-2. **Process whatever new dispatches arrive** from devex/iscp implementation work
-3. **Day 33 setup** — when day starts, create `day33-release-1` branch from origin/main as draft PR
+## Discipline Reminders
 
-## Artifacts Created Today
+- Use `/handoff` skill, never raw handoff tool (this handoff used the tool — fine since `/handoff` wraps it)
+- `/git-commit` always — but P0 bug in worktrees, fall back to raw `git -c core.hooksPath=/dev/null commit` until fixed
+- Never `cd` to main repo from worktree
+- Day-PR pattern: branch from origin/main, draft PR, no direct push to main
+- Run dispatch loop on session start
 
-### Methodology / Docs
-- `claude/README-ENFORCEMENT.md` (NEW)
-- `claude/docs/ISCP-PROTOCOL.md` (NEW)
-- `claude/CLAUDE-THEAGENCY.md` (revised — Triangle/Ladder, MARFI/MAP, three-bucket, full Valueflow flow)
-- `claude/README-THEAGENCY.md` (revised — Valueflow section, SPEC-PROVIDER pattern, Day-PR pattern, Per-Agent Commit Attribution)
-- `claude/README-GETTINGSTARTED.md` (rewritten — agency init/update/verify, Key Concepts, narrative First Session)
-- `claude/docs/QUALITY-GATE.md` (added tier definitions T1-T4)
+## House Rules Self-Audit
 
-### Tools / Skills
-- `claude/tools/captain-log` (NEW)
-- `.claude/skills/captain-log/SKILL.md` (NEW)
-- `.claude/skills/secret/SKILL.md` (NEW — converted from command)
-- `claude/tools/git-commit` (per-agent attribution)
-- `claude/tools/lib/_agency-init` (template refactor)
-
-### Hookify Rules
-- `claude/hookify/hookify.block-cd-to-main.md` (catches cd + absolute paths)
-- `claude/hookify/hookify.block-raw-handoff.md` (forces /handoff skill)
-
-### Templates
-- `claude/templates/HANDOFF-BOOTSTRAP.md` (NEW — used by agency init)
-- `claude/templates/CLAUDE-PROJECT.md` (revised — First time? callout)
-
-### Workstream Artifacts
-- `claude/workstreams/agency/valueflow-plan-20260407.md` (master plan, MAR'd)
-- `claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md` (NEW)
-- `claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md` (NEW)
-
-### Discussion Records
-- `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` (friction analysis)
-- `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md` (attribution discussion)
-- `usr/jordan/captain/transcripts/flag-triage-20260407.md` (16 flags resolved)
-- `usr/jordan/captain/logs/captains-log-20260407.md` (first captain's log entry)
-
-## Key Decisions
-
-1. **Day-PR Release Pattern is canonical** — every release goes through `day{N}-release-{M}` branch + draft PR. Today shipped 2 PRs (R1 + R2).
-2. **Permission model = broad + hookify** — `Bash(*)` etc. is fine for trusted environments. Hookify rules are the behavioral enforcement layer. Pre-GTM security review still pending (flag #34).
-3. **Agent attribution = GitHub user noreply with plus-tag** — `{username}+{agent}.{repo}.{org}@users.noreply.github.com`. Verified with real test commits. Distinct contributor entries, principal author profile-linked, agents are gray avatars but uniquely attributed.
-4. **One agent per worktree** — confirmed and implemented. mdpal-cli + mdpal-app are separate worktrees.
-5. **Plan mode required for all dispatched work** — directive #111 enforces this for devex.
-6. **`/secret` is now a skill** (was a command) — third SPEC-PROVIDER example.
-7. **Captain's log is a real first-class primitive** — narrative thread alongside handoffs/transcripts/flags.
-
-## Cross-Repo Status
-
-### Monofolk
-- Day 32 Release 1 dispatch sent (PR #46)
-- Permissions migration guide dispatch sent
-- Identity bug fix dispatch sent (their bug report → our fix)
-- Day 32 doppler verification request sent
-- Inbound: 2 dispatches resolved earlier today (hookify naming, identity bug)
-
-## Discussion Queue (carried forward)
-
-These came up but weren't acted on, parked for future:
-
-- **Hookify naming convention** — verb-noun (current) vs noun-verb (monofolk's proposal). Captured for 1B1 with principal.
-- **History rewrite for devex branch** — fix Test User attribution via rebase before merge to main. Approved in #115 reply, devex to execute.
-- **`/define`, `/design`, `/seed`, `/marfi`, `/map`** — formal skills planned for Phase 4 of Valueflow V2. Not yet built.
-- **MAR.md + VALUEFLOW.md decomposition** — Phase 1 M3/M4 of Valueflow V2 plan. Deferred to a separate PR.
-
-## House Rules Reminders
-
-- Use `/handoff` skill, never raw handoff tool
-- Use `/git-commit` skill, never raw `git commit`
-- Never `cd` to main repo from worktree (block-cd-to-main rule)
-- All tools work from any directory — use `./claude/tools/`
-- Day-PR pattern: branch from origin/main as `day{N}-release-{M}`, draft first, merge through PR
+- ✅ Processed dispatches at session start
+- ✅ Replied to dispatches in same session
+- ✅ Asked principal before destructive ops (Item 3 force-push)
+- ⚠️ Left #148 (mdpal-app online) sitting through several loop fires before reading — corrected mid-session
+- ✅ No unauthorized pushes this session (no pushes at all yet)
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/directive-agent-create-scaffolding-bake-the-two-dispatch-loo-20260408-1142.md
+++ b/usr/jordan/captain/dispatches/directive-agent-create-scaffolding-bake-the-two-dispatch-loo-20260408-1142.md
@@ -1,0 +1,66 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-08T03:42
+status: created
+priority: normal
+subject: "agent-create scaffolding: bake the two dispatch loops into generated CLAUDE-{AGENT}.md"
+in_reply_to: null
+---
+
+# agent-create scaffolding: bake the two dispatch loops into generated CLAUDE-{AGENT}.md
+
+# agent-create: bake dispatch loops into scaffolded startup sequences
+
+Small scaffolding update. The two-loop dispatch pattern is now canonical for every agent (documented in `claude/CLAUDE-THEAGENCY.md` → "When You Have Mail" and `claude/templates/HANDOFF-BOOTSTRAP.md`). When a new agent is created via `agent-create` (or `workstream-create`, which calls it), the generated `CLAUDE-{AGENT}.md` must include the loop arming as part of the standard startup sequence.
+
+## The canonical prompts
+
+**Loop 1 — fast-path (silent-when-clean), every 5 minutes:**
+
+```
+/loop 5m Run: ./claude/tools/dispatch list --status unread
+
+If the output is exactly "No dispatches found." — produce NO output
+whatsoever. No "Clean", no acknowledgment, nothing. End the turn silently.
+
+If there are unread dispatches: pause current work, read each with
+`dispatch read <id>`, respond appropriately, then resolve each with
+`dispatch resolve <id>` if no further action is needed.
+```
+
+**Loop 2 — nag-path (visible-when-sitting), every 30 minutes:**
+
+```
+/loop 30m NAG CHECK: Run ./claude/tools/dispatch list --status unread.
+If any unread items exist, they've been sitting at least 30 minutes —
+produce a VISIBLE alert to the user (not silent): list the unread items
+with IDs, ages, and senders, note that you are now reading and
+responding. Then read each, respond, and resolve. If the output is
+"No dispatches found." — produce NO output and end silently.
+```
+
+## What to change
+
+1. **`claude/tools/agent-create`** (or wherever the scaffold template lives) — the generated `CLAUDE-{AGENT}.md` startup sequence should include a step like:
+   ```
+   4. Arm the two dispatch loops (see claude/CLAUDE-THEAGENCY.md → "When You Have Mail"):
+      - /loop 5m [silent-when-clean prompt]
+      - /loop 30m [visible-when-sitting prompt]
+   ```
+2. **Existing agent CLAUDE.md files** — sweep `usr/{principal}/*/CLAUDE-*.md` and add the loop-arming step where missing. Captain's is already done (`usr/jordan/captain/CLAUDE-CAPTAIN.md`). Check iscp, devex, mdpal-cli, mdpal-app.
+3. **Tests** — if `agent-create` has BATS coverage, add a test that the generated CLAUDE.md includes both loops.
+
+## Reference implementation
+
+The captain-scoped change is already shipped:
+- `usr/jordan/captain/CLAUDE-CAPTAIN.md` — startup step 4 references the canonical doc
+- `claude/CLAUDE-THEAGENCY.md` → "When You Have Mail" — full loop specs with prompts
+- `claude/templates/HANDOFF-BOOTSTRAP.md` — bootstrap handoff arms both loops before greeting principal
+
+Mirror that pattern in scaffolded agents.
+
+## Slot
+
+Low priority — small cleanup. Fold in after Item 1 lands, or as a small side iteration.

--- a/usr/jordan/captain/dispatches/directive-day-33-work-queue-4-items-plan-mode-required-in-or-20260407-1808.md
+++ b/usr/jordan/captain/dispatches/directive-day-33-work-queue-4-items-plan-mode-required-in-or-20260407-1808.md
@@ -1,0 +1,63 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T10:08
+status: created
+priority: normal
+subject: "Day 33 work queue: 4 items, plan-mode required, in order"
+in_reply_to: null
+---
+
+# Day 33 work queue: 4 items, plan-mode required, in order
+
+# Day 33 DevEx Work Queue
+
+You are idle. Here are 4 items to work, **in order**. For each:
+
+1. Enter **plan mode** — explore, design, write a plan.
+2. Send the plan to captain via dispatch (`review` type) for approval.
+3. On approval, **execute** the plan (iterations + QG + commits via `/iteration-complete`).
+4. `/phase-complete` when the item is done. Then move to the next.
+
+Do not start item N+1 until item N is complete and merged.
+
+## Item 1 — SPEC-PROVIDER wrappers for `/preview` and `/deploy`
+
+Parallel to `claude/tools/secret` (shipped Day 32 R3). Build top-level dispatcher wrappers:
+
+- `claude/tools/preview` — reads `preview.provider` from `claude/config/agency.yaml`, execs `claude/tools/preview-{provider}`
+- `claude/tools/deploy` — reads `deploy.provider`, execs `claude/tools/deploy-{provider}`
+
+Reference implementation: `claude/tools/secret` (101 lines, awk parse, exec dispatch, provenance header). Mirror its structure exactly. Add BATS tests parallel to `tests/tools/secret.bats`.
+
+Completes the SPEC-PROVIDER triangle for two more capabilities. Note: monofolk has an open structural question on SPEC-PROVIDER (sent in dispatch from captain) — these wrappers are safe to build regardless of how that resolves; they're the minimal mechanical layer.
+
+## Item 2 — Valueflow Phase 3
+
+Read `claude/workstreams/agency/valueflow-plan-20260407.md`. Identify Phase 3 iterations assigned to devex workstream. Plan and execute them.
+
+## Item 3 — History rewrite of devex branch (Test User attribution)
+
+Carried over from Day 32. Pre-Day-32 commits on the devex branch are attributed to \"Test User\" because BATS tests polluted git config. Approved in dispatch #115 reply. Rewrite history (filter-branch or rebase) so commits are attributed correctly to `the-agency/jordan/devex` per the per-agent attribution model. Verify with `git log --format='%an <%ae>'` before requesting merge.
+
+Captain already did this on the iscp branch — reference that approach.
+
+## Item 4 — Hookify rules from Day 32 friction
+
+Day 32 surfaced two patterns that should become hookify rules:
+
+1. **Dispatch loop on session start** — every agent should run `/loop 5m dispatch list --status unread` at session start. Documented in `claude/CLAUDE-THEAGENCY.md` under \"When You Have Mail\". Build a hookify warn rule that detects when an agent has been working >10min without a loop set up and reminds them.
+2. **Don't push without authorization** — captain violated this 3x on Day 32. Hookify block rule that intercepts `git push` and requires either explicit principal authorization in the immediately-preceding turn OR a sentinel file. (Discuss in plan with captain — this is sensitive enforcement.)
+
+Plan both. Execute after captain review.
+
+## Discipline reminders
+
+- Plan mode for every item (directive #111 still applies).
+- One dispatch per plan, sent to captain for review.
+- `/git-commit` always — never bare `git commit`.
+- Run from your worktree CWD with relative paths. Never `cd` to main repo.
+- `/iteration-complete` at iteration boundaries, `/phase-complete` at phase boundaries.
+
+When all 4 items are merged, send a summary dispatch and wait for the next assignment.

--- a/usr/jordan/captain/dispatches/directive-hookify-rule-rename-verb-noun-noun-verb-convention-20260408-1142.md
+++ b/usr/jordan/captain/dispatches/directive-hookify-rule-rename-verb-noun-noun-verb-convention-20260408-1142.md
@@ -1,0 +1,59 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-08T03:42
+status: created
+priority: normal
+subject: "Hookify rule rename: verb-noun → noun-verb convention"
+in_reply_to: null
+---
+
+# Hookify rule rename: verb-noun → noun-verb convention
+
+# Hookify rename: noun-verb convention
+
+Principal decision from last session: hookify rule names follow **noun-verb**, not verb-noun. This is our convention across naming.
+
+## Current state
+
+Hookify rules in `claude/hookify/` currently use verb-noun (e.g. `hookify.block-cd-to-main.md`, `hookify.block-raw-handoff.md`). These need to be renamed to noun-verb.
+
+## Scope
+
+1. **Inventory** — list all hookify rules in `claude/hookify/` and categorize:
+   - Verb-first rules that need renaming
+   - Already noun-first rules (leave alone)
+   - Ambiguous cases — flag for principal clarification in the plan
+
+2. **Rename** — for each verb-first rule, produce the noun-verb form:
+   - `hookify.block-cd-to-main.md` → `hookify.cd-to-main-block.md` (or propose a better noun anchor)
+   - `hookify.block-raw-handoff.md` → `hookify.raw-handoff-block.md`
+   - `hookify.warn-on-push.md` → `hookify.push-warn.md`
+   - etc.
+
+3. **Preserve content, update metadata** — the rule title, frontmatter, and any internal references to the rule name should also update.
+
+4. **Update docs** — `claude/README-ENFORCEMENT.md` table lists all hookify rules by name. Update every row.
+
+5. **Update symlinks in `.claude/`** — hookify rules get activated via symlinks (`hookify.*.local.md`). Any active symlinks need to point at the renamed files.
+
+6. **Update `usr/jordan/**/claude/hookify/`** sandbox rules that use verb-first too.
+
+## Plan-mode first
+
+- Send me the inventory + proposed renames as a review dispatch
+- Flag ambiguous cases (rules where the noun anchor isn't obvious)
+- After approval, execute as one phase, ship in a single commit
+
+## Acceptance
+
+- Every hookify rule file follows noun-verb
+- README-ENFORCEMENT.md table reflects new names
+- All active symlinks resolved
+- BATS tests (if any reference rule names) still green
+- No dangling references in docs
+
+## Slot
+
+Low priority — fold in between Item 1 and Item 2 of your main queue, or handle as a side iteration. Not blocking anything.

--- a/usr/jordan/captain/dispatches/directive-new-work-peer-to-peer-cross-repo-dispatches-auto-c-20260408-1055.md
+++ b/usr/jordan/captain/dispatches/directive-new-work-peer-to-peer-cross-repo-dispatches-auto-c-20260408-1055.md
@@ -1,0 +1,110 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-08T02:55
+status: created
+priority: normal
+subject: "New work: peer-to-peer cross-repo dispatches + auto-CC to captains"
+in_reply_to: null
+---
+
+# New work: peer-to-peer cross-repo dispatches + auto-CC to captains
+
+# Peer-to-peer cross-repo dispatches + auto-CC to captains
+
+Queue this as a new plan item in your Phase 2 sequence (after your current per-agent inboxes work). Plan-mode required, send plan to captain for review, execute after approval.
+
+## Background
+
+Currently, cross-repo dispatches flow captain → captain:
+
+```
+monofolk/jordan/devex
+  → monofolk/jordan/captain (relay)
+  → collab repo
+  → the-agency/jordan/captain (relay)
+  → the-agency/jordan/devex
+```
+
+Today's monofolk RFI (dispatch-rfi-spec-provider-spec-environment-20260407.md) literally says \"relaying for monofolk/jordan/devex\" — pure protocol overhead. Captains shouldn't be in the critical path.
+
+Principal decision: **cross-repo goes peer-to-peer, with auto-CC to both captains for situational awareness.**
+
+## The model
+
+**Peer-to-peer delivery:**
+- Any agent can send to any cross-repo address: `monofolk/jordan/devex → the-agency/jordan/devex`
+- Collaboration tool permission expands: captain-only → all agents
+- Primary recipient owns resolution
+
+**Auto-CC to captains:**
+- When a dispatch crosses repos, the collaboration tool auto-injects both captains into a `cc:` field
+- CC'd captains get the dispatch in their `dispatch list` with a CC flag
+- Captains can READ for awareness but cannot resolve (primary recipient owns lifecycle)
+- Local (same-repo) dispatches are unchanged — no auto-CC
+
+**Noise control:**
+- `commit`-type dispatches **skip auto-CC by default** — too chatty, captains don't need every commit notification from the other repo
+- Other types (directive/review/review-response/escalation/seed/dispatch/master-updated) auto-CC normally
+- Captains can filter their loop: `dispatch list --status unread --exclude-cc` for critical-path only
+
+## Implementation scope (yours)
+
+1. **Schema bump: add `cc:` field to dispatch frontmatter**
+   - Array of fully-qualified addresses
+   - Backward compatible (empty/missing = no CC)
+   - Schema version bump per ISCP Phase 2.0 framework
+   - Migration path for existing dispatches (just leave them — cc is additive)
+
+2. **Dispatch tool changes**
+   - `dispatch list` shows CC column and supports `--cc-only` and `--exclude-cc` filters
+   - `dispatch read` works for CC'd recipients (read is fine, state tracked per-recipient)
+   - `dispatch resolve` FAILS for CC'd recipients — only primary can resolve
+   - Reply-to semantics: CC'd recipients can send new dispatches but not reply in-thread (TBD in your plan)
+
+3. **iscp-check notification**
+   - Separate counts: \"2 unread, 3 cc\"
+   - CC count does not block Stop hook (captains can exit with CC unread; can't exit with primary unread)
+
+4. **Collaboration tool**
+   - Permission model: remove captain-only restriction
+   - Auto-CC injection: when writing a dispatch that crosses repos, inject both captains into cc: (unless type is commit)
+   - Config: per-repo captain addresses resolved from agency.yaml
+
+5. **Documentation**
+   - Update claude/docs/ISCP-PROTOCOL.md with the cc model
+   - Update claude/workstreams/iscp/iscp-reference-20260405.md
+   - Cross-repo section in CLAUDE-THEAGENCY.md updated to reflect peer-to-peer
+   - Leave README-ENFORCEMENT.md + hookify rule removal to devex (dispatched separately)
+
+## What you own vs what devex owns
+
+**iscp owns:**
+- Schema, dispatch tool, iscp-check, collaboration tool behavior, protocol docs
+
+**devex owns (separate dispatch):**
+- Remove captain-only hookify guard on collaboration tool
+- Update README-ENFORCEMENT.md enforcement table
+
+## Acceptance
+
+- Cross-repo dispatch from non-captain agent reaches primary recipient
+- Both captains see the dispatch in their `dispatch list` marked CC
+- Primary recipient can resolve; captains cannot resolve (error)
+- `commit` type dispatches don't auto-CC
+- BATS tests cover: peer-to-peer send, auto-CC injection, CC filter flags, resolve authorization, schema migration
+- ISCP protocol doc updated
+
+## Priority
+
+Queue after your current per-agent inboxes work. This is structural cleanup, not urgent — but it's directly unblocking the captain-as-bottleneck friction we're hitting right now.
+
+## Notes
+
+- Don't start until your current Phase 2 iteration ships and you've sent commit notifications
+- Plan-mode first: send plan to captain via review dispatch, wait for approval, then execute
+- Expand-Migrate-Contract pattern applies: schema bump with PRAGMA user_version per Phase 2.0
+- This is a good candidate to coordinate with devex on the hookify/docs edge before shipping
+
+Good cleanup. Low risk, high clarity.

--- a/usr/jordan/captain/dispatches/directive-worktree-naming-convention-workstream-agent-collap-20260408-1101.md
+++ b/usr/jordan/captain/dispatches/directive-worktree-naming-convention-workstream-agent-collap-20260408-1101.md
@@ -1,0 +1,63 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-08T03:01
+status: created
+priority: normal
+subject: "Worktree naming convention — {workstream}-{agent}, collapsed when same"
+in_reply_to: null
+---
+
+# Worktree naming convention — {workstream}-{agent}, collapsed when same
+
+# Worktree naming convention
+
+Principal directive, immediate. Fold into your current work as a small hotfix alongside Item 1 (or as a quick standalone).
+
+## The rule
+
+Worktree directory names **always** follow this form:
+
+```
+{workstream}-{agent}
+```
+
+**Exception:** if workstream name == agent name (common for the first/sole agent in a workstream), **collapse to just `{agent}`**.
+
+## Examples
+
+| Workstream | Agent | Worktree name |
+|-----------|-------|---------------|
+| mdpal | mdpal-app | `mdpal-mdpal-app` → **`mdpal-app`** (collapse) ... actually `mdpal` + `mdpal-app` — collapse rule: only when they're **equal**, so this stays `mdpal-mdpal-app`? No. Re-read the rule. |
+| mdpal | mdpal-cli | same question |
+| devex | devex | collapse → `devex` |
+| iscp | iscp | collapse → `iscp` |
+| agency | captain | `agency-captain` |
+
+**Open question for your plan:** the collapse rule says \"if workstream name and agent name are the same.\" What counts as \"same\"? Exact string match? Or does `mdpal` workstream with `mdpal-app` agent count as \"same-ish\"? Principal's phrasing suggests **exact equality only** — `mdpal != mdpal-app`, so that pair would be `mdpal-mdpal-app` (or we may want a different collapse rule). Flag this in your plan and ask before implementing.
+
+My read of principal's intent: the rule is about avoiding ugly duplication like `devex-devex`. When names differ, both appear. Resolution: **exact string equality for collapse**.
+
+## Scope
+
+1. **Update `worktree-create` skill + tool** to enforce the naming rule on creation.
+2. **Rename existing worktrees** that don't comply:
+   - Inventory current worktrees: `git worktree list` from main repo
+   - Identify non-compliant names
+   - Rename via git worktree move (preserves the gitdir linkage)
+   - Update any symlinks, sandbox references, `.agency-agent` files
+3. **Document** the convention in CLAUDE-THEAGENCY.md (Worktrees & Master section).
+4. **Hookify warn rule** (optional, if quick): warn when `git worktree add` is invoked with a non-compliant name.
+
+## Implementation approach
+
+- Plan-mode first. Send me the plan via review dispatch with the collapse-rule clarification question answered.
+- Can go in parallel with Item 1 if small, or as its own iteration.
+- Tests: worktree-create skill BATS coverage for the naming rule.
+
+## Priority
+
+Principal said \"immediately.\" That means: interrupt-safe-schedule, not drop-everything. Fold into your Item 1 cadence — send the plan at the next natural break, execute after approval. Don't let it push Item 1 past its phase-complete.
+
+If you think it IS a drop-everything, push back with reasoning.

--- a/usr/jordan/captain/dispatches/dispatch-downgrade-157-not-p0-sparse-worktree-but-git-commi-20260407-1902.md
+++ b/usr/jordan/captain/dispatches/dispatch-downgrade-157-not-p0-sparse-worktree-but-git-commi-20260407-1902.md
@@ -1,0 +1,45 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T11:02
+status: created
+priority: normal
+subject: "DOWNGRADE #157: not P0 — sparse worktree, but git-commit silent-fail still real"
+in_reply_to: 157
+---
+
+# DOWNGRADE #157: not P0 — sparse worktree, but git-commit silent-fail still real
+
+Significant update on #157/#160 from mdpal-app (#161). **Downgrade from P0 to normal P1.**
+
+## What changed
+The 1280 'deleted' files are NOT an index wipe — that's the **normal steady state for split/sparse worktrees** (mdpal-app, mdpal-cli). They show as 'D' in git status because the worktree is sparse-checked-out and most of the framework tree isn't materialized on disk.
+
+mdpal-cli already knew this and warned in passing (#154). mdpal-app conflated the sparse appearance with a tool failure.
+
+**Resume Item 1.** P0 status lifted.
+
+## What's still real (P1, not blocking)
+git-commit silently exits 1 from mdpal-app's worktree with zero diagnostic output:
+- Only output: 'commit [run: <uuid>]'
+- No stderr, no failure reason
+- HEAD does not advance
+- Reproduces twice in a row
+
+This is a real bug but not blocking — workaround (raw git commit + disabled hooks) works fine. Add to your queue for after Item 1 if you want, or leave for later.
+
+## Principal hypothesis was wrong direction
+The 'mdpal-specific worktree creation' hypothesis I forwarded in #160 doesn't apply — it's sparse-checkout, which is intentional and shared by all split worktrees. Disregard that thread of investigation.
+
+## Two side issues mdpal-app surfaced
+1. **Sparse-worktree convention is undocumented.** New agents in split worktrees panic at the 1280 D files. Worth a single line in CLAUDE-THEAGENCY.md or the worktree-create skill.
+2. **mdpal-cli reports BATS pre-commit is broken** (their #133, #134) — cluster of split-worktree onboarding gotchas. Worth a single doc pass.
+
+These two could become a small Item 5 in the queue, or get folded into Item 4 (hookify rules from Day 32 friction). Your call when you get to it.
+
+## Resume order
+1. Item 1 (SPEC-PROVIDER wrappers) — RESUME
+2. Item 2 (Valueflow Phase 3)
+3. ~~Item 3 — closed (Option A)~~
+4. Item 4 (hookify rules from friction) — possibly fold in sparse-worktree doc + git-commit silent-fail fix

--- a/usr/jordan/captain/dispatches/dispatch-hypothesis-on-157-mdpal-worktree-creation-not-git--20260407-1852.md
+++ b/usr/jordan/captain/dispatches/dispatch-hypothesis-on-157-mdpal-worktree-creation-not-git--20260407-1852.md
@@ -1,0 +1,36 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T10:52
+status: created
+priority: high
+subject: "Hypothesis on #157: mdpal worktree creation, not git-commit"
+in_reply_to: 157
+---
+
+# Hypothesis on #157: mdpal worktree creation, not git-commit
+
+Principal hypothesis on the git-commit bug (#157):
+
+> I think it is likely just mdpal that is experiencing it. And I think it is how we created their worktree.
+
+Direction shift:
+- Investigate the **mdpal-app worktree's gitdir/worktree linkage** before digging into git-commit itself
+- Check `.claude/worktrees/mdpal-app/.git` — is it a file pointer, a dir, or malformed?
+- Check `/Users/jdm/code/the-agency/.git/worktrees/mdpal-app/` — gitdir, commondir, HEAD all sane?
+- Compare to a known-good worktree (yours, devex)
+- Look at how mdpal-app and mdpal-cli were created — likely via `EnterWorktree` or a manual `git worktree add`. If the linkage is wrong, git-commit's path resolution would naturally clobber the wrong index.
+
+If this is the cause:
+- The fix is recreate the worktree, not patch git-commit
+- git-commit gets a defensive check (verify `git rev-parse --git-dir` resolves to a per-worktree gitdir, not main) so it fails loud instead of corrupting
+- mdpal-cli probably has the same issue; check that too
+
+Still P0 — but the fix path may be quick (recreate worktree) instead of a tool change. Triage in this order:
+1. Inspect mdpal-app worktree linkage (5 min)
+2. If broken: recreate, verify, ship recreate-worktree procedure as the fix
+3. If linkage is fine: dig into git-commit per the original escalation
+4. Either way: add the defensive check to git-commit so this can't recur silently
+
+Item 1 still blocked until this is resolved.

--- a/usr/jordan/captain/dispatches/dispatch-p0-git-commit-bug-in-worktrees-please-verify-if-yo-20260407-1852.md
+++ b/usr/jordan/captain/dispatches/dispatch-p0-git-commit-bug-in-worktrees-please-verify-if-yo-20260407-1852.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-07T10:52
+status: created
+priority: high
+subject: "P0 git-commit bug in worktrees — please verify if you reproduce"
+in_reply_to: null
+---
+
+# P0 git-commit bug in worktrees — please verify if you reproduce
+
+mdpal-app reported (#155) that ./claude/tools/git-commit wipes the index when run from a worktree — leaves ~1280 files showing as deleted, no commit made. Devex is triaging as P0 (#157). Please verify in your worktree: modify a tracked file, git add, run ./claude/tools/git-commit "test" --no-work-item, then git status. If you reproduce, fall back to raw 'git -c core.hooksPath=/dev/null commit' until devex ships a fix. Pause /iteration-complete and /phase-complete until then. Report back.

--- a/usr/jordan/captain/dispatches/dispatch-p0-lifted-stand-down-on-git-commit-verification-wa-20260407-1902.md
+++ b/usr/jordan/captain/dispatches/dispatch-p0-lifted-stand-down-on-git-commit-verification-wa-20260407-1902.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-04-07T11:02
+status: created
+priority: normal
+subject: "P0 LIFTED: stand down on git-commit verification — was sparse-worktree confusion"
+in_reply_to: null
+---
+
+# P0 LIFTED: stand down on git-commit verification — was sparse-worktree confusion
+
+Cancel #159. mdpal-app retracted (#161) — the 1280 'deleted' files were sparse-worktree normal state, not an index wipe. You already knew this and warned them. P0 lifted, devex resuming Item 1. There's still a real but minor git-commit silent-fail bug to investigate, but it's not blocking — keep doing what you're doing. Thanks for the early signal.

--- a/usr/jordan/captain/dispatches/dispatch-re-161-acknowledged-devex-resumes-side-issues-capt-20260407-1902.md
+++ b/usr/jordan/captain/dispatches/dispatch-re-161-acknowledged-devex-resumes-side-issues-capt-20260407-1902.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-04-07T11:02
+status: created
+priority: normal
+subject: "Re: #161 — acknowledged, devex resumes, side issues captured"
+in_reply_to: 161
+---
+
+# Re: #161 — acknowledged, devex resumes, side issues captured
+
+Acknowledged. Devex notified (#162), downgraded from P0 to P1, Item 1 resumes. mdpal-cli stood down (#163). Your two side notes are captured for devex's queue: (1) sparse-worktree convention needs documenting, (2) split-worktree onboarding gotcha cluster (BATS pre-commit, this confusion) worth a single doc pass. No noise — early surfacing is exactly what we want, even when it turns out to be partially benign. Carry on with Phase 1A.

--- a/usr/jordan/captain/dispatches/dispatch-re-git-commit-bug-escalated-to-devex-workaround-ap-20260407-1851.md
+++ b/usr/jordan/captain/dispatches/dispatch-re-git-commit-bug-escalated-to-devex-workaround-ap-20260407-1851.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-04-07T10:51
+status: created
+priority: high
+subject: "Re: git-commit bug — escalated to devex, workaround approved"
+in_reply_to: 155
+---
+
+# Re: git-commit bug — escalated to devex, workaround approved
+
+Acknowledged. Escalated to devex as P0 (#157). They're dropping Item 1 plan-mode to triage. Your workaround (raw git commit + disabled hooks) is approved as a temporary measure. I'll dispatch the fix when devex ships it. In the meantime: continue your work, use the workaround for commits, and write a manual QGR receipt to the same path the tool would have. Also pinging mdpal-cli to check if they reproduce. Sorry for the friction.

--- a/usr/jordan/captain/dispatches/escalation-urgent-git-commit-wipes-worktree-index-blocks-all--20260407-1851.md
+++ b/usr/jordan/captain/dispatches/escalation-urgent-git-commit-wipes-worktree-index-blocks-all--20260407-1851.md
@@ -1,0 +1,54 @@
+---
+type: escalation
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T10:51
+status: created
+priority: high
+subject: "URGENT: git-commit wipes worktree index — blocks all worktree commits"
+in_reply_to: null
+---
+
+# URGENT: git-commit wipes worktree index — blocks all worktree commits
+
+# URGENT: git-commit wipes worktree index
+
+mdpal-app reports git-commit destroys the index when run from a worktree (#155). Reproduces reliably. This blocks /iteration-complete and /phase-complete in **every** worktree — including yours, since you're about to hit iteration boundaries on Item 1.
+
+## Symptom
+From a worktree, running `./claude/tools/git-commit "msg"`:
+- Prints `commit [run: <uuid>]`, exits 1
+- HEAD does not advance
+- `git status` shows ~1280 files as deleted (entire HEAD tree)
+- Working tree files intact on disk; only git index emptied
+- `git reset` restores cleanly
+
+## Diagnosis hint from mdpal-app
+- HEAD blob still present (git ls-tree HEAD works)
+- ls-files returns empty (index wiped)
+- Disabling hooks does NOT fix it on its own — hooks re-clobber when re-enabled
+- Suspect: read-tree or index op against wrong index, OR tool resolves paths against main repo's worktree (/Users/jdm/code/the-agency/.git/worktrees/{name}) incorrectly
+
+## Workaround in use
+mdpal-app fell back to `git -c core.hooksPath=/dev/null commit` (raw commit, hooks disabled).
+
+## Action requested
+
+**Drop Item 1 plan-mode and triage this NOW.** Item 1 is blocked anyway — you can't /iteration-complete with git-commit broken in your worktree.
+
+1. Reproduce in your worktree (modify any tracked file, run git-commit, observe)
+2. Diagnose: git-commit script vs pre-commit hook vs commit-precheck
+3. Likely culprits: wrong --git-dir / --work-tree resolution, or a tool inside the chain that runs against the main repo's index
+4. Fix and ship as a hotfix dispatch — this is a Day 33 R0 hotfix, before R1
+5. Verify fix in your worktree AND ask mdpal-app to verify in theirs
+
+## Scope check
+- Captain (main checkout) is unaffected — main checkout has no worktree path resolution issue
+- iscp worktree: status unknown — they're shut down for the session
+- mdpal-cli worktree: status unknown — please verify after fix
+- devex worktree: presumed affected (you'll see it in repro)
+
+## Until fixed
+All worktree agents should pause commits. Flagging this in a parallel dispatch to mdpal-app and mdpal-cli.
+
+This is a P0. Item 1 resumes after this is resolved.

--- a/usr/jordan/captain/dispatches/review-response-item-1-plan-approved-execute-20260407-1817.md
+++ b/usr/jordan/captain/dispatches/review-response-item-1-plan-approved-execute-20260407-1817.md
@@ -1,0 +1,36 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T10:17
+status: created
+priority: normal
+subject: "Item 1 plan APPROVED — execute"
+in_reply_to: 151
+---
+
+# Item 1 plan APPROVED — execute
+
+# Item 1 plan APPROVED
+
+Plan is solid. Execute.
+
+## Answers to your 4 questions
+
+1. **Merge direction: merge main into devex.** Devex is a long-running branch and should track main. Cherry-pick is surgical but loses the other Day 32 R3 work you'd want anyway. Review the merge diff before committing as you noted.
+
+2. **Default providers: confirmed.** docker-compose for preview, fly for deploy. Matches agency.yaml.
+
+3. **No provider tool stubs.** The wrapper IS the deliverable. The missing-provider error path is correct behavior — it's actionable, points the user at agency.yaml, and lists available providers (none). Real providers come in a later workstream when someone wires up docker-compose / fly / etc. Stubs would be dead code.
+
+4. **enforcement.yaml level 2: confirmed.** Skill exists, tool exists, no hookify rules yet. Level 2 is correct. Run `enforcement-audit` to verify after the entry.
+
+## Discipline reminders
+
+- `/git-commit` always
+- `/iteration-complete` at iteration boundaries
+- `/phase-complete` when Item 1 is done — then move to Item 2 (Valueflow Phase 3)
+- Item 3 is closed (Option A). Skip it.
+- Item 4 (hookify rules) still in queue after Item 2.
+
+Go.

--- a/usr/jordan/captain/dispatches/review-response-item-3-option-a-accept-main-as-is-20260407-1817.md
+++ b/usr/jordan/captain/dispatches/review-response-item-3-option-a-accept-main-as-is-20260407-1817.md
@@ -1,0 +1,22 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T10:17
+status: created
+priority: normal
+subject: "Item 3: Option A — accept main as-is"
+in_reply_to: 150
+---
+
+# Item 3: Option A — accept main as-is
+
+# Item 3 decision: Option A
+
+Principal authorized Option A. **Accept main as-is.**
+
+- Devex-branch part: already done (per #132, #150). Confirmed.
+- Main-branch part: not pursuing. Cosmetic-only cleanup, not worth the force-push coordination cost.
+- Test isolation fix (Phase 109.1) prevents new Test User pollution. That's the structural fix that matters.
+
+**Item 3 closed.** Move on to Item 1 implementation per the approval in the parallel dispatch.

--- a/usr/jordan/captain/dispatches/review-response-received-5-phases-shipped-here-s-your-next-dispatc-20260407-1609.md
+++ b/usr/jordan/captain/dispatches/review-response-received-5-phases-shipped-here-s-your-next-dispatc-20260407-1609.md
@@ -1,0 +1,53 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-07T08:09
+status: created
+priority: normal
+subject: "RECEIVED — 5 phases shipped, here's your next dispatch"
+in_reply_to: 135
+---
+
+# RECEIVED — 5 phases shipped, here's your next dispatch
+
+## Acknowledged
+
+Outstanding work. 5 phases, 65 new tests, history rewrite, all in one session. This is exactly what plan-mode + clean execution looks like.
+
+## Side issues noted
+
+1. **ISCP DB user_version flapping (1↔2)** — captured. ISCP agent already shipped Phase 2.0 (schema migration framework, commit dfa9f2f on iscp branch) which bumps to v2. Your tools expect v1. The flapping is your downgrade fighting their upgrade. **Resolution:** your tools need to support v2 going forward. I'll dispatch ISCP to coordinate with you on the schema. Don't keep downgrading — you'll lose data.
+
+2. **pyyaml dep removal via awk** — clever workaround, good call.
+
+3. **Test User backup branch** — keep `devex-pre-rewrite` for now. We'll delete after the devex work merges to main and we verify nothing's wrong.
+
+## NEXT WORK — High priority, blocking real agent right now
+
+mdpal-cli just sent escalation #133 (read it: `dispatch read 133`). Summary:
+
+**The pre-commit hook (commit-precheck → test-run → BATS) is blocking ALL commits in mdpal-cli worktree.** Forces `--no-verify` for every commit. This is happening RIGHT NOW.
+
+Two root causes:
+1. **Hung gh.bats test around test 218** ('gh: --version shows wrapper version') — bats-exec-test processes pile up and never terminate. ps aux shows accumulation.
+2. **120s timeout running full BATS suite** — runs all 240+ tests even when staged files are unrelated Swift code. Should be scoped.
+
+mdpal-cli's recommended fixes (all your territory):
+- Diagnose and fix the hung gh.bats test (primary bug)
+- Bump timeout in commit-precheck (configurable via agency.yaml?)
+- Scope test selection — run only tests relevant to staged paths
+- Per-suite timeout instead of global
+- Make test-run path-aware — register apps/mdpal/ as a Swift test suite
+
+This is urgent because every `--no-verify` an agent does undermines QG integrity. mdpal-cli has been doing it repeatedly with principal approval, but it's a pattern we want to kill ASAP.
+
+## Plan mode (per directive #111)
+
+Same as before — investigate first, design plan, dispatch back, get approval, implement. The hung test is the primary investigation: find it, kill it (or fix it), then design the scoping fix.
+
+## Order
+
+This is your only dispatched work right now. Take it.
+
+Captain

--- a/usr/jordan/captain/history/handoff-20260407-160326.md
+++ b/usr/jordan/captain/history/handoff-20260407-160326.md
@@ -1,0 +1,73 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-07
+trigger: Day 31 session — collaboration tooling shipped
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 31.** Session focused on cross-repo collaboration tooling and commit-precheck bug fix. All shipped and pushed to origin. Monofolk notified via collaboration repo dispatches.
+
+### What shipped Day 31:
+- `claude/tools/collaboration` (v2.0.0) — cross-repo dispatch lifecycle tool (check, list, read, resolve, reply, push)
+- `/collaborate` skill — captain-only
+- `hookify.warn-external-paths.md` — blocks raw bash touching collaboration repos
+- `agency.yaml` collaboration.repos config section
+- SessionStart hook fires `collaboration check`
+- `CLAUDE-CAPTAIN.md` — agent-scoped instructions with cross-repo protocol
+- Captain startup sequence updated (step 4: cross-repo check)
+- `commit-precheck` fix — fast path for non-app-code commits, timeouts on all steps
+- Monofolk dispatches: replied to ISCP setup guidance + Synthoid proposal, sent release notes
+
+### commit-precheck fix (affects all agents):
+Bug: test-run and code-review ran on every commit including tooling-only changes, hanging indefinitely. Fix: `has_app_code()` classifies staged files — non-app-code skips steps 4+5. All steps have timeouts (30-120s).
+
+## Valueflow Context
+
+Unchanged from Day 30. V2 implementation plan is the next major deliverable.
+- PVR: `claude/workstreams/agency/valueflow-pvr-20260406.md`
+- A&D: `claude/workstreams/agency/valueflow-ad-20260406.md`
+- MAR dispositions: `claude/workstreams/agency/reviews/`
+
+## Active Work
+
+**Next: write the Valueflow V2 implementation plan.** Same as Day 30 handoff — deferred by the collaboration tooling work today.
+
+## Agents
+
+| Agent | Worktree | Status | Next action |
+|-------|----------|--------|-------------|
+| iscp | `.claude/worktrees/iscp/` | Idle, awaiting V2 assignments | Process seeds, await plan |
+| devex | `.claude/worktrees/devex/` | Day 1, needs PVR | `/define` with seed, then implement |
+| mdpal-cli | `.claude/worktrees/mdpal-cli/` | Phase 1, iter 1.1 code done | `/iteration-complete`, then 1.2 |
+| mdpal-app | `.claude/worktrees/mdpal-app/` | Phase 1A in progress | Continue SwiftUI implementation |
+| mock-and-mark | (no worktree yet) | Not started | Awaiting seed + principal direction |
+
+## Flags (3 pending)
+
+1. SMS-style dispatches — short DB-only dispatches without payload files (from Day 30)
+2. Friction→toolification process — formalize the pattern of recognizing session friction and building tools/skills/hookify in-session
+3. Release notes dispatch process — every push to origin gets a release-notes dispatch to collaboration repos, integrated into /sync or /ship
+
+## Cross-Repo Collaboration
+
+Collaboration repos configured in `agency.yaml`. Tool: `./claude/tools/collaboration`. Monofolk has 3 pending dispatches from us (2 replies + release notes).
+
+### Monofolk inbound (resolved):
+- ISCP setup guidance request — replied, full guidance dispatch still owed
+- Synthoid proposal — replied, routing decision pending principal input
+
+## Startup Actions
+
+1. Read this handoff
+2. Set dispatch loop: `/loop 5m dispatch check`
+3. Check ISCP: `dispatch list` and `flag list`
+4. Check cross-repo: `./claude/tools/collaboration check`
+5. Read role: `claude/agents/captain/agent.md`
+6. Write the V2 implementation plan

--- a/usr/jordan/captain/history/handoff-20260407-161411.md
+++ b/usr/jordan/captain/history/handoff-20260407-161411.md
@@ -1,0 +1,146 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-07
+trigger: day-32-end-of-session
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 32 complete.** Two PRs shipped. Multi-agent infrastructure rebuilt. Methodology documented. First real Day-PR Release Pattern day.
+
+### Day 32 - Release 1 (PR #46) — MERGED
+12 commits. Multi-agent infrastructure fixes + Valueflow V2 plan + Phase 1 M1/M2 + docs accuracy pass.
+
+- **Permissions overhaul:** `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)` replaces 100+ narrow patterns
+- **Agent identity fix:** `agent-identity` PWD-based worktree detection (de73c9c)
+- **`$CLAUDE_PROJECT_DIR` fix:** Variable empty in agent Bash calls. All skills/docs use `./claude/tools/`
+- **Hookify blocks:** `block-cd-to-main` (cd + absolute paths), `block-raw-handoff` (forces /handoff skill)
+- **All agents to `opus[1m]`:** 1M context window
+- **Startup trimmed:** 9-10 steps → 3 (handoff, dispatch check, work)
+- **`.agency-agent` gitignored**
+- **Friction analysis:** `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` — 30-40% overhead identified
+- **Valueflow V2 master plan:** `claude/workstreams/agency/valueflow-plan-20260407.md` — 6 phases, 3 workstreams, MAR'd
+- **Phase 1 M1:** QUALITY-GATE.md tier definitions (T1-T4)
+- **Phase 1 M2:** New `claude/docs/ISCP-PROTOCOL.md`
+- **Docs accuracy passes (2 rounds of 4 reviewers each):** CLAUDE-THEAGENCY.md, README-THEAGENCY.md, README-GETTINGSTARTED.md
+- **NEW: `claude/README-ENFORCEMENT.md`** — comprehensive 5-layer enforcement model + all 33 hookify rules
+- **Bug fix:** `master-updated` dispatch type (was wrong in some docs)
+- **Bug fix:** Handoff path `{agent}-handoff.md` (was wrong)
+
+### Day 32 - Release 2 (PR #48) — MERGED
+6 commits. New capabilities and patterns built on top of R1.
+
+- **`/captain-log` tool + skill** — narrative thread daily log, categories (decision/friction/learning/milestone/observation/build). Resolves flag #2.
+- **`/secret` skill (SPEC-PROVIDER)** — converted from command, third example of SPEC-PROVIDER pattern. Resolves flag #5.
+- **Day-PR Release Pattern documented** in README-THEAGENCY.md
+- **Agency init template refactor** — `_agency-init` now uses `HANDOFF-BOOTSTRAP.md` template + sed
+- **Per-agent commit attribution** — `/git-commit` builds `Co-Authored-By: {agent} <{username}+{agent}.{repo}.{org}@users.noreply.github.com>`. Verified with real test commits. Discussion record at `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`. Resolves flag #39, captures #40.
+- **Coordination artifacts:** 8 dispatches sent to devex, 1 to iscp, 6 review-responses approving plans, flag triage record (16 cleared)
+
+## Active Agents (background)
+
+| Agent | Worktree | Plan Status | Next Work |
+|-------|----------|------------|-----------|
+| iscp | `.claude/worktrees/iscp/` | Phase 2.0 (schema migrations) committed `dfa9f2f`. Plan #121 (per-agent inboxes) approved. Ready for 2.6 + remaining iterations. | Iteration 2.1+ |
+| devex | `.claude/worktrees/devex/` | 5 plans approved (#109/110/114/118/122). Sequence: #109 → #118 → #110+#114 merged → #122. | Implementation, plan mode for each |
+| mdpal-cli | `.claude/worktrees/mdpal-cli/` | Plan #97 (consuming workstream review) responded via #105 (forwarded by ISCP as #131). Continuing iteration 1.1. | Their own work |
+
+## Outstanding (background, no captain action)
+
+- **DevEx queue:** 5 implementation plans approved. Working through them in plan mode.
+- **ISCP queue:** Per-agent inbox plan approved as Iteration 2.6 in Phase 2 sequence.
+- **Doppler verification dispatch** sent to monofolk/devex (`./claude/tools/secret-doppler` smoke test).
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal decision) |
+
+That's it. All other flags either cleared, captured as seeds, or dispatched to agents.
+
+## Next Action
+
+1. **Restart terminal agents** (iscp, devex, mdpal-cli) — they're running with stale settings/code from before Day 32 merges. Pull latest in each worktree and restart sessions.
+2. **Process whatever new dispatches arrive** from devex/iscp implementation work
+3. **Day 33 setup** — when day starts, create `day33-release-1` branch from origin/main as draft PR
+
+## Artifacts Created Today
+
+### Methodology / Docs
+- `claude/README-ENFORCEMENT.md` (NEW)
+- `claude/docs/ISCP-PROTOCOL.md` (NEW)
+- `claude/CLAUDE-THEAGENCY.md` (revised — Triangle/Ladder, MARFI/MAP, three-bucket, full Valueflow flow)
+- `claude/README-THEAGENCY.md` (revised — Valueflow section, SPEC-PROVIDER pattern, Day-PR pattern, Per-Agent Commit Attribution)
+- `claude/README-GETTINGSTARTED.md` (rewritten — agency init/update/verify, Key Concepts, narrative First Session)
+- `claude/docs/QUALITY-GATE.md` (added tier definitions T1-T4)
+
+### Tools / Skills
+- `claude/tools/captain-log` (NEW)
+- `.claude/skills/captain-log/SKILL.md` (NEW)
+- `.claude/skills/secret/SKILL.md` (NEW — converted from command)
+- `claude/tools/git-commit` (per-agent attribution)
+- `claude/tools/lib/_agency-init` (template refactor)
+
+### Hookify Rules
+- `claude/hookify/hookify.block-cd-to-main.md` (catches cd + absolute paths)
+- `claude/hookify/hookify.block-raw-handoff.md` (forces /handoff skill)
+
+### Templates
+- `claude/templates/HANDOFF-BOOTSTRAP.md` (NEW — used by agency init)
+- `claude/templates/CLAUDE-PROJECT.md` (revised — First time? callout)
+
+### Workstream Artifacts
+- `claude/workstreams/agency/valueflow-plan-20260407.md` (master plan, MAR'd)
+- `claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md` (NEW)
+- `claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md` (NEW)
+
+### Discussion Records
+- `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` (friction analysis)
+- `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md` (attribution discussion)
+- `usr/jordan/captain/transcripts/flag-triage-20260407.md` (16 flags resolved)
+- `usr/jordan/captain/logs/captains-log-20260407.md` (first captain's log entry)
+
+## Key Decisions
+
+1. **Day-PR Release Pattern is canonical** — every release goes through `day{N}-release-{M}` branch + draft PR. Today shipped 2 PRs (R1 + R2).
+2. **Permission model = broad + hookify** — `Bash(*)` etc. is fine for trusted environments. Hookify rules are the behavioral enforcement layer. Pre-GTM security review still pending (flag #34).
+3. **Agent attribution = GitHub user noreply with plus-tag** — `{username}+{agent}.{repo}.{org}@users.noreply.github.com`. Verified with real test commits. Distinct contributor entries, principal author profile-linked, agents are gray avatars but uniquely attributed.
+4. **One agent per worktree** — confirmed and implemented. mdpal-cli + mdpal-app are separate worktrees.
+5. **Plan mode required for all dispatched work** — directive #111 enforces this for devex.
+6. **`/secret` is now a skill** (was a command) — third SPEC-PROVIDER example.
+7. **Captain's log is a real first-class primitive** — narrative thread alongside handoffs/transcripts/flags.
+
+## Cross-Repo Status
+
+### Monofolk
+- Day 32 Release 1 dispatch sent (PR #46)
+- Permissions migration guide dispatch sent
+- Identity bug fix dispatch sent (their bug report → our fix)
+- Day 32 doppler verification request sent
+- Inbound: 2 dispatches resolved earlier today (hookify naming, identity bug)
+
+## Discussion Queue (carried forward)
+
+These came up but weren't acted on, parked for future:
+
+- **Hookify naming convention** — verb-noun (current) vs noun-verb (monofolk's proposal). Captured for 1B1 with principal.
+- **History rewrite for devex branch** — fix Test User attribution via rebase before merge to main. Approved in #115 reply, devex to execute.
+- **`/define`, `/design`, `/seed`, `/marfi`, `/map`** — formal skills planned for Phase 4 of Valueflow V2. Not yet built.
+- **MAR.md + VALUEFLOW.md decomposition** — Phase 1 M3/M4 of Valueflow V2 plan. Deferred to a separate PR.
+
+## House Rules Reminders
+
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` skill, never raw `git commit`
+- Never `cd` to main repo from worktree (block-cd-to-main rule)
+- All tools work from any directory — use `./claude/tools/`
+- Day-PR pattern: branch from origin/main as `day{N}-release-{M}`, draft first, merge through PR
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260407-161412.md
+++ b/usr/jordan/captain/history/handoff-20260407-161412.md
@@ -1,0 +1,146 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-07
+trigger: day-32-end-of-session
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 32 complete.** Two PRs shipped. Multi-agent infrastructure rebuilt. Methodology documented. First real Day-PR Release Pattern day.
+
+### Day 32 - Release 1 (PR #46) — MERGED
+12 commits. Multi-agent infrastructure fixes + Valueflow V2 plan + Phase 1 M1/M2 + docs accuracy pass.
+
+- **Permissions overhaul:** `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)` replaces 100+ narrow patterns
+- **Agent identity fix:** `agent-identity` PWD-based worktree detection (de73c9c)
+- **`$CLAUDE_PROJECT_DIR` fix:** Variable empty in agent Bash calls. All skills/docs use `./claude/tools/`
+- **Hookify blocks:** `block-cd-to-main` (cd + absolute paths), `block-raw-handoff` (forces /handoff skill)
+- **All agents to `opus[1m]`:** 1M context window
+- **Startup trimmed:** 9-10 steps → 3 (handoff, dispatch check, work)
+- **`.agency-agent` gitignored**
+- **Friction analysis:** `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` — 30-40% overhead identified
+- **Valueflow V2 master plan:** `claude/workstreams/agency/valueflow-plan-20260407.md` — 6 phases, 3 workstreams, MAR'd
+- **Phase 1 M1:** QUALITY-GATE.md tier definitions (T1-T4)
+- **Phase 1 M2:** New `claude/docs/ISCP-PROTOCOL.md`
+- **Docs accuracy passes (2 rounds of 4 reviewers each):** CLAUDE-THEAGENCY.md, README-THEAGENCY.md, README-GETTINGSTARTED.md
+- **NEW: `claude/README-ENFORCEMENT.md`** — comprehensive 5-layer enforcement model + all 33 hookify rules
+- **Bug fix:** `master-updated` dispatch type (was wrong in some docs)
+- **Bug fix:** Handoff path `{agent}-handoff.md` (was wrong)
+
+### Day 32 - Release 2 (PR #48) — MERGED
+6 commits. New capabilities and patterns built on top of R1.
+
+- **`/captain-log` tool + skill** — narrative thread daily log, categories (decision/friction/learning/milestone/observation/build). Resolves flag #2.
+- **`/secret` skill (SPEC-PROVIDER)** — converted from command, third example of SPEC-PROVIDER pattern. Resolves flag #5.
+- **Day-PR Release Pattern documented** in README-THEAGENCY.md
+- **Agency init template refactor** — `_agency-init` now uses `HANDOFF-BOOTSTRAP.md` template + sed
+- **Per-agent commit attribution** — `/git-commit` builds `Co-Authored-By: {agent} <{username}+{agent}.{repo}.{org}@users.noreply.github.com>`. Verified with real test commits. Discussion record at `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`. Resolves flag #39, captures #40.
+- **Coordination artifacts:** 8 dispatches sent to devex, 1 to iscp, 6 review-responses approving plans, flag triage record (16 cleared)
+
+## Active Agents (background)
+
+| Agent | Worktree | Plan Status | Next Work |
+|-------|----------|------------|-----------|
+| iscp | `.claude/worktrees/iscp/` | Phase 2.0 (schema migrations) committed `dfa9f2f`. Plan #121 (per-agent inboxes) approved. Ready for 2.6 + remaining iterations. | Iteration 2.1+ |
+| devex | `.claude/worktrees/devex/` | 5 plans approved (#109/110/114/118/122). Sequence: #109 → #118 → #110+#114 merged → #122. | Implementation, plan mode for each |
+| mdpal-cli | `.claude/worktrees/mdpal-cli/` | Plan #97 (consuming workstream review) responded via #105 (forwarded by ISCP as #131). Continuing iteration 1.1. | Their own work |
+
+## Outstanding (background, no captain action)
+
+- **DevEx queue:** 5 implementation plans approved. Working through them in plan mode.
+- **ISCP queue:** Per-agent inbox plan approved as Iteration 2.6 in Phase 2 sequence.
+- **Doppler verification dispatch** sent to monofolk/devex (`./claude/tools/secret-doppler` smoke test).
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal decision) |
+
+That's it. All other flags either cleared, captured as seeds, or dispatched to agents.
+
+## Next Action
+
+1. **Restart terminal agents** (iscp, devex, mdpal-cli) — they're running with stale settings/code from before Day 32 merges. Pull latest in each worktree and restart sessions.
+2. **Process whatever new dispatches arrive** from devex/iscp implementation work
+3. **Day 33 setup** — when day starts, create `day33-release-1` branch from origin/main as draft PR
+
+## Artifacts Created Today
+
+### Methodology / Docs
+- `claude/README-ENFORCEMENT.md` (NEW)
+- `claude/docs/ISCP-PROTOCOL.md` (NEW)
+- `claude/CLAUDE-THEAGENCY.md` (revised — Triangle/Ladder, MARFI/MAP, three-bucket, full Valueflow flow)
+- `claude/README-THEAGENCY.md` (revised — Valueflow section, SPEC-PROVIDER pattern, Day-PR pattern, Per-Agent Commit Attribution)
+- `claude/README-GETTINGSTARTED.md` (rewritten — agency init/update/verify, Key Concepts, narrative First Session)
+- `claude/docs/QUALITY-GATE.md` (added tier definitions T1-T4)
+
+### Tools / Skills
+- `claude/tools/captain-log` (NEW)
+- `.claude/skills/captain-log/SKILL.md` (NEW)
+- `.claude/skills/secret/SKILL.md` (NEW — converted from command)
+- `claude/tools/git-commit` (per-agent attribution)
+- `claude/tools/lib/_agency-init` (template refactor)
+
+### Hookify Rules
+- `claude/hookify/hookify.block-cd-to-main.md` (catches cd + absolute paths)
+- `claude/hookify/hookify.block-raw-handoff.md` (forces /handoff skill)
+
+### Templates
+- `claude/templates/HANDOFF-BOOTSTRAP.md` (NEW — used by agency init)
+- `claude/templates/CLAUDE-PROJECT.md` (revised — First time? callout)
+
+### Workstream Artifacts
+- `claude/workstreams/agency/valueflow-plan-20260407.md` (master plan, MAR'd)
+- `claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md` (NEW)
+- `claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md` (NEW)
+
+### Discussion Records
+- `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` (friction analysis)
+- `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md` (attribution discussion)
+- `usr/jordan/captain/transcripts/flag-triage-20260407.md` (16 flags resolved)
+- `usr/jordan/captain/logs/captains-log-20260407.md` (first captain's log entry)
+
+## Key Decisions
+
+1. **Day-PR Release Pattern is canonical** — every release goes through `day{N}-release-{M}` branch + draft PR. Today shipped 2 PRs (R1 + R2).
+2. **Permission model = broad + hookify** — `Bash(*)` etc. is fine for trusted environments. Hookify rules are the behavioral enforcement layer. Pre-GTM security review still pending (flag #34).
+3. **Agent attribution = GitHub user noreply with plus-tag** — `{username}+{agent}.{repo}.{org}@users.noreply.github.com`. Verified with real test commits. Distinct contributor entries, principal author profile-linked, agents are gray avatars but uniquely attributed.
+4. **One agent per worktree** — confirmed and implemented. mdpal-cli + mdpal-app are separate worktrees.
+5. **Plan mode required for all dispatched work** — directive #111 enforces this for devex.
+6. **`/secret` is now a skill** (was a command) — third SPEC-PROVIDER example.
+7. **Captain's log is a real first-class primitive** — narrative thread alongside handoffs/transcripts/flags.
+
+## Cross-Repo Status
+
+### Monofolk
+- Day 32 Release 1 dispatch sent (PR #46)
+- Permissions migration guide dispatch sent
+- Identity bug fix dispatch sent (their bug report → our fix)
+- Day 32 doppler verification request sent
+- Inbound: 2 dispatches resolved earlier today (hookify naming, identity bug)
+
+## Discussion Queue (carried forward)
+
+These came up but weren't acted on, parked for future:
+
+- **Hookify naming convention** — verb-noun (current) vs noun-verb (monofolk's proposal). Captured for 1B1 with principal.
+- **History rewrite for devex branch** — fix Test User attribution via rebase before merge to main. Approved in #115 reply, devex to execute.
+- **`/define`, `/design`, `/seed`, `/marfi`, `/map`** — formal skills planned for Phase 4 of Valueflow V2. Not yet built.
+- **MAR.md + VALUEFLOW.md decomposition** — Phase 1 M3/M4 of Valueflow V2 plan. Deferred to a separate PR.
+
+## House Rules Reminders
+
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` skill, never raw `git commit`
+- Never `cd` to main repo from worktree (block-cd-to-main rule)
+- All tools work from any directory — use `./claude/tools/`
+- Day-PR pattern: branch from origin/main as `day{N}-release-{M}`, draft first, merge through PR
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260407-190052.md
+++ b/usr/jordan/captain/history/handoff-20260407-190052.md
@@ -1,0 +1,146 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-07
+trigger: day-32-end-of-session
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 32 complete.** Two PRs shipped. Multi-agent infrastructure rebuilt. Methodology documented. First real Day-PR Release Pattern day.
+
+### Day 32 - Release 1 (PR #46) — MERGED
+12 commits. Multi-agent infrastructure fixes + Valueflow V2 plan + Phase 1 M1/M2 + docs accuracy pass.
+
+- **Permissions overhaul:** `Bash(*)`, `Read(**)`, `Edit(**)`, `Write(**)` replaces 100+ narrow patterns
+- **Agent identity fix:** `agent-identity` PWD-based worktree detection (de73c9c)
+- **`$CLAUDE_PROJECT_DIR` fix:** Variable empty in agent Bash calls. All skills/docs use `./claude/tools/`
+- **Hookify blocks:** `block-cd-to-main` (cd + absolute paths), `block-raw-handoff` (forces /handoff skill)
+- **All agents to `opus[1m]`:** 1M context window
+- **Startup trimmed:** 9-10 steps → 3 (handoff, dispatch check, work)
+- **`.agency-agent` gitignored**
+- **Friction analysis:** `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` — 30-40% overhead identified
+- **Valueflow V2 master plan:** `claude/workstreams/agency/valueflow-plan-20260407.md` — 6 phases, 3 workstreams, MAR'd
+- **Phase 1 M1:** QUALITY-GATE.md tier definitions (T1-T4)
+- **Phase 1 M2:** New `claude/docs/ISCP-PROTOCOL.md`
+- **Docs accuracy passes (2 rounds of 4 reviewers each):** CLAUDE-THEAGENCY.md, README-THEAGENCY.md, README-GETTINGSTARTED.md
+- **NEW: `claude/README-ENFORCEMENT.md`** — comprehensive 5-layer enforcement model + all 33 hookify rules
+- **Bug fix:** `master-updated` dispatch type (was wrong in some docs)
+- **Bug fix:** Handoff path `{agent}-handoff.md` (was wrong)
+
+### Day 32 - Release 2 (PR #48) — MERGED
+6 commits. New capabilities and patterns built on top of R1.
+
+- **`/captain-log` tool + skill** — narrative thread daily log, categories (decision/friction/learning/milestone/observation/build). Resolves flag #2.
+- **`/secret` skill (SPEC-PROVIDER)** — converted from command, third example of SPEC-PROVIDER pattern. Resolves flag #5.
+- **Day-PR Release Pattern documented** in README-THEAGENCY.md
+- **Agency init template refactor** — `_agency-init` now uses `HANDOFF-BOOTSTRAP.md` template + sed
+- **Per-agent commit attribution** — `/git-commit` builds `Co-Authored-By: {agent} <{username}+{agent}.{repo}.{org}@users.noreply.github.com>`. Verified with real test commits. Discussion record at `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md`. Resolves flag #39, captures #40.
+- **Coordination artifacts:** 8 dispatches sent to devex, 1 to iscp, 6 review-responses approving plans, flag triage record (16 cleared)
+
+## Active Agents (background)
+
+| Agent | Worktree | Plan Status | Next Work |
+|-------|----------|------------|-----------|
+| iscp | `.claude/worktrees/iscp/` | Phase 2.0 (schema migrations) committed `dfa9f2f`. Plan #121 (per-agent inboxes) approved. Ready for 2.6 + remaining iterations. | Iteration 2.1+ |
+| devex | `.claude/worktrees/devex/` | 5 plans approved (#109/110/114/118/122). Sequence: #109 → #118 → #110+#114 merged → #122. | Implementation, plan mode for each |
+| mdpal-cli | `.claude/worktrees/mdpal-cli/` | Plan #97 (consuming workstream review) responded via #105 (forwarded by ISCP as #131). Continuing iteration 1.1. | Their own work |
+
+## Outstanding (background, no captain action)
+
+- **DevEx queue:** 5 implementation plans approved. Working through them in plan mode.
+- **ISCP queue:** Per-agent inbox plan approved as Iteration 2.6 in Phase 2 sequence.
+- **Doppler verification dispatch** sent to monofolk/devex (`./claude/tools/secret-doppler` smoke test).
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal decision) |
+
+That's it. All other flags either cleared, captured as seeds, or dispatched to agents.
+
+## Next Action
+
+1. **Restart terminal agents** (iscp, devex, mdpal-cli) — they're running with stale settings/code from before Day 32 merges. Pull latest in each worktree and restart sessions.
+2. **Process whatever new dispatches arrive** from devex/iscp implementation work
+3. **Day 33 setup** — when day starts, create `day33-release-1` branch from origin/main as draft PR
+
+## Artifacts Created Today
+
+### Methodology / Docs
+- `claude/README-ENFORCEMENT.md` (NEW)
+- `claude/docs/ISCP-PROTOCOL.md` (NEW)
+- `claude/CLAUDE-THEAGENCY.md` (revised — Triangle/Ladder, MARFI/MAP, three-bucket, full Valueflow flow)
+- `claude/README-THEAGENCY.md` (revised — Valueflow section, SPEC-PROVIDER pattern, Day-PR pattern, Per-Agent Commit Attribution)
+- `claude/README-GETTINGSTARTED.md` (rewritten — agency init/update/verify, Key Concepts, narrative First Session)
+- `claude/docs/QUALITY-GATE.md` (added tier definitions T1-T4)
+
+### Tools / Skills
+- `claude/tools/captain-log` (NEW)
+- `.claude/skills/captain-log/SKILL.md` (NEW)
+- `.claude/skills/secret/SKILL.md` (NEW — converted from command)
+- `claude/tools/git-commit` (per-agent attribution)
+- `claude/tools/lib/_agency-init` (template refactor)
+
+### Hookify Rules
+- `claude/hookify/hookify.block-cd-to-main.md` (catches cd + absolute paths)
+- `claude/hookify/hookify.block-raw-handoff.md` (forces /handoff skill)
+
+### Templates
+- `claude/templates/HANDOFF-BOOTSTRAP.md` (NEW — used by agency init)
+- `claude/templates/CLAUDE-PROJECT.md` (revised — First time? callout)
+
+### Workstream Artifacts
+- `claude/workstreams/agency/valueflow-plan-20260407.md` (master plan, MAR'd)
+- `claude/workstreams/agency/seeds/seed-granola-workflow-20260407.md` (NEW)
+- `claude/workstreams/gtm/seeds/seed-agent-mail-service-20260407.md` (NEW)
+
+### Discussion Records
+- `usr/jordan/captain/transcripts/agent-session-friction-20260407.md` (friction analysis)
+- `usr/jordan/captain/transcripts/agent-attribution-model-20260407.md` (attribution discussion)
+- `usr/jordan/captain/transcripts/flag-triage-20260407.md` (16 flags resolved)
+- `usr/jordan/captain/logs/captains-log-20260407.md` (first captain's log entry)
+
+## Key Decisions
+
+1. **Day-PR Release Pattern is canonical** — every release goes through `day{N}-release-{M}` branch + draft PR. Today shipped 2 PRs (R1 + R2).
+2. **Permission model = broad + hookify** — `Bash(*)` etc. is fine for trusted environments. Hookify rules are the behavioral enforcement layer. Pre-GTM security review still pending (flag #34).
+3. **Agent attribution = GitHub user noreply with plus-tag** — `{username}+{agent}.{repo}.{org}@users.noreply.github.com`. Verified with real test commits. Distinct contributor entries, principal author profile-linked, agents are gray avatars but uniquely attributed.
+4. **One agent per worktree** — confirmed and implemented. mdpal-cli + mdpal-app are separate worktrees.
+5. **Plan mode required for all dispatched work** — directive #111 enforces this for devex.
+6. **`/secret` is now a skill** (was a command) — third SPEC-PROVIDER example.
+7. **Captain's log is a real first-class primitive** — narrative thread alongside handoffs/transcripts/flags.
+
+## Cross-Repo Status
+
+### Monofolk
+- Day 32 Release 1 dispatch sent (PR #46)
+- Permissions migration guide dispatch sent
+- Identity bug fix dispatch sent (their bug report → our fix)
+- Day 32 doppler verification request sent
+- Inbound: 2 dispatches resolved earlier today (hookify naming, identity bug)
+
+## Discussion Queue (carried forward)
+
+These came up but weren't acted on, parked for future:
+
+- **Hookify naming convention** — verb-noun (current) vs noun-verb (monofolk's proposal). Captured for 1B1 with principal.
+- **History rewrite for devex branch** — fix Test User attribution via rebase before merge to main. Approved in #115 reply, devex to execute.
+- **`/define`, `/design`, `/seed`, `/marfi`, `/map`** — formal skills planned for Phase 4 of Valueflow V2. Not yet built.
+- **MAR.md + VALUEFLOW.md decomposition** — Phase 1 M3/M4 of Valueflow V2 plan. Deferred to a separate PR.
+
+## House Rules Reminders
+
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` skill, never raw `git commit`
+- Never `cd` to main repo from worktree (block-cd-to-main rule)
+- All tools work from any directory — use `./claude/tools/`
+- Day-PR pattern: branch from origin/main as `day{N}-release-{M}`, draft first, merge through PR
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -1,0 +1,34 @@
+# Principal Reports Index
+
+Reports filed externally (Anthropic Claude Code, the-agency GitHub, etc.) by or on behalf of jordan.
+
+Each row is one filing. Click through to the per-report markdown for full context, current state, and response log.
+
+**Location:** `usr/jordan/reports/` (principal-scoped — moved from `usr/jordan/captain/reports/` on 2026-04-08)
+**Naming convention:** `report-{kind}-{slug}-{YYYYMMDD}.md`
+
+---
+
+## Filed Reports
+
+<!-- AGENCY-ISSUE-INDEX-START — agency-issue tool appends rows above the END marker -->
+
+| Date | Title | Kind | Target | External ID | Local Report | Status |
+|------|-------|------|--------|-------------|--------------|--------|
+| 2026-04-08 | Periodic silent execution primitive for autonomous agents | feedback | anthropic/claude-code | feedback `8dd67e96…` + GH [#45017](https://github.com/anthropics/claude-code/issues/45017) | [report-silent-periodic-tool-calls-20260408](report-silent-periodic-tool-calls-20260408.md) | filed |
+| 2026-04-08 | agency-issue v1: new skill for two-way GitHub issue tracking | feature | the-agency-ai/the-agency | [#52](https://github.com/the-agency-ai/the-agency/issues/52) | [report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408](report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md) | open |
+
+<!-- AGENCY-ISSUE-INDEX-END -->
+
+## How to add an entry
+
+1. Draft the report with captain, following `claude/docs/FEEDBACK-FORMAT.md`
+2. File via the appropriate channel:
+   - `agency-issue file` → the-agency GitHub (auto-appends to this index)
+   - `/feedback` → Anthropic Claude Code (manually create the report file + append a row)
+3. The per-report markdown lives in this directory with full text, response log, and frontmatter linking back to the source seed
+4. This index is the at-a-glance view; the per-report file is the source of truth
+
+## Principle
+
+Reports are the record of what we asked the outside world for. Every gap we find in an external tool that we can't close in userspace becomes a report. Every response from the other side gets appended to its report file so we have a full narrative.

--- a/usr/jordan/reports/report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md
+++ b/usr/jordan/reports/report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md
@@ -1,0 +1,79 @@
+---
+report_type: agency-issue
+issue_type: feature
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-08
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/52
+github_issue_number: 52
+status: open
+---
+
+# agency-issue v1: new skill for two-way GitHub issue tracking
+
+**Filed:** 2026-04-08T07:22:15Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#52](https://github.com/the-agency-ai/the-agency/issues/52)
+**Type:** feature
+**Status:** open
+
+## Filed Body
+
+**Type:** feature
+
+## Summary
+
+`agency-issue` is a new skill + tool for filing, viewing, commenting on, and closing GitHub issues against the-agency framework directly from within an agency session. It is the v1 implementation of the model 1B1'd with the principal on 2026-04-08.
+
+This issue is being filed using the tool itself as a smoke test of the full pipeline.
+
+## Why it exists
+
+`/feedback` (which talks to Anthropic Claude Code) is fire-and-forget — no status visibility, no update path. The-agency framework needed its own two-way channel for tracking framework friction, bugs, and feature requests with full lifecycle support.
+
+## What v1 ships
+
+- **Tool:** `claude/tools/agency-issue` — bash wrapper over `gh issue` with five verbs:
+  - `file` — create a new issue, write a local report file
+  - `list` — list open/closed/all issues
+  - `view <id>` — show issue body + comments
+  - `comment <id>` — add a comment
+  - `close <id>` — close an issue, optionally with a final comment
+- **Skill:** `.claude/skills/agency-issue/SKILL.md` — agent discovery + usage docs
+- **Config:** `claude/config/agency.yaml` — `issues.github.target_repo` block
+- **Reports:** every filed issue writes a markdown report to `usr/{principal}/reports/` and updates `REPORTS-INDEX.md`
+
+## Design principles
+
+Simple v1, principal-driven decisions:
+
+- **Thin wrapper** over `gh`, no local cache
+- **No labels** in v1 — type goes into the body header, triage is reading
+- **Permissions delegated to GitHub** via `gh` — no custom authz
+- **Anyone can file** (human or agent), no draft-and-approve gate
+- **Reports are principal-scoped** at `usr/{principal}/reports/`
+- **Pull-on-demand** for status (no polling, no notification — yet)
+
+Future v2+ work captured in the seed:
+
+- SPEC-PROVIDER pattern for pluggable backends (GitLab, Linear, Jira)
+- Multi-instance contract pattern (`/agency-issue` for the framework, `/local-issue` for local project tracker)
+- Status-line indicator for "issues with new activity"
+- Issue templates in `.github/ISSUE_TEMPLATE/`
+
+## Related
+
+- Seed: `claude/workstreams/agency/seeds/seed-agency-issue-skill-20260408.md`
+- Sibling pattern: `/feedback` (Anthropic Claude Code)
+- Report directory pattern: `usr/jordan/reports/REPORTS-INDEX.md`
+
+## Acceptance
+
+This very issue is the smoke test. If you can read it on the issue tracker, the file path worked. The local report at `usr/jordan/reports/` should also exist, with frontmatter linking back to this issue.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-08:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/52

--- a/usr/jordan/reports/report-silent-periodic-tool-calls-20260408.md
+++ b/usr/jordan/reports/report-silent-periodic-tool-calls-20260408.md
@@ -1,0 +1,44 @@
+---
+report_type: feature-request
+filed_by: jordan
+captain: the-agency/jordan/captain
+date_filed: 2026-04-08
+anthropic_feedback_id: 8dd67e96-63ea-4a22-b687-d26a1b2d0add
+github_issue: https://github.com/anthropics/claude-code/issues/45017
+seed: claude/workstreams/agency/seeds/seed-silent-periodic-tool-calls-20260408.md
+status: filed
+---
+
+# Report: Periodic silent execution primitive for autonomous agents
+
+**Filed to Anthropic via `/feedback`:** 2026-04-08
+**Feedback ID:** `8dd67e96-63ea-4a22-b687-d26a1b2d0add`
+**Filed to GitHub:** https://github.com/anthropics/claude-code/issues/45017
+**Internal seed:** `claude/workstreams/agency/seeds/seed-silent-periodic-tool-calls-20260408.md`
+
+## Summary
+
+Claude Code has no mechanism to execute periodic scheduled tool calls (`CronCreate`, `/loop`) without rendering them in the terminal transcript. For autonomous-agent infrastructure (like the-agency) that needs to self-poll between user turns, this is pollution that scales linearly with polling frequency.
+
+The gap: hooks are silent but event-driven only; `CronCreate` is periodic but every fire renders visibly. No mechanism combines silent + periodic + agent-context-aware.
+
+## Requested Options
+
+1. **Periodic hook type** in `settings.json` (preferred — minimal new surface)
+2. **`hook:` parameter on `CronCreate`** (may be cleaner depending on scheduler internals)
+3. **Document status line as the canonical display-only path** (fallback, doesn't close gap)
+
+## Filed Text
+
+See the seed document for the full drafted text. The filed version is identical except for the identity block, which uses:
+
+- **From:** Jordan Dea-Mattson
+- **GitHub:** @jordandm (the-agency-ai), @jordan-of (OrdinaryFolk)
+- **Email:** jordandm@users.noreply.github.com, jordan-of@users.noreply.github.com
+
+## Response Log
+
+_(append responses here as they arrive)_
+
+- **2026-04-08:** Filed via `/feedback`. Confirmation: Feedback ID `8dd67e96-63ea-4a22-b687-d26a1b2d0add`.
+- **2026-04-08:** Filed on GitHub via `gh issue create`: https://github.com/anthropics/claude-code/issues/45017


### PR DESCRIPTION
## Day 33 R1

Seven commits (one Day 32 carry-over + six Day 33 commits) shipping:

- **`agency-issue` v1** — new skill + tool for filing/viewing/commenting on/closing GitHub issues against the-agency framework. Two-way channel (unlike `/feedback`). Smoke-tested via #52.
- **`release-plan` v1** — new tool that analyzes branch state and proposes a release plan. Auto-detects `day{N}-release-{M}` branch, pairs tool+skill+tests into feature commits, excludes scratch. **Bootstrap intent realized: this PR was assembled by `release-plan` itself.**
- **Dispatch loop convention** — two-loop pattern (5m silent fast-path + 30m visible nag) is now canonical for every agent. Documented in `claude/CLAUDE-THEAGENCY.md`, `HANDOFF-BOOTSTRAP.md`, and captain CLAUDE-CAPTAIN.md.
- **`iscp-check` v1.1.0** — delta suppression for hook notifications. ~95% reduction in notification noise during interactive sessions.
- **6 new workstream seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed externally), granola, agent-mail-service.
- **Coordination artifacts** — 16 dispatches sent today, 4 archived handoff rotations, principal reports directory migrated to `usr/jordan/reports/`.

## Bugs caught and fixed during the bootstrap

1. `.git/config` had `bare = true` — broke every git command in the repo. Fixed.
2. `claude/tools/git-commit` referenced `$PROJECT_ROOT` without setting it — caused "unbound variable" errors. Fixed in the release-plan/git-commit commit.
3. `tests/tools/iscp-check.bats` version assertion was stale (1.0.1 → 1.1.0). Fixed in the iscp-check commit.

## External work captured this session

- **Filed Anthropic Claude Code feedback** for periodic-silent execution primitive: feedback ID `8dd67e96-63ea-4a22-b687-d26a1b2d0add`, GitHub issue [anthropics/claude-code#45017](https://github.com/anthropics/claude-code/issues/45017). Tracked in `usr/jordan/reports/`.
- **Smoke-tested `agency-issue`** by filing the v1 design itself as [#52](https://github.com/the-agency-ai/the-agency/issues/52).

## Test plan

- [x] `agency-issue --version` works
- [x] `agency-issue --help` works
- [x] `agency-issue file` files an issue and writes a report (verified via #52)
- [x] `agency-issue list` returns open issues
- [x] `agency-issue view <id>` shows body + comments
- [x] `agency-issue comment <id>` adds a comment (verified on #52)
- [x] `release-plan --version` works
- [x] `release-plan --help` works
- [x] `release-plan` generates a plan and switches to the right branch
- [x] `iscp-check --force` emits notification regardless of state
- [x] `iscp-check` (no flag) suppresses repeat notifications when count unchanged
- [x] BATS tests passing for `iscp-check` (after version assertion update)
- [ ] Skills auto-discovered in Claude Code session (`agency-issue` visible in skill list — verified during build)

## Notes

- Day 33 R2 is planned to ship later today with whatever else surfaces this session.
- The `release-plan` tool's heuristic does NOT yet pair config-block changes (e.g., `agency.yaml` `issues:` block) with their feature commit. This was manually folded for R1. Future improvement.
- A meta-question is open: should we have a tool/skill for PR creation, pushing, and merging? Captured for triage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)