### PR TITLE
Day 33 R2: iscp-check --statusline mode, status line mail indicator, PR lifecycle seed

### DIFF
--- a/claude/tools/agency-issue
+++ b/claude/tools/agency-issue
@@ -356,6 +356,7 @@ _cmd_file() {
         cat "$body_tmp"
     } > "$final_body"
 
+    _check_gh
     _ensure_reports_dir
 
     # File via gh
@@ -400,12 +401,14 @@ _cmd_list() {
         *) _die "list: invalid --state '$state'. Must be open, closed, or all" ;;
     esac
 
+    _check_gh
     gh issue list --repo "$TARGET_REPO" --state "$state" --limit "$limit"
 }
 
 _cmd_view() {
     local id="${1:-}"
     [[ -n "$id" ]] || _die "view: issue id required"
+    _check_gh
     # gh issue view shows body+metadata; --comments is a SEPARATE mode that shows only comments.
     # To get both, call gh twice.
     gh issue view "$id" --repo "$TARGET_REPO"
@@ -433,12 +436,15 @@ _cmd_comment() {
         esac
     done
 
+    if [[ -z "$body" && -z "$body_file" ]]; then
+        _die "comment: --body or --body-file required"
+    fi
+
+    _check_gh
     if [[ -n "$body_file" ]]; then
         gh issue comment "$id" --repo "$TARGET_REPO" --body-file "$body_file"
-    elif [[ -n "$body" ]]; then
-        gh issue comment "$id" --repo "$TARGET_REPO" --body "$body"
     else
-        _die "comment: --body or --body-file required"
+        gh issue comment "$id" --repo "$TARGET_REPO" --body "$body"
     fi
 }
 
@@ -455,6 +461,7 @@ _cmd_close() {
         esac
     done
 
+    _check_gh
     if [[ -n "$comment" ]]; then
         gh issue close "$id" --repo "$TARGET_REPO" --comment "$comment"
     else
@@ -464,13 +471,17 @@ _cmd_close() {
 
 # --- Main ---
 
+# Arg validation runs BEFORE the gh auth check so bad args surface
+# their own errors instead of "gh not authenticated". Each verb function
+# parses its flags first and calls _check_gh only when it's about to
+# make a gh call.
 case "${1:-}" in
     --version) echo "agency-issue $TOOL_VERSION"; exit 0 ;;
     --help|-h|"") _show_help; exit 0 ;;
-    file) _check_gh; shift; _cmd_file "$@" ;;
-    list) _check_gh; shift; _cmd_list "$@" ;;
-    view) _check_gh; shift; _cmd_view "$@" ;;
-    comment) _check_gh; shift; _cmd_comment "$@" ;;
-    close) _check_gh; shift; _cmd_close "$@" ;;
+    file) shift; _cmd_file "$@" ;;
+    list) shift; _cmd_list "$@" ;;
+    view) shift; _cmd_view "$@" ;;
+    comment) shift; _cmd_comment "$@" ;;
+    close) shift; _cmd_close "$@" ;;
     *) _die "Unknown verb: $1. Run 'agency-issue --help' for usage." ;;
 esac

--- a/claude/tools/iscp-check
+++ b/claude/tools/iscp-check
@@ -44,27 +44,40 @@ source "$SCRIPT_DIR/lib/_iscp-db"
 
 # Handle flags
 FORCE=false
+STATUSLINE=false
 case "${1:-}" in
     --version) echo "iscp-check $TOOL_VERSION"; exit 0 ;;
     --force) FORCE=true ;;
+    --statusline) STATUSLINE=true ;;
     --help|-h)
         cat <<'HELP'
 iscp-check — ISCP notification hook
 
-Usage: iscp-check [--force|--version|--help]
+Usage: iscp-check [--force|--statusline|--version|--help]
 
 Checks for unread ISCP items (dispatches, flags, dropbox, notifications)
 and outputs a JSON systemMessage if any are found. Silent when empty.
 
-By default (delta mode), emits a notification only when the unread total
-has INCREASED since the last invocation — prevents repeated "you have N
-items" spam on every UserPromptSubmit/Stop when the counts haven't changed.
+Modes:
 
-Pass --force to emit unconditionally when items are waiting (used by
-SessionStart hook so every new session sees the current state).
+  (default)     Hook mode with delta suppression. Emits a JSON systemMessage
+                only when the unread total has INCREASED since the last call.
+                Used for SessionStart/UserPromptSubmit/Stop hooks.
 
-Designed for hook consumption (SessionStart, UserPromptSubmit, Stop).
-Every failure path exits silently — never blocks the agent.
+  --force       Hook mode without delta suppression. Emits unconditionally
+                when items are waiting. Used by SessionStart so every new
+                session sees the current state regardless of prior state.
+
+  --statusline  Status-line mode. Outputs a SHORT plain-text one-liner
+                suitable for the Claude Code statusLine command — e.g.
+                "📬 2" or "📬 2d 1f" or empty when nothing unread. Always
+                current; no delta suppression; no state file writes. Safe
+                to call on every UI tick. Silent by design — status line
+                commands render ONLY in the footer bar, never in the chat
+                transcript. This is the display-only silent polling path.
+
+Designed for hook consumption (SessionStart, UserPromptSubmit, Stop) and
+status line polling. Every failure path exits silently — never blocks.
 HELP
         exit 0 ;;
 esac
@@ -88,6 +101,27 @@ fi
 counts=$(iscp_db_count_unread "$my_agent" 2>/dev/null) || exit 0
 
 IFS='|' read -r flags dispatches dropbox notifications <<< "$counts"
+
+# --- Statusline mode: compact one-liner for the footer, no state writes ---
+# Runs on every UI tick. Must be FAST. Output goes ONLY to the footer —
+# never to the transcript. Silent when zero. No delta logic — always shows
+# the current count.
+if [[ "$STATUSLINE" == "true" ]]; then
+    total=$(( flags + dispatches + dropbox + notifications ))
+    if [[ "$total" -eq 0 ]]; then
+        # Nothing to show — empty output
+        exit 0
+    fi
+    # Compact format: "📬 2d 1f" — letters for type (d=dispatch, f=flag,
+    # x=dropbox, n=notif). Dispatches and flags are the common cases.
+    parts=()
+    [[ "$dispatches" -gt 0 ]] && parts+=("${dispatches}d")
+    [[ "$flags" -gt 0 ]] && parts+=("${flags}f")
+    [[ "$dropbox" -gt 0 ]] && parts+=("${dropbox}x")
+    [[ "$notifications" -gt 0 ]] && parts+=("${notifications}n")
+    echo "📬 $(IFS=' '; echo "${parts[*]}")"
+    exit 0
+fi
 
 # Silent when all zeros
 total=$(( flags + dispatches + dropbox + notifications ))

--- a/claude/tools/iscp-check
+++ b/claude/tools/iscp-check
@@ -104,16 +104,23 @@ IFS='|' read -r flags dispatches dropbox notifications <<< "$counts"
 
 # --- Statusline mode: compact one-liner for the footer, no state writes ---
 # Runs on every UI tick. Must be FAST. Output goes ONLY to the footer —
-# never to the transcript. Silent when zero. No delta logic — always shows
-# the current count.
+# never to the transcript. No delta logic — always shows current state.
+#
+# The mailbox is ALWAYS rendered, even when empty. A visible empty mailbox
+# ("📪") is different from "no mailbox in the footer at all" — the former
+# confirms the wiring is working and the inbox is empty; the latter is
+# ambiguous (not wired? broken? old code?). Always-visible removes the
+# ambiguity.
 if [[ "$STATUSLINE" == "true" ]]; then
     total=$(( flags + dispatches + dropbox + notifications ))
     if [[ "$total" -eq 0 ]]; then
-        # Nothing to show — empty output
+        # Empty mailbox glyph — visible, distinct from "no indicator"
+        echo "📪"
         exit 0
     fi
     # Compact format: "📬 2d 1f" — letters for type (d=dispatch, f=flag,
     # x=dropbox, n=notif). Dispatches and flags are the common cases.
+    # 📬 (open with raised flag) vs 📪 (closed) makes the state glanceable.
     parts=()
     [[ "$dispatches" -gt 0 ]] && parts+=("${dispatches}d")
     [[ "$flags" -gt 0 ]] && parts+=("${flags}f")

--- a/claude/tools/iscp-check
+++ b/claude/tools/iscp-check
@@ -70,11 +70,14 @@ Modes:
 
   --statusline  Status-line mode. Outputs a SHORT plain-text one-liner
                 suitable for the Claude Code statusLine command — e.g.
