### PR TITLE
Day 34 R1 — agency-version tool + statusline version display

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,5 +1,6 @@
 {
   "schema_version": "1.0",
+  "agency_version": "34.1",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/tools/agency-version
+++ b/claude/tools/agency-version
@@ -1,0 +1,88 @@
+#!/bin/bash
+#
+# What Problem: There is no single-word answer to "what version of the Agency
+# framework is this repo on?" Manifest.json tracks per-component versions but
+# no top-level framework version. Without it we can't show drift, can't answer
+# "is presence-detect current?", and can't display a version in the statusline.
+#
+# How & Why: Read agency_version from claude/config/manifest.json and print it.
+# Verbs kept minimal for v1 — print, --statusline (silent on missing), --json.
+# Drift detection and audit verbs are deferred (flag #51 / audit tool). One
+# tool, one responsibility for now: "what version is this?"
+#
+# Format: day{N}.{release}, e.g. "34.1". Just the number, no prefix.
+#
+# Written: 2026-04-09 during captain Day 34 R1 (agency-version build)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+MANIFEST="$PROJECT_ROOT/claude/config/manifest.json"
+
+_usage() {
+    cat <<'EOF'
+agency-version — print the Agency framework version for this repo
+
+USAGE
+  agency-version              Print the version (e.g. "34.1")
+  agency-version --statusline Print version for statusline (silent if missing)
+  agency-version --json       Print version as JSON
+  agency-version --help       Show this help
+
+READS
+  claude/config/manifest.json → agency_version
+EOF
+}
+
+_read_version() {
+    if [[ ! -f "$MANIFEST" ]]; then
+        return 1
+    fi
+    # jq if available, else grep fallback (statusline must be fast + dep-free)
+    if command -v jq >/dev/null 2>&1; then
+        jq -r '.agency_version // empty' "$MANIFEST" 2>/dev/null
+    else
+        grep -E '"agency_version"[[:space:]]*:' "$MANIFEST" 2>/dev/null \
+            | head -1 \
+            | sed -E 's/.*"agency_version"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/'
+    fi
+}
+
+mode="${1:-print}"
+
+case "$mode" in
+    --help|-h|help)
+        _usage
+        exit 0
+        ;;
+    --statusline)
+        version=$(_read_version 2>/dev/null || true)
+        [[ -z "$version" ]] && exit 0
+        printf '%s' "$version"
+        ;;
+    --json)
+        version=$(_read_version) || { echo '{"error":"manifest not found"}'; exit 1; }
+        if [[ -z "$version" ]]; then
+            echo '{"error":"agency_version not set"}'
+            exit 1
+        fi
+        printf '{"agency_version":"%s"}\n' "$version"
+        ;;
+    print|"")
+        version=$(_read_version) || {
+            echo "error: manifest not found at $MANIFEST" >&2
+            exit 1
+        }
+        if [[ -z "$version" ]]; then
+            echo "error: agency_version not set in manifest" >&2
+            exit 1
+        fi
+        printf '%s\n' "$version"
+        ;;
+    *)
+        echo "error: unknown argument: $mode" >&2
+        _usage >&2
+        exit 2
+        ;;
+esac

--- a/claude/tools/statusline.sh
+++ b/claude/tools/statusline.sh
@@ -171,6 +171,19 @@ if [ -n "$vim_mode" ]; then
     vim_info=" [${vim_mode}]"
 fi
 
+# --- Agency framework version ---
+# Reads agency_version from claude/config/manifest.json via agency-version tool.
+# Silent when missing (tool prints nothing in --statusline mode).
+av_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+agency_ver=""
+if [ -x "$av_script_dir/agency-version" ]; then
+    agency_ver=$("$av_script_dir/agency-version" --statusline 2>/dev/null || true)
+fi
+agency_ver_info=""
+if [ -n "$agency_ver" ]; then
+    agency_ver_info=" | ${agency_ver}"
+fi
+
 # --- ISCP mail indicator ---
 # Silent periodic polling via status line — shows unread dispatch/flag count
 # in the footer bar without touching the transcript. See iscp-check --statusline.
@@ -190,7 +203,7 @@ if [ -n "$iscp_mail" ]; then
 fi
 
 # --- Assemble ---
-status_line="${version_model} | ${location}"
+status_line="${version_model}${agency_ver_info} | ${location}"
 if [ -n "$ctx_label" ]; then
     status_line="${status_line} | ${ctx_label}"
 fi

