### PR TITLE
feat: merge-not-rebase git discipline

### DIFF
--- a/.claude/skills/post-merge/SKILL.md
+++ b/.claude/skills/post-merge/SKILL.md
@@ -1,11 +1,11 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git reset:*), Bash(git tag:*), Bash(git branch:*), Bash(gh pr:*), Read, Glob, Skill
-description: Run after a PR is merged on GitHub. Verifies merge, resets master, invokes /sync-all.
+allowed-tools: Bash(git fetch:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git rev-list:*), Bash(git tag:*), Bash(git branch:*), Bash(gh pr:*), Read, Glob, Skill
+description: Run after a PR is merged on GitHub. Verifies merge, merges origin into master, invokes /sync-all.
 ---
 
 # Post-Merge
 
-Run after a PR is merged on GitHub. Verifies the merge, resets master to origin, then invokes `/sync-all`.
+Run after a PR is merged on GitHub. Verifies the merge, merges origin into master, then invokes `/sync-all`. **Never resets master to origin.** See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
 
 ## Arguments
 
@@ -31,13 +31,19 @@ Run `gh pr view {number} --json state,mergedAt,mergeCommit`. Confirm state is "M
 
 Run `git fetch origin`.
 
-### Step 4: Reset master
+### Step 4: Merge origin/master
 
-If master has local-only commits (ahead of origin/master):
-1. Tag before resetting: `git tag sync/pre-reset-$(date +%Y%m%d-%H%M%S)`
-2. `git reset --hard origin/master`
+Check divergence: `git rev-list --left-right --count origin/master...HEAD`
 
-If master is behind: just `git rebase origin/master`.
+If diverged (both sides > 0 — expected after squash PR merge):
+1. Verify merge-base exists: `git merge-base origin/master HEAD`. If fails, ABORT.
+2. Tag for recovery: `git tag sync/pre-merge-$(date +%Y%m%d-%H%M%S)`
+3. Merge: `git merge origin/master -m "Merge origin/master (post-PR-merge sync)"`
+4. If conflicts: `git merge --abort`, report, ask user.
+
+If behind only: `git merge origin/master`
+
+**Never `git reset --hard origin/master`.** See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 5: Invoke sync-all
 

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -1,47 +1,21 @@
 ---
-allowed-tools: Bash(git rebase:*), Bash(git fetch:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git stash:*), Read, Glob, Grep
-description: Rebase current branch onto a target branch with safety checks. Purely local — never pushes.
+allowed-tools: Read
+description: DEPRECATED — use `git merge <target>` or `/sync` instead. Rebase is blocked by hookify.
 ---
 
-# Rebase
+# Rebase (DEPRECATED)
 
-Rebase the current branch onto a target branch (default: master) with safety checks. Purely local — never pushes.
+**This skill is deprecated.** All branch synchronization now uses merge, not rebase.
 
-## Arguments
+Rebase rewrites history, breaks worktree merge-bases, and caused a fleet-wide data loss incident in a multi-worktree monorepo. See `claude/docs/GIT-MERGE-NOT-REBASE.md` for the full rationale and incident report.
 
-- $ARGUMENTS: Optional target branch (default: `master`). Examples: `master`, `origin/master`, `origin/develop`.
+## Use Instead
 
-## Steps
+| What you want | Use |
+|---------------|-----|
+| Sync your branch with master | `git merge master` |
+| Sync local master with origin | `/sync-all` |
+| Merge and push to origin | `/sync` |
+| Sync worktree with master | `/worktree-sync` |
 
-### Step 1: Safety checks
-
-1. Verify working tree is clean: `git status --porcelain`. If dirty, ask the user to commit or stash.
-2. Get current branch: `git rev-parse --abbrev-ref HEAD`. If detached HEAD, abort.
-3. If on master, abort: "Cannot rebase master onto itself. Switch to a feature branch first."
-
-### Step 2: Fetch (if remote target)
-
-If the target starts with `origin/`, run `git fetch origin` first.
-
-### Step 3: Show divergence
-
-Run `git log --oneline HEAD..{target}` and `git log --oneline {target}..HEAD` to show:
-- How many commits the target has that we don't
-- How many commits we have that the target doesn't
-
-### Step 4: Rebase
-
-Run `git rebase {target}`.
-
-If conflicts occur:
-- Show the conflicting files
-- Ask the user to resolve, then `git rebase --continue`
-- Or offer `git rebase --abort` to cancel
-
-### Step 5: Report
-
-```
-Rebase complete:
-  Branch: {current} rebased onto {target}
-  Commits replayed: N
-```
+The `block-raw-rebase` hookify rule blocks all `git rebase` commands. This is intentional and enforced framework-wide.