-                "📬 2" or "📬 2d 1f" or empty when nothing unread. Always
-                current; no delta suppression; no state file writes. Safe
-                to call on every UI tick. Silent by design — status line
-                commands render ONLY in the footer bar, never in the chat
-                transcript. This is the display-only silent polling path.
+                "📬 2d 1f" when the current agent has unread items, or
+                silent (no output) when the inbox is empty. No delta
+                suppression; no state file writes. Safe to call on every
+                UI tick. The footer glyph only appears when there's
+                something to notice; absence is the normal state. Status
+                line commands render ONLY in the footer bar, never in
+                the chat transcript. This is the display-only silent
+                polling path.
 
 Designed for hook consumption (SessionStart, UserPromptSubmit, Stop) and
 status line polling. Every failure path exits silently — never blocks.
@@ -106,21 +109,18 @@ IFS='|' read -r flags dispatches dropbox notifications <<< "$counts"
 # Runs on every UI tick. Must be FAST. Output goes ONLY to the footer —
 # never to the transcript. No delta logic — always shows current state.
 #
-# The mailbox is ALWAYS rendered, even when empty. A visible empty mailbox
-# ("📪") is different from "no mailbox in the footer at all" — the former
-# confirms the wiring is working and the inbox is empty; the latter is
-# ambiguous (not wired? broken? old code?). Always-visible removes the
-# ambiguity.
+# Silent when the current agent has ZERO unread items. The mailbox glyph
+# only appears when there's something to notice — the absence of the glyph
+# is the normal state. (Principal directive 2026-04-08: the icon should
+# only be there if the current agent has unread messages.)
 if [[ "$STATUSLINE" == "true" ]]; then
     total=$(( flags + dispatches + dropbox + notifications ))
     if [[ "$total" -eq 0 ]]; then
-        # Empty mailbox glyph — visible, distinct from "no indicator"
-        echo "📪"
+        # Silent — no output, no glyph in the footer
         exit 0
     fi
     # Compact format: "📬 2d 1f" — letters for type (d=dispatch, f=flag,
     # x=dropbox, n=notif). Dispatches and flags are the common cases.
-    # 📬 (open with raised flag) vs 📪 (closed) makes the state glanceable.
     parts=()
     [[ "$dispatches" -gt 0 ]] && parts+=("${dispatches}d")
     [[ "$flags" -gt 0 ]] && parts+=("${flags}f")

--- a/claude/tools/nit-add
+++ b/claude/tools/nit-add
@@ -92,17 +92,15 @@ EOF
   echo "Created nits file: $NITS_FILE"
 fi
 