--- a/tests/tools/agency-version.bats
+++ b/tests/tools/agency-version.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/agency-version
+#
+# Covers the three verbs (print / --statusline / --json), help, unknown args,
+# and the missing-manifest / missing-field error paths. No network.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+    cd "${REPO_ROOT}"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Help
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --help shows usage" {
+    run_tool agency-version --help
+    assert_success
+    assert_output_contains "agency-version"
+    assert_output_contains "statusline"
+}
+
+@test "agency-version: -h shows usage" {
+    run_tool agency-version -h
+    assert_success
+    assert_output_contains "agency-version"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Default print
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: default prints version from manifest" {
+    run_tool agency-version
+    assert_success
+    # Version format: N.N (day.release)
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+@test "agency-version: print verb prints version" {
+    run_tool agency-version print
+    assert_success
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --statusline mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --statusline prints bare version" {
+    run_tool agency-version --statusline
+    assert_success
+    [[ "$output" =~ ^[0-9]+\.[0-9]+$ ]]
+}
+
+@test "agency-version: --statusline is silent when manifest missing" {
+    # Point tool at a fake project root with no manifest
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    run bash "${fake_root}/claude/tools/agency-version" --statusline
+    assert_success
+    [[ -z "$output" ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --json mode
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: --json prints JSON object" {
+    run_tool agency-version --json
+    assert_success
+    assert_output_contains '"agency_version"'
+}
+
+@test "agency-version: --json fails when field missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    echo '{"schema_version":"1.0"}' > "${fake_root}/claude/config/manifest.json"
+    run bash "${fake_root}/claude/tools/agency-version" --json
+    [[ "$status" -ne 0 ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version: unknown arg exits non-zero" {
+    run_tool agency-version --bogus
+    [[ "$status" -ne 0 ]]
+}
+
+@test "agency-version: default fails when manifest missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    run bash "${fake_root}/claude/tools/agency-version"
+    [[ "$status" -ne 0 ]]
+}
+
+@test "agency-version: default fails when field missing" {
+    fake_root="${BATS_TEST_TMPDIR}/fake"
+    mkdir -p "${fake_root}/claude/tools" "${fake_root}/claude/config"
+    cp "${REPO_ROOT}/claude/tools/agency-version" "${fake_root}/claude/tools/"
+    echo '{"schema_version":"1.0"}' > "${fake_root}/claude/config/manifest.json"
+    run bash "${fake_root}/claude/tools/agency-version"
+    [[ "$status" -ne 0 ]]
+}

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -3,7 +3,7 @@ type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
 date: 2026-04-08
-trigger: mid-session-day-33
+trigger: end-of-day-33
 ---
 
 ## Identity
@@ -12,72 +12,120 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 
 ## Current State
 
-**Day 33 in progress.** R1 shipped and merged (PR #53). R2 in draft as PR #54 with substantial content. Monofolk's merge-not-rebase contribution (PR #55) merged into main and incorporated into R2 via merge (not rebase) — discipline applied on its first day.
+**Day 33 complete.** Two releases shipped, one upstream contribution incorporated, one real-world agency-update test executed, first bug-found-and-filed via the new tooling loop. Local main is at `6cac2fa`, in sync with origin.
 
-## Day 33 - Release 1 (PR #53) — MERGED
+## Shipped Today (Day 33)
+
+### PR #53 — Day 33 R1 (MERGED)
 
 7 commits. Day 32 carry-over + Day 33 core work.
 
-- **agency-issue v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1 with principal. Smoke-tested by filing the-agency-ai/the-agency#52 using the tool itself.
-- **release-plan v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern: built the tool then used it to assemble R1 and R2.**
-- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag).
-- **iscp-check v1.1.0** — delta suppression, stops the "You have N" repeat on every Stop event.
-- **6 seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed as Anthropic feedback + GH #45017), granola carry-over, agent-mail-service.
-- **3 pre-existing bugs caught and fixed** — .git/config bare=true, git-commit PROJECT_ROOT unbound, iscp-check.bats stale version.
+- **`agency-issue` v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1. Smoke-tested by filing [#52](https://github.com/the-agency-ai/the-agency/issues/52) using the tool itself
+- **`release-plan` v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern:** built then used to assemble its own release
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag)
+- **iscp-check v1.1.0** — delta suppression, stops the repeated "You have N" notifications
+- **6 seeds** — fleet-awareness, agency-issue, release-plan, silent-tool-calls (filed externally), granola carry-over, agent-mail-service
+- **3 pre-existing bugs fixed** — `.git/config bare=true`, `git-commit PROJECT_ROOT` unbound, `iscp-check.bats` stale version
 
-## Day 33 - Release 2 (PR #54) — DRAFT
+### PR #55 — merge-not-rebase (UPSTREAM, MERGED)
 
-13+ commits on top of R1. Still in flight.
+Monofolk's contribution. Two hookify blocks (`block-raw-rebase`, `block-reset-to-origin`), four skill migrations (sync-all, sync, post-merge, rebase deprecated), `GIT-MERGE-NOT-REBASE.md` reference doc, CLAUDE-THEAGENCY.md update. Incorporated into our R2 same-day via `git merge origin/main`.
 
-- **iscp-check --statusline mode** + statusline.sh integration — shows 📬 Nd Mf in the footer when current agent has unread mail; silent when empty (per principal directive — icon only appears when there's something to notice)
-- **release-plan heuristic for config-block pairing** — agency.yaml section changes now fold into matching feature commits (e.g., agency.yaml `issues:` block changes go with the agency-issue feature commit)
-- **BATS tests for agency-issue** — 19 tests covering version/help, arg validation, verb dispatch, required-flag checks. Arg validation moved before gh auth check so bad args surface real errors.
-- **BATS tests for release-plan** — 16 tests covering classification, feature pairing, agency.yaml config-block pairing, output options, base ref comparison.
-- **Monofolk merge-not-rebase contribution (PR #55) incorporated** — merged into day33-release-2 via `git merge origin/main` (not rebase). All skills now merge-based, hookify rules block raw rebase and reset --hard origin/*.
-- **nit-add + nit-resolve migrated to merge-based pull** — the two tools were using `git pull --rebase` with `git rebase --abort` cleanup, blocked by the new hookify rule from #55. Migrated to `git pull --no-rebase`.
-- **Monofolk RFI reply sent** — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT, all 5 questions with options considered and reasoning. Delivered via collaboration repo.
-- **Worktree naming rule answered to devex** (#169 review-response, #166 unblocked)
-- **iscp notified of --statusline extension** (#170 heads-up)
-- **Captain's log for Day 33 written** (7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction)
+### PR #54 — Day 33 R2 (MERGED)
 
-### R2 content pending
+13 commits on top of R1 + #55.
 
-- This handoff update (complete once this file lands)
-- Push and update PR #54 description
-- Principal call on merging R2
-- Agency-update test on a real downstream project (1B1 pending on parameters)
+- **iscp-check `--statusline` mode** + statusline.sh integration — silent periodic polling via Claude Code status line; `📬 Nd Mf` in footer when current agent has unread mail, silent when empty
+- **release-plan config-block pairing** — agency.yaml section changes fold into matching feature commits
+- **agency-issue BATS tests** (19) + arg-validation refactor (validate before gh auth check)
+- **release-plan BATS tests** (16)
+- **nit-add + nit-resolve** migrated to merge-based pull (were broken by new block-raw-rebase)
+- **Monofolk RFI reply** sent — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT (5 questions, options considered, reasoning)
+- **Worktree naming answered** (#169 → devex) — prefix collapse rule unblocks #166
+- **iscp statusline heads-up** (#170)
+- **Captain's log for Day 33** — 7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction
+- **PR lifecycle tool seed** — captured for future, on hold pending upstream work
+
+### Agency-update test (presence-detect)
+
+Real-world dogfood test on `~/code/presence-detect` (5-day-old installation at 2.0.0 / `4d6f6683` → 2.0.0 / `6cac2fa9`).
+
+**Backups created first:**
+- Filesystem copy at `~/code/presence-detect.backup-20260408-202749` (116 MB)
+- Git tag `agency-update-backup-20260408`
+- (Remote push not possible — no remote configured)
+
+**Dry-run summary:** +1085 new, ~66 modified, -1 deleted. Single deletion was benign (renamed hookify rule).
+
+**Real update succeeded:**
+- All framework files propagated
+- `agency verify` 10/12 passes (2 deferred Figma providers)
+- All R1 + R2 + #55 content spot-checked and present downstream
+- Pre-existing uncommitted work preserved
+
+**One bug found: [#56](https://github.com/the-agency-ai/the-agency/issues/56)** — `agency update` does not propagate new top-level YAML sections from `agency.yaml`. Only framework metadata is bumped. **Filed via `agency-issue` tool** (first real bug found-and-filed via the new tooling loop). **Captain will fix tomorrow morning and close via `agency-issue close`.**
+
+## Dispatches Sent Today
+
+| ID | Type | To | Subject |
+|----|------|-----|---------|
+| #149 | directive | devex | Day 33 work queue (4 items) |
+| #152 | review-response | devex | Item 3: accept main as-is |
+| #153 | review-response | devex | Item 1: SPEC-PROVIDER wrappers plan approved |
+| #157 | escalation | devex | ~~P0 git-commit bug~~ (downgraded in #162) |
+| #162 | dispatch | devex | P0 → P1 downgrade (sparse worktree confusion) |
+| #165 | directive | iscp | Peer-to-peer cross-repo dispatches + auto-CC |
+| #166 | directive | devex | Worktree naming convention |
+| #167 | directive | devex | Hookify noun-verb rename |
+| #168 | directive | devex | agent-create scaffolding with dispatch loops |
+| #169 | review-response | devex | Worktree naming = B (prefix collapse) |
+| #170 | dispatch | iscp | iscp-check --statusline heads-up |
+
+## Cross-Repo (Monofolk)
+
+**Sent today:**
+- Reply to merge-not-rebase contribution — acknowledging, adopted, shipped into R2
+- Reply to SPEC-PROVIDER + SPEC-ENVIRONMENT RFI — full 1B1 answers with reasoning
+- R2 shipped dispatch — what's in it for monofolk, adoption notes, agency-update test results, #56 heads-up
+
+**No pending inbound.** Collaboration repo is clean on our side.
 
 ## Active Agents (background)
 
 | Agent | State | Notes |
 |-------|-------|-------|
-| devex | Queue of 4 items from #149 + worktree naming (#166 unblocked today), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1/R2 updates |
-| iscp | Working on Phase 2 (per-agent inboxes plan approved). Received #170 heads-up on iscp-check extension. Also received peer-to-peer directive (#165) | Needs to merge master for R1 |
+| devex | Queue: 4 items from #149, plus #166 (unblocked), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1 + R2 |
+| iscp | Phase 2 (per-agent inboxes plan approved). Received #170 + peer-to-peer directive (#165) | Needs to merge master for R1 + R2 |
 | mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
 | mdpal-cli | Own iteration | Needs to merge master |
 
-## Monofolk Cross-Repo
-
-- **Day 33 morning:** Received RFI on SPEC-PROVIDER + SPEC-ENVIRONMENT. 1B1'd with principal. Full reply sent today.
-- **Day 33 afternoon:** Received merge-not-rebase contribution (PR #55). Merged into main (ba6deed). Replied acknowledging, noting discipline applied on its first day (merged into R2, not rebased).
-- **No pending inbound** from monofolk.
-
 ## Open Items
 
-### Pending principal calls
+### Tomorrow morning (immediate)
 
-- **Merge R2** — PR #54 still draft, pending principal go-ahead
-- **Agency-update test** — principal offered a real-world test of R1+R2+#55 on an existing project. 1B1 pending on: project path, backup tag, branch, dry-run vs real run
-- **Anthropic Claude Code backlog** — 4 unfiled issues parked for tomorrow morning
+1. **Fix issue #56** — `agency update` YAML section migration. Investigate `claude/tools/lib/_agency-init`, implement three-way merge (preserve user values in existing sections, add new top-level sections from source with a comment). Test via re-running agency update on presence-detect. Close issue via `agency-issue close 56 --comment "Fixed in PR #NN"`.
+2. **Triage the 4 unfiled Anthropic Claude Code issues** from `usr/jordan/captain/anthropic-issues-to-file-20260406.md`. Verify #2 (brace expansion) is still relevant with current `Bash(*)` permissions. Close #4 (silent /feedback) in tracking doc. File #1 and #3 via `/feedback`.
 
-### Carried forward (deferred to Day 34+)
+### Parked / deferred
 
-- Git-commit `--staged` default behavior fix (when staging area non-empty)
-- Pull-rebase hookify gap investigation (block-raw-rebase pattern may miss `git pull --rebase`)
-- PR lifecycle tool build (on hold, seed captured)
-- Fleet awareness /define (seed ready, PVR not yet started)
-- Hookify noun-verb rename (dispatched to devex as #167, their work)
-- Agent-create scaffolding with dispatch loops (dispatched to devex as #168, their work)
+- **Local presence-detect state** — left as-is with the agency-update diff uncommitted. Backups intact. Principal can commit when ready, after the #56 fix re-runs for the clean delta.
+- **PR lifecycle tool** — seed captured, on hold pending upstream work
+- **Fleet awareness `/define`** — seed ready, PVR not yet started
+- **Captain's log for #56 filing + #56 fix** — log tomorrow
+- **Pull-rebase hookify gap** — investigate whether `block-raw-rebase` pattern misses `git pull --rebase`
+- **`git-commit --staged` default when staging area non-empty** — small usability fix
+
+### Dispatched to devex (their work)
+
+- #149 Item 2: Valueflow Phase 3
+- #149 Item 4: hookify rules from Day 32 friction
+- #166: worktree naming rule implementation
+- #167: hookify noun-verb rename
+- #168: agent-create scaffolding with dispatch loops
+
+### Dispatched to iscp (their work)
+
+- #165: peer-to-peer cross-repo dispatches + auto-CC to captains (protocol work)
 
 ## Active Flags
 
@@ -85,31 +133,37 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 |----|------|--------|
 | 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
 
-## Next Action (start of next session or continuation)
-
-1. Push R2 content to update PR #54 description
-2. **1B1 with principal on agency-update test parameters** (see Open Items)
-3. If principal approves merge of R2: merge PR #54, then post-merge sync
-4. Run agency-update test on the selected downstream project
-5. Tomorrow morning: triage + file Anthropic Claude Code backlog (4 issues)
-
 ## Key Decisions This Session
 
-1. **Dispatch loop convention is universal** — every agent, every session, 5m silent + 30m visible nag
-2. **Bootstrap pattern confirmed** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done twice (R1 with release-plan, R2 with release-plan's improvements)
-3. **Always-visible mailbox was wrong** — corrected to silent-when-empty per principal directive. The icon only appears when the current agent has unread mail.
-4. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`.
-5. **SPEC-PROVIDER orthogonality confirmed** — environment and provider are fully independent concepts. Answered all 5 monofolk RFI questions.
-6. **Worktree naming = prefix collapse** — `devex/devex` → `devex`, `mdpal/mdpal-app` → `mdpal-app`, `agency/captain` → `agency-captain`. Devex unblocked to plan #166.
+1. **Bootstrap pattern confirmed twice** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done with `agency-issue` (R1) and `release-plan` (R1 + R2)
+2. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`
+3. **Worktree naming = prefix collapse** — unblocks devex #166
+4. **Dispatch loop convention is universal** — every agent, every session
+5. **Mailbox statusline = silent when empty** — icon only appears when current agent has unread mail (corrected from an earlier wrong interpretation)
+6. **SPEC-PROVIDER orthogonality confirmed** — environment and provider fully independent (RFI answer to monofolk)
+7. **First dogfood bug-found-and-filed loop completed** — issue #56 filed via agency-issue, will be closed via agency-issue after tomorrow's fix
+8. **Destructive operations require explicit authorization** — principal reminded captain to pause and confirm before push/merge/reset even when strategy is chosen. Going forward: strategy selection is NOT execution authorization.
 
 ## Discipline Reminders
 
-- **Never rebase** — framework-wide block active (block-raw-rebase hookify rule)
-- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin hookify rule)
+- **Never rebase** — framework-wide block active (block-raw-rebase)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin)
+- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; always pause and confirm before push/merge/close/delete
 - Use `/handoff` skill, never raw handoff tool
-- Use `/git-commit` (with `--staged` flag when pre-staging) — never bare `git commit`
+- Use `/git-commit` (with `--staged` flag when pre-staging), never bare `git commit`
 - Run dispatch loop on session start (5m + 30m)
 - Cross-repo dispatches via collaboration repo, not direct
 - Per-agent attribution in all commits via the new email format
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
+2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have acknowledged R2
+3. **Check for dispatches from devex/iscp/mdpal** — they may have picked up the merge
+4. **Tomorrow morning work:**
+   - Fix #56 (agency.yaml three-way merge)
+   - Triage + file Anthropic Claude Code backlog
+   - Day 34 R1 if more work surfaces
+5. **Captain's log** — append today's loop closing (#56 filed, fixed tomorrow) and anything new
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260408-205115.md
+++ b/usr/jordan/captain/history/handoff-20260408-205115.md
@@ -1,0 +1,115 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-08
+trigger: mid-session-day-33
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 33 in progress.** R1 shipped and merged (PR #53). R2 in draft as PR #54 with substantial content. Monofolk's merge-not-rebase contribution (PR #55) merged into main and incorporated into R2 via merge (not rebase) — discipline applied on its first day.
+
+## Day 33 - Release 1 (PR #53) — MERGED
+
+7 commits. Day 32 carry-over + Day 33 core work.
+
+- **agency-issue v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1 with principal. Smoke-tested by filing the-agency-ai/the-agency#52 using the tool itself.
+- **release-plan v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern: built the tool then used it to assemble R1 and R2.**
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag).
+- **iscp-check v1.1.0** — delta suppression, stops the "You have N" repeat on every Stop event.
+- **6 seeds** — fleet awareness, agency-issue, release-plan, silent-tool-calls (filed as Anthropic feedback + GH #45017), granola carry-over, agent-mail-service.
+- **3 pre-existing bugs caught and fixed** — .git/config bare=true, git-commit PROJECT_ROOT unbound, iscp-check.bats stale version.
+
+## Day 33 - Release 2 (PR #54) — DRAFT
+
+13+ commits on top of R1. Still in flight.
+
+- **iscp-check --statusline mode** + statusline.sh integration — shows 📬 Nd Mf in the footer when current agent has unread mail; silent when empty (per principal directive — icon only appears when there's something to notice)
+- **release-plan heuristic for config-block pairing** — agency.yaml section changes now fold into matching feature commits (e.g., agency.yaml `issues:` block changes go with the agency-issue feature commit)
+- **BATS tests for agency-issue** — 19 tests covering version/help, arg validation, verb dispatch, required-flag checks. Arg validation moved before gh auth check so bad args surface real errors.
+- **BATS tests for release-plan** — 16 tests covering classification, feature pairing, agency.yaml config-block pairing, output options, base ref comparison.
+- **Monofolk merge-not-rebase contribution (PR #55) incorporated** — merged into day33-release-2 via `git merge origin/main` (not rebase). All skills now merge-based, hookify rules block raw rebase and reset --hard origin/*.
+- **nit-add + nit-resolve migrated to merge-based pull** — the two tools were using `git pull --rebase` with `git rebase --abort` cleanup, blocked by the new hookify rule from #55. Migrated to `git pull --no-rebase`.
+- **Monofolk RFI reply sent** — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT, all 5 questions with options considered and reasoning. Delivered via collaboration repo.
+- **Worktree naming rule answered to devex** (#169 review-response, #166 unblocked)
+- **iscp notified of --statusline extension** (#170 heads-up)
+- **Captain's log for Day 33 written** (7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction)
+
+### R2 content pending
+
+- This handoff update (complete once this file lands)
+- Push and update PR #54 description
+- Principal call on merging R2
+- Agency-update test on a real downstream project (1B1 pending on parameters)
+
+## Active Agents (background)
+
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Queue of 4 items from #149 + worktree naming (#166 unblocked today), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1/R2 updates |
+| iscp | Working on Phase 2 (per-agent inboxes plan approved). Received #170 heads-up on iscp-check extension. Also received peer-to-peer directive (#165) | Needs to merge master for R1 |
+| mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
+| mdpal-cli | Own iteration | Needs to merge master |
+
+## Monofolk Cross-Repo
+
+- **Day 33 morning:** Received RFI on SPEC-PROVIDER + SPEC-ENVIRONMENT. 1B1'd with principal. Full reply sent today.
+- **Day 33 afternoon:** Received merge-not-rebase contribution (PR #55). Merged into main (ba6deed). Replied acknowledging, noting discipline applied on its first day (merged into R2, not rebased).
+- **No pending inbound** from monofolk.
+
+## Open Items
+
+### Pending principal calls
+
+- **Merge R2** — PR #54 still draft, pending principal go-ahead
+- **Agency-update test** — principal offered a real-world test of R1+R2+#55 on an existing project. 1B1 pending on: project path, backup tag, branch, dry-run vs real run
+- **Anthropic Claude Code backlog** — 4 unfiled issues parked for tomorrow morning
+
+### Carried forward (deferred to Day 34+)
+
+- Git-commit `--staged` default behavior fix (when staging area non-empty)
+- Pull-rebase hookify gap investigation (block-raw-rebase pattern may miss `git pull --rebase`)
+- PR lifecycle tool build (on hold, seed captured)
+- Fleet awareness /define (seed ready, PVR not yet started)
+- Hookify noun-verb rename (dispatched to devex as #167, their work)
+- Agent-create scaffolding with dispatch loops (dispatched to devex as #168, their work)
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
+
+## Next Action (start of next session or continuation)
+
+1. Push R2 content to update PR #54 description
+2. **1B1 with principal on agency-update test parameters** (see Open Items)
+3. If principal approves merge of R2: merge PR #54, then post-merge sync
+4. Run agency-update test on the selected downstream project
+5. Tomorrow morning: triage + file Anthropic Claude Code backlog (4 issues)
+
+## Key Decisions This Session
+
+1. **Dispatch loop convention is universal** — every agent, every session, 5m silent + 30m visible nag
+2. **Bootstrap pattern confirmed** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done twice (R1 with release-plan, R2 with release-plan's improvements)
+3. **Always-visible mailbox was wrong** — corrected to silent-when-empty per principal directive. The icon only appears when the current agent has unread mail.
+4. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`.
+5. **SPEC-PROVIDER orthogonality confirmed** — environment and provider are fully independent concepts. Answered all 5 monofolk RFI questions.
+6. **Worktree naming = prefix collapse** — `devex/devex` → `devex`, `mdpal/mdpal-app` → `mdpal-app`, `agency/captain` → `agency-captain`. Devex unblocked to plan #166.
+
+## Discipline Reminders
+
+- **Never rebase** — framework-wide block active (block-raw-rebase hookify rule)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin hookify rule)
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` (with `--staged` flag when pre-staging) — never bare `git commit`
+- Run dispatch loop on session start (5m + 30m)
+- Cross-repo dispatches via collaboration repo, not direct
+- Per-agent attribution in all commits via the new email format
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/tmp/test-issue-body.md
+++ b/usr/jordan/captain/tmp/test-issue-body.md
@@ -1,0 +1,49 @@
+## Summary
+
+`agency-issue` is a new skill + tool for filing, viewing, commenting on, and closing GitHub issues against the-agency framework directly from within an agency session. It is the v1 implementation of the model 1B1'd with the principal on 2026-04-08.
+
+This issue is being filed using the tool itself as a smoke test of the full pipeline.
+
+## Why it exists
+
+`/feedback` (which talks to Anthropic Claude Code) is fire-and-forget — no status visibility, no update path. The-agency framework needed its own two-way channel for tracking framework friction, bugs, and feature requests with full lifecycle support.
+
+## What v1 ships
+
+- **Tool:** `claude/tools/agency-issue` — bash wrapper over `gh issue` with five verbs:
+  - `file` — create a new issue, write a local report file
+  - `list` — list open/closed/all issues
+  - `view <id>` — show issue body + comments
+  - `comment <id>` — add a comment
+  - `close <id>` — close an issue, optionally with a final comment
+- **Skill:** `.claude/skills/agency-issue/SKILL.md` — agent discovery + usage docs
+- **Config:** `claude/config/agency.yaml` — `issues.github.target_repo` block
+- **Reports:** every filed issue writes a markdown report to `usr/{principal}/reports/` and updates `REPORTS-INDEX.md`
+
+## Design principles
+
+Simple v1, principal-driven decisions:
+
+- **Thin wrapper** over `gh`, no local cache
+- **No labels** in v1 — type goes into the body header, triage is reading
+- **Permissions delegated to GitHub** via `gh` — no custom authz
+- **Anyone can file** (human or agent), no draft-and-approve gate
+- **Reports are principal-scoped** at `usr/{principal}/reports/`
+- **Pull-on-demand** for status (no polling, no notification — yet)
+
+Future v2+ work captured in the seed:
+
+- SPEC-PROVIDER pattern for pluggable backends (GitLab, Linear, Jira)
+- Multi-instance contract pattern (`/agency-issue` for the framework, `/local-issue` for local project tracker)
+- Status-line indicator for "issues with new activity"
+- Issue templates in `.github/ISSUE_TEMPLATE/`
+
+## Related
+
+- Seed: `claude/workstreams/agency/seeds/seed-agency-issue-skill-20260408.md`
+- Sibling pattern: `/feedback` (Anthropic Claude Code)
+- Report directory pattern: `usr/jordan/reports/REPORTS-INDEX.md`
+
+## Acceptance
+
+This very issue is the smoke test. If you can read it on the issue tracker, the file path worked. The local report at `usr/jordan/reports/` should also exist, with frontmatter linking back to this issue.

--- a/usr/jordan/captain/tmp/yaml-migration-issue-body.md
+++ b/usr/jordan/captain/tmp/yaml-migration-issue-body.md
@@ -1,0 +1,120 @@
+## Problem
+
+`agency update` does not propagate new top-level YAML sections from the upstream `claude/config/agency.yaml` to downstream adopters. New config sections added in framework releases are invisible to existing installations; only the framework metadata (`updated_at`, `source_commit`) is bumped.
+
+This is a real gap in the update path. A downstream adopter who runs `agency update` regularly will never receive new optional config schemas like `issues:`, `preview:`, `deploy:`, `crawl:`, `testing:`, and so on — even though the framework code that consumes those sections DOES land. The tools fall back to their hardcoded defaults instead of the adopter's opt-in config, and the adopter has no visible signal that new sections exist.
+
+## Steps to Reproduce
+
+1. Install the-agency in a project at framework commit `A`.
+2. In the upstream framework, add a new top-level section to `claude/config/agency.yaml` at commit `B` (e.g., add `issues: { provider: "github", github: { target_repo: "owner/repo" } }`).
+3. Merge `B` to main.
+4. Run `agency update` in the downstream project.
+5. Inspect `claude/config/agency.yaml` in the downstream.
+
+**Expected:** the new `issues:` section appears in the downstream agency.yaml (with a commented-out hint that says "new section added by framework update X — review and customize").
+
+**Actual:** the `issues:` section is missing. Only the `framework.updated_at` and `framework.source_commit` fields are changed.
+
+## Diagnostic Evidence (2026-04-08 test)
+
+Ran `agency update` on `~/code/presence-detect` (installed 2026-04-03 from commit `4d6f6683`). Source commit was `6cac2fa9` (Day 33 R2 merged into the-agency main, 5 days of framework evolution).
+
+```
+$ agency update
+From:    2.0.0 (4d6f6683)
+To:      2.0.0 (6cac2fa9)
+Changes: +1085 ~66 -1
+```
+
+Verification that framework files propagated correctly:
+- `claude/tools/agency-issue` → present ✅
+- `claude/tools/release-plan` → present ✅
+- `claude/tools/iscp-check` v1.1.0 → present ✅
+- `claude/hookify/hookify.block-raw-rebase.md` → present ✅
+- `claude/hookify/hookify.block-reset-to-origin.md` → present ✅
+- `claude/docs/GIT-MERGE-NOT-REBASE.md` → present ✅
+- `claude/CLAUDE-THEAGENCY.md` → updated ✅
+- `.claude/skills/agency-issue/SKILL.md` → present ✅
+
+But:
+
+```
+$ wc -l ~/code/presence-detect/claude/config/agency.yaml claude/config/agency.yaml
+      43 /Users/jdm/code/presence-detect/claude/config/agency.yaml
+     128 claude/config/agency.yaml
+     171 total
+```
+
+**85 lines of config schema never propagated.** Checking specific sections:
+
+```
+$ grep -E "^(issues|preview|deploy|crawl|testing):" ~/code/presence-detect/claude/config/agency.yaml
+(no output — none of these sections exist downstream)
+```
+
+The diff against prior HEAD of agency.yaml in presence-detect:
+
+```diff
+- framework.updated_at: "2026-04-03T13:06:30+00:00"
+- framework.source_commit: "4d6f6683d12065dceafbeb5afef006f4c845b698"
++ framework.updated_at: "2026-04-08T12:34:57+00:00"
++ framework.source_commit: "6cac2fa9e7e293d415e397606f678f371b9c6f8a"
+```
+
+**Two lines changed.** The entire new-sections delta is lost.
+
+## Root Cause (preliminary)
+
+`claude/tools/lib/_agency-init` handles agency.yaml management. For existing installations, it only updates the `framework.*` metadata block (the "updated_at" and "source_commit" fields) and leaves the rest of the file untouched. This is the correct default — overwriting the whole file would destroy user customizations to existing sections.
+
+But the correct behavior is a **three-way merge**, not a metadata-only update:
+
+- **Preserve user-customized values** in existing sections (what it does today)
+- **Add new top-level sections** from source that don't exist in target (what's missing)
+- **Flag removed upstream sections** as orphaned for user review (what's missing)
+- **Never silently modify** user values in existing sections without a migration note
+
+The `settings-merge` tool already does this kind of additive merge for `.claude/settings.json` (it does an array union for permissions). The same pattern needs to apply to agency.yaml section additions.
+
+## Requested Behavior
+
+When `agency update` encounters a top-level YAML section in source that does not exist in target:
+
+1. **Add the section** with all its default values
+2. **Prepend a comment** that says something like `# Added by framework update on YYYY-MM-DD from commit SHA — review and customize as needed.`
+3. **Report in the update summary** which new sections were added, so the adopter knows to review them
+4. **Never modify** existing sections with user values
+
+The implementation should live in `claude/tools/lib/_agency-init` or a new helper like `_yaml-merge`, and should be idempotent (re-running update doesn't re-add or duplicate sections).
+
+## Why This Matters
+
+This gap means every new optional config schema we ship in the framework requires downstream adopters to manually patch their agency.yaml to opt in. The tools that consume those sections fall back to hardcoded defaults instead — which means:
+
+- `issues:` section → `agency-issue` tool defaults to `the-agency-ai/the-agency` instead of the adopter's chosen repo
+- `preview:` / `deploy:` sections → Preview/deploy providers default instead of adopter's choice
+- `crawl:` section → Crawl provider can't be overridden
+- `testing:` section → Test runner never knows about adopter's custom suites
+
+We hit this during the 2026-04-08 agency-update test on a real downstream project. The update succeeded in every other dimension (1085 files propagated, 66 updated, hookify rules activated, merge-not-rebase discipline applied, all verify checks pass), but the YAML schema migration gap was immediately visible on the first update.
+
+## Related
+
+- Found during: 2026-04-08 agency-update test on `~/code/presence-detect` (installed 2026-04-03 at commit 4d6f6683, updated to commit 6cac2fa9 in this session)
+- Related tool: `claude/tools/lib/_agency-init`
+- Related pattern: `settings-merge` does the right thing for `.claude/settings.json`
+- Sibling pattern: the Claude Code `settings.json` merge logic that unions arrays rather than overwriting
+- Local report: `usr/jordan/reports/report-agency-issue-*-20260408.md` (written by the filing)
+
+## Acceptance
+
+- New sections added to upstream `agency.yaml` appear in downstream `agency.yaml` after `agency update`
+- Existing sections in downstream are never modified
+- Added sections carry a comment identifying the update that brought them in
+- Summary of `agency update` reports new sections added
+- Idempotent: re-running update does not duplicate or re-add
+
+## Note
+
+This issue will be fixed tomorrow. The bug was caught today during the first real agency-update test from the-agency R2. The principal chose to file it now (dogfooding `agency-issue` itself) and patch it tomorrow morning as the first real use of the bug-report → fix → close cycle.

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -18,6 +18,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-04-08 | Periodic silent execution primitive for autonomous agents | feedback | anthropic/claude-code | feedback `8dd67e96…` + GH [#45017](https://github.com/anthropics/claude-code/issues/45017) | [report-silent-periodic-tool-calls-20260408](report-silent-periodic-tool-calls-20260408.md) | filed |
 | 2026-04-08 | agency-issue v1: new skill for two-way GitHub issue tracking | feature | the-agency-ai/the-agency | [#52](https://github.com/the-agency-ai/the-agency/issues/52) | [report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408](report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md) | open |
 
+| 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md
+++ b/usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md
@@ -1,0 +1,150 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-08
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/56
+github_issue_number: 56
+status: open
+---
+
+# agency update does not propagate new top-level YAML sections from agency.yaml
+
+**Filed:** 2026-04-08T12:45:36Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#56](https://github.com/the-agency-ai/the-agency/issues/56)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+## Problem
+
+`agency update` does not propagate new top-level YAML sections from the upstream `claude/config/agency.yaml` to downstream adopters. New config sections added in framework releases are invisible to existing installations; only the framework metadata (`updated_at`, `source_commit`) is bumped.
+
+This is a real gap in the update path. A downstream adopter who runs `agency update` regularly will never receive new optional config schemas like `issues:`, `preview:`, `deploy:`, `crawl:`, `testing:`, and so on — even though the framework code that consumes those sections DOES land. The tools fall back to their hardcoded defaults instead of the adopter's opt-in config, and the adopter has no visible signal that new sections exist.
+
+## Steps to Reproduce
+
+1. Install the-agency in a project at framework commit `A`.
+2. In the upstream framework, add a new top-level section to `claude/config/agency.yaml` at commit `B` (e.g., add `issues: { provider: "github", github: { target_repo: "owner/repo" } }`).
+3. Merge `B` to main.
+4. Run `agency update` in the downstream project.
+5. Inspect `claude/config/agency.yaml` in the downstream.
+
+**Expected:** the new `issues:` section appears in the downstream agency.yaml (with a commented-out hint that says "new section added by framework update X — review and customize").
+
+**Actual:** the `issues:` section is missing. Only the `framework.updated_at` and `framework.source_commit` fields are changed.
+
+## Diagnostic Evidence (2026-04-08 test)
+
+Ran `agency update` on `~/code/presence-detect` (installed 2026-04-03 from commit `4d6f6683`). Source commit was `6cac2fa9` (Day 33 R2 merged into the-agency main, 5 days of framework evolution).
+
+```
+$ agency update
+From:    2.0.0 (4d6f6683)
+To:      2.0.0 (6cac2fa9)
+Changes: +1085 ~66 -1
+```
+
+Verification that framework files propagated correctly:
+- `claude/tools/agency-issue` → present ✅
+- `claude/tools/release-plan` → present ✅
+- `claude/tools/iscp-check` v1.1.0 → present ✅
+- `claude/hookify/hookify.block-raw-rebase.md` → present ✅
+- `claude/hookify/hookify.block-reset-to-origin.md` → present ✅
+- `claude/docs/GIT-MERGE-NOT-REBASE.md` → present ✅
+- `claude/CLAUDE-THEAGENCY.md` → updated ✅
+- `.claude/skills/agency-issue/SKILL.md` → present ✅
+
+But:
+
+```
+$ wc -l ~/code/presence-detect/claude/config/agency.yaml claude/config/agency.yaml
+      43 /Users/jdm/code/presence-detect/claude/config/agency.yaml
+     128 claude/config/agency.yaml
+     171 total
+```
+
+**85 lines of config schema never propagated.** Checking specific sections:
+
+```
+$ grep -E "^(issues|preview|deploy|crawl|testing):" ~/code/presence-detect/claude/config/agency.yaml
+(no output — none of these sections exist downstream)
+```
+
+The diff against prior HEAD of agency.yaml in presence-detect:
+
+```diff
+- framework.updated_at: "2026-04-03T13:06:30+00:00"
+- framework.source_commit: "4d6f6683d12065dceafbeb5afef006f4c845b698"
++ framework.updated_at: "2026-04-08T12:34:57+00:00"
++ framework.source_commit: "6cac2fa9e7e293d415e397606f678f371b9c6f8a"
+```
+
+**Two lines changed.** The entire new-sections delta is lost.
+
+## Root Cause (preliminary)
+
+`claude/tools/lib/_agency-init` handles agency.yaml management. For existing installations, it only updates the `framework.*` metadata block (the "updated_at" and "source_commit" fields) and leaves the rest of the file untouched. This is the correct default — overwriting the whole file would destroy user customizations to existing sections.
+
+But the correct behavior is a **three-way merge**, not a metadata-only update:
+
+- **Preserve user-customized values** in existing sections (what it does today)
+- **Add new top-level sections** from source that don't exist in target (what's missing)
+- **Flag removed upstream sections** as orphaned for user review (what's missing)
+- **Never silently modify** user values in existing sections without a migration note
+
+The `settings-merge` tool already does this kind of additive merge for `.claude/settings.json` (it does an array union for permissions). The same pattern needs to apply to agency.yaml section additions.
+
+## Requested Behavior
+
+When `agency update` encounters a top-level YAML section in source that does not exist in target:
+
+1. **Add the section** with all its default values
+2. **Prepend a comment** that says something like `# Added by framework update on YYYY-MM-DD from commit SHA — review and customize as needed.`
+3. **Report in the update summary** which new sections were added, so the adopter knows to review them
+4. **Never modify** existing sections with user values
+
+The implementation should live in `claude/tools/lib/_agency-init` or a new helper like `_yaml-merge`, and should be idempotent (re-running update doesn't re-add or duplicate sections).
+
+## Why This Matters
+
+This gap means every new optional config schema we ship in the framework requires downstream adopters to manually patch their agency.yaml to opt in. The tools that consume those sections fall back to hardcoded defaults instead — which means:
+
+- `issues:` section → `agency-issue` tool defaults to `the-agency-ai/the-agency` instead of the adopter's chosen repo
+- `preview:` / `deploy:` sections → Preview/deploy providers default instead of adopter's choice
+- `crawl:` section → Crawl provider can't be overridden
+- `testing:` section → Test runner never knows about adopter's custom suites
+
+We hit this during the 2026-04-08 agency-update test on a real downstream project. The update succeeded in every other dimension (1085 files propagated, 66 updated, hookify rules activated, merge-not-rebase discipline applied, all verify checks pass), but the YAML schema migration gap was immediately visible on the first update.
+
+## Related
+
+- Found during: 2026-04-08 agency-update test on `~/code/presence-detect` (installed 2026-04-03 at commit 4d6f6683, updated to commit 6cac2fa9 in this session)
+- Related tool: `claude/tools/lib/_agency-init`
+- Related pattern: `settings-merge` does the right thing for `.claude/settings.json`
+- Sibling pattern: the Claude Code `settings.json` merge logic that unions arrays rather than overwriting
+- Local report: `usr/jordan/reports/report-agency-issue-*-20260408.md` (written by the filing)
+
+## Acceptance
+
+- New sections added to upstream `agency.yaml` appear in downstream `agency.yaml` after `agency update`
+- Existing sections in downstream are never modified
+- Added sections carry a comment identifying the update that brought them in
+- Summary of `agency update` reports new sections added
+- Idempotent: re-running update does not duplicate or re-add
+
+## Note
+
+This issue will be fixed tomorrow. The bug was caught today during the first real agency-update test from the-agency R2. The principal chose to file it now (dogfooding `agency-issue` itself) and patch it tomorrow morning as the first real use of the bug-report → fix → close cycle.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-08:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/56


### PR DESCRIPTION
## Summary

Day 34 Release 1 (34.1). Single-feature release: the `agency-version` tool and its integration into the statusline.

## What

- `claude/config/manifest.json` — new top-level `agency_version: "34.1"` field (single source of truth for framework version)
- `claude/tools/agency-version` — bash tool with verbs: default `print`, `--statusline` (silent on missing), `--json`, `--help`
- `claude/tools/statusline.sh` — reads agency-version and renders between model and location (`2.1.87 with Opus | 34.1 | the-agency (main) …`)
- `tests/tools/agency-version.bats` — 11 BATS tests covering print, statusline, json, help, unknown args, missing manifest, missing field

## Why

Answers the question 'what version of the Agency framework is this repo on?' with a single word. Also drops the long-standing drift problem where manifest.json tracked per-component versions but had no top-level framework marker. Enables upcoming work:

- Drift detection (file hash comparison vs manifest) — flag #51 follow-up
- Framework version in every downstream installation's statusline (so you can tell at a glance whether a repo is current)
- Foundation for the audit tool that scans a repo's readiness for update

## Scheme

Version format: `{day}.{release}` (e.g. `34.1`). Day = Agency workday (weekdays only). Release = rapid-release increment within the day. No `v` prefix, no semver noise.

## Commit

`118ae29` — Day 34.1: feat: agency-version tool + statusline version display

## Test plan

- [x] `bats tests/tools/agency-version.bats` — 11/11 green
- [x] Statusline smoke test — renders `34.1` correctly between model and location
- [x] `--statusline` silent when manifest missing — verified
- [x] `--json` fails cleanly when `agency_version` field missing — verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)