--- a/.claude/skills/sync-all/SKILL.md
+++ b/.claude/skills/sync-all/SKILL.md
@@ -1,11 +1,11 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git rebase:*), Bash(git merge:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git worktree:*), Bash(git tag:*), Bash(git reset:*), Bash(git -C:*), Bash(./claude/tools/dispatch*), Read, Write, Glob, Grep, Edit
-description: Fetch, rebase master, merge worktree work into master, sync all worktrees. NEVER pushes.
+allowed-tools: Bash(git fetch:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git rev-list:*), Bash(git worktree:*), Bash(git tag:*), Bash(git -C:*), Bash(git diff:*), Bash(./claude/tools/dispatch*), Read, Write, Glob, Grep, Edit
+description: Fetch, merge origin into master, merge worktree work into master, sync all worktrees. NEVER pushes.
 ---
 
 # Sync All — Local Master Sync
 
-Fetch, rebase master, merge unique worktree work into master, and sync all worktrees. This is the daily rhythm command. **NEVER pushes to remote.**
+Fetch, merge origin into master, merge unique worktree work into master, and sync all worktrees. This is the daily rhythm command. **NEVER pushes to remote. NEVER rebases. NEVER resets to origin.**
 
 ## Steps
 
@@ -26,10 +26,15 @@ Check if master has diverged from origin/master:
 - `git log --oneline master..origin/master` — remote-only commits
 
 If diverged (squash PR scenario):
-1. Tag before resetting: `git tag sync/pre-reset-$(date +%Y%m%d-%H%M%S)`
-2. Ask the user before resetting to origin/master
+1. **Guard: verify merge-base exists.** Run `git merge-base origin/master HEAD`. If this fails (exit code 1 — no common ancestor), ABORT: "ERROR: No common ancestor. Run `git merge --allow-unrelated-histories origin/master` manually."
+2. Tag for recovery: `git tag sync/pre-merge-$(date +%Y%m%d-%H%M%S)`
+3. Merge: `git merge origin/master -m "Merge origin/master (post-squash-PR sync)"`
+4. If conflicts: `git merge --abort`, report, ask user. Do NOT auto-resolve.
+5. No worktree rebase needed — worktrees pick up changes via `git merge master`.
 