-# Step 1: Pull latest
-echo "Pulling latest changes..."
-git pull --rebase 2>/dev/null || {
-  # If rebase fails due to conflicts, abort and try regular pull
-  git rebase --abort 2>/dev/null || true
-  git pull || {
-    # If regular pull also has conflicts, handle them
-    if git diff --name-only --diff-filter=U | grep -q "$NITS_FILE"; then
-      handle_merge_conflict
-    fi
-  }
+# Step 1: Pull latest (merge-based, per merge-not-rebase discipline).
+# Previously used `git pull --rebase` with a `git rebase --abort` cleanup,
+# but rebase is now blocked framework-wide (hookify.block-raw-rebase).
+# `git pull` with default merge behavior is the correct path: on conflict
+# in $NITS_FILE, the handler resolves it explicitly below.
+git pull --no-rebase 2>/dev/null || {
+  if git diff --name-only --diff-filter=U | grep -q "$NITS_FILE"; then
+    handle_merge_conflict
+  fi
 }
 
 # Step 2: Find the highest existing NIT ID

--- a/claude/tools/nit-resolve
+++ b/claude/tools/nit-resolve
@@ -67,15 +67,13 @@ handle_merge_conflict() {
   return 0
 }
 
-# Step 1: Pull latest
-echo "Pulling latest changes..."
-git pull --rebase 2>/dev/null || {
-  git rebase --abort 2>/dev/null || true
-  git pull || {
-    if git diff --name-only --diff-filter=U | grep -q "$NITS_FILE"; then
-      handle_merge_conflict
-    fi
-  }
+# Step 1: Pull latest (merge-based, per merge-not-rebase discipline).
+# Previously used `git pull --rebase` with a `git rebase --abort` cleanup,
+# but rebase is now blocked framework-wide (hookify.block-raw-rebase).
+git pull --no-rebase 2>/dev/null || {
+  if git diff --name-only --diff-filter=U | grep -q "$NITS_FILE"; then
+    handle_merge_conflict
+  fi
 }
 
 # Step 2: Verify the NIT exists

--- a/claude/tools/release-plan
+++ b/claude/tools/release-plan
@@ -306,6 +306,72 @@ feature_groups() {
     grep '^feature:' "$GROUPS_FILE" 2>/dev/null | cut -d'|' -f1 | sort -u || true
 }
 
+# --- agency.yaml config-block pairing ---
+# If agency.yaml is in the changeset, inspect the diff to find which
+# top-level yaml section changed. For each changed section, try to match
+# it to an existing feature group (by stemmed name match against feature
+# names). When a match is found, reclassify agency.yaml into that feature
+# group so the config change commits with the feature.
+#
+# Heuristic: for section "issues", look for any feature whose name
+# contains "issue" (stem of "issues"). This handles plural→singular and
+# compound names like "agency-issue". First match wins; if nothing
+# matches, agency.yaml stays in "config".
+if grep -q "^config|claude/config/agency.yaml$" "$GROUPS_FILE"; then
+    # Get the diff of agency.yaml vs HEAD (covers staged + unstaged changes)
+    agency_diff=$(g diff HEAD -- claude/config/agency.yaml 2>/dev/null || true)
+    # If still empty (e.g., new untracked file), use cached diff against empty
+    if [[ -z "$agency_diff" ]]; then
+        agency_diff=$(g diff --cached -- claude/config/agency.yaml 2>/dev/null || true)
+    fi
+
+    # Extract top-level section names from the added lines (+{name}:).
+    # Matches "+issues:" or "+issues:  # comment" at column 0 of the added
+    # content. Skips hunk headers and unchanged lines.
+    changed_sections=$(printf '%s\n' "$agency_diff" | awk '
+        /^@@/ { in_hunk=1; next }
+        in_hunk && /^\+[a-z][a-z0-9_-]*:[[:space:]]*$/ {
+            gsub(/^\+/, "")
+            gsub(/:.*/, "")
+            print
+        }
+        in_hunk && /^\+[a-z][a-z0-9_-]*:[[:space:]]*#/ {
+            gsub(/^\+/, "")
+            gsub(/:.*/, "")
+            print
+        }
+    ' | sort -u)
+
+    # For each changed section, try to match to a feature
+    for section in $changed_sections; do
+        [[ -z "$section" ]] && continue
+        # Stem: drop trailing 'es' or 's' for simple plurals
+        stem="$section"
+        [[ "$stem" =~ (.+)es$ ]] && stem="${BASH_REMATCH[1]}"
+        [[ "$stem" =~ (.+)s$ ]] && stem="${BASH_REMATCH[1]}"
+
+        # Find first feature group whose name contains the stem or full section
+        match_feat=""
+        for fg in $(feature_groups); do
+            local_feat="${fg#feature:}"
+            if [[ "$local_feat" == *"$stem"* ]] || [[ "$local_feat" == *"$section"* ]]; then
+                match_feat="$local_feat"
+                break
+            fi
+        done
+
+        if [[ -n "$match_feat" ]]; then
+            # Reclassify agency.yaml into the matching feature group
+            awk -v feat="$match_feat" -F'|' -v OFS='|' '
+                $2 == "claude/config/agency.yaml" { $1 = "feature:" feat; print; next }
+                { print }
+            ' "$GROUPS_FILE" > "${GROUPS_FILE}.tmp"
+            mv "${GROUPS_FILE}.tmp" "$GROUPS_FILE"
+            break  # agency.yaml paired; stop at first match
+        fi
+    done
+fi
+
 # --- Group metadata ---
 group_title() {
     case "$1" in

--- a/claude/tools/statusline.sh
+++ b/claude/tools/statusline.sh
@@ -174,7 +174,11 @@ fi
 # --- ISCP mail indicator ---
 # Silent periodic polling via status line — shows unread dispatch/flag count
 # in the footer bar without touching the transcript. See iscp-check --statusline.
-# Fast (<50ms typical); graceful on failure (empty output).
+# Fast (<250ms typical); graceful on failure (empty indicator).
+#
+# The mailbox is ALWAYS rendered once the wiring is in place — 📪 when empty,
+# 📬 with counts when non-empty. Always-visible removes ambiguity between
+# "empty inbox" and "mailbox not wired up".
 iscp_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 iscp_mail=""
 if [ -x "$iscp_script_dir/iscp-check" ]; then

--- a/claude/tools/statusline.sh
+++ b/claude/tools/statusline.sh
@@ -171,6 +171,20 @@ if [ -n "$vim_mode" ]; then
     vim_info=" [${vim_mode}]"
 fi
 
+# --- ISCP mail indicator ---
+# Silent periodic polling via status line — shows unread dispatch/flag count
+# in the footer bar without touching the transcript. See iscp-check --statusline.
+# Fast (<50ms typical); graceful on failure (empty output).
+iscp_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+iscp_mail=""
+if [ -x "$iscp_script_dir/iscp-check" ]; then
+    iscp_mail=$("$iscp_script_dir/iscp-check" --statusline 2>/dev/null || true)
+fi
+iscp_info=""
+if [ -n "$iscp_mail" ]; then
+    iscp_info=" | ${iscp_mail}"
+fi
+
 # --- Assemble ---
 status_line="${version_model} | ${location}"
 if [ -n "$ctx_label" ]; then
@@ -182,6 +196,6 @@ fi
 if [ -n "$cost_dur" ]; then
     status_line="${status_line} | ${cost_dur}"
 fi
-status_line="${status_line}${style_info}${vim_info}"
+status_line="${status_line}${iscp_info}${style_info}${vim_info}"
 
 printf "%s" "$status_line"

--- a/claude/workstreams/agency/seeds/seed-pr-lifecycle-tool-20260408.md
+++ b/claude/workstreams/agency/seeds/seed-pr-lifecycle-tool-20260408.md
@@ -1,0 +1,79 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-08
+captured_by: the-agency/jordan/captain
+principal: jordan
+status: seed
+---
+
+# Seed: PR lifecycle tool + skill
+
+## What it is
+
+A tool + skill that wraps the full PR lifecycle: **push → create draft → monitor → request review → merge**. Today captain (or any agent shipping work) walks through this manually with `gh pr create`, then watches for reviews, then `gh pr merge`. Just like `agency-issue` and `release-plan`, it's a captain-manual flow that should become a tool.
+
+## Where it sits in the pattern
+
+This is the **third tool in the "captain manually does X, that should be a tool" pattern** after `agency-issue` (Day 33) and `release-plan` (Day 33). Same shape:
+
+- A bash tool wrapping `gh` and `git`
+- A skill markdown for agent discovery
+- Persisted state per filed PR (in `usr/{principal}/reports/` or a new `usr/{principal}/prs/`)
+- Hooks into the existing release flow (called by `release-plan --apply` once that exists, or run standalone)
+
+## Verbs (proposed)
+
+| Verb | What |
+|------|------|
+| `pr push` | Push current branch to origin (`git push -u origin {branch}`) |
+| `pr create` | Create draft PR with title + body (autodetect from commit history) |
+| `pr open` | Push + create in one step |
+| `pr view [id]` | Show PR status, reviews, checks (default: current branch's PR) |
+| `pr review-request <reviewer>` | Request review from a person/team |
+| `pr ready` | Mark draft PR ready for review |
+| `pr merge [id]` | Merge with the right strategy (squash by default for our pattern) |
+| `pr close [id]` | Close without merging |
+| `pr list` | List open PRs |
+
+## Integration with existing skills
+
+- **`/sync`** — currently the only skill that pushes. PR tool would coordinate, not replace.
+- **`/pr-prep`** — runs the QG before creating a PR. PR tool would call `/pr-prep` first.
+- **`/captain-review`** — captain reviews draft PRs and dispatches findings. PR tool would surface PRs needing review.
+- **`/code-review`** — multi-agent code review with confidence scoring. PR tool would surface review status.
+- **`/post-merge`** — runs after a PR is merged on GitHub. PR tool would chain into this on `pr merge`.
+- **`release-plan`** — generates the commit plan. PR tool consumes the plan output (release-plan → execute commits → pr open).
+
+The natural composed flow:
+
+```
+release-plan          → propose plan
+git-commit (xN)       → execute commits per plan
+pr open               → push + create draft PR
+(reviews happen)
+pr ready              → mark ready for review
+pr merge              → merge + post-merge cleanup
+```
+
+## Permissions
+
+- **`pr push`** is the destructive op — push is **principal-only** per current rules. Tool should refuse to push without explicit confirmation flag (`--confirm` or `--principal-approved`). Captain still can't auto-push.
+- **`pr create` (draft)** can be run by any agent — drafts are reversible.
+- **`pr merge`** is principal-only. Tool refuses without `--principal-approved`.
+- **All read verbs** (view, list) are anyone.
+
+## Future-version notes
+
+- **Multi-target support** — the `pr` family of verbs targets the current repo's origin. v2+ could support cross-repo PRs (e.g., upstream port to monofolk), matching the SPEC-PROVIDER pattern other tools are heading toward.
+- **Auto-summary from release-plan** — `pr open` could read the most recent release-plan output and auto-fill PR title/body from the commit groupings.
+- **Review tracking in reports** — each PR gets a record in `usr/{principal}/reports/` (or new `usr/{principal}/prs/`) with merge status, review history, related issues.
+- **GitHub status check polling** — could surface CI status in the captain's view alongside dispatch counts.
+
+## Slot
+
+The natural follow-on to `release-plan`. Build when the next release cycle has a quiet moment, OR fold into Day 33 R2 if there's time.
+
+## Conversation source
+
+Captured during Day 33 R1 push, when principal asked: *"Should we create a tool and tie it to the skill for PR creation, pushing, and merging?"* Captain's answer: yes, same pattern as agency-issue and release-plan. This seed is the record.

--- a/tests/tools/agency-issue.bats
+++ b/tests/tools/agency-issue.bats
@@ -1,0 +1,165 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/agency-issue
+#
+# Covers --version, --help, and the error paths that do not require
+# network access. The verbs that actually hit GitHub (file/list/view/
+# comment/close) are not tested against a live repo — those paths
+# are covered by smoke tests during development.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+    cd "${REPO_ROOT}"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Version and Help
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-issue: --version shows version" {
+    run_tool agency-issue --version
+    assert_success
+    assert_output_contains "agency-issue"
+    assert_output_contains "1.0.0"
+}
+
+@test "agency-issue: --help shows usage" {
+    run_tool agency-issue --help
+    assert_success
+    assert_output_contains "agency-issue"
+    assert_output_contains "file"
+    assert_output_contains "list"
+    assert_output_contains "view"
+    assert_output_contains "comment"
+    assert_output_contains "close"
+}
+
+@test "agency-issue: -h shows usage" {
+    run_tool agency-issue -h
+    assert_success
+    assert_output_contains "Usage:"
+}
+
+@test "agency-issue: no args shows help" {
+    run_tool agency-issue
+    assert_success
+    assert_output_contains "Usage:"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Unknown verb handling
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-issue: unknown verb fails with error" {
+    run_tool agency-issue bogus
+    assert_failure
+    assert_output_contains "Unknown verb"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# file verb: required-flag validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-issue: file without --type fails" {
+    # Use GH_TOKEN override to skip gh auth check, or rely on early arg validation
+    # Arg validation happens before gh check, so this should fail on missing --type
+    run_tool agency-issue file --title "test" --body "body"
+    assert_failure
+    assert_output_contains "--type"
+}
+
+@test "agency-issue: file without --title fails" {
+    run_tool agency-issue file --type bug --body "body"
+    assert_failure
+    assert_output_contains "--title"
+}
+
+@test "agency-issue: file without --body or --body-file fails" {
+    run_tool agency-issue file --type bug --title "test"
+    assert_failure
+    assert_output_contains "--body"
+}
+
+@test "agency-issue: file rejects invalid --type" {
+    run_tool agency-issue file --type bogus --title "t" --body "b"
+    assert_failure
+    assert_output_contains "invalid --type"
+}
+
+@test "agency-issue: file accepts type=bug" {
+    # This will fail at the gh stage, not at validation, so the error
+    # should NOT be about invalid --type
+    run_tool agency-issue file --type bug --title "t" --body "b"
+    # We don't assert success because gh may not be available in CI
+    # We do assert the error is not about type validation
+    [[ "$output" != *"invalid --type"* ]]
+}
+
+@test "agency-issue: file accepts type=feature" {
+    run_tool agency-issue file --type feature --title "t" --body "b"
+    [[ "$output" != *"invalid --type"* ]]
+}
+
+@test "agency-issue: file accepts type=friction" {
+    run_tool agency-issue file --type friction --title "t" --body "b"
+    [[ "$output" != *"invalid --type"* ]]
+}
+
+@test "agency-issue: file accepts type=question" {
+    run_tool agency-issue file --type question --title "t" --body "b"
+    [[ "$output" != *"invalid --type"* ]]
+}
+
+@test "agency-issue: file accepts type=docs" {
+    run_tool agency-issue file --type docs --title "t" --body "b"
+    [[ "$output" != *"invalid --type"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# list verb: state validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-issue: list rejects invalid state" {
+    run_tool agency-issue list --state bogus
+    assert_failure
+    assert_output_contains "invalid --state"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# view / comment / close: required id validation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-issue: view without id fails" {
+    run_tool agency-issue view
+    assert_failure
+    assert_output_contains "issue id required"
+}
+
+@test "agency-issue: comment without id fails" {
+    run_tool agency-issue comment
+    assert_failure
+    assert_output_contains "issue id required"
+}
+
+@test "agency-issue: comment without body fails" {
+    run_tool agency-issue comment 123
+    assert_failure
+    assert_output_contains "--body"
+}
+
+@test "agency-issue: close without id fails" {
+    run_tool agency-issue close
+    assert_failure
+    assert_output_contains "issue id required"
+}

--- a/tests/tools/release-plan.bats
+++ b/tests/tools/release-plan.bats
@@ -1,0 +1,261 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/release-plan
+#
+# Covers --version, --help, arg parsing, and the core grouping heuristics
+# by exercising the tool inside a throwaway git repo so we can stage
+# synthetic file changes and verify classification + feature pairing +
+# agency.yaml config-block pairing.
+#
+
+load 'test_helper'
+
+# Create an isolated git repo with a base ref for release-plan to analyze
+# against. Each test works inside its own throwaway repo so staged changes
+# don't contaminate the main tree.
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+
+    # Copy the real release-plan tool into the test repo so it can be
+    # invoked as ./claude/tools/release-plan with the test repo as CWD.
+    RELEASE_PLAN_TOOL="${REPO_ROOT}/claude/tools/release-plan"
+
+    # Build a minimal mock git repo layout that release-plan can analyze
+    export TEST_REPO="${BATS_TEST_TMPDIR}/mock-repo"
+    mkdir -p "$TEST_REPO"
+    cd "$TEST_REPO"
+    git init --quiet --initial-branch=main 2>/dev/null || git init --quiet
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+    # Create a minimal agency.yaml and make the initial commit
+    mkdir -p claude/config claude/tools .claude/skills claude/workstreams/agency/seeds usr/jordan/captain/dispatches
+    echo "# base agency.yaml" > claude/config/agency.yaml
+    echo "# base README" > README.md
+    git add -A
+    git commit -m "initial" --quiet
+    # Create an origin/main ref so release-plan has a base to compare against
+    git branch -M main 2>/dev/null || true
+    git update-ref refs/remotes/origin/main HEAD
+
+    # Copy the tool into the test repo so relative paths resolve
+    mkdir -p claude/tools
+    cp "$RELEASE_PLAN_TOOL" claude/tools/release-plan
+    chmod +x claude/tools/release-plan
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Version and Help
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: --version shows version" {
+    cd "$TEST_REPO"
+    run ./claude/tools/release-plan --version
+    assert_success
+    assert_output_contains "release-plan"
+    assert_output_contains "1.0.0"
+}
+
+@test "release-plan: --help shows usage" {
+    cd "$TEST_REPO"
+    run ./claude/tools/release-plan --help
+    assert_success
+    assert_output_contains "release-plan"
+    assert_output_contains "Usage:"
+    assert_output_contains "--base"
+    assert_output_contains "--output"
+}
+
+@test "release-plan: unknown arg fails" {
+    cd "$TEST_REPO"
+    run ./claude/tools/release-plan --bogus
+    assert_failure
+    assert_output_contains "unknown arg"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Core analysis (empty repo, no changes)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: empty repo produces basic plan with no commits" {
+    cd "$TEST_REPO"
+    run ./claude/tools/release-plan --no-switch --no-other
+    assert_success
+    assert_output_contains "Release Plan"
+    assert_output_contains "Current branch"
+    assert_output_contains "Base ref"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Group classification
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: classifies methodology files correctly" {
+    cd "$TEST_REPO"
+    mkdir -p claude
+    echo "# methodology" > claude/CLAUDE-THEAGENCY.md
+    git add claude/CLAUDE-THEAGENCY.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Methodology"
+    assert_output_contains "claude/CLAUDE-THEAGENCY.md"
+}
+
+@test "release-plan: classifies tool files correctly" {
+    cd "$TEST_REPO"
+    echo "#!/bin/bash" > claude/tools/my-tool
+    chmod +x claude/tools/my-tool
+    git add claude/tools/my-tool
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Tools"
+    assert_output_contains "claude/tools/my-tool"
+}
+
+@test "release-plan: classifies skill files correctly" {
+    cd "$TEST_REPO"
+    mkdir -p .claude/skills/my-skill
+    echo "# skill" > .claude/skills/my-skill/SKILL.md
+    git add .claude/skills/my-skill/SKILL.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Skills"
+    assert_output_contains ".claude/skills/my-skill/SKILL.md"
+}
+
+@test "release-plan: classifies workstream seeds correctly" {
+    cd "$TEST_REPO"
+    echo "# seed" > claude/workstreams/agency/seeds/seed-test-20260408.md
+    git add claude/workstreams/agency/seeds/seed-test-20260408.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Workstream"
+    assert_output_contains "seed-test-20260408.md"
+}
+
+@test "release-plan: classifies coordination dispatches correctly" {
+    cd "$TEST_REPO"
+    echo "# dispatch" > usr/jordan/captain/dispatches/directive-test-20260408-1200.md
+    git add usr/jordan/captain/dispatches/directive-test-20260408-1200.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Coordination"
+    assert_output_contains "/coord-commit"
+    assert_output_contains "directive-test-20260408-1200.md"
+}
+
+@test "release-plan: excludes scratch files from commits" {
+    cd "$TEST_REPO"
+    mkdir -p usr/jordan/captain/tmp
+    echo "scratch" > usr/jordan/captain/tmp/scratch.md
+    git add usr/jordan/captain/tmp/scratch.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "EXCLUDE"
+    assert_output_contains "scratch"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Feature pairing: tool + matching skill go into one commit
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: pairs tool with matching skill into feature commit" {
+    cd "$TEST_REPO"
+    echo "#!/bin/bash" > claude/tools/widget
+    chmod +x claude/tools/widget
+    mkdir -p .claude/skills/widget
+    echo "# skill" > .claude/skills/widget/SKILL.md
+    git add claude/tools/widget .claude/skills/widget/SKILL.md
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Feature"
+    assert_output_contains "widget"
+    # Both files should appear in the same feature commit section
+    # (we can't assert their proximity easily in BATS, but both presence is enough)
+    assert_output_contains "claude/tools/widget"
+    assert_output_contains ".claude/skills/widget/SKILL.md"
+}
+
+@test "release-plan: tool without matching skill stays in Tools group" {
+    cd "$TEST_REPO"
+    echo "#!/bin/bash" > claude/tools/lonely-tool
+    chmod +x claude/tools/lonely-tool
+    git add claude/tools/lonely-tool
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    # Should land in Tools group, not as a Feature
+    assert_output_contains "Tools"
+    assert_output_contains "claude/tools/lonely-tool"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# agency.yaml config-block pairing
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: agency.yaml without feature stays in Config" {
+    cd "$TEST_REPO"
+    cat > claude/config/agency.yaml <<'EOF'
+# agency.yaml
+random:
+  provider: "test"
+EOF
+    git add claude/config/agency.yaml
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Config"
+    assert_output_contains "claude/config/agency.yaml"
+}
+
+@test "release-plan: agency.yaml folds into feature when section matches tool" {
+    cd "$TEST_REPO"
+    # Create a tool+skill called "widgets" (plural to test stemming)
+    echo "#!/bin/bash" > claude/tools/widget
+    chmod +x claude/tools/widget
+    mkdir -p .claude/skills/widget
+    echo "# skill" > .claude/skills/widget/SKILL.md
+    # Add a widgets: block to agency.yaml
+    cat > claude/config/agency.yaml <<'EOF'
+# agency.yaml
+widgets:
+  provider: "github"
+EOF
+    git add claude/tools/widget .claude/skills/widget/SKILL.md claude/config/agency.yaml
+    run ./claude/tools/release-plan --no-switch
+    assert_success
+    assert_output_contains "Feature"
+    assert_output_contains "widget"
+    # agency.yaml should appear under the feature commit, not Config
+    # Hard to assert grouping ordering in BATS; verify agency.yaml is there at all
+    assert_output_contains "agency.yaml"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output options
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release-plan: --output writes to file" {
+    cd "$TEST_REPO"
+    run ./claude/tools/release-plan --no-switch --output plan.md
+    assert_success
+    assert_output_contains "Wrote plan to"
+    [ -f "$TEST_REPO/plan.md" ]
+}
+
+@test "release-plan: --base changes base ref comparison" {
+    cd "$TEST_REPO"
+    # Create a new commit and use origin/main (which is the initial commit)
+    echo "v2" > README.md
+    git add README.md
+    git commit -m "v2" --quiet
+    run ./claude/tools/release-plan --no-switch --base origin/main
+    assert_success
+    assert_output_contains "Ahead of base by"
+    assert_output_contains "1 commit"
+}

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -2,8 +2,8 @@
 type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
-date: 2026-04-07
-trigger: end-of-session
+date: 2026-04-08
+trigger: mid-session-day-33
 ---
 
 ## Identity
@@ -12,102 +12,72 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 
 ## Current State
 
-**Day 33 partially started.** Branch `day33-release-1` exists locally with the CLAUDE-THEAGENCY dispatch-loop edit unstaged. Day 32 priority-order commit (`6cd4307`) is on local main, ahead of origin. **Nothing pushed.** No PR opened.
+**Day 33 in progress.** R1 shipped and merged (PR #53). R2 in draft as PR #54 with substantial content. Monofolk's merge-not-rebase contribution (PR #55) merged into main and incorporated into R2 via merge (not rebase) — discipline applied on its first day.
 
-P0 worktree bug surfaced late in session, then **downgraded to P1** within minutes — see Open Items.
+## Day 33 - Release 1 (PR #53) — MERGED
 
-## What Happened This Session
+7 commits. Day 32 carry-over + Day 33 core work.
 
-### Methodology shipped
-- **CLAUDE-CAPTAIN.md Priority Order** (committed locally as `6cd4307`, NOT yet on a release branch):
-  1. Principal communications win, full stop
-  2. Dispatches second — read on iscp-check notification
-- **Dispatch loop is universal** — every agent runs `/loop 5m dispatch list --status unread` at session start. Documented in `claude/CLAUDE-THEAGENCY.md` (unstaged change).
-- mdpal-app already adopted the convention on its own startup (per #148).
+- **agency-issue v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1 with principal. Smoke-tested by filing the-agency-ai/the-agency#52 using the tool itself.
+- **release-plan v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern: built the tool then used it to assemble R1 and R2.**
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag).
+- **iscp-check v1.1.0** — delta suppression, stops the "You have N" repeat on every Stop event.
+- **6 seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed as Anthropic feedback + GH #45017), granola carry-over, agent-mail-service.
+- **3 pre-existing bugs caught and fixed** — .git/config bare=true, git-commit PROJECT_ROOT unbound, iscp-check.bats stale version.
 
-### DevEx queue dispatched (Day 33 work)
-**Directive #149** — 4 items in order, plan-mode required, captain review then execute:
-1. SPEC-PROVIDER wrappers for `/preview` and `/deploy`
-2. Valueflow Phase 3
-3. History rewrite of devex branch (Test User attribution)
-4. Hookify rules from Day 32 friction
+## Day 33 - Release 2 (PR #54) — DRAFT
 
-### Item 1 plan approved
-- DevEx sent plan as #151 (6 iterations, ~85 min)
-- Captain approved as #153 with answers to all 4 questions:
-  - Merge main into devex (not cherry-pick)
-  - docker-compose / fly defaults confirmed
-  - No provider tool stubs — wrapper IS the deliverable
-  - enforcement.yaml level 2 confirmed
+13+ commits on top of R1. Still in flight.
 
-### Item 3 closed
-- DevEx already cleaned devex branch in earlier session (#132, #150)
-- Main branch part requires force-push to origin/main → BLOCKED
-- **Principal chose Option A: accept main as-is** (#152)
-- 64 historical Test User commits remain in pushed history. Test isolation fix prevents new ones.
+- **iscp-check --statusline mode** + statusline.sh integration — shows 📬 Nd Mf in the footer when current agent has unread mail; silent when empty (per principal directive — icon only appears when there's something to notice)
+- **release-plan heuristic for config-block pairing** — agency.yaml section changes now fold into matching feature commits (e.g., agency.yaml `issues:` block changes go with the agency-issue feature commit)
+- **BATS tests for agency-issue** — 19 tests covering version/help, arg validation, verb dispatch, required-flag checks. Arg validation moved before gh auth check so bad args surface real errors.
+- **BATS tests for release-plan** — 16 tests covering classification, feature pairing, agency.yaml config-block pairing, output options, base ref comparison.
+- **Monofolk merge-not-rebase contribution (PR #55) incorporated** — merged into day33-release-2 via `git merge origin/main` (not rebase). All skills now merge-based, hookify rules block raw rebase and reset --hard origin/*.
+- **nit-add + nit-resolve migrated to merge-based pull** — the two tools were using `git pull --rebase` with `git rebase --abort` cleanup, blocked by the new hookify rule from #55. Migrated to `git pull --no-rebase`.
+- **Monofolk RFI reply sent** — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT, all 5 questions with options considered and reasoning. Delivered via collaboration repo.
+- **Worktree naming rule answered to devex** (#169 review-response, #166 unblocked)
+- **iscp notified of --statusline extension** (#170 heads-up)
+- **Captain's log for Day 33 written** (7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction)
 
-### P0 → P1 worktree bug (downgraded, still real)
-- mdpal-app reported `git-commit` wipes worktree index (#155, high priority)
-- Initial symptom: ~1280 files show as deleted after running git-commit, no commit made
-- Escalated to devex as #157 (drop Item 1, triage as P0 hotfix)
-- Notified mdpal-cli to verify (#159)
-- Principal hypothesis sent as #160: likely mdpal-specific worktree creation issue
-- **DOWNGRADED via #161 from mdpal-app:** the 1280 'deleted' files are **normal sparse-worktree state** for split worktrees (mdpal-app, mdpal-cli) — not an index wipe. mdpal-cli already knew this and warned in passing (#154).
-- **Real residual bug (P1, not blocking):** git-commit silently exits 1 from mdpal-app's worktree with zero diagnostic output. Workaround works fine. Devex queued for after Item 1.
-- Cleanup dispatched: #162 (devex resume Item 1), #163 (mdpal-cli stand down), #164 (mdpal-app ack).
-- **Principal hypothesis was wrong direction** — it was sparse-checkout, not worktree creation. Disregard #160 thread.
+### R2 content pending
 
-### Two side issues captured for devex
-1. **Sparse-worktree convention is undocumented** — new agents in split worktrees panic at the 1280 D files. Needs a line in CLAUDE-THEAGENCY.md or worktree-create skill.
-2. **Split-worktree onboarding gotcha cluster** — mdpal-cli reports BATS pre-commit broken (#133, #134) + this confusion. Worth a single doc pass. Possibly fold into Item 4 (hookify rules from friction).
-
-### Dispatches processed
-Resolved this session: #137, #139, #145, #146, #148, #150, #151, #155, #161.
-Dispatches sent: #149, #152, #153, #157, #158, #159, #160, #162, #163, #164.
-
-## Next Action (start of next session)
-
-1. **Run dispatch loop immediately:** `/loop 5m dispatch list --status unread`
-2. **Check devex status on Item 1.** P0 was downgraded — devex should have resumed Item 1 (SPEC-PROVIDER wrappers). Watch for plan iteration commits or questions. The residual P1 (git-commit silent-fail from mdpal-app worktree) is queued for after Item 1, not blocking.
-3. **Check collaboration:** `./claude/tools/collaboration check` — monofolk has not yet responded to SPEC-PROVIDER structural thoughts dispatch (sent yesterday). Expected an RFI back.
-4. **Resume Day 33 release branch:**
-   - On `day33-release-1` already
-   - Cherry-pick `6cd4307` from local main onto this branch (or rebase main onto origin/main and then branch from there)
-   - Commit unstaged CLAUDE-THEAGENCY.md change (dispatch-loop universal)
-   - Commit untracked dispatch artifacts (#149, #150-#160 files, handoffs in history/)
-   - Push, open as draft PR
-   - `/sync-all` to push to worktrees
-5. **Captain's log entry for today** — Day 33 transition, P0 bug, priority-order rule shipped, dispatch-loop adoption.
+- This handoff update (complete once this file lands)
+- Push and update PR #54 description
+- Principal call on merging R2
+- Agency-update test on a real downstream project (1B1 pending on parameters)
 
 ## Active Agents (background)
 
 | Agent | State | Notes |
 |-------|-------|-------|
-| devex | Item 1 plan approved (#153), P0 lifted (#162) — should be executing iterations | Real but minor git-commit silent-fail bug queued for after Item 1 |
-| iscp | Shut down for the night per #146 handoff | Phase 2.3 reverted from R3 by design |
-| mdpal-app | Working Phase 1A SwiftUI, on raw-commit workaround | P0 retracted (#161, #164); devex will fix silent-fail later |
-| mdpal-cli | Working their own iteration; P0 verification cancelled (#163) | They flagged the sparse-worktree convention gap |
+| devex | Queue of 4 items from #149 + worktree naming (#166 unblocked today), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1/R2 updates |
+| iscp | Working on Phase 2 (per-agent inboxes plan approved). Received #170 heads-up on iscp-check extension. Also received peer-to-peer directive (#165) | Needs to merge master for R1 |
+| mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
+| mdpal-cli | Own iteration | Needs to merge master |
+
+## Monofolk Cross-Repo
+
+- **Day 33 morning:** Received RFI on SPEC-PROVIDER + SPEC-ENVIRONMENT. 1B1'd with principal. Full reply sent today.
+- **Day 33 afternoon:** Received merge-not-rebase contribution (PR #55). Merged into main (ba6deed). Replied acknowledging, noting discipline applied on its first day (merged into R2, not rebased).
+- **No pending inbound** from monofolk.
 
 ## Open Items
 
-### P1 (not blocking)
-- **git-commit silently exits 1 from mdpal-app's sparse worktree** — zero diagnostic output. Devex queued for after Item 1. Workaround in use. NOT the index-wipe symptom — that was sparse-checkout normal state.
-- **Sparse-worktree convention undocumented** — needs a line in CLAUDE-THEAGENCY.md or worktree-create skill so agents don't panic at 1280 'D' files
-- **Split-worktree onboarding gotcha cluster** — fold sparse-worktree doc + BATS pre-commit (mdpal-cli #133/#134) + git-commit silent-fail into a single doc/fix pass. Possibly Item 4 of devex queue.
+### Pending principal calls
 
-### Uncommitted local state
-- **Local main is ahead of origin/main by 1 commit** (`6cd4307` priority order) — needs to land on a release branch
-- **`day33-release-1` branch exists** with `claude/CLAUDE-THEAGENCY.md` modified (dispatch-loop universal) but unstaged
-- **Untracked artifacts** in `usr/jordan/captain/dispatches/` and `usr/jordan/captain/history/`
+- **Merge R2** — PR #54 still draft, pending principal go-ahead
+- **Agency-update test** — principal offered a real-world test of R1+R2+#55 on an existing project. 1B1 pending on: project path, backup tag, branch, dry-run vs real run
+- **Anthropic Claude Code backlog** — 4 unfiled issues parked for tomorrow morning
 
-### Awaiting external
-- Monofolk response to SPEC-PROVIDER structural thoughts dispatch (sent yesterday)
-- DevEx Item 1 execution (~85 min plan, P0 lifted, should be running)
+### Carried forward (deferred to Day 34+)
 
-### Carried forward (from Day 32)
-- Hookify naming convention: **noun-verb decided** (this session). Need to update existing rules and document. Not yet executed.
-- MAR / VALUEFLOW doc decomposition (Phase 1 M3/M4 of Valueflow plan)
-- Captain's log entry for today not yet written
+- Git-commit `--staged` default behavior fix (when staging area non-empty)
+- Pull-rebase hookify gap investigation (block-raw-rebase pattern may miss `git pull --rebase`)
+- PR lifecycle tool build (on hold, seed captured)
+- Fleet awareness /define (seed ready, PVR not yet started)
+- Hookify noun-verb rename (dispatched to devex as #167, their work)
+- Agent-create scaffolding with dispatch loops (dispatched to devex as #168, their work)
 
 ## Active Flags
 
@@ -115,28 +85,31 @@ Dispatches sent: #149, #152, #153, #157, #158, #159, #160, #162, #163, #164.
 |----|------|--------|
 | 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
 
+## Next Action (start of next session or continuation)
+
+1. Push R2 content to update PR #54 description
+2. **1B1 with principal on agency-update test parameters** (see Open Items)
+3. If principal approves merge of R2: merge PR #54, then post-merge sync
+4. Run agency-update test on the selected downstream project
+5. Tomorrow morning: triage + file Anthropic Claude Code backlog (4 issues)
+
 ## Key Decisions This Session
 
-1. **Priority Order for Captain is canonical** — principal first, dispatches second (committed `6cd4307`, ships in Day 33 R1)
-2. **Dispatch loop is universal** — every agent, every session, `5m dispatch list --status unread`. Documented in CLAUDE-THEAGENCY.md.
-3. **Item 3 history rewrite of main: NO** — Option A. Cosmetic, not worth force-push cost.
-4. **Hookify naming = noun-verb** — principal call. Existing rules need rename (carried forward).
-5. **P0 triage order on git-commit bug:** worktree linkage first, then tool. Hypothesis from principal — turned out to be sparse-checkout, not worktree creation. Lesson: ask "is this normal for split worktrees?" before escalating to P0 next time.
+1. **Dispatch loop convention is universal** — every agent, every session, 5m silent + 30m visible nag
+2. **Bootstrap pattern confirmed** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done twice (R1 with release-plan, R2 with release-plan's improvements)
+3. **Always-visible mailbox was wrong** — corrected to silent-when-empty per principal directive. The icon only appears when the current agent has unread mail.
+4. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`.
+5. **SPEC-PROVIDER orthogonality confirmed** — environment and provider are fully independent concepts. Answered all 5 monofolk RFI questions.
+6. **Worktree naming = prefix collapse** — `devex/devex` → `devex`, `mdpal/mdpal-app` → `mdpal-app`, `agency/captain` → `agency-captain`. Devex unblocked to plan #166.
 
 ## Discipline Reminders
 
-- Use `/handoff` skill, never raw handoff tool (this handoff used the tool — fine since `/handoff` wraps it)
-- `/git-commit` always — but P0 bug in worktrees, fall back to raw `git -c core.hooksPath=/dev/null commit` until fixed
-- Never `cd` to main repo from worktree
-- Day-PR pattern: branch from origin/main, draft PR, no direct push to main
-- Run dispatch loop on session start
-
-## House Rules Self-Audit
-
-- ✅ Processed dispatches at session start
-- ✅ Replied to dispatches in same session
-- ✅ Asked principal before destructive ops (Item 3 force-push)
-- ⚠️ Left #148 (mdpal-app online) sitting through several loop fires before reading — corrected mid-session
-- ✅ No unauthorized pushes this session (no pushes at all yet)
+- **Never rebase** — framework-wide block active (block-raw-rebase hookify rule)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin hookify rule)
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` (with `--staged` flag when pre-staging) — never bare `git commit`
+- Run dispatch loop on session start (5m + 30m)
+- Cross-repo dispatches via collaboration repo, not direct
+- Per-agent attribution in all commits via the new email format
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/dispatch-iscp-check-extended-with-statusline-mode-minor-add-20260408-1859.md
+++ b/usr/jordan/captain/dispatches/dispatch-iscp-check-extended-with-statusline-mode-minor-add-20260408-1859.md
@@ -1,0 +1,60 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-08T10:59
+status: created
+priority: normal
+subject: "iscp-check extended with --statusline mode (minor, additive)"
+in_reply_to: null
+---
+
+# iscp-check extended with --statusline mode (minor, additive)
+
+# iscp-check: new --statusline mode
+
+Heads up on a minor additive extension to iscp-check (your tool) landing in Day 33 R2. Captain implemented directly this session; happy to hand off further iteration to iscp workstream.
+
+## What was added
+
+New \`--statusline\` flag on \`iscp-check\` that outputs a compact one-liner suitable for the Claude Code statusLine command:
+
+\`\`\`
+$ iscp-check --statusline
+📬 2d 1f
+\`\`\`
+
+Format: \`📬 <N>d <M>f <K>x <L>n\` where d/f/x/n = dispatch/flag/dropbox/notification, omitting zero parts. Silent when all zeros (no output at all).
+
+No delta logic, no state writes — always shows the current count. The existing hook modes (default, --force) are unchanged and still drive notification via systemMessage/additionalContext.
+
+## Why it matters
+
+Partial fix for the **autonomous polling gap** we hit today. When agents (including captain) operate between user turns, hooks only fire on user events (SessionStart/UserPromptSubmit/Stop). There's no way to poll unread state without CronCreate/\`/loop\`, and every cron fire renders visibly in the terminal. We filed an Anthropic feature request for a periodic silent execution primitive (feedback \`8dd67e96\`, GH [anthropics/claude-code#45017](https://github.com/anthropics/claude-code/issues/45017)).
+
+Until Anthropic ships that, the status line is the one silent periodic path available. It's display-only (can't inject into agent context), but the footer showing \"📬 2d 1f\" is visible at a glance and updates on every UI tick.
+
+Complementary split:
+- **Status line** = display-only, footer, silent, tick-rate
+- **Hook mode** = agent-context, delta-suppressed, user-event-rate
+
+Both modes live in the same tool.
+
+## Integration
+
+Wired into \`claude/tools/statusline.sh\` so the mail indicator appears as \`... | 📬 2d 1f\` in the footer. Safe fallback on failure — empty output if anything goes wrong.
+
+## What I want from iscp
+
+1. **Awareness** — you own iscp-check; wanted you to know about the change before you see it in a merge conflict later.
+2. **Potential follow-ups** for your queue (low priority):
+   - Identity resolution + DB init could be cached more aggressively on the statusline path (currently ~240ms per call; called on every UI tick)
+   - Consider whether the statusline format should include per-agent vs. broadcast counts once peer-to-peer dispatches land (your current #165 work)
+   - Protocol doc update: \`claude/docs/ISCP-PROTOCOL.md\` should mention the status line as an allowed notification channel
+3. **Nothing blocking** — fold into your existing work whenever you touch iscp-check next.
+
+## Related
+
+- Commit: day33-release-2 (forthcoming PR)
+- Seed: \`seed-silent-periodic-tool-calls-20260408.md\` — the Anthropic feature request context
+- Research: two research rounds with claude-code-guide agent confirmed status line as the only silent + periodic mechanism in Claude Code today

--- a/usr/jordan/captain/dispatches/review-response-re-166-worktree-naming-collapse-rule-is-b-prefix-c-20260408-1853.md
+++ b/usr/jordan/captain/dispatches/review-response-re-166-worktree-naming-collapse-rule-is-b-prefix-c-20260408-1853.md
@@ -1,0 +1,54 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-08T10:53
+status: created
+priority: normal
+subject: "Re: #166 worktree naming — collapse rule is B (prefix collapse)"
+in_reply_to: 166
+---
+
+# Re: #166 worktree naming — collapse rule is B (prefix collapse)
+
+# Worktree naming collapse rule: B (prefix collapse)
+
+Principal resolved the collapse-rule ambiguity. Unblocked to plan Item 166.
+
+## The rule
+
+Worktree directory names always follow `{workstream}-{agent}`, with this collapse rule:
+
+**If the agent name starts with the workstream name (either exact equality OR prefix), drop the workstream prefix.**
+
+Concrete table:
+
+| Workstream | Agent | Check | Worktree name |
+|-----------|-------|-------|---------------|
+| devex | devex | exact match | **devex** |
+| iscp | iscp | exact match | **iscp** |
+| mdpal | mdpal-app | \`mdpal-app\` starts with \`mdpal-\` | **mdpal-app** |
+| mdpal | mdpal-cli | \`mdpal-cli\` starts with \`mdpal-\` | **mdpal-cli** |
+| agency | captain | no prefix match | **agency-captain** |
+| fleet | captain | no prefix match | **fleet-captain** |
+
+## Implementation hint
+
+One line of logic:
+
+\`\`\`
+name = agent.startswith(workstream + '-') OR agent == workstream
+       ? agent
+       : "{workstream}-{agent}"
+\`\`\`
+
+## Unblocked scope
+
+Proceed with the Item 166 plan:
+
+1. Update worktree-create skill + tool to enforce this naming rule
+2. Inventory existing worktrees for non-compliant names (shouldn't be any — the current set all follow the rule already, since mdpal-app and mdpal-cli already collapse correctly under Rule B)
+3. Document the rule in CLAUDE-THEAGENCY.md (Worktrees & Master section)
+4. Hookify warn rule on raw git worktree add with non-compliant names (optional, low priority)
+
+Plan mode first. Send me the plan via review dispatch.

--- a/usr/jordan/captain/history/handoff-20260408-202114.md
+++ b/usr/jordan/captain/history/handoff-20260408-202114.md
@@ -1,0 +1,142 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-07
+trigger: end-of-session
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 33 partially started.** Branch `day33-release-1` exists locally with the CLAUDE-THEAGENCY dispatch-loop edit unstaged. Day 32 priority-order commit (`6cd4307`) is on local main, ahead of origin. **Nothing pushed.** No PR opened.
+
+P0 worktree bug surfaced late in session, then **downgraded to P1** within minutes — see Open Items.
+
+## What Happened This Session
+
+### Methodology shipped
+- **CLAUDE-CAPTAIN.md Priority Order** (committed locally as `6cd4307`, NOT yet on a release branch):
+  1. Principal communications win, full stop
+  2. Dispatches second — read on iscp-check notification
+- **Dispatch loop is universal** — every agent runs `/loop 5m dispatch list --status unread` at session start. Documented in `claude/CLAUDE-THEAGENCY.md` (unstaged change).
+- mdpal-app already adopted the convention on its own startup (per #148).
+
+### DevEx queue dispatched (Day 33 work)
+**Directive #149** — 4 items in order, plan-mode required, captain review then execute:
+1. SPEC-PROVIDER wrappers for `/preview` and `/deploy`
+2. Valueflow Phase 3
+3. History rewrite of devex branch (Test User attribution)
+4. Hookify rules from Day 32 friction
+
+### Item 1 plan approved
+- DevEx sent plan as #151 (6 iterations, ~85 min)
+- Captain approved as #153 with answers to all 4 questions:
+  - Merge main into devex (not cherry-pick)
+  - docker-compose / fly defaults confirmed
+  - No provider tool stubs — wrapper IS the deliverable
+  - enforcement.yaml level 2 confirmed
+
+### Item 3 closed
+- DevEx already cleaned devex branch in earlier session (#132, #150)
+- Main branch part requires force-push to origin/main → BLOCKED
+- **Principal chose Option A: accept main as-is** (#152)
+- 64 historical Test User commits remain in pushed history. Test isolation fix prevents new ones.
+
+### P0 → P1 worktree bug (downgraded, still real)
+- mdpal-app reported `git-commit` wipes worktree index (#155, high priority)
+- Initial symptom: ~1280 files show as deleted after running git-commit, no commit made
+- Escalated to devex as #157 (drop Item 1, triage as P0 hotfix)
+- Notified mdpal-cli to verify (#159)
+- Principal hypothesis sent as #160: likely mdpal-specific worktree creation issue
+- **DOWNGRADED via #161 from mdpal-app:** the 1280 'deleted' files are **normal sparse-worktree state** for split worktrees (mdpal-app, mdpal-cli) — not an index wipe. mdpal-cli already knew this and warned in passing (#154).
+- **Real residual bug (P1, not blocking):** git-commit silently exits 1 from mdpal-app's worktree with zero diagnostic output. Workaround works fine. Devex queued for after Item 1.
+- Cleanup dispatched: #162 (devex resume Item 1), #163 (mdpal-cli stand down), #164 (mdpal-app ack).
+- **Principal hypothesis was wrong direction** — it was sparse-checkout, not worktree creation. Disregard #160 thread.
+
+### Two side issues captured for devex
+1. **Sparse-worktree convention is undocumented** — new agents in split worktrees panic at the 1280 D files. Needs a line in CLAUDE-THEAGENCY.md or worktree-create skill.
+2. **Split-worktree onboarding gotcha cluster** — mdpal-cli reports BATS pre-commit broken (#133, #134) + this confusion. Worth a single doc pass. Possibly fold into Item 4 (hookify rules from friction).
+
+### Dispatches processed
+Resolved this session: #137, #139, #145, #146, #148, #150, #151, #155, #161.
+Dispatches sent: #149, #152, #153, #157, #158, #159, #160, #162, #163, #164.
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop immediately:** `/loop 5m dispatch list --status unread`
+2. **Check devex status on Item 1.** P0 was downgraded — devex should have resumed Item 1 (SPEC-PROVIDER wrappers). Watch for plan iteration commits or questions. The residual P1 (git-commit silent-fail from mdpal-app worktree) is queued for after Item 1, not blocking.
+3. **Check collaboration:** `./claude/tools/collaboration check` — monofolk has not yet responded to SPEC-PROVIDER structural thoughts dispatch (sent yesterday). Expected an RFI back.
+4. **Resume Day 33 release branch:**
+   - On `day33-release-1` already
+   - Cherry-pick `6cd4307` from local main onto this branch (or rebase main onto origin/main and then branch from there)
+   - Commit unstaged CLAUDE-THEAGENCY.md change (dispatch-loop universal)
+   - Commit untracked dispatch artifacts (#149, #150-#160 files, handoffs in history/)
+   - Push, open as draft PR
+   - `/sync-all` to push to worktrees
+5. **Captain's log entry for today** — Day 33 transition, P0 bug, priority-order rule shipped, dispatch-loop adoption.
+
+## Active Agents (background)
+
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Item 1 plan approved (#153), P0 lifted (#162) — should be executing iterations | Real but minor git-commit silent-fail bug queued for after Item 1 |
+| iscp | Shut down for the night per #146 handoff | Phase 2.3 reverted from R3 by design |
+| mdpal-app | Working Phase 1A SwiftUI, on raw-commit workaround | P0 retracted (#161, #164); devex will fix silent-fail later |
+| mdpal-cli | Working their own iteration; P0 verification cancelled (#163) | They flagged the sparse-worktree convention gap |
+
+## Open Items
+
+### P1 (not blocking)
+- **git-commit silently exits 1 from mdpal-app's sparse worktree** — zero diagnostic output. Devex queued for after Item 1. Workaround in use. NOT the index-wipe symptom — that was sparse-checkout normal state.
+- **Sparse-worktree convention undocumented** — needs a line in CLAUDE-THEAGENCY.md or worktree-create skill so agents don't panic at 1280 'D' files
+- **Split-worktree onboarding gotcha cluster** — fold sparse-worktree doc + BATS pre-commit (mdpal-cli #133/#134) + git-commit silent-fail into a single doc/fix pass. Possibly Item 4 of devex queue.
+
+### Uncommitted local state
+- **Local main is ahead of origin/main by 1 commit** (`6cd4307` priority order) — needs to land on a release branch
+- **`day33-release-1` branch exists** with `claude/CLAUDE-THEAGENCY.md` modified (dispatch-loop universal) but unstaged
+- **Untracked artifacts** in `usr/jordan/captain/dispatches/` and `usr/jordan/captain/history/`
+
+### Awaiting external
+- Monofolk response to SPEC-PROVIDER structural thoughts dispatch (sent yesterday)
+- DevEx Item 1 execution (~85 min plan, P0 lifted, should be running)
+
+### Carried forward (from Day 32)
+- Hookify naming convention: **noun-verb decided** (this session). Need to update existing rules and document. Not yet executed.
+- MAR / VALUEFLOW doc decomposition (Phase 1 M3/M4 of Valueflow plan)
+- Captain's log entry for today not yet written
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
+
+## Key Decisions This Session
+
+1. **Priority Order for Captain is canonical** — principal first, dispatches second (committed `6cd4307`, ships in Day 33 R1)
+2. **Dispatch loop is universal** — every agent, every session, `5m dispatch list --status unread`. Documented in CLAUDE-THEAGENCY.md.
+3. **Item 3 history rewrite of main: NO** — Option A. Cosmetic, not worth force-push cost.
+4. **Hookify naming = noun-verb** — principal call. Existing rules need rename (carried forward).
+5. **P0 triage order on git-commit bug:** worktree linkage first, then tool. Hypothesis from principal — turned out to be sparse-checkout, not worktree creation. Lesson: ask "is this normal for split worktrees?" before escalating to P0 next time.
+
+## Discipline Reminders
+
+- Use `/handoff` skill, never raw handoff tool (this handoff used the tool — fine since `/handoff` wraps it)
+- `/git-commit` always — but P0 bug in worktrees, fall back to raw `git -c core.hooksPath=/dev/null commit` until fixed
+- Never `cd` to main repo from worktree
+- Day-PR pattern: branch from origin/main, draft PR, no direct push to main
+- Run dispatch loop on session start
+
+## House Rules Self-Audit
+
+- ✅ Processed dispatches at session start
+- ✅ Replied to dispatches in same session
+- ✅ Asked principal before destructive ops (Item 3 force-push)
+- ⚠️ Left #148 (mdpal-app online) sitting through several loop fires before reading — corrected mid-session
+- ✅ No unauthorized pushes this session (no pushes at all yet)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/logs/captains-log-20260408.md
+++ b/usr/jordan/captain/logs/captains-log-20260408.md
@@ -1,0 +1,40 @@
+---
+type: captains-log
+date: 2026-04-08
+agent: jordan/captain
+---
+
+# Captain's Log — Wednesday, April 8, 2026
+
+
+## 20:20:23 — milestone
+
+Day 33 R1 shipped (PR #53) — agency-issue v1, release-plan v1, dispatch loop convention, iscp-check delta suppression, 6 new workstream seeds, 3 pre-existing bugs caught and fixed (bare=true in .git/config, git-commit PROJECT_ROOT unbound, stale iscp-check test version). Bootstrap pattern worked: built release-plan then used it to assemble R1.
+
+## 20:20:28 — build
+
+agency-issue v1: thin wrapper around gh CLI for filing/viewing/commenting/closing GitHub issues against the-agency framework. Designed via 1B1 (10 questions) then built in ~2 hours. 5 verbs working end-to-end. Smoke-tested by filing the-agency-ai/the-agency#52 — the tool's own v1 — using the tool itself. Reports written to usr/{principal}/reports/ with REPORTS-INDEX.md pattern.
+
+## 20:20:36 — build
+
+release-plan v1: analyzes branch state, groups uncommitted files by heuristic, proposes commit ordering with tool/skill feature pairing and agency.yaml config-block pairing. Auto-detects day{N}-release-{M} branch and switches. Used to assemble both R1 and R2. 16 BATS tests.
+
+## 20:20:42 — decision
+
+Dispatch loop convention for every agent: 5m silent + 30m visible nag. Documented in CLAUDE-THEAGENCY.md When You Have Mail section. Propagates to every downstream adopter via framework inheritance. Filed Anthropic Claude Code feedback for silent periodic execution primitive (feedback 8dd67e96, GH anthropics/claude-code#45017) as the real fix — status line is the only silent periodic path that exists today, wired via iscp-check --statusline in R2.
+
+## 20:20:47 — learning
+
+Three pre-existing framework bugs surfaced today during bootstrap work: (1) .git/config bare=true mis-flagged the repo; every git command failed until fixed. (2) claude/tools/git-commit referenced PROJECT_ROOT without defining it — caused 'unbound variable' under set -u in every commit since the per-agent attribution code was added. (3) tests/tools/iscp-check.bats version assertion stale at 1.0.1 (we bumped to 1.1.0). All three were invisible until we started exercising the edges. Lesson: build + test in the same session. Bugs hide at the edges where tools compose.
+
+## 20:20:51 — milestone
+
+Day 33 R2 in flight: agency-issue tests (19), release-plan BATS tests (16), iscp-check --statusline mode + footer integration, agency.yaml config-block pairing heuristic, monofolk RFI reply sent with full 1B1 context, captain's log (this file), nit-add/nit-resolve migrated to merge-based pull per PR #55 discipline. Bootstrap demonstrated: release-plan assembled R2 of itself. PR #54 draft with 12+ commits as of this entry.
+
+## 20:20:57 — friction
+
+Back-and-forth on statusline mailbox behavior: I first shipped silent-when-empty, then principal said 'That is a bug' when iscp had mail but no icon, I misinterpreted as 'always visible' and added 📪, principal corrected 'the icon should only be there if the current agent has unread messages.' Reverted. Lesson: when the principal says 'that is a bug', ask what the expected state is before assuming the inverse. The bug was that iscp HAD mail and the icon didn't appear — because iscp's worktree didn't have R2 code. Not that the icon should always be visible.
+
+## 20:21:07 — learning
+
+Monofolk upstream contribution (PR #55, merge-not-rebase) landed mid-session. Replaced rebase-based sync across the framework with merge-based. Two hookify block rules (block-reset-to-origin, block-raw-rebase), four skill updates, one reference doc. We incorporated via merge (not rebase) into day33-release-2 in accordance with the new discipline — on its first day. Found two existing tools (nit-add, nit-resolve) still using git rebase --abort as cleanup, migrated them to merge-based pull. This is exactly the cross-agency feedback loop we want: you hit a bug, you fix it, you send it upstream with full context, the upstream merges and incorporates.


### PR DESCRIPTION
## Day 33 R2

Three commits on top of R1:

- **iscp-check --statusline mode** + integration into `claude/tools/statusline.sh`. Partial fix for the autonomous-polling gap while the Anthropic feature request (GH [anthropics/claude-code#45017](https://github.com/anthropics/claude-code/issues/45017)) is pending. Status line is the one silent periodic mechanism that exists today — shows mail count in the footer bar without touching the transcript.
- **PR lifecycle tool seed** — captures the design for a future `/pr` skill (push/create/merge) following the same "captain manually does X, should be a tool" pattern as agency-issue and release-plan. Implementation on hold per principal (upstream work relevant).
- **Coordination artifacts** — #169 (worktree naming collapse rule answer to devex), #170 (iscp heads-up on the --statusline extension).

## Expected effect

When iscp, devex, mdpal-app, mdpal-cli merge this and R1 into their worktrees, they get:
- Silent notification delta suppression (from R1)
- Mail count in the footer bar
- No more "You have N dispatch(es)" repeats on every Stop

## Test plan

- [x] `iscp-check --statusline` outputs compact one-liner when mail present
- [x] `iscp-check --statusline` silent when zero
- [x] `iscp-check` default mode still delta-suppressed
- [x] `iscp-check` --force still works
- [x] BATS tests all pass (13/13)
- [x] `statusline.sh` renders with mail indicator when present
- [x] `statusline.sh` renders without mail indicator when clean
- [ ] Live verification after merge: footer shows 📬 indicator in running sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)