### PR TITLE
Day 34 R2 — run-in Triangle + fix #56, #57, #171 regression

### DIFF
--- a/.claude/skills/run-in/SKILL.md
+++ b/.claude/skills/run-in/SKILL.md
@@ -1,0 +1,71 @@
+---
+description: Run a command in a target directory without touching the parent shell's CWD. Use any time you would write "cd foo && bar" — that pattern is blocked by the block-compound-bash hookify rule.
+---
+
+# run-in
+
+Run a command in a target directory via a subshell. The parent shell's CWD
+is never touched. Exit code is propagated. Standard Agency telemetry.
+
+## When to use
+
+- You would otherwise write `cd foo && bar && cd -` — don't. Use `run-in`.
+- You need to run an Agency tool on another repo (e.g., `agency verify` on
+  a downstream installation).
+- You need to run a git command on another worktree without leaving your
+  shell parked in that worktree.
+- You want observability on the directory-scoped execution (log_start /
+  log_end are built in).
+
+## Signature
+
+```
+run-in <target-dir> -- <command> [args...]
+```
+
+The `--` separator is required and distinguishes the target directory from
+the command and its argv.
+
+## Examples
+
+```bash
+# Run a command on another repo without leaking CWD
+./claude/tools/run-in ~/code/presence-detect -- ./claude/tools/agency verify
+
+# Run a git command in a worktree from your captain shell
+./claude/tools/run-in .claude/worktrees/devex -- git status
+
+# Run a test suite in a sandbox dir
+./claude/tools/run-in "$BATS_TEST_TMPDIR/mock" -- bats mock.bats
+```
+
+## What NOT to do
+
+```bash
+# ❌ BLOCKED by hookify.block-compound-bash
+cd ~/code/presence-detect && agency verify
+
+# ❌ BLOCKED (parent shell CWD leaks)
+cd .claude/worktrees/devex && git status && cd -
+
+# ✅ Use run-in instead
+./claude/tools/run-in ~/code/presence-detect -- agency verify
+./claude/tools/run-in .claude/worktrees/devex -- git status
+```
+
+## Why subshell isolation matters
+
+Agent identity resolution uses the current working directory to determine
+which agent is running (via `agent-identity`). If a worktree agent `cd`s to
+the main checkout and forgets to `cd -`, subsequent commands resolve the
+wrong identity, handoffs write to the wrong file, and dispatches go to the
+wrong agent. `run-in` runs the command in a subshell — the parent shell's
+CWD is untouchable by construction, so identity resolution stays correct.
+
+## Related
+
+- Hookify rule: `claude/hookify/hookify.block-compound-bash.md`
+- Tool: `claude/tools/run-in`
+- Companion seed: telemetry-mining for compound command patterns (flag #54)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "34.1",
+  "agency_version": "34.2",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/hookify/hookify.block-compound-bash.md
+++ b/claude/hookify/hookify.block-compound-bash.md
@@ -1,0 +1,46 @@
+---
+name: block-compound-bash
+enabled: true
+event: bash
+pattern: (\s|^)(&&|\|\||;|\|)(\s|$)|\$\(|`[^`]*`|cd\s+[^;]+&&
+action: block
+---
+
+**BLOCKED: Compound bash commands are not allowed.**
+
+You wrote a bash command with `&&`, `||`, `;`, `|`, `$(…)`, backticks, or `cd X && …`. Every one of those is a compound construct that must be split into separate Bash tool calls — or replaced with a purpose-built Agency tool.
+
+## Why this is a hard block
+
+1. **Permission-prompt noise.** Claude Code parses compound commands and prompts for permission on every segment. `cd foo && bar && cd -` can fire three prompts. Every compound command is a multiplier on friction. Splitting into separate Bash calls triggers one prompt per call, and many tools are pre-approved already.
+
+2. **State leakage.** `cd foo && bar && cd -` forgets `cd -` half the time. The parent shell parks in `foo` and every subsequent command runs in the wrong directory. Agent identity (which is resolved via CWD) then resolves wrong, handoffs write to the wrong agent's file, and dispatches go to the wrong inbox. This is not hypothetical — it has happened in captain sessions and produced real bugs.
+
+3. **Observability loss.** Each Agency tool logs its runs via `log_start` / `log_end`. A compound command is opaque — the telemetry sees one `bash` call, not the three things that happened inside it. We lose the audit trail at the exact point we need it most (when something breaks).
+
+4. **Bypass of the tool ecosystem.** Many compound patterns exist because the agent didn't know there's already a purpose-built tool. `grep foo | head` should be a single `Grep` tool call with `head_limit`. `cd repo && git status` should be `./claude/tools/run-in repo -- git status`. The block forces you to find the right primitive instead of papering over with shell plumbing.
+
+5. **Hermeticity for tests and subprocess correctness.** `$(…)` and backticks run a subshell that inherits environment, which can leak env vars into BATS tests or other sensitive contexts. Splitting the work into explicit steps keeps every subprocess boundary visible.
+
+## What to do instead
+
+| You wanted to write… | Use instead |
+|----------------------|-------------|
+| `cd X && cmd`        | `./claude/tools/run-in X -- cmd` |
+| `cd X && cmd && cd -`| `./claude/tools/run-in X -- cmd` (parent CWD never changes — no restore needed) |
+| `cmd1 && cmd2`       | Two separate Bash tool calls (parallel if independent, sequential if dependent) |
+| `cmd1 ; cmd2`        | Two separate Bash tool calls |
+| `cmd \| head`        | Grep tool with `head_limit`, or separate `cmd` + Read |
+| `cmd \| grep foo`    | Grep tool directly |
+| `grep x \| xargs y`  | Separate steps, or a dedicated Agency tool |
+| `$(cmd)` substitution| Run `cmd` first in one call, capture the value, pass to the next call |
+| `` `cmd` `` backticks| Same as `$(…)` — split into steps |
+
+## Related
+
+- Tool: `claude/tools/run-in` (replacement for the `cd X && cmd` pattern)
+- Skill: `/run-in`
+- Reference: `claude/CLAUDE-THEAGENCY.md` "Bash Tool Usage" section
+- Companion workstream: telemetry analysis of compound command patterns (flag #54) — mines the log of compound command attempts to identify which OTHER patterns deserve their own purpose-built tool
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/tools/commit-precheck
+++ b/claude/tools/commit-precheck
@@ -141,6 +141,39 @@ main() {
     REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
     cd "$REPO_ROOT"
 
+    # ────────────────────────────────────────────────────────────────────────
+    # Gate 0: block Test User attribution (merge-durable guard against the
+    # recurring BATS pollution bug — dispatches #109 and #171).
+    #
+    # If .git/config grew a [user] section with Test User / test@example.com,
+    # a BATS test leaked pre-commit env vars and polluted the live config.
+    # Block the commit, print diagnostics, and tell the author how to clean.
+    # ────────────────────────────────────────────────────────────────────────
+    local git_user_name git_user_email
+    git_user_name=$(git config user.name 2>/dev/null || true)
+    git_user_email=$(git config user.email 2>/dev/null || true)
+    if [[ "$git_user_name" == "Test User" ]] || [[ "$git_user_email" == "test@example.com" ]]; then
+        echo "✗ BLOCKED: commit identity is Test User <test@example.com>" >&2
+        echo "  → Your .git/config has a polluted [user] section (likely from a" >&2
+        echo "    BATS test leaking env vars). Clean with:" >&2
+        echo "      git config --local --unset user.email" >&2
+        echo "      git config --local --unset user.name" >&2
+        echo "    Then verify: git config user.name && git config user.email" >&2
+        echo "  → Root cause: see dispatches #109 and #171." >&2
+        echo "*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*" >&2
+        end_run "blocked" "Test User attribution"
+        exit 1
+    fi
+    if grep -q '^\[user\]' "$REPO_ROOT/.git/config" 2>/dev/null; then
+        if grep -A2 '^\[user\]' "$REPO_ROOT/.git/config" 2>/dev/null | grep -qE 'Test User|test@example\.com'; then
+            echo "✗ BLOCKED: .git/config contains a polluted [user] section" >&2
+            echo "  → Clean with: git config --local --unset-all user.email && git config --local --unset-all user.name" >&2
+            echo "*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*" >&2
+            end_run "blocked" "Polluted .git/config [user] section"
+            exit 1
+        fi
+    fi
+
     # No staged changes = nothing to check
     if git diff --cached --quiet; then
         log_info "No staged changes"

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -220,16 +220,18 @@ _update_main() {
     fi
 
     # =====================================================================
-    # Step 4: Update agency.yaml framework section
+    # Step 4: Update agency.yaml framework section + append new top-level
+    # sections (issue #56 — new sections from source never propagated)
     # =====================================================================
     log_step "Updating agency.yaml"
 
     if [[ "$DRY_RUN" == "false" ]]; then
         local yaml_file="$TARGET_DIR/claude/config/agency.yaml"
+        local src_yaml="$SOURCE_DIR/claude/config/agency.yaml"
         local updated_at
         updated_at=$(date -u '+%Y-%m-%dT%H:%M:%S+00:00')
 
-        # Update version, updated_at, source_commit in the framework section
+        # --- Update metadata in the framework section (existing behavior) ---
         if [[ "$(uname)" == "Darwin" ]]; then
             sed -i '' "s|^  version: .*|  version: \"$to_version\"|" "$yaml_file"
             sed -i '' "s|^  updated_at: .*|  updated_at: \"$updated_at\"|" "$yaml_file"
@@ -238,6 +240,52 @@ _update_main() {
             sed -i "s|^  version: .*|  version: \"$to_version\"|" "$yaml_file"
             sed -i "s|^  updated_at: .*|  updated_at: \"$updated_at\"|" "$yaml_file"
             sed -i "s|^  source_commit: .*|  source_commit: \"$to_commit\"|" "$yaml_file"
+        fi
+
+        # --- Append new top-level sections from source (issue #56) ---
+        # Top-level key: a line matching ^[A-Za-z_][A-Za-z0-9_]*:
+        # For each key present in source but missing in target, extract the
+        # section (from that key through the line before the next top-level
+        # key or EOF) and append it to target with a comment marker.
+        local added_sections=""
+        local src_keys tgt_keys
+        # Dedupe in-place to tolerate duplicate top-level keys in source
+        src_keys=$(awk '/^[A-Za-z_][A-Za-z0-9_]*:/ { sub(/:.*/,""); if (!seen[$0]++) print }' "$src_yaml" 2>/dev/null || true)
+        tgt_keys=$(awk '/^[A-Za-z_][A-Za-z0-9_]*:/ { sub(/:.*/,""); if (!seen[$0]++) print }' "$yaml_file" 2>/dev/null || true)
+
+        local key
+        while IFS= read -r key; do
+            [[ -z "$key" ]] && continue
+            # Skip if key already present in target
+            if printf '%s\n' "$tgt_keys" | grep -qxF "$key"; then
+                continue
+            fi
+
+            # Extract section for this key from source: from ^key: up to (but
+            # not including) the next top-level key, trimming trailing blank
+            # lines from the block.
+            local section
+            section=$(awk -v k="$key" '
+                $0 ~ "^"k":" { in_block=1; print; next }
+                in_block && /^[A-Za-z_][A-Za-z0-9_]*:/ { in_block=0 }
+                in_block { print }
+            ' "$src_yaml")
+
+            [[ -z "$section" ]] && continue
+
+            # Buffer — we will append all new sections in one block
+            if [[ -z "$added_sections" ]]; then
+                added_sections=$(printf '\n# ─────────────────────────────────────────────────────────────────────────\n# New sections added by agency update — review and customize as needed.\n# Added by framework version %s (%s)\n# ─────────────────────────────────────────────────────────────────────────\n' "$to_version" "$to_commit")
+            fi
+            added_sections=$(printf '%s\n\n%s' "$added_sections" "$section")
+            log_info "  + new section: $key"
+        done <<<"$src_keys"
+
+        if [[ -n "$added_sections" ]]; then
+            # Ensure target ends with newline before appending
+            [[ -n "$(tail -c1 "$yaml_file" 2>/dev/null)" ]] && printf '\n' >> "$yaml_file"
+            printf '%s\n' "$added_sections" >> "$yaml_file"
+            log_info "Appended new top-level sections to agency.yaml"
         fi
     fi
 

--- a/claude/tools/run-in
+++ b/claude/tools/run-in
@@ -1,0 +1,138 @@
+#!/bin/bash
+#
+# What Problem: Agents constantly write compound bash commands like
+# "cd foo && bar && cd -" to run a command in a different directory. This is
+# noisy (Claude Code's compound-command permission prompts fire on every
+# segment), error-prone (forgetting "cd -" leaks the parent shell's CWD),
+# breaks agent identity resolution (which depends on CWD), and produces zero
+# telemetry. We've hit this pattern all day in captain sessions and it's the
+# #1 source of Bash tool noise.
+#
+# How & Why: A single instrumented command that runs any command in a target
+# directory via a SUBSHELL, so the parent shell's CWD is never touched. Two
+# positional args: the target directory, then "--" separator, then the
+# command and its args preserved as argv boundaries. The subshell uses
+# `exec "$@"` so the command replaces the subshell process (correct signal
+# forwarding, no extra pid). Exit code propagates. Standard log_start/log_end
+# instrumentation so every directory-scoped execution is observable.
+#
+# The enforcement triangle:
+#   Tool:    this file (claude/tools/run-in)
+#   Skill:   /run-in
+#   Hookify: block-compound-bash (blocks &&, ||, ;, pipes in Bash tool calls)
+#
+# Usage:
+#   run-in <target-dir> -- <command> [args...]
+#   run-in --version
+#   run-in --help
+#
+# Examples:
+#   run-in /path/to/other-repo -- git status
+#   run-in ~/code/presence-detect -- ./claude/tools/agency verify
+#   run-in .claude/worktrees/devex -- ./claude/tools/dispatch list
+#
+# Written: 2026-04-09 during captain Day 34 (run-in Triangle build)
+
+set -euo pipefail
+
+VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source log helper if available
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+    # shellcheck source=/dev/null
+    source "$SCRIPT_DIR/lib/_log-helper"
+fi
+
+show_help() {
+    cat <<'EOF'
+run-in — run a command in a target directory without leaking CWD
+
+USAGE
+  run-in <target-dir> -- <command> [args...]
+  run-in --version
+  run-in --help
+
+BEHAVIOR
+  Runs <command> in <target-dir> via a subshell. The parent shell's CWD
+  is never touched. Exit code of the command is propagated. Standard
+  Agency telemetry via log_start/log_end.
+
+WHY
+  Compound bash commands ("cd foo && bar && cd -") are blocked by the
+  block-compound-bash hookify rule. Use run-in instead. See
+  claude/hookify/hookify.block-compound-bash.md for the full rationale.
+
+EXAMPLES
+  run-in /path/to/other-repo -- git status
+  run-in ~/code/presence-detect -- ./claude/tools/agency verify
+  run-in .claude/worktrees/devex -- ./claude/tools/dispatch list
+
+OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!
+EOF
+}
+
+# Parse args
+if [[ $# -eq 0 ]]; then
+    show_help
+    exit 2
+fi
+
+case "$1" in
+    --version|-v)
+        echo "run-in $VERSION"
+        exit 0
+        ;;
+    --help|-h)
+        show_help
+        exit 0
+        ;;
+esac
+
+TARGET_DIR="$1"
+shift
+
+# Require the "--" separator so the command boundary is explicit
+if [[ $# -lt 1 ]] || [[ "$1" != "--" ]]; then
+    echo "run-in: missing '--' separator between target-dir and command" >&2
+    echo "  usage: run-in <target-dir> -- <command> [args...]" >&2
+    exit 2
+fi
+shift  # consume --
+
+if [[ $# -lt 1 ]]; then
+    echo "run-in: no command provided after '--'" >&2
+    echo "  usage: run-in <target-dir> -- <command> [args...]" >&2
+    exit 2
+fi
+
+# Resolve target directory
+if [[ ! -d "$TARGET_DIR" ]]; then
+    echo "run-in: target directory does not exist: $TARGET_DIR" >&2
+    exit 1
+fi
+
+# Start logging
+RUN_ID=""
+if type log_start &>/dev/null; then
+    RUN_ID=$(log_start "run-in" "$TARGET_DIR :: $*")
+fi
+
+# Run the command in a subshell. The parent shell's CWD is never touched.
+# `exec` replaces the subshell with the target command so signals forward
+# cleanly and there's no extra pid on the process tree.
+set +e
+(
+    cd "$TARGET_DIR" && exec "$@"
+)
+rc=$?
+set -e
+
+# End logging
+if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
+    local_status="success"
+    [[ "$rc" -ne 0 ]] && local_status="failure"
+    log_end "$RUN_ID" "$local_status" "$rc" 0 "$TARGET_DIR :: $*"
+fi
+
+exit "$rc"

--- a/claude/tools/worktree-sync
+++ b/claude/tools/worktree-sync
@@ -146,32 +146,44 @@ else
     # --- Merge master ---
     MERGED=true
     MERGE_OUTPUT=$(git merge master 2>&1) || {
-        # Merge conflict — abort and restore
+        # Merge conflict — abort and restore. After this block runs the repo
+        # is back at PRE_MERGE_HEAD with MERGE_HEAD cleared. The message has
+        # to make that clear so the caller doesn't try to 'git merge --abort'
+        # themselves (issue #57 — 'Resolve manually' was misleading because
+        # the merge WAS already aborted automatically).
         ABORT_OK=true
         git merge --abort 2>/dev/null || ABORT_OK=false
         CONFLICT_FILES=$(echo "$MERGE_OUTPUT" | grep "CONFLICT" || echo "(unknown)")
 
-        echo "worktree-sync: merge conflict with master" >&2
-        echo "$CONFLICT_FILES" >&2
+        echo "worktree-sync: merge with master had conflicts — merge was automatically aborted." >&2
+        echo "  Repo state: restored to pre-merge HEAD ($PRE_MERGE_HEAD)." >&2
+        echo "  Conflict files:" >&2
+        echo "$CONFLICT_FILES" | sed 's/^/    /' >&2
 
         if [[ "$ABORT_OK" == false ]]; then
-            echo "worktree-sync: WARNING — git merge --abort failed" >&2
+            echo "  WARNING: git merge --abort failed — repo may not be fully restored." >&2
         fi
 
         # Unstash if we stashed (disable trap since we're handling it)
+        STASH_MSG="no stash taken"
         if [[ "$STASHED" == true ]]; then
             STASHED=false
-            if ! git stash pop --quiet 2>/dev/null; then
-                echo "worktree-sync: WARNING — stash pop failed after merge abort. Work is safe in git stash." >&2
+            if git stash pop --quiet 2>/dev/null; then
+                STASH_MSG="stashed work restored via git stash pop"
+            else
+                STASH_MSG="stash pop failed — your stashed work is still in git stash (run 'git stash list')"
             fi
         fi
+        echo "  Stash: $STASH_MSG." >&2
+
+        echo "  Next steps: review the conflict files listed above, decide whether to keep/delete/reconcile them, then retry worktree-sync. Do NOT run 'git merge --abort' — the merge has already been aborted." >&2
 
         if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
-            log_end "$RUN_ID" "failure" 1 0 "merge conflict"
+            log_end "$RUN_ID" "failure" 1 0 "merge conflict (aborted automatically)"
         fi
 
         if [[ "$AUTO_MODE" == true ]]; then
-            jq -n -c --arg msg "worktree-sync: merge conflict with master. Resolve manually." '{"systemMessage": $msg}'
+            jq -n -c --arg msg "worktree-sync: merge conflict with master — merge was automatically aborted, repo restored. Review conflict files before retrying." '{"systemMessage": $msg}'
         fi
         exit 1
     }

--- a/claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md
+++ b/claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md
@@ -1,0 +1,85 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-09
+origin: captain Day 34 session — run-in Triangle build
+status: captured
+---
+
+# Telemetry-Driven Tool Discovery
+
+## The insight in one sentence
+
+**The Bash tool log is a list of the tools we haven't built yet.**
+
+## What happened
+
+While building the `run-in` tool (and its hookify block against compound bash commands), Jordan said: *"We can analyze the record of compound commands and build other tools."*
+
+That statement flipped a framework switch. It named a pattern that we've been doing informally for weeks but had never articulated as a discipline. Every time an agent writes `cd foo && bar && cd -`, that is not just a noisy bash command — it is a **request for a tool that does not yet exist**. The agent is papering over a missing primitive with shell plumbing. The friction is legible; the telemetry log sees it.
+
+If the telemetry log captures every compound bash command, then the log itself is a queue of "tools that should exist but don't." We do not have to guess which tools to build next. We can **mine** the log for frequency, classify the patterns, and build a dedicated Agency tool for each high-frequency pattern.
+
+## The loop
+
+```
+1. Agent writes a compound bash command (the hackaround).
+2. Telemetry records the attempt and the pattern.
+3. A scanner mines the log for high-frequency compound patterns.
+4. For each pattern, the question: is there already a tool?
+   - If yes: the agent didn't find it → discovery problem (skill, CLAUDE.md pointer).
+   - If no: build a purpose-built tool → deprecate the pattern.
+5. A hookify rule blocks the hackaround pattern, pointing to the new tool.
+6. Agent uses the new tool. Telemetry records it cleanly. Audit trail intact.
+7. Observe the next high-frequency pattern. Repeat.
+```
+
+## Why this is a framework primitive, not a one-off idea
+
+Most frameworks evolve by *intuition* — someone notices a pain point and builds a tool. TheAgency already does this. But the telemetry-driven loop **inverts the causality**: the data chooses the tools, not the human. The human's job shifts from *spotting* friction to *interpreting* the friction that the data already surfaces.
+
+This has implications far beyond compound bash commands:
+
+- **Every missing tool announces itself through workaround patterns.** Compound bash is one category. Others include repeated ad-hoc scripts in `tmp/`, duplicated inline logic across tool calls, multi-step manual sequences that always happen together, repeated permission prompts on the same operation.
+- **The friction is legible.** We do not need user feedback, surveys, or agent introspection to find it. The telemetry already has it.
+- **Tool adoption has a built-in feedback signal.** If the hackaround pattern keeps appearing after the tool ships, the tool has a discoverability problem. Fix the skill, fix the hookify rule, fix the docs.
+- **Deprecation is mechanical.** When a tool covers a pattern well, the hookify rule blocks the hackaround. The pattern stops appearing in the log. The tool's value is measured by the absence of the thing it replaced.
+
+## The framework pattern name
+
+**Friction → Telemetry → Tool → Block → Flow.**
+
+Five steps. Each step is observable. Each step has a primitive in the framework already:
+
+| Step | Primitive |
+|------|-----------|
+| Friction | The raw Bash tool call attempt |
+| Telemetry | `log_start` / `log_end` in every Agency tool + the `bash` event hook |
+| Tool | `claude/tools/{tool}` with the Triangle |
+| Block | `claude/hookify/hookify.block-{pattern}.md` |
+| Flow | The new primitive is used; telemetry confirms the pattern has stopped |
+
+## Where this belongs
+
+- **README-THEAGENCY.md** — add a section "Telemetry-Driven Tool Discovery" that explains this loop as a design principle. This is a first-class framework claim about *how TheAgency evolves*, not just a tactical observation.
+- **CLAUDE-THEAGENCY.md** — add a short paragraph under Tool Discipline pointing to the loop, with a pointer to this seed for the long explanation.
+- **Articles / talks / book** — this is the framing for "why TheAgency builds tools the way it builds tools." The telemetry-driven loop is the *methodology*; the Triangle (Tool + Skill + Hookify) is the *structure*; the Ladder (document → skill → tool → warn → block) is the *adoption curve*. All three together form the complete story of framework evolution.
+
+## Immediate next actions
+
+1. **Build the scanner.** A small Agency tool that reads `tool-runs.jsonl` (or wherever Bash tool calls land), extracts compound commands, classifies by shape (cd-compound, pipe-chain, sequence, substitution), and ranks by frequency. Output: a ranked list of "tools to build."
+2. **Run the scanner against our current logs.** See what's on top. The top entry after `cd-compound` becomes the next Triangle build.
+3. **Repeat weekly.** Telemetry-driven tool discovery is not a one-shot — it's a recurring review. Surface the ranked list in the captain's log as a weekly pattern review.
+
+## The harder question this surfaces
+
+If the Bash tool log is a list of the tools we haven't built, then **every framework has a telemetry-shaped shadow of the tools it's missing**. Most frameworks never look at it. Most projects don't even collect it. Teams building with LLMs are producing massive streams of friction data right now, and almost none of it is being mined for tool opportunities.
+
+This feels like a *thesis*, not just a tactic. The framework that mines its own friction is the framework that evolves fastest. TheAgency ships that as a built-in.
+
+## Related
+
+- Tool: `claude/tools/run-in` (the first tool built under this discipline)
+- Hookify: `claude/hookify/hookify.block-compound-bash.md`
+- Flag #54 — "Analyze telemetry logs of Bash tool calls to mine compound command patterns"
+- Framework primitives: Triangle, Ladder, Valueflow

--- a/tests/tools/run-in.bats
+++ b/tests/tools/run-in.bats
@@ -1,0 +1,113 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/run-in
+#
+# Focus: subshell isolation, exit code propagation, argv boundaries, error
+# surfaces for missing dir and missing separator.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+    cd "${REPO_ROOT}"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Help / version
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: --version prints version" {
+    run_tool run-in --version
+    assert_success
+    assert_output_contains "run-in"
+    assert_output_contains "1.0.0"
+}
+
+@test "run-in: --help shows usage" {
+    run_tool run-in --help
+    assert_success
+    assert_output_contains "run-in"
+    assert_output_contains "target-dir"
+}
+
+@test "run-in: no args shows help and exits non-zero" {
+    run_tool run-in
+    [[ "$status" -ne 0 ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Happy path — subshell isolation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: runs command in target dir" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- pwd
+    assert_success
+    assert_output_contains "target"
+}
+
+@test "run-in: parent shell CWD is unchanged after invocation" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    local before_cwd
+    before_cwd="$(pwd)"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- pwd
+    assert_success
+    [[ "$(pwd)" == "$before_cwd" ]]
+}
+
+@test "run-in: argv boundaries preserved for command with args" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- echo "hello world" "arg two"
+    assert_success
+    assert_output_contains "hello world"
+    assert_output_contains "arg two"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Exit code propagation
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: propagates non-zero exit code from command" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- bash -c "exit 42"
+    [[ "$status" -eq 42 ]]
+}
+
+@test "run-in: propagates zero exit code from successful command" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" -- true
+    assert_success
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Error surfaces
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "run-in: missing target dir fails with clear error" {
+    run_tool run-in "${BATS_TEST_TMPDIR}/does-not-exist" -- pwd
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "does not exist"
+}
+
+@test "run-in: missing -- separator fails with usage" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" pwd
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "separator"
+}
+
+@test "run-in: no command after -- fails with usage" {
+    mkdir -p "${BATS_TEST_TMPDIR}/target"
+    run_tool run-in "${BATS_TEST_TMPDIR}/target" --
+    [[ "$status" -ne 0 ]]
+    assert_output_contains "no command"
+}

--- a/tests/tools/worktree-sync.bats
+++ b/tests/tools/worktree-sync.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+#
+# Tests for claude/tools/worktree-sync
+#
+# Focus: issue #57 — the "resolve manually" message after a successful
+# conflict-abort is misleading. After a conflict, worktree-sync internally
+# aborts the merge and pops the stash; the error message should reflect that
+# the merge was automatically aborted, not that the user needs to resolve
+# anything by hand.
+#
+# Strategy: create a throwaway git repo with master + a feature branch that
+# has a delete-vs-modify conflict with master, register the feature branch as
+# a worktree, run worktree-sync from inside the worktree, and assert on
+# exit code + message content.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+
+    # Build a throwaway git repo with a conflict between master and feature.
+    # delete-vs-modify is the exact pattern from dispatch #171.
+    export MOCK_ROOT="${BATS_TEST_TMPDIR}/mock-main"
+    mkdir -p "${MOCK_ROOT}"
+    cd "${MOCK_ROOT}"
+
+    git init --quiet --initial-branch=master
+    git config user.email "tester@example.invalid"
+    git config user.name "Tester"
+
+    echo "root file" > README.md
+    echo "shared content" > shared.txt
+    git add README.md shared.txt
+    git commit --quiet -m "initial"
+
+    # Feature branch modifies shared.txt
+    git checkout --quiet -b feature
+    echo "feature change" > shared.txt
+    git add shared.txt
+    git commit --quiet -m "feature: modify shared"
+
+    # Master deletes shared.txt (delete-vs-modify scenario)
+    git checkout --quiet master
+    git rm --quiet shared.txt
+    git commit --quiet -m "master: delete shared"
+
+    # Register feature as worktree
+    export WORKTREE_PATH="${BATS_TEST_TMPDIR}/mock-worktree"
+    git worktree add --quiet "${WORKTREE_PATH}" feature
+}
+
+teardown() {
+    # Clean up the worktree registration before wiping tmpdir
+    if [[ -d "${MOCK_ROOT}" ]]; then
+        (cd "${MOCK_ROOT}" && git worktree remove --force "${WORKTREE_PATH}" 2>/dev/null || true)
+    fi
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #57 — conflict recovery message
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "worktree-sync: conflict-abort exits non-zero" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+}
+
+@test "worktree-sync: conflict-abort message does NOT say bare 'Resolve manually'" {
+    # Regression guard for #57 — the old message was:
+    #   'merge conflict with master. Resolve manually.'
+    # which is misleading because the merge was already aborted internally.
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+    # Must NOT contain the bare misleading phrase
+    if echo "$output" | grep -qE 'Resolve manually\.?$'; then
+        echo "Output still contains the misleading 'Resolve manually' message:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "worktree-sync: conflict-abort message explains that merge was aborted" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    [[ "$status" -ne 0 ]]
+    # Must contain a word indicating the merge was aborted / reverted
+    if ! echo "$output" | grep -qiE 'abort|reverted|restored'; then
+        echo "Output does not tell the user the merge was aborted:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "worktree-sync: repo state is clean after conflict-abort (no MERGE_HEAD)" {
+    cd "${WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    # MERGE_HEAD must not exist — proves the tool aborted its own merge
+    [[ ! -f "${WORKTREE_PATH}/.git/MERGE_HEAD" ]] && [[ ! -f "${MOCK_ROOT}/.git/worktrees/mock-worktree/MERGE_HEAD" ]]
+}

--- a/usr/jordan/captain/dispatches/directive-directive-fix-docker-socket-reachability-58-no-app-20260409-0908.md
+++ b/usr/jordan/captain/dispatches/directive-directive-fix-docker-socket-reachability-58-no-app-20260409-0908.md
@@ -1,0 +1,62 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T01:08
+status: created
+priority: normal
+subject: "DIRECTIVE: fix docker socket reachability (#58) — no approval needed, just do it"
+in_reply_to: null
+---
+
+# DIRECTIVE: fix docker socket reachability (#58) — no approval needed, just do it
+
+New work for your queue. Jordan explicit direction: do not wait for approval on this or the existing #171 items. Just do it.
+
+## Task
+
+Fix GitHub issue #58 — docker CLI cannot connect to daemon when Docker Desktop is running. Full context in the issue.
+
+https://github.com/the-agency-ai/the-agency/issues/58
+
+## Scope
+
+- Investigate why `docker-test.sh` fails with unix:///var/run/docker.sock when Docker Desktop IS running
+- Implement one of the three acceptance options (auto-detect, actionable error, or docker-heal tool)
+- Write bug-exposing test — simulate 'Docker Desktop running but CLI can't reach' and verify the fix works
+- Red → green, commit on devex branch, land via /phase-complete
+
+## Authorization level
+
+FULL AUTONOMY on this and all Day 33 queue items previously dispatched.
+- Do NOT wait for captain or principal approval on per-step decisions.
+- Execute the red-green cycle on your own.
+- Commit and land on your own.
+- Only escalate if you hit a true blocker (conflict, ambiguity about intent, missing permission).
+
+## Context on process expectation
+
+Jordan just said explicitly: 'Tell DevEx don't wait for approval to do it. Just do it.' This applies not just to #58 but to the entire open queue:
+- #8 Item 1 /phase-complete (SPEC-PROVIDER preview/deploy) — just do it
+- #9-#13 from dispatch #149 — just do them in order
+- #171 unblock sequence (merge conflict resolve, handoff restore, stash cleanup) — just do it per the direction in #173
+- #166, #167, #168 per previous dispatches — just do them
+
+You have standing authorization to execute. Loop back only with results, not for permission.
+
+## Report back
+
+- Resolve each dispatch as you complete its item
+- Send review-response on major milestones (e.g., 'issue #58 closed', 'Day 33 queue item N complete')
+- Do NOT send 'blocked on approval' dispatches — there is no approval gate on your queue
+
+## Current main commits you should merge in
+
+- ac73ce9 run-in Triangle + #57 worktree-sync fix
+- 2a62f8d #171 Gate 0 Test User block
+- c746d04 #56 agency update yaml sections
+- 118ae29 34.1 agency-version
+
+Merge main first, then tackle #58.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/review-response-re-171-acknowledged-triaging-with-principal-20260409-0828.md
+++ b/usr/jordan/captain/dispatches/review-response-re-171-acknowledged-triaging-with-principal-20260409-0828.md
@@ -1,0 +1,25 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T00:28
+status: created
+priority: normal
+subject: "RE: #171 — acknowledged, triaging with principal"
+in_reply_to: 171
+---
+
+# RE: #171 — acknowledged, triaging with principal
+
+Acknowledged — I read #171. Apologies for the silence; I found the dispatch on my loop check this morning, surfaced it to Jordan, then got pulled into another discussion without replying here. That was my miss.
+
+Status: triaging the 5 items with Jordan now. You will get per-item direction in follow-up dispatches. Do not take any action on items 1-5 until I reply on that specific item.
+
+Immediate reassurance on what you flagged:
+- You did the right thing stopping before destructive ops
+- The archive file with Day 33 handoff content is preserved — we will restore it
+- The Test User regression has a known root cause (merge lost the test_helper.bash fix); the fix needs to land on main, not devex
+
+Standing queue (#8-#13) remains parked until this is cleared.
+
+Next update within the hour.

--- a/usr/jordan/captain/dispatches/review-response-re-171-per-item-direction-unblock-sequence-back-to-20260409-0848.md
+++ b/usr/jordan/captain/dispatches/review-response-re-171-per-item-direction-unblock-sequence-back-to-20260409-0848.md
@@ -1,0 +1,100 @@
+---
+type: review-response
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-09T00:48
+status: created
+priority: normal
+subject: "RE: #171 — per-item direction, unblock sequence, back-to-work trigger"
+in_reply_to: 171
+---
+
+# RE: #171 — per-item direction, unblock sequence, back-to-work trigger
+
+Triage complete with Jordan. Here is exactly what to do, in order, and when you can resume the Day 33 queue.
+
+═══════════════════════════════════════════════════
+GOOD NEWS FIRST
+═══════════════════════════════════════════════════
+
+Main is now safe to merge. Two things shipped to main in the last few minutes:
+
+1. Commit 2a62f8d — 'fix: #171 Gate 0 — block Test User attribution in commit-precheck'
+   Pre-commit hook now hard-blocks any commit with Test User <test@example.com> attribution.
+   Prints cleanup instructions on failure. Belt + suspenders alongside your existing
+   test_helper.bash env-var unset guard (which was already on main — your diagnosis that
+   main lost the fix was not quite right; main had the fix, but main's .git/config had
+   a POLLUTED [user] section from an earlier leak that the runtime guard couldn't
+   retroactively clean).
+
+2. Main's .git/config [user] section cleaned. Identity now resolves correctly from global.
+
+This means the root cause is fixed AND any recurrence is now blocked at the pre-commit
+gate. Safe to merge main.
+
+═══════════════════════════════════════════════════
+PER-ITEM DIRECTION
+═══════════════════════════════════════════════════
+
+ITEM 1 — Merge conflict on .claude/logs/tool-runs.jsonl: RESOLVE AS 'ACCEPT MAIN'
+  The file is gitignored on main — deletion is intentional. Take main's side:
+    git rm .claude/logs/tool-runs.jsonl
+    git commit (the in-progress merge)
+  Then the worktree-sync merge completes.
+
+ITEM 2 — /session-resume has no recovery path: FRAMEWORK BUG, FILING SEPARATELY
+  Captain will file this as an agency-issue with a bug-exposing test + fix in today's
+  session. Not blocking you. File your own flag if you have specific recovery
+  suggestions; otherwise ignore and carry on.
+
+ITEM 3 — 4 Test User commits on devex branch: LEAVE AS-IS, SQUASH ON LANDING (option C)
+  Do NOT filter-branch. Do NOT rewrite history. When you /phase-complete, the squash
+  will collapse the 4 commits into one new commit correctly attributed to you. The
+  polluted commits never reach main. Cost: ugly branch history for a few hours.
+
+ITEM 4 — Handoff file reverted to Day 32 content: RESTORE FROM ARCHIVE (option A)
+  The Day 33 content exists in usr/jordan/devex/history/handoff-20260408-195821.md
+  (currently untracked). Copy it back over devex-handoff.md, commit via coord-commit.
+  Captain will investigate the handoff-tool root cause as a separate flag — don't block
+  on it.
+
+ITEM 5 — Stash pile: DROP STASH@{0}, LEAVE THE REST
+  - stash@{0} (failed worktree-sync artifact, 7-line tool-runs.jsonl diff): SAFE TO DROP.
+    Run: git stash drop stash@{0}
+  - stash@{1} and stash@{2} ('On main', ghostty + messages.db): NOT YOURS.
+    Captain will take custody on main. Leave them alone.
+
+═══════════════════════════════════════════════════
+EXECUTION ORDER
+═══════════════════════════════════════════════════
+
+1. Merge main into devex (picks up Gate 0 fix + all of 34.1). Let worktree-sync retry OR
+   do it by hand: git merge main
+2. Resolve conflict per Item 1 (git rm tool-runs.jsonl, commit the merge)
+3. Restore handoff from archive per Item 4, coord-commit
+4. Drop stash@{0} per Item 5
+5. Verify identity: git config user.name && git config user.email
+   Expect: Jordan Dea-Mattson / jdm@devopspm.com (NOT Test User)
+6. Run a quick no-op commit on devex to confirm Gate 0 fires correctly on your side too
+   (optional but reassuring)
+
+═══════════════════════════════════════════════════
+BACK-TO-WORK TRIGGER
+═══════════════════════════════════════════════════
+
+As soon as steps 1-5 above are done, you are unblocked and can resume the Day 33 queue:
+  - Task #8: Item 1 /phase-complete (SPEC-PROVIDER preview/deploy) — YOUR NEXT ACTION
+  - Tasks #9-#13: remain queued per #149
+
+Dispatch this response back via review-response with 'unblocked' or 'blocked: <reason>'
+so captain knows where you stand. If anything in steps 1-5 fails in an unexpected way,
+STOP and escalate, don't freelance.
+
+═══════════════════════════════════════════════════
+APOLOGIES
+═══════════════════════════════════════════════════
+
+You escalated #171 last night and it sat unread until 07:30 this morning. That is on
+captain — loop check missed it, then I got pulled into other discussions after surfacing
+it to Jordan without replying here. Fixing the process gap: both dispatch loops are now
+confirmed running this session. You should not experience this silence again.

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -20,6 +20,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 
 | 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
 | 2026-04-09 | worktree-sync: misleading 'resolve manually' message after successful conflict-abort | bug | the-agency-ai/the-agency | #57 | [report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409](usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md) | open |
+| 2026-04-09 | Docker CLI cannot connect to daemon even when Docker Desktop is running | bug | the-agency-ai/the-agency | #58 | [report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409](usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -19,6 +19,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-04-08 | agency-issue v1: new skill for two-way GitHub issue tracking | feature | the-agency-ai/the-agency | [#52](https://github.com/the-agency-ai/the-agency/issues/52) | [report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408](report-agency-issue-agency-issue-v1-new-skill-for-two-way-github-issue-20260408.md) | open |
 
 | 2026-04-08 | agency update does not propagate new top-level YAML sections from agency.yaml | bug | the-agency-ai/the-agency | #56 | [report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408](usr/jordan/reports/report-agency-issue-agency-update-does-not-propagate-new-top-level-yam-20260408.md) | open |
+| 2026-04-09 | worktree-sync: misleading 'resolve manually' message after successful conflict-abort | bug | the-agency-ai/the-agency | #57 | [report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409](usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md
+++ b/usr/jordan/reports/report-agency-issue-docker-cli-cannot-connect-to-daemon-even-when-dock-20260409.md
@@ -1,0 +1,65 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-09
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/58
+github_issue_number: 58
+status: open
+---
+
+# Docker CLI cannot connect to daemon even when Docker Desktop is running
+
+**Filed:** 2026-04-09T01:07:59Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#58](https://github.com/the-agency-ai/the-agency/issues/58)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+**Type:** bug / devex blocker
+
+## Problem
+
+Running `./tests/docker-test.sh` fails with:
+
+```
+failed to connect to the docker API at unix:///var/run/docker.sock; check if the path is correct and if the daemon is running: dial unix /var/run/docker.sock: connect: no such file or directory
+```
+
+even when Docker Desktop is running on the host. This blocks every test run that requires container isolation, including the BATS suite verification path used by `worktree-sync.bats`, `run-in.bats`, and all ISCP tests in `docker-test.sh --iscp-only`.
+
+## Why this is a devex blocker
+
+1. **No self-heal path.** When Docker Desktop starts on macOS, the `docker` CLI uses a context that points somewhere other than `/var/run/docker.sock` (probably `~/.docker/run/docker.sock`). The CLI can't reach the daemon without the right `DOCKER_HOST` or context selection. The agent has no way to detect or fix this without principal intervention.
+2. **Framework test verification is blocked.** Every test-writing session ends with a 'run this in docker' step that may silently fail for reasons unrelated to the test. Today this happened during the `run-in` and `#57` test builds — the tests had to be run via raw `bats` instead of the isolation container.
+3. **Principal-intervention tax.** Every time this fails, the agent has to escalate to the principal to check Docker. That's fine when the principal is at the keyboard, but it's a hard block when they're on remote control or asleep.
+
+## Expected
+
+At least one of these should be true:
+
+- (a) `docker-test.sh` auto-detects a running Docker Desktop and sets `DOCKER_HOST` or selects the right context before running tests.
+- (b) `docker-test.sh` prints an actionable fix-it-yourself diagnostic if the daemon is unreachable — e.g., 'Run: docker context use desktop-linux' or 'Set DOCKER_HOST=unix://$HOME/.docker/run/docker.sock'.
+- (c) A framework tool `docker-heal` (or similar) that an agent can invoke to get Docker talking without principal help.
+
+## Acceptance criteria
+
+- `./tests/docker-test.sh --file tests/tools/iscp-check.bats` runs successfully from a fresh shell on a Mac with Docker Desktop running, without manual DOCKER_HOST or context setup.
+- If the daemon is genuinely not running, the error message includes a concrete remediation command.
+
+## Related
+
+- Flag #53 (captured today) — 'Docker Desktop is running but docker CLI cannot connect'
+- Dispatch #171 (devex escalation) — /session-resume reliance on worktree-sync; docker test gap would have made the #57 red-green cycle impossible without falling back to local bats.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-09:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/58

--- a/usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md
+++ b/usr/jordan/reports/report-agency-issue-worktree-sync-misleading-resolve-manually-message--20260409.md
@@ -1,0 +1,79 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-04-09
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/57
+github_issue_number: 57
+status: open
+---
+
+# worktree-sync: misleading 'resolve manually' message after successful conflict-abort
+
+**Filed:** 2026-04-09T00:49:59Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#57](https://github.com/the-agency-ai/the-agency/issues/57)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+**Type:** bug
+
+## Problem
+
+When `worktree-sync --auto` hits a merge conflict with master, it internally runs `git merge --abort` (successfully) and pops any stash it took. The tool then exits non-zero with the message:
+
+```
+worktree-sync: merge conflict with master. Resolve manually.
+```
+
+But the repo is NOT in a conflicted state at this point — the merge was already aborted. MERGE_HEAD is gone. The user sees a dirty working tree (from the stash pop) and tries to run `git merge --abort` manually, which fails with 'no merge to abort'.
+
+This caused a devex agent to get stuck in dispatch #171. They reported:
+- 'file staged as new file'
+- 'no MERGE_HEAD so git merge --abort fails with no merge to abort'
+- blocked because /session-resume relies on worktree-sync and has no documented recovery path
+
+## Impact
+
+1. **Confusing error message** — says 'resolve manually' when the merge was already aborted; user doesn't know what to resolve.
+2. **/session-resume fragility** — the skill's Step 1 calls worktree-sync; when it exits non-zero, the skill has no documented recovery path and the entire session-resume ritual blocks.
+3. **Devex-class blocker** — when a worktree agent can't complete session-resume, their entire queue blocks on a friendly mid-session bug.
+
+## Expected
+
+After a conflict-then-abort, the tool should print something like:
+
+```
+worktree-sync: merge with master had conflicts — the merge was automatically aborted.
+  Repo state: restored to pre-merge HEAD (SHA).
+  Conflict files: .claude/logs/tool-runs.jsonl
+  Stash: popped (or: still in stash@{0}).
+  
+  Next steps:
+    1. Review the conflict files — decide whether they should be deleted, kept, or reconciled.
+    2. If deleted on master (common for gitignored files), run: git rm <file>
+    3. Retry worktree-sync after cleanup.
+```
+
+And `/session-resume` should catch worktree-sync failure, print the diagnostic, and continue with handoff read + dispatch check even if sync failed.
+
+## Fix scope (this issue)
+
+This issue covers ONLY the misleading worktree-sync message. The /session-resume recovery path is tracked separately.
+
+## Related
+
+- Dispatch #171 (devex blocker that surfaced this)
+- Dispatch #109 (original Test User pollution — separately fixed on main today as Gate 0)
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-04-09:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/57


### PR DESCRIPTION
## Summary

Day 34 Release 2 (34.2). Stacked on top of [#60 (R1 — agency-version)](https://github.com/the-agency-ai/the-agency/pull/60). Four commits: three fixes + one feature Triangle + version bump.

**Base:** `day34-release-1` (will retarget to main automatically when #60 merges).

## Commits

| SHA | What |
|-----|------|
| `c746d04` | **fix #56** — `agency update` now detects top-level YAML keys in source `agency.yaml` that are missing from target, extracts the section bodies, and appends them with a comment marker noting the framework version. Dedupes duplicate top-level keys. Verified end-to-end on `~/code/presence-detect` — `agency.yaml` went from 43 → 124 lines, all 9 missing sections (`commits`, `collaboration`, `quality`, `preview`, `deploy`, `crawl`, `issues`, `testing`, `design`) propagated. |
| `2a62f8d` | **fix #171 regression** — Gate 0 in `commit-precheck` hard-blocks any commit with `Test User <test@example.com>` attribution. Belt + suspenders alongside existing `test_helper.bash` env-var unset guard. Same turn: cleaned live `[user]` pollution from main's `.git/config`. Prints cleanup instructions on failure. Smoke-tested both firing and non-firing paths. |
| `ac73ce9` | **feat: run-in Triangle + fix #57** — new `claude/tools/run-in` runs a command in a target directory via subshell, parent CWD untouched. `/run-in` skill, `hookify.block-compound-bash` wide block on all compound patterns (`&&`/`\|\|`/`;`/`\|`/`$(…)`/backticks/`cd X && …`) with educative WHY. 11 BATS tests on run-in. Also fixes #57 — `worktree-sync` post-conflict message now explicitly says the merge was automatically aborted, lists conflict files, reports stash state, and tells the caller not to run `git merge --abort`. 4 bug-exposing BATS tests on worktree-sync. Seed: `telemetry-driven tool discovery`. |
| `bdab384` | **34.2** version bump marker |

## Issues resolved

- Closes #56 — agency update yaml section propagation
- Closes #57 — worktree-sync misleading 'resolve manually' message  
- Resolves dispatch #171 — devex unblock sequence dispatched (#172, #173, #174)

## Issues filed

- #58 — Docker CLI can't connect to daemon (dispatched to devex with standing autonomy directive)

## Meta-insight captured

New seed `seed-telemetry-driven-tool-discovery-20260409.md` names the pattern: **the Bash tool log is a list of the tools we haven't built yet.** Every compound bash command is a request for a missing primitive. Framework pattern: **Friction → Telemetry → Tool → Block → Flow**. Queued for CLAUDE.md + README-THEAGENCY + articles revision (flag #55).

## Flags captured for future work

#53 docker socket self-heal, #54 compound command telemetry analysis, #55 CLAUDE.md + README revision, #56 commit-precheck missing end-event on failure, #57 telemetry identity resolution broken, #58 /why-did-this-fail skill, #59 surface run IDs + exit codes, #60 handoff tool investigation

## Test plan

- [x] `bats tests/tools/run-in.bats` — 11/11 green
- [x] `bats tests/tools/worktree-sync.bats` — 4/4 green (red-green cycle on #57)
- [x] End-to-end `agency update` on presence-detect — clean propagation, 124 lines
- [x] Gate 0 smoke test — blocks Test User identity, unblocks normal identity
- [x] run-in dogfood — ran `git status` in presence-detect from captain shell, parent CWD preserved
- [x] Precheck scoped tests all green before final commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)