### PR TITLE
Day 34 R1 — agency-version + run-in Triangle + fix #56, #57, #171 regression

### DIFF
--- a/.claude/skills/run-in/SKILL.md
+++ b/.claude/skills/run-in/SKILL.md
@@ -1,0 +1,71 @@
+---
+description: Run a command in a target directory without touching the parent shell's CWD. Use any time you would write "cd foo && bar" — that pattern is blocked by the block-compound-bash hookify rule.
+---
+
+# run-in
+
+Run a command in a target directory via a subshell. The parent shell's CWD
+is never touched. Exit code is propagated. Standard Agency telemetry.
+
+## When to use
+
+- You would otherwise write `cd foo && bar && cd -` — don't. Use `run-in`.
+- You need to run an Agency tool on another repo (e.g., `agency verify` on
+  a downstream installation).
+- You need to run a git command on another worktree without leaving your
+  shell parked in that worktree.
+- You want observability on the directory-scoped execution (log_start /
+  log_end are built in).
+
+## Signature
+
+```
+run-in <target-dir> -- <command> [args...]
+```
+
+The `--` separator is required and distinguishes the target directory from
+the command and its argv.
+
+## Examples
+
+```bash
+# Run a command on another repo without leaking CWD
+./claude/tools/run-in ~/code/presence-detect -- ./claude/tools/agency verify
+
+# Run a git command in a worktree from your captain shell
+./claude/tools/run-in .claude/worktrees/devex -- git status
+
+# Run a test suite in a sandbox dir
+./claude/tools/run-in "$BATS_TEST_TMPDIR/mock" -- bats mock.bats
+```
+
+## What NOT to do
+
+```bash
+# ❌ BLOCKED by hookify.block-compound-bash
+cd ~/code/presence-detect && agency verify
+
+# ❌ BLOCKED (parent shell CWD leaks)
+cd .claude/worktrees/devex && git status && cd -
+
+# ✅ Use run-in instead
+./claude/tools/run-in ~/code/presence-detect -- agency verify
+./claude/tools/run-in .claude/worktrees/devex -- git status
+```
+
+## Why subshell isolation matters
+
+Agent identity resolution uses the current working directory to determine
+which agent is running (via `agent-identity`). If a worktree agent `cd`s to
+the main checkout and forgets to `cd -`, subsequent commands resolve the
+wrong identity, handoffs write to the wrong file, and dispatches go to the
+wrong agent. `run-in` runs the command in a subshell — the parent shell's
+CWD is untouchable by construction, so identity resolution stays correct.
+
+## Related
+
+- Hookify rule: `claude/hookify/hookify.block-compound-bash.md`
+- Tool: `claude/tools/run-in`
+- Companion seed: telemetry-mining for compound command patterns (flag #54)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "agency_version": "34.1",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "34.1",
+  "agency_version": "34.2",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/hookify/hookify.block-compound-bash.md
+++ b/claude/hookify/hookify.block-compound-bash.md
@@ -1,0 +1,46 @@
+---
+name: block-compound-bash
+enabled: true
+event: bash
+pattern: (\s|^)(&&|\|\||;|\|)(\s|$)|\$\(|`[^`]*`|cd\s+[^;]+&&
+action: block
+---
+
+**BLOCKED: Compound bash commands are not allowed.**
+
+You wrote a bash command with `&&`, `||`, `;`, `|`, `$(…)`, backticks, or `cd X && …`. Every one of those is a compound construct that must be split into separate Bash tool calls — or replaced with a purpose-built Agency tool.
+
+## Why this is a hard block
+
+1. **Permission-prompt noise.** Claude Code parses compound commands and prompts for permission on every segment. `cd foo && bar && cd -` can fire three prompts. Every compound command is a multiplier on friction. Splitting into separate Bash calls triggers one prompt per call, and many tools are pre-approved already.
+
+2. **State leakage.** `cd foo && bar && cd -` forgets `cd -` half the time. The parent shell parks in `foo` and every subsequent command runs in the wrong directory. Agent identity (which is resolved via CWD) then resolves wrong, handoffs write to the wrong agent's file, and dispatches go to the wrong inbox. This is not hypothetical — it has happened in captain sessions and produced real bugs.
+
+3. **Observability loss.** Each Agency tool logs its runs via `log_start` / `log_end`. A compound command is opaque — the telemetry sees one `bash` call, not the three things that happened inside it. We lose the audit trail at the exact point we need it most (when something breaks).
+
+4. **Bypass of the tool ecosystem.** Many compound patterns exist because the agent didn't know there's already a purpose-built tool. `grep foo | head` should be a single `Grep` tool call with `head_limit`. `cd repo && git status` should be `./claude/tools/run-in repo -- git status`. The block forces you to find the right primitive instead of papering over with shell plumbing.
+
+5. **Hermeticity for tests and subprocess correctness.** `$(…)` and backticks run a subshell that inherits environment, which can leak env vars into BATS tests or other sensitive contexts. Splitting the work into explicit steps keeps every subprocess boundary visible.
+
+## What to do instead
+
+| You wanted to write… | Use instead |
+|----------------------|-------------|
+| `cd X && cmd`        | `./claude/tools/run-in X -- cmd` |
+| `cd X && cmd && cd -`| `./claude/tools/run-in X -- cmd` (parent CWD never changes — no restore needed) |
+| `cmd1 && cmd2`       | Two separate Bash tool calls (parallel if independent, sequential if dependent) |
+| `cmd1 ; cmd2`        | Two separate Bash tool calls |
+| `cmd \| head`        | Grep tool with `head_limit`, or separate `cmd` + Read |
+| `cmd \| grep foo`    | Grep tool directly |
+| `grep x \| xargs y`  | Separate steps, or a dedicated Agency tool |
+| `$(cmd)` substitution| Run `cmd` first in one call, capture the value, pass to the next call |
+| `` `cmd` `` backticks| Same as `$(…)` — split into steps |
+
+## Related
+
+- Tool: `claude/tools/run-in` (replacement for the `cd X && cmd` pattern)
+- Skill: `/run-in`
+- Reference: `claude/CLAUDE-THEAGENCY.md` "Bash Tool Usage" section
+- Companion workstream: telemetry analysis of compound command patterns (flag #54) — mines the log of compound command attempts to identify which OTHER patterns deserve their own purpose-built tool
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/tools/agency-version
+++ b/claude/tools/agency-version
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# What Problem: There is no single-word answer to "what version of the Agency
+# framework is this repo on?" Manifest.json tracks per-component versions but
+# no top-level framework version. Without it we can't show drift, can't answer
+# "is presence-detect current?", and can't display a version in the statusline.
+#
+# How & Why: Read agency_version from claude/config/manifest.json and print it.
+# Verbs kept minimal for v1 — print, --statusline (silent on missing), --json.
+# Drift detection and audit verbs are deferred (flag #51 / audit tool). One
+# tool, one responsibility for now: "what version is this?"
+#
+# Format: day{N}.{release}, e.g. "34.1". Just the number, no prefix.
+#
+# Written: 2026-04-09 during captain Day 34 R1 (agency-version build)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$PROJECT_ROOT/claude/config/manifest.json"
+
+_usage() {
+    cat <<'EOF'
+agency-version — print the Agency framework version for this repo
+
+USAGE
+  agency-version              Print the version (e.g. "34.1")
+  agency-version --statusline Print version for statusline (silent if missing)
+  agency-version --json       Print version as JSON
+  agency-version --help       Show this help
+
+READS
+  claude/config/manifest.json → agency_version
+EOF
+}
+
+_read_version() {
+    if [[ ! -f "$MANIFEST" ]]; then
+        return 1
+    fi
+    # jq if available, else grep fallback (statusline must be fast + dep-free)
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.agency_version // empty' "$MANIFEST" 2>/dev/null
+    else
+        grep -E '"agency_version"[[:space:]]*:' "$MANIFEST" 2>/dev/null \
+            | head -1 \
+            | sed -E 's/.*"agency_version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+    fi
+}
+
+mode="${1:-print}"
+
+case "$mode" in
+    --help|-h|help)
+        _usage
+        exit 0
+        ;;
+    --statusline)
+        version=$(_read_version 2>/dev/null || true)
+        [[ -z "$version" ]] && exit 0
+        printf '%s' "$version"
+        ;;
+    --json)
+        version=$(_read_version) || { echo '{"error":"manifest not found"}'; exit 1; }
+        if [[ -z "$version" ]]; then
+            echo '{"error":"agency_version not set"}'
+            exit 1
+        fi
+        printf '{"agency_version":"%s"}\n' "$version"
+        ;;
+    print|"")
+        version=$(_read_version) || {
+            echo "error: manifest not found at $MANIFEST" >&2
+            exit 1
+        }
+        if [[ -z "$version" ]]; then
+            echo "error: agency_version not set in manifest" >&2
+            exit 1
+        fi
+        printf '%s\n' "$version"
+        ;;
+    *)
+        echo "error: unknown argument: $mode" >&2
+        _usage >&2
+        exit 2
+        ;;
+esac

--- a/claude/tools/commit-precheck
+++ b/claude/tools/commit-precheck
@@ -141,6 +141,39 @@ main() {
     REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
     cd "$REPO_ROOT"
 
+    # ────────────────────────────────────────────────────────────────────────
+    # Gate 0: block Test User attribution (merge-durable guard against the
+    # recurring BATS pollution bug — dispatches #109 and #171).
+    #
+    # If .git/config grew a [user] section with Test User / test@example.com,
+    # a BATS test leaked pre-commit env vars and polluted the live config.
+    # Block the commit, print diagnostics, and tell the author how to clean.
+    # ────────────────────────────────────────────────────────────────────────
+    local git_user_name git_user_email
+    git_user_name=$(git config user.name 2>/dev/null || true)
+    git_user_email=$(git config user.email 2>/dev/null || true)
+    if [[ "$git_user_name" == "Test User" ]] || [[ "$git_user_email" == "test@example.com" ]]; then
+        echo "✗ BLOCKED: commit identity is Test User <test@example.com>" >&2
+        echo "  → Your .git/config has a polluted [user] section (likely from a" >&2
+        echo "    BATS test leaking env vars). Clean with:" >&2
+        echo "      git config --local --unset user.email" >&2
+        echo "      git config --local --unset user.name" >&2
+        echo "    Then verify: git config user.name && git config user.email" >&2
+        echo "  → Root cause: see dispatches #109 and #171." >&2
+        echo "*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*" >&2
+        end_run "blocked" "Test User attribution"
+        exit 1
+    fi
+    if grep -q '^\[user\]' "$REPO_ROOT/.git/config" 2>/dev/null; then
+        if grep -A2 '^\[user\]' "$REPO_ROOT/.git/config" 2>/dev/null | grep -qE 'Test User|test@example\.com'; then
+            echo "✗ BLOCKED: .git/config contains a polluted [user] section" >&2
+            echo "  → Clean with: git config --local --unset-all user.email && git config --local --unset-all user.name" >&2
+            echo "*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*" >&2
+            end_run "blocked" "Polluted .git/config [user] section"
+            exit 1
+        fi
+    fi
+
     # No staged changes = nothing to check
     if git diff --cached --quiet; then
         log_info "No staged changes"

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -220,16 +220,18 @@ _update_main() {
     fi
 
     # =====================================================================
-    # Step 4: Update agency.yaml framework section
+    # Step 4: Update agency.yaml framework section + append new top-level
+    # sections (issue #56 — new sections from source never propagated)
     # =====================================================================
     log_step "Updating agency.yaml"
 
     if [[ "$DRY_RUN" == "false" ]]; then
         local yaml_file="$TARGET_DIR/claude/config/agency.yaml"
+        local src_yaml="$SOURCE_DIR/claude/config/agency.yaml"
         local updated_at
         updated_at=$(date -u '+%Y-%m-%dT%H:%M:%S+00:00')
 
-        # Update version, updated_at, source_commit in the framework section
+        # --- Update metadata in the framework section (existing behavior) ---
         if [[ "$(uname)" == "Darwin" ]]; then
             sed -i '' "s|^  version: .*|  version: \"$to_version\"|" "$yaml_file"
             sed -i '' "s|^  updated_at: .*|  updated_at: \"$updated_at\"|" "$yaml_file"
@@ -238,6 +240,52 @@ _update_main() {
             sed -i "s|^  version: .*|  version: \"$to_version\"|" "$yaml_file"
             sed -i "s|^  updated_at: .*|  updated_at: \"$updated_at\"|" "$yaml_file"
             sed -i "s|^  source_commit: .*|  source_commit: \"$to_commit\"|" "$yaml_file"
+        fi
+
+        # --- Append new top-level sections from source (issue #56) ---
+        # Top-level key: a line matching ^[A-Za-z_][A-Za-z0-9_]*:
+        # For each key present in source but missing in target, extract the
+        # section (from that key through the line before the next top-level
+        # key or EOF) and append it to target with a comment marker.
+        local added_sections=""
+        local src_keys tgt_keys
+        # Dedupe in-place to tolerate duplicate top-level keys in source
+        src_keys=$(awk '/^[A-Za-z_][A-Za-z0-9_]*:/ { sub(/:.*/,""); if (!seen[$0]++) print }' "$src_yaml" 2>/dev/null || true)
+        tgt_keys=$(awk '/^[A-Za-z_][A-Za-z0-9_]*:/ { sub(/:.*/,""); if (!seen[$0]++) print }' "$yaml_file" 2>/dev/null || true)
+
+        local key
+        while IFS= read -r key; do
+            [[ -z "$key" ]] && continue
+            # Skip if key already present in target
+            if printf '%s\n' "$tgt_keys" | grep -qxF "$key"; then
+                continue
+            fi
+
+            # Extract section for this key from source: from ^key: up to (but
+            # not including) the next top-level key, trimming trailing blank
+            # lines from the block.
+            local section
+            section=$(awk -v k="$key" '
+                $0 ~ "^"k":" { in_block=1; print; next }
+                in_block && /^[A-Za-z_][A-Za-z0-9_]*:/ { in_block=0 }
+                in_block { print }
+            ' "$src_yaml")
+
+            [[ -z "$section" ]] && continue
+
+            # Buffer — we will append all new sections in one block
+            if [[ -z "$added_sections" ]]; then
+                added_sections=$(printf '\n# ─────────────────────────────────────────────────────────────────────────\n# New sections added by agency update — review and customize as needed.\n# Added by framework version %s (%s)\n# ─────────────────────────────────────────────────────────────────────────\n' "$to_version" "$to_commit")
+            fi
+            added_sections=$(printf '%s\n\n%s' "$added_sections" "$section")
+            log_info "  + new section: $key"
+        done <<<"$src_keys"
+
+        if [[ -n "$added_sections" ]]; then
+            # Ensure target ends with newline before appending
+            [[ -n "$(tail -c1 "$yaml_file" 2>/dev/null)" ]] && printf '\n' >> "$yaml_file"
+            printf '%s\n' "$added_sections" >> "$yaml_file"
+            log_info "Appended new top-level sections to agency.yaml"
         fi
     fi
 

--- a/claude/tools/run-in
+++ b/claude/tools/run-in
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# What Problem: Agents constantly write compound bash commands like
+# "cd foo && bar && cd -" to run a command in a different directory. This is
+# noisy (Claude Code's compound-command permission prompts fire on every
+# segment), error-prone (forgetting "cd -" leaks the parent shell's CWD),
+# breaks agent identity resolution (which depends on CWD), and produces zero
+# telemetry. We've hit this pattern all day in captain sessions and it's the
+# #1 source of Bash tool noise.
+#
+# How & Why: A single instrumented command that runs any command in a target
+# directory via a SUBSHELL, so the parent shell's CWD is never touched. Two
+# positional args: the target directory, then "--" separator, then the
+# command and its args preserved as argv boundaries. The subshell uses
+# `exec "$@"` so the command replaces the subshell process (correct signal
+# forwarding, no extra pid). Exit code propagates. Standard log_start/log_end
+# instrumentation so every directory-scoped execution is observable.
+#
+# The enforcement triangle:
+#   Tool:    this file (claude/tools/run-in)
+#   Skill:   /run-in
+#   Hookify: block-compound-bash (blocks &&, ||, ;, pipes in Bash tool calls)
+#
+# Usage:
+#   run-in <target-dir> -- <command> [args...]
+#   run-in --version
+#   run-in --help
+#
+# Examples:
+#   run-in /path/to/other-repo -- git status
+#   run-in ~/code/presence-detect -- ./claude/tools/agency verify
+#   run-in .claude/worktrees/devex -- ./claude/tools/dispatch list
+#
+# Written: 2026-04-09 during captain Day 34 (run-in Triangle build)
+
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source log helper if available
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib/_log-helper"
+fi
+
+show_help() {
+    cat <<'EOF'
+run-in — run a command in a target directory without leaking CWD
+
+USAGE
+  run-in <target-dir> -- <command> [args...]
+  run-in --version
+  run-in --help
+
+BEHAVIOR
+  Runs <command> in <target-dir> via a subshell. The parent shell's CWD
+  is never touched. Exit code of the command is propagated. Standard
+  Agency telemetry via log_start/log_end.
+
+WHY
+  Compound bash commands ("cd foo && bar && cd -") are blocked by the
+  block-compound-bash hookify rule. Use run-in instead. See
+  claude/hookify/hookify.block-compound-bash.md for the full rationale.
+
+EXAMPLES
+  run-in /path/to/other-repo -- git status
+  run-in ~/code/presence-detect -- ./claude/tools/agency verify
+  run-in .claude/worktrees/devex -- ./claude/tools/dispatch list
+
+OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
+EOF
+}
+
+# Parse args
+if [[ $# -eq 0 ]]; then
+    show_help
+    exit 2
+fi
+
+case "$1" in
+    --version|-v)
+        echo "run-in $VERSION"
+        exit 0
+        ;;
+    --help|-h)
+        show_help
+        exit 0
+        ;;
+esac
+
+TARGET_DIR="$1"
+shift
+
+# Require the "--" separator so the command boundary is explicit
+if [[ $# -lt 1 ]] || [[ "$1" != "--" ]]; then
+    echo "run-in: missing '--' separator between target-dir and command" >&2
+    echo "  usage: run-in <target-dir> -- <command> [args...]" >&2
+    exit 2
+fi
+shift  # consume --
+
+if [[ $# -lt 1 ]]; then
+    echo "run-in: no command provided after '--'" >&2
+    echo "  usage: run-in <target-dir> -- <command> [args...]" >&2
+    exit 2
+fi
+
+# Resolve target directory
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "run-in: target directory does not exist: $TARGET_DIR" >&2
+    exit 1
+fi
+
+# Start logging
+RUN_ID=""
+if type log_start &>/dev/null; then
+    RUN_ID=$(log_start "run-in" "$TARGET_DIR :: $*")
+fi
+
+# Run the command in a subshell. The parent shell's CWD is never touched.
+# `exec` replaces the subshell with the target command so signals forward
+# cleanly and there's no extra pid on the process tree.
+set +e
+(
+    cd "$TARGET_DIR" && exec "$@"
+)
+rc=$?
+set -e
+
+# End logging
+if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+    local_status="success"
+    [[ "$rc" -ne 0 ]] && local_status="failure"
+    log_end "$RUN_ID" "$local_status" "$rc" 0 "$TARGET_DIR :: $*"
+fi
+
+exit "$rc"

--- a/claude/tools/statusline.sh
+++ b/claude/tools/statusline.sh
@@ -171,6 +171,19 @@ if [ -n "$vim_mode" ]; then
     vim_info=" [${vim_mode}]"
 fi
 
+# --- Agency framework version ---
+# Reads agency_version from claude/config/manifest.json via agency-version tool.
+# Silent when missing (tool prints nothing in --statusline mode).
+av_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+agency_ver=""
+if [ -x "$av_script_dir/agency-version" ]; then
+    agency_ver=$("$av_script_dir/agency-version" --statusline 2>/dev/null || true)
+fi
+agency_ver_info=""
+if [ -n "$agency_ver" ]; then
+    agency_ver_info=" | ${agency_ver}"
+fi
+
 # --- ISCP mail indicator ---
 # Silent periodic polling via status line — shows unread dispatch/flag count
 # in the footer bar without touching the transcript. See iscp-check --statusline.
@@ -190,7 +203,7 @@ if [ -n "$iscp_mail" ]; then
 fi
 
 # --- Assemble ---
-status_line="${version_model} | ${location}"
+status_line="${version_model}${agency_ver_info} | ${location}"
 if [ -n "$ctx_label" ]; then
     status_line="${status_line} | ${ctx_label}"
 fi

--- a/claude/tools/worktree-sync
+++ b/claude/tools/worktree-sync
@@ -146,32 +146,44 @@ else
     # --- Merge master ---
     MERGED=true
     MERGE_OUTPUT=$(git merge master 2>&1) || {
-        # Merge conflict — abort and restore
+        # Merge conflict — abort and restore. After this block runs the repo
+        # is back at PRE_MERGE_HEAD with MERGE_HEAD cleared. The message has
+        # to make that clear so the caller doesn't try to 'git merge --abort'
+        # themselves (issue #57 — 'Resolve manually' was misleading because
+        # the merge WAS already aborted automatically).
         ABORT_OK=true
         git merge --abort 2>/dev/null || ABORT_OK=false
         CONFLICT_FILES=$(echo "$MERGE_OUTPUT" | grep "CONFLICT" || echo "(unknown)")
 
-        echo "worktree-sync: merge conflict with master" >&2
-        echo "$CONFLICT_FILES" >&2
+        echo "worktree-sync: merge with master had conflicts — merge was automatically aborted." >&2
+        echo "  Repo state: restored to pre-merge HEAD ($PRE_MERGE_HEAD)." >&2
+        echo "  Conflict files:" >&2
+        echo "$CONFLICT_FILES" | sed 's/^/    /' >&2
 
         if [[ "$ABORT_OK" == false ]]; then
-            echo "worktree-sync: WARNING — git merge --abort failed" >&2
+            echo "  WARNING: git merge --abort failed — repo may not be fully restored." >&2
         fi
 
         # Unstash if we stashed (disable trap since we're handling it)
+        STASH_MSG="no stash taken"
         if [[ "$STASHED" == true ]]; then
             STASHED=false
-            if ! git stash pop --quiet 2>/dev/null; then
-                echo "worktree-sync: WARNING — stash pop failed after merge abort. Work is safe in git stash." >&2
+            if git stash pop --quiet 2>/dev/null; then
+                STASH_MSG="stashed work restored via git stash pop"
+            else
+                STASH_MSG="stash pop failed — your stashed work is still in git stash (run 'git stash list')"
             fi
         fi
+        echo "  Stash: $STASH_MSG." >&2
+
+        echo "  Next steps: review the conflict files listed above, decide whether to keep/delete/reconcile them, then retry worktree-sync. Do NOT run 'git merge --abort' — the merge has already been aborted." >&2
 
         if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
-            log_end "$RUN_ID" "failure" 1 0 "merge conflict"
+            log_end "$RUN_ID" "failure" 1 0 "merge conflict (aborted automatically)"
         fi
 
         if [[ "$AUTO_MODE" == true ]]; then
-            jq -n -c --arg msg "worktree-sync: merge conflict with master. Resolve manually." '{"systemMessage": $msg}'
+            jq -n -c --arg msg "worktree-sync: merge conflict with master — merge was automatically aborted, repo restored. Review conflict files before retrying." '{"systemMessage": $msg}'
         fi
         exit 1
     }

--- a/claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md
+++ b/claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md
@@ -1,0 +1,85 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-09
+origin: captain Day 34 session — run-in Triangle build
+status: captured
+---
+
+# Telemetry-Driven Tool Discovery
+
+## The insight in one sentence
+
+**The Bash tool log is a list of the tools we haven't built yet.**
+
+## What happened
+
+While building the `run-in` tool (and its hookify block against compound bash commands), Jordan said: *"We can analyze the record of compound commands and build other tools."*
+
+That statement flipped a framework switch. It named a pattern that we've been doing informally for weeks but had never articulated as a discipline. Every time an agent writes `cd foo && bar && cd -`, that is not just a noisy bash command — it is a **request for a tool that does not yet exist**. The agent is papering over a missing primitive with shell plumbing. The friction is legible; the telemetry log sees it.
+
+If the telemetry log captures every compound bash command, then the log itself is a queue of "tools that should exist but don't." We do not have to guess which tools to build next. We can **mine** the log for frequency, classify the patterns, and build a dedicated Agency tool for each high-frequency pattern.
+
+## The loop
+
+```
+1. Agent writes a compound bash command (the hackaround).
+2. Telemetry records the attempt and the pattern.
+3. A scanner mines the log for high-frequency compound patterns.
+4. For each pattern, the question: is there already a tool?
+   - If yes: the agent didn't find it → discovery problem (skill, CLAUDE.md pointer).
+   - If no: build a purpose-built tool → deprecate the pattern.
+5. A hookify rule blocks the hackaround pattern, pointing to the new tool.
+6. Agent uses the new tool. Telemetry records it cleanly. Audit trail intact.
+7. Observe the next high-frequency pattern. Repeat.
+```
+
+## Why this is a framework primitive, not a one-off idea
+
+Most frameworks evolve by *intuition* — someone notices a pain point and builds a tool. TheAgency already does this. But the telemetry-driven loop **inverts the causality**: the data chooses the tools, not the human. The human's job shifts from *spotting* friction to *interpreting* the friction that the data already surfaces.
+
+This has implications far beyond compound bash commands:
+
+- **Every missing tool announces itself through workaround patterns.** Compound bash is one category. Others include repeated ad-hoc scripts in `tmp/`, duplicated inline logic across tool calls, multi-step manual sequences that always happen together, repeated permission prompts on the same operation.
+- **The friction is legible.** We do not need user feedback, surveys, or agent introspection to find it. The telemetry already has it.
+- **Tool adoption has a built-in feedback signal.** If the hackaround pattern keeps appearing after the tool ships, the tool has a discoverability problem. Fix the skill, fix the hookify rule, fix the docs.
+- **Deprecation is mechanical.** When a tool covers a pattern well, the hookify rule blocks the hackaround. The pattern stops appearing in the log. The tool's value is measured by the absence of the thing it replaced.
+
+## The framework pattern name
+
+**Friction → Telemetry → Tool → Block → Flow.**
+
+Five steps. Each step is observable. Each step has a primitive in the framework already:
+
+| Step | Primitive |
+|------|-----------|
+| Friction | The raw Bash tool call attempt |
+| Telemetry | `log_start` / `log_end` in every Agency tool + the `bash` event hook |
+| Tool | `claude/tools/{tool}` with the Triangle |
+| Block | `claude/hookify/hookify.block-{pattern}.md` |
+| Flow | The new primitive is used; telemetry confirms the pattern has stopped |
+
+## Where this belongs
+
+- **README-THEAGENCY.md** — add a section "Telemetry-Driven Tool Discovery" that explains this loop as a design principle. This is a first-class framework claim about *how TheAgency evolves*, not just a tactical observation.
+- **CLAUDE-THEAGENCY.md** — add a short paragraph under Tool Discipline pointing to the loop, with a pointer to this seed for the long explanation.
+- **Articles / talks / book** — this is the framing for "why TheAgency builds tools the way it builds tools." The telemetry-driven loop is the *methodology*; the Triangle (Tool + Skill + Hookify) is the *structure*; the Ladder (document → skill → tool → warn → block) is the *adoption curve*. All three together form the complete story of framework evolution.
+
+## Immediate next actions
+
+1. **Build the scanner.** A small Agency tool that reads `tool-runs.jsonl` (or wherever Bash tool calls land), extracts compound commands, classifies by shape (cd-compound, pipe-chain, sequence, substitution), and ranks by frequency. Output: a ranked list of "tools to build."
+2. **Run the scanner against our current logs.** See what's on top. The top entry after `cd-compound` becomes the next Triangle build.
+3. **Repeat weekly.** Telemetry-driven tool discovery is not a one-shot — it's a recurring review. Surface the ranked list in the captain's log as a weekly pattern review.
+
+## The harder question this surfaces
+
+If the Bash tool log is a list of the tools we haven't built, then **every framework has a telemetry-shaped shadow of the tools it's missing**. Most frameworks never look at it. Most projects don't even collect it. Teams building with LLMs are producing massive streams of friction data right now, and almost none of it is being mined for tool opportunities.
+
+This feels like a *thesis*, not just a tactic. The framework that mines its own friction is the framework that evolves fastest. TheAgency ships that as a built-in.
+
+## Related
+
+- Tool: `claude/tools/run-in` (the first tool built under this discipline)
+- Hookify: `claude/hookify/hookify.block-compound-bash.md`
+- Flag #54 — "Analyze telemetry logs of Bash tool calls to mine compound command patterns"
+- Framework primitives: Triangle, Ladder, Valueflow

--- a/tests/tools/agency-version.bats
+++ b/tests/tools/agency-version.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/agency-version
+#
+# Covers the three verbs (print / --statusline / --json), help, unknown args,
+# and the missing-manifest / missing-field error paths. No network.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+    cd "${REPO_ROOT}"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Help
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --help shows usage" {
+    run_tool agency-version --help
+    assert_success
+    assert_output_contains "agency-version"
+    assert_output_contains "statusline"
+}
+
+@test "agency-version: -h shows usage" {
+    run_tool agency-version -h
+    assert_success
+    assert_output_contains "agency-version"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default print
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: default prints version from manifest" {
+    run_tool agency-version
+    assert_success
+    # Version format: N.N (day.release)
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+@test "agency-version: print verb prints version" {
+    run_tool agency-version print
+    assert_success
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --statusline mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --statusline prints bare version" {
+    run_tool agency-version --statusline
+    assert_success
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+@test "agency-version: --statusline is silent when manifest missing" {
+    # Point tool at a fake project root with no manifest
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    run bash "${fake_root}/claude/tools/agency-version" --statusline
+    assert_success
+    [[ -z "$output" ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --json mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --json prints JSON object" {
+    run_tool agency-version --json
+    assert_success
+    assert_output_contains '"agency_version"'
+}
+
+@test "agency-version: --json fails when field missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    echo '{"schema_version":"1.0"}' > "${fake_root}/claude/config/manifest.json"
+    run bash "${fake_root}/claude/tools/agency-version" --json
+    [[ "$status" -ne 0 ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: unknown arg exits non-zero" {
+    run_tool agency-version --bogus
+    [[ "$status" -ne 0 ]]
+}
+
+@test "agency-version: default fails when manifest missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    run bash "${fake_root}/claude/tools/agency-version"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "agency-version: default fails when field missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    echo '{"schema_version":"1.0"}' > "${fake_root}/claude/config/manifest.json"
+    run bash "${fake_root}/claude/tools/agency-version"
+    [[ "$status" -ne 0 ]]
+}

--- a/tests/tools/run-in.bats
+++ b/tests/tools/run-in.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/run-in
+#
+# Focus: subshell isolation, exit code propagation, argv boundaries, error
+# surfaces for missing dir and missing separator.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+    cd "${REPO_ROOT}"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Help / version
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: --version prints version" {
+    run_tool run-in --version
+    assert_success
+    assert_output_contains "run-in"
+    assert_output_contains "1.0.0"
+}
+
+@test "run-in: --help shows usage" {
+    run_tool run-in --help
+    assert_success
+    assert_output_contains "run-in"
+    assert_output_contains "target-dir"
+}
+
+@test "run-in: no args shows help and exits non-zero" {
+    run_tool run-in
+    [[ "$status" -ne 0 ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy path — subshell isolation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: runs command in target dir" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- pwd
+    assert_success
+    assert_output_contains "target"
+}
+
+@test "run-in: parent shell CWD is unchanged after invocation" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    local before_cwd
+    before_cwd="$(pwd)"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- pwd
+    assert_success
+    [[ "$(pwd)" == "$before_cwd" ]]
+}
+
+@test "run-in: argv boundaries preserved for command with args" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- echo "hello world" "arg two"
+    assert_success
+    assert_output_contains "hello world"
+    assert_output_contains "arg two"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exit code propagation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: propagates non-zero exit code from command" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- bash -c "exit 42"
+    [[ "$status" -eq 42 ]]
+}
+
+@test "run-in: propagates zero exit code from successful command" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- true
+    assert_success
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error surfaces
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: missing target dir fails with clear error" {
+    run_tool run-in "${BATS_TEST_TMPDIR}/does-not-exist" -- pwd
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "does not exist"
+}
+
+@test "run-in: missing -- separator fails with usage" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" pwd
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "separator"
+}
+
+@test "run-in: no command after -- fails with usage" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" --
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "no command"
+}

--- a/tests/tools/worktree-sync.bats
+++ b/tests/tools/worktree-sync.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/worktree-sync
+#
+# Focus: issue #57 — the "resolve manually" message after a successful
+# conflict-abort is misleading. After a conflict, worktree-sync internally
+# aborts the merge and pops the stash; the error message should reflect that
+# the merge was automatically aborted, not that the user needs to resolve
+# anything by hand.
+#
+# Strategy: create a throwaway git repo with master + a feature branch that
+# has a delete-vs-modify conflict with master, register the feature branch as
+# a worktree, run worktree-sync from inside the worktree, and assert on
+# exit code + message content.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+
+    # Build a throwaway git repo with a conflict between master and feature.
+    # delete-vs-modify is the exact pattern from dispatch #171.
+    export MOCK_ROOT="${BATS_TEST_TMPDIR}/mock-main"
+    mkdir -p "${MOCK_ROOT}"
+    cd "${MOCK_ROOT}"
+
+    git init --quiet --initial-branch=master
+    git config user.email "tester@example.invalid"
+    git config user.name "Tester"
+
+    echo "root file" > README.md
+    echo "shared content" > shared.txt
+    git add README.md shared.txt
+    git commit --quiet -m "initial"
+
+    # Feature branch modifies shared.txt
+    git checkout --quiet -b feature
+    echo "feature change" > shared.txt
+    git add shared.txt
+    git commit --quiet -m "feature: modify shared"
+
+    # Master deletes shared.txt (delete-vs-modify scenario)
+    git checkout --quiet master
+    git rm --quiet shared.txt
+    git commit --quiet -m "master: delete shared"
+
+    # Register feature as worktree
+    export WORKTREE_PATH="${BATS_TEST_TMPDIR}/mock-worktree"
+    git worktree add --quiet "${WORKTREE_PATH}" feature
+}
+
+teardown() {
+    # Clean up the worktree registration before wiping tmpdir
+    if [[ -d "${MOCK_ROOT}" ]]; then
+        (cd "${MOCK_ROOT}" && git worktree remove --force "${WORKTREE_PATH}" 2>/dev/null || true)
+    fi
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #57 — conflict recovery message
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "worktree-sync: conflict-abort exits non-zero" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+}
+
+@test "worktree-sync: conflict-abort message does NOT say bare 'Resolve manually'" {
+    # Regression guard for #57 — the old message was:
+    #   'merge conflict with master. Resolve manually.'
+    # which is misleading because the merge was already aborted internally.
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+    # Must NOT contain the bare misleading phrase
+    if echo "$output" | grep -qE 'Resolve manually\.?$'; then
+        echo "Output still contains the misleading 'Resolve manually' message:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "worktree-sync: conflict-abort message explains that merge was aborted" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+    # Must contain a word indicating the merge was aborted / reverted
+    if ! echo "$output" | grep -qiE 'abort|reverted|restored'; then
+        echo "Output does not tell the user the merge was aborted:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "worktree-sync: repo state is clean after conflict-abort (no MERGE_HEAD)" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    # MERGE_HEAD must not exist — proves the tool aborted its own merge
+    [[ ! -f "${WORKTREE_PATH}/.git/MERGE_HEAD" ]] && [[ ! -f "${MOCK_ROOT}/.git/worktrees/mock-worktree/MERGE_HEAD" ]]
+}

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -3,7 +3,7 @@ type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
 date: 2026-04-08
-trigger: mid-session-day-33
+trigger: end-of-day-33
 ---
 
 ## Identity
@@ -12,72 +12,120 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 
 ## Current State
 
-**Day 33 in progress.** R1 shipped and merged (PR #53). R2 in draft as PR #54 with substantial content. Monofolk's merge-not-rebase contribution (PR #55) merged into main and incorporated into R2 via merge (not rebase) — discipline applied on its first day.
+**Day 33 complete.** Two releases shipped, one upstream contribution incorporated, one real-world agency-update test executed, first bug-found-and-filed via the new tooling loop. Local main is at `6cac2fa`, in sync with origin.
 
-## Day 33 - Release 1 (PR #53) — MERGED
+## Shipped Today (Day 33)
+
+### PR #53 — Day 33 R1 (MERGED)
 
 7 commits. Day 32 carry-over + Day 33 core work.
 
-- **agency-issue v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1 with principal. Smoke-tested by filing the-agency-ai/the-agency#52 using the tool itself.
-- **release-plan v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern: built the tool then used it to assemble R1 and R2.**
-- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag).
-- **iscp-check v1.1.0** — delta suppression, stops the "You have N" repeat on every Stop event.
-- **6 seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed as Anthropic feedback + GH #45017), granola carry-over, agent-mail-service.
-- **3 pre-existing bugs caught and fixed** — .git/config bare=true, git-commit PROJECT_ROOT unbound, iscp-check.bats stale version.
+- **`agency-issue` v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1. Smoke-tested by filing [#52](https://github.com/the-agency-ai/the-agency/issues/52) using the tool itself
+- **`release-plan` v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern:** built then used to assemble its own release
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag)
+- **iscp-check v1.1.0** — delta suppression, stops the repeated "You have N" notifications
+- **6 seeds** — fleet-awareness, agency-issue, release-plan, silent-tool-calls (filed externally), granola carry-over, agent-mail-service
+- **3 pre-existing bugs fixed** — `.git/config bare=true`, `git-commit PROJECT_ROOT` unbound, `iscp-check.bats` stale version
 
-## Day 33 - Release 2 (PR #54) — DRAFT
+### PR #55 — merge-not-rebase (UPSTREAM, MERGED)
 
-13+ commits on top of R1. Still in flight.
+Monofolk's contribution. Two hookify blocks (`block-raw-rebase`, `block-reset-to-origin`), four skill migrations (sync-all, sync, post-merge, rebase deprecated), `GIT-MERGE-NOT-REBASE.md` reference doc, CLAUDE-THEAGENCY.md update. Incorporated into our R2 same-day via `git merge origin/main`.
 
-- **iscp-check --statusline mode** + statusline.sh integration — shows 📬 Nd Mf in the footer when current agent has unread mail; silent when empty (per principal directive — icon only appears when there's something to notice)
-- **release-plan heuristic for config-block pairing** — agency.yaml section changes now fold into matching feature commits (e.g., agency.yaml `issues:` block changes go with the agency-issue feature commit)
-- **BATS tests for agency-issue** — 19 tests covering version/help, arg validation, verb dispatch, required-flag checks. Arg validation moved before gh auth check so bad args surface real errors.
-- **BATS tests for release-plan** — 16 tests covering classification, feature pairing, agency.yaml config-block pairing, output options, base ref comparison.
-- **Monofolk merge-not-rebase contribution (PR #55) incorporated** — merged into day33-release-2 via `git merge origin/main` (not rebase). All skills now merge-based, hookify rules block raw rebase and reset --hard origin/*.
-- **nit-add + nit-resolve migrated to merge-based pull** — the two tools were using `git pull --rebase` with `git rebase --abort` cleanup, blocked by the new hookify rule from #55. Migrated to `git pull --no-rebase`.
-- **Monofolk RFI reply sent** — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT, all 5 questions with options considered and reasoning. Delivered via collaboration repo.
-- **Worktree naming rule answered to devex** (#169 review-response, #166 unblocked)
-- **iscp notified of --statusline extension** (#170 heads-up)
-- **Captain's log for Day 33 written** (7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction)
+### PR #54 — Day 33 R2 (MERGED)
 
-### R2 content pending
+13 commits on top of R1 + #55.
 
-- This handoff update (complete once this file lands)
-- Push and update PR #54 description
-- Principal call on merging R2
-- Agency-update test on a real downstream project (1B1 pending on parameters)
+- **iscp-check `--statusline` mode** + statusline.sh integration — silent periodic polling via Claude Code status line; `📬 Nd Mf` in footer when current agent has unread mail, silent when empty
+- **release-plan config-block pairing** — agency.yaml section changes fold into matching feature commits
+- **agency-issue BATS tests** (19) + arg-validation refactor (validate before gh auth check)
+- **release-plan BATS tests** (16)
+- **nit-add + nit-resolve** migrated to merge-based pull (were broken by new block-raw-rebase)
+- **Monofolk RFI reply** sent — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT (5 questions, options considered, reasoning)
+- **Worktree naming answered** (#169 → devex) — prefix collapse rule unblocks #166
+- **iscp statusline heads-up** (#170)
+- **Captain's log for Day 33** — 7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction
+- **PR lifecycle tool seed** — captured for future, on hold pending upstream work
+
+### Agency-update test (presence-detect)
+
+Real-world dogfood test on `~/code/presence-detect` (5-day-old installation at 2.0.0 / `4d6f6683` → 2.0.0 / `6cac2fa9`).
+
+**Backups created first:**
+- Filesystem copy at `~/code/presence-detect.backup-20260408-202749` (116 MB)
+- Git tag `agency-update-backup-20260408`
+- (Remote push not possible — no remote configured)
+
+**Dry-run summary:** +1085 new, ~66 modified, -1 deleted. Single deletion was benign (renamed hookify rule).
+
+**Real update succeeded:**
+- All framework files propagated
+- `agency verify` 10/12 passes (2 deferred Figma providers)
+- All R1 + R2 + #55 content spot-checked and present downstream
+- Pre-existing uncommitted work preserved
+
+**One bug found: [#56](https://github.com/the-agency-ai/the-agency/issues/56)** — `agency update` does not propagate new top-level YAML sections from `agency.yaml`. Only framework metadata is bumped. **Filed via `agency-issue` tool** (first real bug found-and-filed via the new tooling loop). **Captain will fix tomorrow morning and close via `agency-issue close`.**
+
+## Dispatches Sent Today
+
+| ID | Type | To | Subject |
+|----|------|-----|---------|
+| #149 | directive | devex | Day 33 work queue (4 items) |
+| #152 | review-response | devex | Item 3: accept main as-is |
+| #153 | review-response | devex | Item 1: SPEC-PROVIDER wrappers plan approved |
+| #157 | escalation | devex | ~~P0 git-commit bug~~ (downgraded in #162) |
+| #162 | dispatch | devex | P0 → P1 downgrade (sparse worktree confusion) |
+| #165 | directive | iscp | Peer-to-peer cross-repo dispatches + auto-CC |
+| #166 | directive | devex | Worktree naming convention |
+| #167 | directive | devex | Hookify noun-verb rename |
+| #168 | directive | devex | agent-create scaffolding with dispatch loops |
+| #169 | review-response | devex | Worktree naming = B (prefix collapse) |
+| #170 | dispatch | iscp | iscp-check --statusline heads-up |
+
+## Cross-Repo (Monofolk)
+
+**Sent today:**
+- Reply to merge-not-rebase contribution — acknowledging, adopted, shipped into R2
+- Reply to SPEC-PROVIDER + SPEC-ENVIRONMENT RFI — full 1B1 answers with reasoning
+- R2 shipped dispatch — what's in it for monofolk, adoption notes, agency-update test results, #56 heads-up
+
+**No pending inbound.** Collaboration repo is clean on our side.
 
 ## Active Agents (background)
 
 | Agent | State | Notes |
 |-------|-------|-------|
-| devex | Queue of 4 items from #149 + worktree naming (#166 unblocked today), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1/R2 updates |
-| iscp | Working on Phase 2 (per-agent inboxes plan approved). Received #170 heads-up on iscp-check extension. Also received peer-to-peer directive (#165) | Needs to merge master for R1 |
+| devex | Queue: 4 items from #149, plus #166 (unblocked), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1 + R2 |
+| iscp | Phase 2 (per-agent inboxes plan approved). Received #170 + peer-to-peer directive (#165) | Needs to merge master for R1 + R2 |
 | mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
 | mdpal-cli | Own iteration | Needs to merge master |
 
-## Monofolk Cross-Repo
-
-- **Day 33 morning:** Received RFI on SPEC-PROVIDER + SPEC-ENVIRONMENT. 1B1'd with principal. Full reply sent today.
-- **Day 33 afternoon:** Received merge-not-rebase contribution (PR #55). Merged into main (ba6deed). Replied acknowledging, noting discipline applied on its first day (merged into R2, not rebased).
-- **No pending inbound** from monofolk.
-
 ## Open Items
 
-### Pending principal calls
+### Tomorrow morning (immediate)
 
-- **Merge R2** — PR #54 still draft, pending principal go-ahead
-- **Agency-update test** — principal offered a real-world test of R1+R2+#55 on an existing project. 1B1 pending on: project path, backup tag, branch, dry-run vs real run
-- **Anthropic Claude Code backlog** — 4 unfiled issues parked for tomorrow morning
+1. **Fix issue #56** — `agency update` YAML section migration. Investigate `claude/tools/lib/_agency-init`, implement three-way merge (preserve user values in existing sections, add new top-level sections from source with a comment). Test via re-running agency update on presence-detect. Close issue via `agency-issue close 56 --comment "Fixed in PR #NN"`.
+2. **Triage the 4 unfiled Anthropic Claude Code issues** from `usr/jordan/captain/anthropic-issues-to-file-20260406.md`. Verify #2 (brace expansion) is still relevant with current `Bash(*)` permissions. Close #4 (silent /feedback) in tracking doc. File #1 and #3 via `/feedback`.
 
-### Carried forward (deferred to Day 34+)
+### Parked / deferred
 
-- Git-commit `--staged` default behavior fix (when staging area non-empty)
-- Pull-rebase hookify gap investigation (block-raw-rebase pattern may miss `git pull --rebase`)
-- PR lifecycle tool build (on hold, seed captured)
-- Fleet awareness /define (seed ready, PVR not yet started)
-- Hookify noun-verb rename (dispatched to devex as #167, their work)
-- Agent-create scaffolding with dispatch loops (dispatched to devex as #168, their work)
+- **Local presence-detect state** — left as-is with the agency-update diff uncommitted. Backups intact. Principal can commit when ready, after the #56 fix re-runs for the clean delta.
+- **PR lifecycle tool** — seed captured, on hold pending upstream work
+- **Fleet awareness `/define`** — seed ready, PVR not yet started
+- **Captain's log for #56 filing + #56 fix** — log tomorrow
+- **Pull-rebase hookify gap** — investigate whether `block-raw-rebase` pattern misses `git pull --rebase`
+- **`git-commit --staged` default when staging area non-empty** — small usability fix
+
+### Dispatched to devex (their work)
+
+- #149 Item 2: Valueflow Phase 3
+- #149 Item 4: hookify rules from Day 32 friction
+- #166: worktree naming rule implementation
+- #167: hookify noun-verb rename
+- #168: agent-create scaffolding with dispatch loops
+
+### Dispatched to iscp (their work)
+
+- #165: peer-to-peer cross-repo dispatches + auto-CC to captains (protocol work)
 
 ## Active Flags
 
@@ -85,31 +133,37 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 |----|------|--------|
 | 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
 
-## Next Action (start of next session or continuation)
-
-1. Push R2 content to update PR #54 description
-2. **1B1 with principal on agency-update test parameters** (see Open Items)
-3. If principal approves merge of R2: merge PR #54, then post-merge sync
-4. Run agency-update test on the selected downstream project
-5. Tomorrow morning: triage + file Anthropic Claude Code backlog (4 issues)
-
 ## Key Decisions This Session
 
-1. **Dispatch loop convention is universal** — every agent, every session, 5m silent + 30m visible nag
-2. **Bootstrap pattern confirmed** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done twice (R1 with release-plan, R2 with release-plan's improvements)
-3. **Always-visible mailbox was wrong** — corrected to silent-when-empty per principal directive. The icon only appears when the current agent has unread mail.
-4. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`.
-5. **SPEC-PROVIDER orthogonality confirmed** — environment and provider are fully independent concepts. Answered all 5 monofolk RFI questions.
-6. **Worktree naming = prefix collapse** — `devex/devex` → `devex`, `mdpal/mdpal-app` → `mdpal-app`, `agency/captain` → `agency-captain`. Devex unblocked to plan #166.
+1. **Bootstrap pattern confirmed twice** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done with `agency-issue` (R1) and `release-plan` (R1 + R2)
+2. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`
+3. **Worktree naming = prefix collapse** — unblocks devex #166
+4. **Dispatch loop convention is universal** — every agent, every session
+5. **Mailbox statusline = silent when empty** — icon only appears when current agent has unread mail (corrected from an earlier wrong interpretation)
+6. **SPEC-PROVIDER orthogonality confirmed** — environment and provider fully independent (RFI answer to monofolk)
+7. **First dogfood bug-found-and-filed loop completed** — issue #56 filed via agency-issue, will be closed via agency-issue after tomorrow's fix
+8. **Destructive operations require explicit authorization** — principal reminded captain to pause and confirm before push/merge/reset even when strategy is chosen. Going forward: strategy selection is NOT execution authorization.
 
 ## Discipline Reminders
 
-- **Never rebase** — framework-wide block active (block-raw-rebase hookify rule)
-- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin hookify rule)
+- **Never rebase** — framework-wide block active (block-raw-rebase)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin)
+- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; always pause and confirm before push/merge/close/delete
 - Use `/handoff` skill, never raw handoff tool
-- Use `/git-commit` (with `--staged` flag when pre-staging) — never bare `git commit`
+- Use `/git-commit` (with `--staged` flag when pre-staging), never bare `git commit`
 - Run dispatch loop on session start (5m + 30m)
 - Cross-repo dispatches via collaboration repo, not direct
 - Per-agent attribution in all commits via the new email format
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
+2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have acknowledged R2
+3. **Check for dispatches from devex/iscp/mdpal** — they may have picked up the merge
+4. **Tomorrow morning work:**
+   - Fix #56 (agency.yaml three-way merge)
+   - Triage + file Anthropic Claude Code backlog
+   - Day 34 R1 if more work surfaces
+5. **Captain's log** — append today's loop closing (#56 filed, fixed tomorrow) and anything new
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/directive-directive-fix-docker-socket-reachability-58-no-app-20260409-0908.md
+++ b/usr/jordan/captain/dispatches/directive-directive-fix-docker-socket-reachability-58-no-app-20260409-0908.md
@@ -1,0 +1,62 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T01:08
+status: created
+priority: normal
+subject: "DIRECTIVE: fix docker socket reachability (#58) — no approval needed, just do it"
+in_reply_to: null
+---
+
+# DIRECTIVE: fix docker socket reachability (#58) — no approval needed, just do it
+
+New work for your queue. Jordan explicit direction: do not wait for approval on this or the existing #171 items. Just do it.
+
+## Task
+
+Fix GitHub issue #58 — docker CLI cannot connect to daemon when Docker Desktop is running. Full context in the issue.
+
+https://github.com/the-agency-ai/the-agency/issues/58
+
+## Scope
+
+- Investigate why `docker-test.sh` fails with unix:///var/run/docker.sock when Docker Desktop IS running
+- Implement one of the three acceptance options (auto-detect, actionable error, or docker-heal tool)
+- Write bug-exposing test — simulate 'Docker Desktop running but CLI can't reach' and verify the fix works
+- Red → green, commit on devex branch, land via /phase-complete
+
+## Authorization level
+
+FULL AUTONOMY on this and all Day 33 queue items previously dispatched.
+- Do NOT wait for captain or principal approval on per-step decisions.
+- Execute the red-green cycle on your own.
+- Commit and land on your own.
+- Only escalate if you hit a true blocker (conflict, ambiguity about intent, missing permission).
+
+## Context on process expectation
+
+Jordan just said explicitly: 'Tell DevEx don't wait for approval to do it. Just do it.' This applies not just to #58 but to the entire open queue:
+- #8 Item 1 /phase-complete (SPEC-PROVIDER preview/deploy) — just do it
+- #9-#13 from dispatch #149 — just do them in order
+- #171 unblock sequence (merge conflict resolve, handoff restore, stash cleanup) — just do it per the direction in #173
+- #166, #167, #168 per previous dispatches — just do them
+
+You have standing authorization to execute. Loop back only with results, not for permission.
+
+## Report back
+
+- Resolve each dispatch as you complete its item
+- Send review-response on major milestones (e.g., 'issue #58 closed', 'Day 33 queue item N complete')
+- Do NOT send 'blocked on approval' dispatches — there is no approval gate on your queue
+
+## Current main commits you should merge in
+
+- ac73ce9 run-in Triangle + #57 worktree-sync fix
+- 2a62f8d #171 Gate 0 Test User block
+- c746d04 #56 agency update yaml sections
+- 118ae29 34.1 agency-version
+
+Merge main first, then tackle #58.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/review-response-re-171-acknowledged-triaging-with-principal-20260409-0828.md
+++ b/usr/jordan/captain/dispatches/review-response-re-171-acknowledged-triaging-with-principal-20260409-0828.md
@@ -1,0 +1,25 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T00:28
+status: created
+priority: normal
+subject: "RE: #171 — acknowledged, triaging with principal"
+in_reply_to: 171
+---
+
+# RE: #171 — acknowledged, triaging with principal
+
+Acknowledged — I read #171. Apologies for the silence; I found the dispatch on my loop check this morning, surfaced it to Jordan, then got pulled into another discussion without replying here. That was my miss.
+
+Status: triaging the 5 items with Jordan now. You will get per-item direction in follow-up dispatches. Do not take any action on items 1-5 until I reply on that specific item.
+
+Immediate reassurance on what you flagged:
+- You did the right thing stopping before destructive ops
+- The archive file with Day 33 handoff content is preserved — we will restore it
+- The Test User regression has a known root cause (merge lost the test_helper.bash fix); the fix needs to land on main, not devex
+
+Standing queue (#8-#13) remains parked until this is cleared.
+
+Next update within the hour.

--- a/usr/jordan/captain/dispatches/review-response-re-171-per-item-direction-unblock-sequence-back-to-20260409-0848.md
+++ b/usr/jordan/captain/dispatches/review-response-re-171-per-item-direction-unblock-sequence-back-to-20260409-0848.md
@@ -1,0 +1,100 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T00:48
+status: created
+priority: normal
+subject: "RE: #171 — per-item direction, unblock sequence, back-to-work trigger"
+in_reply_to: 171
+---
+
+# RE: #171 — per-item direction, unblock sequence, back-to-work trigger
+
+Triage complete with Jordan. Here is exactly what to do, in order, and when you can resume the Day 33 queue.
+
+═══════════════════════════════════════════════════
+GOOD NEWS FIRST
+═══════════════════════════════════════════════════
+
+Main is now safe to merge. Two things shipped to main in the last few minutes:
+
+1. Commit 2a62f8d — 'fix: #171 Gate 0 — block Test User attribution in commit-precheck'
+   Pre-commit hook now hard-blocks any commit with Test User <test@example.com> attribution.
+   Prints cleanup instructions on failure. Belt + suspenders alongside your existing
+   test_helper.bash env-var unset guard (which was already on main — your diagnosis that
+   main lost the fix was not quite right; main had the fix, but main's .git/config had
+   a POLLUTED [user] section from an earlier leak that the runtime guard couldn't
+   retroactively clean).
+
+2. Main's .git/config [user] section cleaned. Identity now resolves correctly from global.
+
+This means the root cause is fixed AND any recurrence is now blocked at the pre-commit
+gate. Safe to merge main.
+
+═══════════════════════════════════════════════════
+PER-ITEM DIRECTION
+═══════════════════════════════════════════════════
+
+ITEM 1 — Merge conflict on .claude/logs/tool-runs.jsonl: RESOLVE AS 'ACCEPT MAIN'
+  The file is gitignored on main — deletion is intentional. Take main's side:
+    git rm .claude/logs/tool-runs.jsonl
+    git commit (the in-progress merge)
+  Then the worktree-sync merge completes.
+
+ITEM 2 — /session-resume has no recovery path: FRAMEWORK BUG, FILING SEPARATELY
+  Captain will file this as an agency-issue with a bug-exposing test + fix in today's
+  session. Not blocking you. File your own flag if you have specific recovery
+  suggestions; otherwise ignore and carry on.
+
+ITEM 3 — 4 Test User commits on devex branch: LEAVE AS-IS, SQUASH ON LANDING (option C)
+  Do NOT filter-branch. Do NOT rewrite history. When you /phase-complete, the squash
+  will collapse the 4 commits into one new commit correctly attributed to you. The
+  polluted commits never reach main. Cost: ugly branch history for a few hours.
+
+ITEM 4 — Handoff file reverted to Day 32 content: RESTORE FROM ARCHIVE (option A)
+  The Day 33 content exists in usr/jordan/devex/history/handoff-20260408-195821.md
+  (currently untracked). Copy it back over devex-handoff.md, commit via coord-commit.
+  Captain will investigate the handoff-tool root cause as a separate flag — don't block
+  on it.
+
+ITEM 5 — Stash pile: DROP STASH@{0}, LEAVE THE REST
+  - stash@{0} (failed worktree-sync artifact, 7-line tool-runs.jsonl diff): SAFE TO DROP.
+    Run: git stash drop stash@{0}
+  - stash@{1} and stash@{2} ('On main', ghostty + messages.db): NOT YOURS.
+    Captain will take custody on main. Leave them alone.
+
+═══════════════════════════════════════════════════
+EXECUTION ORDER
+═══════════════════════════════════════════════════
+
+1. Merge main into devex (picks up Gate 0 fix + all of 34.1). Let worktree-sync retry OR
+   do it by hand: git merge main
+2. Resolve conflict per Item 1 (git rm tool-runs.jsonl, commit the merge)
+3. Restore handoff from archive per Item 4, coord-commit
+4. Drop stash@{0} per Item 5
+5. Verify identity: git config user.name && git config user.email
+   Expect: Jordan Dea-Mattson / jdm@devopspm.com (NOT Test User)
+6. Run a quick no-op commit on devex to confirm Gate 0 fires correctly on your side too
+   (optional but reassuring)
+
+═══════════════════════════════════════════════════
+BACK-TO-WORK TRIGGER
+═══════════════════════════════════════════════════
+
+As soon as steps 1-5 above are done, you are unblocked and can resume the Day 33 queue:
+  - Task #8: Item 1 /phase-complete (SPEC-PROVIDER preview/deploy) — YOUR NEXT ACTION
+  - Tasks #9-#13: remain queued per #149
+
+Dispatch this response back via review-response with 'unblocked' or 'blocked: <reason>'
+so captain knows where you stand. If anything in steps 1-5 fails in an unexpected way,
+STOP and escalate, don't freelance.
+
+═══════════════════════════════════════════════════
+APOLOGIES
+═══════════════════════════════════════════════════
+
+You escalated #171 last night and it sat unread until 07:30 this morning. That is on
+captain — loop check missed it, then I got pulled into other discussions after surfacing
+it to Jordan without replying here. Fixing the process gap: both dispatch loops are now
+confirmed running this session. You should not experience this silence again.

--- a/usr/jordan/captain/history/handoff-20260408-205115.md
+++ b/usr/jordan/captain/history/handoff-20260408-205115.md
@@ -1,0 +1,115 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-08
+trigger: mid-session-day-33
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 33 in progress.** R1 shipped and merged (PR #53). R2 in draft as PR #54 with substantial content. Monofolk's merge-not-rebase contribution (PR #55) merged into main and incorporated into R2 via merge (not rebase) — discipline applied on its first day.
+
+## Day 33 - Release 1 (PR #53) — MERGED
+
+7 commits. Day 32 carry-over + Day 33 core work.
+
+- **agency-issue v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1 with principal. Smoke-tested by filing the-agency-ai/the-agency#52 using the tool itself.
+- **release-plan v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern: built the tool then used it to assemble R1 and R2.**
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag).
+- **iscp-check v1.1.0** — delta suppression, stops the "You have N" repeat on every Stop event.
+- **6 seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed as Anthropic feedback + GH #45017), granola carry-over, agent-mail-service.
+- **3 pre-existing bugs caught and fixed** — .git/config bare=true, git-commit PROJECT_ROOT unbound, iscp-check.bats stale version.
+
+## Day 33 - Release 2 (PR #54) — DRAFT
+
+13+ commits on top of R1. Still in flight.
+
+- **iscp-check --statusline mode** + statusline.sh integration — shows 📬 Nd Mf in the footer when current agent has unread mail; silent when empty (per principal directive — icon only appears when there's something to notice)
+- **release-plan heuristic for config-block pairing** — agency.yaml section changes now fold into matching feature commits (e.g., agency.yaml `issues:` block changes go with the agency-issue feature commit)
+- **BATS tests for agency-issue** — 19 tests covering version/help, arg validation, verb dispatch, required-flag checks. Arg validation moved before gh auth check so bad args surface real errors.
+- **BATS tests for release-plan** — 16 tests covering classification, feature pairing, agency.yaml config-block pairing, output options, base ref comparison.
+- **Monofolk merge-not-rebase contribution (PR #55) incorporated** — merged into day33-release-2 via `git merge origin/main` (not rebase). All skills now merge-based, hookify rules block raw rebase and reset --hard origin/*.
+- **nit-add + nit-resolve migrated to merge-based pull** — the two tools were using `git pull --rebase` with `git rebase --abort` cleanup, blocked by the new hookify rule from #55. Migrated to `git pull --no-rebase`.
+- **Monofolk RFI reply sent** — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT, all 5 questions with options considered and reasoning. Delivered via collaboration repo.
+- **Worktree naming rule answered to devex** (#169 review-response, #166 unblocked)
+- **iscp notified of --statusline extension** (#170 heads-up)
+- **Captain's log for Day 33 written** (7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction)
+
+### R2 content pending
+
+- This handoff update (complete once this file lands)
+- Push and update PR #54 description
+- Principal call on merging R2
+- Agency-update test on a real downstream project (1B1 pending on parameters)
+
+## Active Agents (background)
+
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Queue of 4 items from #149 + worktree naming (#166 unblocked today), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1/R2 updates |
+| iscp | Working on Phase 2 (per-agent inboxes plan approved). Received #170 heads-up on iscp-check extension. Also received peer-to-peer directive (#165) | Needs to merge master for R1 |
+| mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
+| mdpal-cli | Own iteration | Needs to merge master |
+
+## Monofolk Cross-Repo
+
+- **Day 33 morning:** Received RFI on SPEC-PROVIDER + SPEC-ENVIRONMENT. 1B1'd with principal. Full reply sent today.
+- **Day 33 afternoon:** Received merge-not-rebase contribution (PR #55). Merged into main (ba6deed). Replied acknowledging, noting discipline applied on its first day (merged into R2, not rebased).
+- **No pending inbound** from monofolk.
+
+## Open Items
+
+### Pending principal calls
+
+- **Merge R2** — PR #54 still draft, pending principal go-ahead
+- **Agency-update test** — principal offered a real-world test of R1+R2+#55 on an existing project. 1B1 pending on: project path, backup tag, branch, dry-run vs real run
+- **Anthropic Claude Code backlog** — 4 unfiled issues parked for tomorrow morning
+
+### Carried forward (deferred to Day 34+)
+
+- Git-commit `--staged` default behavior fix (when staging area non-empty)
+- Pull-rebase hookify gap investigation (block-raw-rebase pattern may miss `git pull --rebase`)
+- PR lifecycle tool build (on hold, seed captured)
+- Fleet awareness /define (seed ready, PVR not yet started)
+- Hookify noun-verb rename (dispatched to devex as #167, their work)
+- Agent-create scaffolding with dispatch loops (dispatched to devex as #168, their work)
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
+
+## Next Action (start of next session or continuation)
+
+1. Push R2 content to update PR #54 description
+2. **1B1 with principal on agency-update test parameters** (see Open Items)
+3. If principal approves merge of R2: merge PR #54, then post-merge sync
+4. Run agency-update test on the selected downstream project
+5. Tomorrow morning: triage + file Anthropic Claude Code backlog (4 issues)
+
+## Key Decisions This Session
+
+1. **Dispatch loop convention is universal** — every agent, every session, 5m silent + 30m visible nag
+2. **Bootstrap pattern confirmed** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done twice (R1 with release-plan, R2 with release-plan's improvements)
+3. **Always-visible mailbox was wrong** — corrected to silent-when-empty per principal directive. The icon only appears when the current agent has unread mail.
+4. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`.
+5. **SPEC-PROVIDER orthogonality confirmed** — environment and provider are fully independent concepts. Answered all 5 monofolk RFI questions.
+6. **Worktree naming = prefix collapse** — `devex/devex` → `devex`, `mdpal/mdpal-app` → `mdpal-app`, `agency/captain` → `agency-captain`. Devex unblocked to plan #166.
+
+## Discipline Reminders
+
+- **Never rebase** — framework-wide block active (block-raw-rebase hookify rule)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin hookify rule)
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` (with `--staged` flag when pre-staging) — never bare `git commit`
+- Run dispatch loop on session start (5m + 30m)
+- Cross-repo dispatches via collaboration repo, not direct
+- Per-agent attribution in all commits via the new email format
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/tmp/test-issue-body.md
+++ b/usr/jordan/captain/tmp/test-issue-body.md
@@ -1,0 +1,49 @@
+## Summary
+
+`agency-issue` is a new skill + tool for filing, viewing, commenting on, and closing GitHub issues against the-agency framework directly from within an agency session. It is the v1 implementation of the model 1B1'd with the principal on 2026-04-08.
+
+This issue is being filed using the tool itself as a smoke test of the full pipeline.
+
+## Why it exists
+
+`/feedback` (which talks to Anthropic Claude Code) is fire-and-forget — no status visibility, no update path. The-agency framework needed its own two-way channel for tracking framework friction, bugs, and feature requests with full lifecycle support.
+
+## What v1 ships
+
+- **Tool:** `claude/tools/agency-issue` — bash wrapper over `gh issue` with five verbs:
+  - `file` — create a new issue, write a local report file
+  - `list` — list open/closed/all issues
+  - `view <id>` — show issue body + comments
+  - `comment <id>` — add a comment
+  - `close <id>` — close an issue, optionally with a final comment
+- **Skill:** `.claude/skills/agency-issue/SKILL.md` — agent discovery + usage docs
+- **Config:** `claude/config/agency.yaml` — `issues.github.target_repo` block
+- **Reports:** every filed issue writes a markdown report to `usr/{principal}/reports/` and updates `REPORTS-INDEX.md`
+
+## Design principles
+
+Simple v1, principal-driven decisions:
+
+- **Thin wrapper** over `gh`, no local cache
+- **No labels** in v1 — type goes into the body header, triage is reading
+- **Permissions delegated to GitHub** via `gh` — no custom authz
+- **Anyone can file** (human or agent), no draft-and-approve gate
+- **Reports are principal-scoped** at `usr/{principal}/reports/`
+- **Pull-on-demand** for status (no polling, no notification — yet)
+
+Future v2+ work captured in the seed:
+
+- SPEC-PROVIDER pattern for pluggable backends (GitLab, Linear, Jira)
+- Multi-instance contract pattern (`/agency-issue` for the framework, `/local-issue` for local project tracker)
+- Status-line indicator for "issues with new activity"
+- Issue templates in `.github/ISSUE_TEMPLATE/`
+
+## Related
+
+- Seed: `claude/workstreams/agency/seeds/seed-agency-issue-skill-20260408.md`
+- Sibling pattern: `/feedback` (Anthropic Claude Code)
+- Report directory pattern: `usr/jordan/reports/REPORTS-INDEX.md`
+
+## Acceptance
+
+This very issue is the smoke test. If you can read it on the issue tracker, the file path worked. The local report at `usr/jordan/reports/` should also exist, with frontmatter linking back to this issue.

--- a/usr/jordan/captain/tmp/yaml-migration-issue-body.md
+++ b/usr/jordan/captain/tmp/yaml-migration-issue-body.md
@@ -1,0 +1,120 @@
+## Problem
+
+`agency update` does not propagate new top-level YAML sections from the upstream `claude/config/agency.yaml` to downstream adopters. New config sections added in framework releases are invisible to existing installations; only the framework metadata (`updated_at`, `source_commit`) is bumped.
+
+This is a real gap in the update path. A downstream adopter who runs `agency update` regularly will never receive new optional config schemas like `issues:`, `preview:`, `deploy:`, `crawl:`, `testing:`, and so on — even though the framework code that consumes those sections DOES land. The tools fall back to their hardcoded defaults instead of the adopter's opt-in config, and the adopter has no visible signal that new sections exist.
+
+## Steps to Reproduce
+
+1. Install the-agency in a project at framework commit `A`.
+2. In the upstream framework, add a new top-level section to `claude/config/agency.yaml` at commit `B` (e.g., add `issues: { provider: "github", github: { target_repo: "owner/repo" } }`).
+3. Merge `B` to main.
+4. Run `agency update` in the downstream project.
+5. Inspect `claude/config/agency.yaml` in the downstream.
+
+**Expected:** the new `issues:` section appears in the downstream agency.yaml (with a commented-out hint that says "new section added by framework update X — review and customize").
+
+**Actual:** the `issues:` section is missing. Only the `framework.updated_at` and `framework.source_commit` fields are changed.
+
+## Diagnostic Evidence (2026-04-08 test)
+
+Ran `agency update` on `~/code/presence-detect` (installed 2026-04-03 from commit `4d6f6683`). Source commit was `6cac2fa9` (Day 33 R2 merged into the-agency main, 5 days of framework evolution).
+
+```
+$ agency update
+From:    2.0.0 (4d6f6683)
+To:      2.0.0 (6cac2fa9)
+Changes: +1085 ~66 -1
+```
+
+Verification that framework files propagated correctly:
+- `claude/tools/agency-issue` → present ✅
+- `claude/tools/release-plan` → present ✅
+- `claude/tools/iscp-check` v1.1.0 → present ✅
+- `claude/hookify/hookify.block-raw-rebase.md` → present ✅
+- `claude/hookify/hookify.block-reset-to-origin.md` → present ✅
+- `claude/docs/GIT-MERGE-NOT-REBASE.md` → present ✅
+- `claude/CLAUDE-THEAGENCY.md` → updated ✅
+- `.claude/skills/agency-issue/SKILL.md` → present ✅
+
+But:
+
+```
+$ wc -l ~/code/presence-detect/claude/config/agency.yaml claude/config/agency.yaml
+      43 /Users/jdm/code/presence-detect/claude/config/agency.yaml
+     128 claude/config/agency.yaml
+     171 total
+```
+
+**85 lines of config schema never propagated.** Checking specific sections:
+
+```
+$ grep -E "^(issues|preview|deploy|crawl|testing):" ~/code/presence-detect/claude/config/agency.yaml
+(no output — none of these sections exist downstream)
+```
+
+The diff against prior HEAD of agency.yaml in presence-detect:
+
+```diff
+- framework.updated_at: "2026-04-03T13:06:30+00:00"
+- framework.source_commit: "4d6f6683d12065dceafbeb5afef006f4c845b698"
++ framework.updated_at: "2026-04-08T12:34:57+00:00"
++ framework.source_commit: "6cac2fa9e7e293d415e397606f678f371b9c6f8a"
+```
+
+**Two lines changed.** The entire new-sections delta is lost.
+
+## Root Cause (preliminary)
+
+`claude/tools/lib/_agency-init` handles agency.yaml management. For existing installations, it only updates the `framework.*` metadata block (the "updated_at" and "source_commit" fields) and leaves the rest of the file untouched. This is the correct default — overwriting the whole file would destroy user customizations to existing sections.
+
+But the correct behavior is a **three-way merge**, not a metadata-only update:
+
+- **Preserve user-customized values** in existing sections (what it does today)
+- **Add new top-level sections** from source that don't exist in target (what's missing)
+- **Flag removed upstream sections** as orphaned for user review (what's missing)
+- **Never silently modify** user values in existing sections without a migration note
+
+The `settings-merge` tool already does this kind of additive merge for `.claude/settings.json` (it does an array union for permissions). The same pattern needs to apply to agency.yaml section additions.
+
+## Requested Behavior
+
+When `agency update` encounters a top-level YAML section in source that does not exist in target:
+
+1. **Add the section** with all its default values
+2. **Prepend a comment** that says something like `# Added by framework update on YYYY-MM-DD from commit SHA — review and customize as needed.`
+3. **Report in the update summary** which new sections were added, so the adopter knows to review them
+4. **Never modify** existing sections with user values
+
+The implementation should live in `claude/tools/lib/_agency-init` or a new helper like `_yaml-merge`, and should be idempotent (re-running update doesn't re-add or duplicate sections).
+
+## Why This Matters
+
+This gap means every new optional config schema we ship in the framework requires downstream adopters to manually patch their agency.yaml to opt in. The tools that consume those sections fall back to hardcoded defaults instead — which means:
+
+- `issues:` section → `agency-issue` tool defaults to `the-agency-ai/the-agency` instead of the adopter's chosen repo
+- `preview:` / `deploy:` sections → Preview/deploy providers default instead of adopter's choice
+- `crawl:` section → Crawl provider can't be overridden
+- `testing:` section → Test runner never knows about adopter's custom suites
+
+We hit this during the 2026-04-08 agency-update test on a real downstream project. The update succeeded in every other dimension (1085 files propagated, 66 updated, hookify rules activated, merge-not-rebase discipline applied, all verify checks pass), but the YAML schema migration gap was immediately visible on the first update.
+
+## Related
+
+- Found during: 2026-04-08 agency-update test on `~/code/presence-detect` (installed 2026-04-03 at commit 4d6f6683, updated to commit 6cac2fa9 in this session)
+- Related tool: `claude/tools/lib/_agency-init`
+- Related pattern: `settings-merge` does the right thing for `.claude/settings.json`
+- Sibling pattern: the Claude Code `settings.json` merge logic that unions arrays rather than overwriting
+- Local report: `usr/jordan/reports/report-agency-issue-*-20260408.md` (written by the filing)
+
+## Acceptance
+
+- New sections added to upstream `agency.yaml` appear in downstream `agency.yaml` after `agency update`
+- Existing sections in downstream are never modified
+- Added sections carry a comment identifying the update that brought them in
+- Summary of `agency update` reports new sections added
+- Idempotent: re-running update does not duplicate or re-add
+
+## Note
+
+This issue will be fixed tomorrow. The bug was caught today during the first real agency-update test from the-agency R2. The principal chose to file it now (dogfooding `agency-issue` itself) and patch it tomorrow morning as the first real use of the bug-report → fix → close cycle.

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -20,6 +20,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 
 | 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
 | 2026-04-09 | worktree-sync: misleading 'resolve manually' message after successful conflict-abort | bug | the-agency-ai/the-agency | #57 | [report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409](usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md) | open |
+| 2026-04-09 | Docker CLI cannot connect to daemon even when Docker Desktop is running | bug | the-agency-ai/the-agency | #58 | [report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409](usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -19,6 +19,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-04-08 | agency-issue v1: new skill for two-way GitHub issue tracking | feature | the-agency-ai/the-agency | [#52](https://github.com/the-agency-ai/the-agency/issues/52) | [report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408](report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md) | open |
 
 | 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
+| 2026-04-09 | worktree-sync: misleading 'resolve manually' message after successful conflict-abort | bug | the-agency-ai/the-agency | #57 | [report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409](usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -18,6 +18,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-04-08 | Periodic silent execution primitive for autonomous agents | feedback | anthropic/claude-code | feedback `8dd67e96…` + GH [#45017](https://github.com/anthropics/claude-code/issues/45017) | [report-silent-periodic-tool-calls-20260408](report-silent-periodic-tool-calls-20260408.md) | filed |
 | 2026-04-08 | agency-issue v1: new skill for two-way GitHub issue tracking | feature | the-agency-ai/the-agency | [#52](https://github.com/the-agency-ai/the-agency/issues/52) | [report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408](report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md) | open |
 
+| 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md
+++ b/usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md
@@ -1,0 +1,150 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-08
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/56
+github_issue_number: 56
+status: open
+---
+
+# agency update does not propagate new top-level YAML sections from agency.yaml
+
+**Filed:** 2026-04-08T12:45:36Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#56](https://github.com/the-agency-ai/the-agency/issues/56)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+## Problem
+
+`agency update` does not propagate new top-level YAML sections from the upstream `claude/config/agency.yaml` to downstream adopters. New config sections added in framework releases are invisible to existing installations; only the framework metadata (`updated_at`, `source_commit`) is bumped.
+
+This is a real gap in the update path. A downstream adopter who runs `agency update` regularly will never receive new optional config schemas like `issues:`, `preview:`, `deploy:`, `crawl:`, `testing:`, and so on — even though the framework code that consumes those sections DOES land. The tools fall back to their hardcoded defaults instead of the adopter's opt-in config, and the adopter has no visible signal that new sections exist.
+
+## Steps to Reproduce
+
+1. Install the-agency in a project at framework commit `A`.
+2. In the upstream framework, add a new top-level section to `claude/config/agency.yaml` at commit `B` (e.g., add `issues: { provider: "github", github: { target_repo: "owner/repo" } }`).
+3. Merge `B` to main.
+4. Run `agency update` in the downstream project.
+5. Inspect `claude/config/agency.yaml` in the downstream.
+
+**Expected:** the new `issues:` section appears in the downstream agency.yaml (with a commented-out hint that says "new section added by framework update X — review and customize").
+
+**Actual:** the `issues:` section is missing. Only the `framework.updated_at` and `framework.source_commit` fields are changed.
+
+## Diagnostic Evidence (2026-04-08 test)
+
+Ran `agency update` on `~/code/presence-detect` (installed 2026-04-03 from commit `4d6f6683`). Source commit was `6cac2fa9` (Day 33 R2 merged into the-agency main, 5 days of framework evolution).
+
+```
+$ agency update
+From:    2.0.0 (4d6f6683)
+To:      2.0.0 (6cac2fa9)
+Changes: +1085 ~66 -1
+```
+
+Verification that framework files propagated correctly:
+- `claude/tools/agency-issue` → present ✅
+- `claude/tools/release-plan` → present ✅
+- `claude/tools/iscp-check` v1.1.0 → present ✅
+- `claude/hookify/hookify.block-raw-rebase.md` → present ✅
+- `claude/hookify/hookify.block-reset-to-origin.md` → present ✅
+- `claude/docs/GIT-MERGE-NOT-REBASE.md` → present ✅
+- `claude/CLAUDE-THEAGENCY.md` → updated ✅
+- `.claude/skills/agency-issue/SKILL.md` → present ✅
+
+But:
+
+```
+$ wc -l ~/code/presence-detect/claude/config/agency.yaml claude/config/agency.yaml
+      43 /Users/jdm/code/presence-detect/claude/config/agency.yaml
+     128 claude/config/agency.yaml
+     171 total
+```
+
+**85 lines of config schema never propagated.** Checking specific sections:
+
+```
+$ grep -E "^(issues|preview|deploy|crawl|testing):" ~/code/presence-detect/claude/config/agency.yaml
+(no output — none of these sections exist downstream)
+```
+
+The diff against prior HEAD of agency.yaml in presence-detect:
+
+```diff
+- framework.updated_at: "2026-04-03T13:06:30+00:00"
+- framework.source_commit: "4d6f6683d12065dceafbeb5afef006f4c845b698"
++ framework.updated_at: "2026-04-08T12:34:57+00:00"
++ framework.source_commit: "6cac2fa9e7e293d415e397606f678f371b9c6f8a"
+```
+
+**Two lines changed.** The entire new-sections delta is lost.
+
+## Root Cause (preliminary)
+
+`claude/tools/lib/_agency-init` handles agency.yaml management. For existing installations, it only updates the `framework.*` metadata block (the "updated_at" and "source_commit" fields) and leaves the rest of the file untouched. This is the correct default — overwriting the whole file would destroy user customizations to existing sections.
+
+But the correct behavior is a **three-way merge**, not a metadata-only update:
+
+- **Preserve user-customized values** in existing sections (what it does today)
+- **Add new top-level sections** from source that don't exist in target (what's missing)
+- **Flag removed upstream sections** as orphaned for user review (what's missing)
+- **Never silently modify** user values in existing sections without a migration note
+
+The `settings-merge` tool already does this kind of additive merge for `.claude/settings.json` (it does an array union for permissions). The same pattern needs to apply to agency.yaml section additions.
+
+## Requested Behavior
+
+When `agency update` encounters a top-level YAML section in source that does not exist in target:
+
+1. **Add the section** with all its default values
+2. **Prepend a comment** that says something like `# Added by framework update on YYYY-MM-DD from commit SHA — review and customize as needed.`
+3. **Report in the update summary** which new sections were added, so the adopter knows to review them
+4. **Never modify** existing sections with user values
+
+The implementation should live in `claude/tools/lib/_agency-init` or a new helper like `_yaml-merge`, and should be idempotent (re-running update doesn't re-add or duplicate sections).
+
+## Why This Matters
+
+This gap means every new optional config schema we ship in the framework requires downstream adopters to manually patch their agency.yaml to opt in. The tools that consume those sections fall back to hardcoded defaults instead — which means:
+
+- `issues:` section → `agency-issue` tool defaults to `the-agency-ai/the-agency` instead of the adopter's chosen repo
+- `preview:` / `deploy:` sections → Preview/deploy providers default instead of adopter's choice
+- `crawl:` section → Crawl provider can't be overridden
+- `testing:` section → Test runner never knows about adopter's custom suites
+
+We hit this during the 2026-04-08 agency-update test on a real downstream project. The update succeeded in every other dimension (1085 files propagated, 66 updated, hookify rules activated, merge-not-rebase discipline applied, all verify checks pass), but the YAML schema migration gap was immediately visible on the first update.
+
+## Related
+
+- Found during: 2026-04-08 agency-update test on `~/code/presence-detect` (installed 2026-04-03 at commit 4d6f6683, updated to commit 6cac2fa9 in this session)
+- Related tool: `claude/tools/lib/_agency-init`
+- Related pattern: `settings-merge` does the right thing for `.claude/settings.json`
+- Sibling pattern: the Claude Code `settings.json` merge logic that unions arrays rather than overwriting
+- Local report: `usr/jordan/reports/report-agency-issue-*-20260408.md` (written by the filing)
+
+## Acceptance
+
+- New sections added to upstream `agency.yaml` appear in downstream `agency.yaml` after `agency update`
+- Existing sections in downstream are never modified
+- Added sections carry a comment identifying the update that brought them in
+- Summary of `agency update` reports new sections added
+- Idempotent: re-running update does not duplicate or re-add
+
+## Note
+
+This issue will be fixed tomorrow. The bug was caught today during the first real agency-update test from the-agency R2. The principal chose to file it now (dogfooding `agency-issue` itself) and patch it tomorrow morning as the first real use of the bug-report → fix → close cycle.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-08:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/56

--- a/usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md
+++ b/usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md
@@ -1,0 +1,65 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-09
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/58
+github_issue_number: 58
+status: open
+---
+
+# Docker CLI cannot connect to daemon even when Docker Desktop is running
+
+**Filed:** 2026-04-09T01:07:59Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#58](https://github.com/the-agency-ai/the-agency/issues/58)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+**Type:** bug / devex blocker
+
+## Problem
+
+Running `./tests/docker-test.sh` fails with:
+
+```
+failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
+```
+
+even when Docker Desktop is running on the host. This blocks every test run that requires container isolation, including the BATS suite verification path used by `worktree-sync.bats`, `run-in.bats`, and all ISCP tests in `docker-test.sh --iscp-only`.
+
+## Why this is a devex blocker
+
+1. **No self-heal path.** When Docker Desktop starts on macOS, the `docker` CLI uses a context that points somewhere other than `/var/run/docker.sock` (probably `~/.docker/run/docker.sock`). The CLI can't reach the daemon without the right `DOCKER_HOST` or context selection. The agent has no way to detect or fix this without principal intervention.
+2. **Framework test verification is blocked.** Every test-writing session ends with a 'run this in docker' step that may silently fail for reasons unrelated to the test. Today this happened during the `run-in` and `#57` test builds — the tests had to be run via raw `bats` instead of the isolation container.
+3. **Principal-intervention tax.** Every time this fails, the agent has to escalate to the principal to check Docker. That's fine when the principal is at the keyboard, but it's a hard block when they're on remote control or asleep.
+
+## Expected
+
+At least one of these should be true:
+
+- (a) `docker-test.sh` auto-detects a running Docker Desktop and sets `DOCKER_HOST` or selects the right context before running tests.
+- (b) `docker-test.sh` prints an actionable fix-it-yourself diagnostic if the daemon is unreachable — e.g., 'Run: docker context use desktop-linux' or 'Set DOCKER_HOST=unix://$HOME/.docker/run/docker.sock'.
+- (c) A framework tool `docker-heal` (or similar) that an agent can invoke to get Docker talking without principal help.
+
+## Acceptance criteria
+
+- `./tests/docker-test.sh --file tests/tools/iscp-check.bats` runs successfully from a fresh shell on a Mac with Docker Desktop running, without manual DOCKER_HOST or context setup.
+- If the daemon is genuinely not running, the error message includes a concrete remediation command.
+
+## Related
+
+- Flag #53 (captured today) — 'Docker Desktop is running but docker CLI cannot connect'
+- Dispatch #171 (devex escalation) — /session-resume reliance on worktree-sync; docker test gap would have made the #57 red-green cycle impossible without falling back to local bats.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-09:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/58

--- a/usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md
+++ b/usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md
@@ -1,0 +1,79 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-09
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/57
+github_issue_number: 57
+status: open
+---
+
+# worktree-sync: misleading 'resolve manually' message after successful conflict-abort
+
+**Filed:** 2026-04-09T00:49:59Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#57](https://github.com/the-agency-ai/the-agency/issues/57)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+**Type:** bug
+
+## Problem
+
+When `worktree-sync --auto` hits a merge conflict with master, it internally runs `git merge --abort` (successfully) and pops any stash it took. The tool then exits non-zero with the message:
+
+```
+worktree-sync: merge conflict with master. Resolve manually.
+```
+
+But the repo is NOT in a conflicted state at this point — the merge was already aborted. MERGE_HEAD is gone. The user sees a dirty working tree (from the stash pop) and tries to run `git merge --abort` manually, which fails with 'no merge to abort'.
+
+This caused a devex agent to get stuck in dispatch #171. They reported:
+- 'file staged as new file'
+- 'no MERGE_HEAD so git merge --abort fails with no merge to abort'
+- blocked because /session-resume relies on worktree-sync and has no documented recovery path
+
+## Impact
+
+1. **Confusing error message** — says 'resolve manually' when the merge was already aborted; user doesn't know what to resolve.
+2. **/session-resume fragility** — the skill's Step 1 calls worktree-sync; when it exits non-zero, the skill has no documented recovery path and the entire session-resume ritual blocks.
+3. **Devex-class blocker** — when a worktree agent can't complete session-resume, their entire queue blocks on a friendly mid-session bug.
+
+## Expected
+
+After a conflict-then-abort, the tool should print something like:
+
+```
+worktree-sync: merge with master had conflicts — the merge was automatically aborted.
+  Repo state: restored to pre-merge HEAD (SHA).
+  Conflict files: .claude/logs/tool-runs.jsonl
+  Stash: popped (or: still in stash@{0}).
+  
+  Next steps:
+    1. Review the conflict files — decide whether they should be deleted, kept, or reconciled.
+    2. If deleted on master (common for gitignored files), run: git rm <file>
+    3. Retry worktree-sync after cleanup.
+```
+
+And `/session-resume` should catch worktree-sync failure, print the diagnostic, and continue with handoff read + dispatch check even if sync failed.
+
+## Fix scope (this issue)
+
+This issue covers ONLY the misleading worktree-sync message. The /session-resume recovery path is tracked separately.
+
+## Related
+
+- Dispatch #171 (devex blocker that surfaced this)
+- Dispatch #109 (original Test User pollution — separately fixed on main today as Gate 0)
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-09:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/57


### PR DESCRIPTION
## Summary

Day 34 releases 34.1 and 34.2 bundled. Five commits spanning four fixes + two feature Triangles + one framework primitive.

**Versions shipped:**
- `34.1` — agency-version tool + statusline display
- `34.2` — run-in Triangle + fixes

## Commits

| SHA | What |
|-----|------|
| `118ae29` | **34.1** — `agency-version` tool (`--statusline` / `--json` / help), wired into `statusline.sh`, new `agency_version` field in manifest.json, 11 BATS tests |
| `c746d04` | **fix #56** — `agency update` now propagates new top-level YAML sections from source `agency.yaml` to target, with a comment marker noting framework version. Verified end-to-end on `~/code/presence-detect` (43 → 124 lines, 9 missing sections added cleanly). |
| `2a62f8d` | **fix #171 regression** — Gate 0 in `commit-precheck` hard-blocks any commit with `Test User <test@example.com>` attribution. Belt + suspenders alongside existing `test_helper.bash` env-var unset guard. Cleaned live `[user]` pollution from main's `.git/config` in the same turn. |
| `ac73ce9` | **feat: run-in Triangle** — new `claude/tools/run-in` (run a command in a target directory via subshell, parent CWD untouched), `/run-in` skill, `hookify.block-compound-bash` wide block on `&&`/`\|\|`/`;`/`\|`/`$(…)`/backticks with educative WHY, 11 BATS tests. Also contains **fix #57** — `worktree-sync` no longer says 'Resolve manually' after auto-aborting a conflict; prints clear post-abort diagnostic with conflict files, stash state, and explicit 'do NOT run git merge --abort' guidance. 4 bug-exposing BATS tests. Seed: telemetry-driven tool discovery (Friction → Telemetry → Tool → Block → Flow loop). |
| `bdab384` | **34.2** — version bump marker |

## Issues resolved

- Closes #56 — agency update yaml section propagation
- Closes #57 — worktree-sync misleading 'resolve manually' message
- Resolves dispatch #171 — devex unblock sequence dispatched

## Issues filed for follow-up

- #58 — Docker CLI can't connect to daemon (dispatched to devex with full autonomy directive)

## Dispatches sent

- #172 ack → devex
- #173 per-item unblock direction → devex  
- #174 standing autonomy + #58 → devex

## Flags captured for future work

- #53 docker socket self-heal
- #54 compound command telemetry analysis workstream
- #55 CLAUDE.md + README revision for telemetry-driven tool discovery
- #56 commit-precheck missing end-event on failure
- #57 telemetry identity resolution broken
- #58 /why-did-this-fail skill
- #59 surface run IDs + exit codes on tool failure
- #60 handoff tool investigation (4bc05a1 blob forensics)

## Meta-insight captured

New seed: `seed-telemetry-driven-tool-discovery-20260409.md` — the Bash tool log is a list of the tools we haven't built yet. Every compound bash command is a request for a missing primitive. Framework pattern: **Friction → Telemetry → Tool → Block → Flow**. Queued for CLAUDE.md + README + articles revision.

## Test plan

- [x] `bats tests/tools/agency-version.bats` — 11/11 green
- [x] `bats tests/tools/run-in.bats` — 11/11 green  
- [x] `bats tests/tools/worktree-sync.bats` — 4/4 green
- [x] End-to-end `agency update` on presence-detect — clean propagation
- [x] Statusline smoke test — `34.1` / `34.2` renders between model and location
- [x] Pre-commit Gate 0 smoke test — blocks Test User, unblocks normal identity

🤖 Generated with [Claude Code](https://claude.com/claude-code)