-If behind: `git rebase origin/master`
+If behind only: `git merge origin/master`
+
+**Never `git reset --hard origin/master`. Never `git rebase origin/master`.** See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 4: Enumerate worktrees
 

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,11 +1,11 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git rebase:*), Bash(git push:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Read
-description: Rebase current branch onto target and push to origin with --force-with-lease. The ONLY command that pushes.
+allowed-tools: Bash(git fetch:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git push:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Read
+description: Merge target into current branch and push to origin. The ONLY command that pushes.
 ---
 
 # Sync — Push to Origin
 
-Rebase current branch onto target and push to origin with `--force-with-lease`. This is the **only** command that pushes to a remote. Requires explicit confirmation.
+Merge target into current branch and push to origin. This is the **only** command that pushes to a remote. Requires explicit confirmation. **Never rebases.** See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
 
 ## Arguments
 
@@ -32,17 +32,17 @@ Show the commits that will be pushed.
 ### Step 4: Confirm
 
 Ask the user:
-> Push {N} commits to origin/{branch} with --force-with-lease?
+> Merge {target} into {branch} and push to origin/{branch}?
 
 **Do not push without explicit confirmation.**
 
-### Step 5: Rebase
+### Step 5: Merge
 
-Run `git rebase {target}`. Handle conflicts (show, ask user to resolve or abort).
+Run `git merge {target}`. Handle conflicts (show, ask user to resolve or abort).
 
 ### Step 6: Push
 
-Run `git push origin {branch} --force-with-lease`.
+Run `git push origin {branch}`.
 
 ### Step 7: Report
 

--- a/claude/CLAUDE-THEAGENCY.md
+++ b/claude/CLAUDE-THEAGENCY.md
@@ -622,8 +622,9 @@ Extract what you need — don't dump whole pages into context. Summarize, don't 
 
 - **Remote master is read-only.** All changes reach origin through PRs. Never push to origin/master.
 - **Never push without explicit permission.** Pushing is always deliberate. Mechanically enforced by hookify rules (block master push, warn on any push).
-- **Never `reset --hard` without confirming work is preserved.** A diverged branch may have new commits. Check first.
-- **`/rebase` and `/sync-all` are purely local.** `/sync` is the only command that pushes.
+- **Never `reset --hard origin/*`.** This drops all local commits not on origin, including framework files. Mechanically blocked by `block-reset-to-origin` hookify rule.
+- **Never `git rebase`.** All branch sync uses merge. Rebase rewrites history and breaks worktree merge-bases. Mechanically blocked by `block-raw-rebase` hookify rule. See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
+- **`/sync-all` and `/sync` are merge-based.** `/sync-all` merges origin into local master (never pushes). `/sync` merges and pushes (the only push command).
 - **Lead commit messages with Phase-Iteration slug.** Format: `Phase 1.3: feat: concise summary`. The slug is first, before the prefix.
 
 **By role:**

--- a/claude/docs/GIT-MERGE-NOT-REBASE.md
+++ b/claude/docs/GIT-MERGE-NOT-REBASE.md
@@ -84,3 +84,68 @@ Every skill that merges origin/master should include this guard:
 ```
 
 This catches disconnected histories before they cause damage. If the histories are disconnected, the user must run `git merge --allow-unrelated-histories origin/master` manually to connect them — a one-time operation that creates a permanent merge commit.
+
+## PR Scope Management
+
+When a project uses the captain's PR rebuild workflow (squash local work into scope-based PR branches), it needs a `pr-scopes.json` file to define which paths belong to which PR.
+
+### Setup
+
+Create `pr-scopes.json` in your project's scripts directory (e.g., `usr/{principal}/scripts/pr-scopes.json`):
+
+```json
+{
+  "feature-a": {
+    "include": [
+      "apps/backend/src/feature-a/",
+      "apps/frontend/pages/feature-a/",
+      "usr/{principal}/feature-a/"
+    ]
+  },
+  "feature-b": {
+    "include": [
+      "apps/backend/src/feature-b/",
+      "usr/{principal}/feature-b/"
+    ]
+  },
+  "shared": {
+    "exclude": [
+      "apps/backend/src/feature-a/",
+      "apps/frontend/pages/feature-a/",
+      "usr/{principal}/feature-a/",
+      "apps/backend/src/feature-b/",
+      "usr/{principal}/feature-b/"
+    ]
+  }
+}
+```
+
+### Scope Types
+
+- **INCLUDE scopes** — list the paths that belong to this PR. Only these paths are staged. Use for feature/workstream PRs.
+- **EXCLUDE scopes** — list the paths to exclude (claimed by other scopes). Everything else is staged. Use for shared/infrastructure PRs (one per project, typically named `devex` or `shared`).
+
+### Rules
+
+1. **Every worktree gets a scope.** When you create a worktree, add a scope to pr-scopes.json with its paths.
+2. **Include Agency artifacts.** Each scope should include `usr/{principal}/{project}/` so handoffs, QGRs, and dispatches travel with the feature code.
+3. **The EXCLUDE scope catches everything else.** Shared files (root package.json, framework updates, CLAUDE.md changes) land in the EXCLUDE scope. Update its exclude list when adding new INCLUDE scopes.
+4. **Paths that don't exist are silently skipped.** This is expected — a scope may include paths that only exist after the feature is built.
+
+### Adding a New Scope
+
+When creating a new worktree/workstream:
+
+1. Identify the app code paths the worktree will create/modify
+2. Add an INCLUDE scope to pr-scopes.json with those paths + `usr/{principal}/{name}/`
+3. Add those same paths to the EXCLUDE scope's exclude list
+4. Commit the updated pr-scopes.json
+
+### The PR Rebuild Flow
+
+The captain's `pr-rebuild.sh` script:
+1. Creates/resets a PR branch from `origin/master`
+2. Runs `git merge --squash master` to bring in local work
+3. Filters by scope (INCLUDE: selectively `git add`; EXCLUDE: `git reset HEAD` on excluded paths)
+4. Commits the scoped changes
+5. The PR branch has a clean single-commit diff against origin/master

--- a/claude/docs/GIT-MERGE-NOT-REBASE.md
+++ b/claude/docs/GIT-MERGE-NOT-REBASE.md
@@ -1,0 +1,86 @@
+# Git Discipline: Merge, Never Rebase
+
+## The Rule
+
+All branch synchronization in Agency projects uses **merge**, never **rebase**. This applies to:
+
+- Master syncing with origin (`/sync-all`)
+- Worktrees syncing with master (`/worktree-sync`, `git merge master`)
+- Branches syncing before push (`/sync`)
+- Post-PR-merge recovery (`/post-merge`)
+
+## Why
+
+Rebase rewrites commit history. In an Agency project with multiple worktrees, rewritten history breaks merge-bases between master and every worktree. This can cause:
+
+1. **Data loss** — `git reset --hard origin/master` after detecting divergence drops all local commits not on origin, including installed framework files
+2. **Cascade conflicts** — rebased master forces all worktrees to rebase too, creating conflict cascading across the fleet
+3. **Disconnected histories** — if local and origin have different root commits (e.g., from initial repo setup differences), rebase cannot reconcile them
+
+Merge preserves history. The merge commit creates a permanent connection point. Future operations find this as the merge-base and proceed normally.
+
+## The Incident (2026-04-08)
+
+A monofolk project with 13 active worktrees ran `/sync-all`. The divergence handler (Step 2.5) detected that origin/master had 157 new commits (from merged squash PRs) while local master had 363 commits (Agency framework + worktree work). The handler ran `git reset --hard origin/master`, which:
+
+- Dropped the entire Agency framework installation from local master
+- Broke all 13 worktrees (no valid merge-base with the reset master)
+- Lost the statusline, hooks, permissions, dispatch system
+- Required a 2-hour restore from a recovery tag + manual conflict resolution
+
+Root cause: local repo and origin had different root commits (identical content, different SHAs — from GPG signature differences during initial setup). This made `git merge-base` return nothing, and the reset handler assumed all local work was already on origin.
+
+## Enforcement (Triangle)
+
+| Layer | Component | What it does |
+|-------|-----------|-------------|
+| **Hookify** | `block-reset-to-origin` | Blocks `git reset --hard origin/*` |
+| **Hookify** | `block-raw-rebase` | Blocks `git rebase` |
+| **Skill** | `/sync-all` | Uses `git merge origin/master` with merge-base guard |
+| **Skill** | `/sync` | Uses `git merge <target>` before push (not rebase) |
+| **Skill** | `/post-merge` | Uses `git merge origin/master` after PR merge (not reset) |
+| **Skill** | `/worktree-sync` | Uses `git merge master` (already correct) |
+| **Skill** | `/rebase` | DEPRECATED — points to merge-based alternatives |
+
+## CLAUDE.md Updates
+
+Projects adopting this pattern should update their CLAUDE-THEAGENCY.md `Git & Remote Discipline` section:
+
+### Replace this:
+
+```markdown
+- **Never `reset --hard` without confirming work is preserved.** A diverged branch may have new commits. Check first.
+- **`/rebase` and `/sync-all` are purely local.** `/sync` is the only command that pushes.
+```
+
+### With this:
+
+```markdown
+- **Never `reset --hard origin/*`.** This drops all local commits not on origin, including framework files. Mechanically blocked by `block-reset-to-origin` hookify rule.
+- **Never `git rebase`.** All branch sync uses merge. Rebase rewrites history and breaks worktree merge-bases. Mechanically blocked by `block-raw-rebase` hookify rule. See `claude/docs/GIT-MERGE-NOT-REBASE.md`.
+- **`/sync-all` and `/sync` are merge-based.** `/sync-all` merges origin into local master (never pushes). `/sync` merges and pushes (the only push command).
+```
+
+### Update the role table:
+
+In the "By role" table, the "Merge master" row is already correct (`git merge master`). No change needed.
+
+### Update the sync-all description in the Worktrees section:
+
+Replace references to "rebase" in `/sync-all` descriptions with "merge":
+
+```markdown
+- `/sync-all` — merges origin/master into local master, merges worktree work into master. Purely local, never pushes.
+```
+
+## Merge-Base Guard Pattern
+
+Every skill that merges origin/master should include this guard:
+
+```
+1. Run `git merge-base origin/master HEAD`
+2. If exit code 1 (no common ancestor): ABORT with actionable error
+3. If exit code 0: proceed with merge
+```
+
+This catches disconnected histories before they cause damage. If the histories are disconnected, the user must run `git merge --allow-unrelated-histories origin/master` manually to connect them — a one-time operation that creates a permanent merge commit.

--- a/claude/hookify/hookify.block-raw-rebase.md
+++ b/claude/hookify/hookify.block-raw-rebase.md
@@ -1,0 +1,19 @@
+---
+name: block-raw-rebase
+enabled: true
+event: bash
+pattern: git\s+rebase\b
+action: block
+---
+
+**BLOCKED: Raw `git rebase` is not allowed.**
+
+Rebase rewrites history and breaks worktree merge-bases. All branch synchronization uses merge, not rebase. This prevents history divergence between local and origin that can cause data loss on sync.
+
+Use instead:
+- `/sync-all` — merges origin/master into local master (never rebases)
+- `/worktree-sync` — merges master into your worktree (never rebases)
+- `/sync` — merges target into current branch and pushes to origin
+- `git merge master` — direct merge if you need it manually
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/hookify/hookify.block-reset-to-origin.md
+++ b/claude/hookify/hookify.block-reset-to-origin.md
@@ -1,0 +1,17 @@
+---
+name: block-reset-to-origin
+enabled: true
+event: bash
+pattern: git\s+reset\s+--hard\s+origin
+action: block
+---
+
+**BLOCKED: `git reset --hard origin/*` destroys local work.**
+
+This command drops all local commits not on origin — including installed framework files, worktree merges, and coordination artifacts. Use merge-based sync instead.
+
+Use instead:
+- `/sync-all` — merges origin/master safely (never resets)
+- `git merge origin/master` — if you need to pull origin's changes manually
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*


### PR DESCRIPTION
## Summary

- Block destructive git operations (`reset --hard origin/*`, `rebase`) that caused a fleet-wide data loss incident in a 13-worktree monorepo
- Migrate all framework sync skills (sync-all, sync, post-merge) from rebase-based to merge-based
- Deprecate `/rebase` skill with migration table
- Add reference doc with incident report, enforcement triangle, CLAUDE.md update guidance, and PR scope management docs

## Files

| File | What |
|------|------|
| `claude/hookify/hookify.block-reset-to-origin.md` | Blocks `git reset --hard origin/*` |
| `claude/hookify/hookify.block-raw-rebase.md` | Blocks `git rebase` |
| `.claude/skills/sync-all/SKILL.md` | Merge-base guard + merge (not reset/rebase) |
| `.claude/skills/sync/SKILL.md` | Merge before push (not rebase) |
| `.claude/skills/post-merge/SKILL.md` | Merge after PR merge (not reset) |
| `.claude/skills/rebase/SKILL.md` | Deprecated with migration table |
| `claude/docs/GIT-MERGE-NOT-REBASE.md` | Reference doc |
| `claude/CLAUDE-THEAGENCY.md` | Updated Git & Remote Discipline |

## Test plan

- [ ] Verify hookify rules activate on `agency init` / `agency update`
- [ ] Run `/sync-all` with diverged master — confirm merge (not reset)
- [ ] Run `/sync` — confirm merge (not rebase) before push
- [ ] Run `/post-merge` after squash PR — confirm merge (not reset)
- [ ] Attempt `git rebase` — confirm blocked by hookify
- [ ] Attempt `git reset --hard origin/master` — confirm blocked by hookify
- [ ] Verify `/rebase` skill shows deprecation message

Generated with [Claude Code](https://claude.com/claude-code)
