### PR TITLE
Day 34 R3 — worktree-sync main/master fix + skill allowed-tools audit

### DIFF
--- a/.claude/skills/captain-log/SKILL.md
+++ b/.claude/skills/captain-log/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/captain-log *), Bash(./claude/tools/captain-log)
 description: Append to or read the captain's narrative log — decisions, friction, learning, milestones
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Captain's Log
 

--- a/.claude/skills/captain-review/SKILL.md
+++ b/.claude/skills/captain-review/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git rev-parse:*), Bash(gh pr:*), Read, Write, Glob, Grep, Agent, Skill
 description: Review all draft PRs and generate dispatch reports for routing findings to worktree agents.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Captain Review
 

--- a/.claude/skills/code-review/SKILL.md
+++ b/.claude/skills/code-review/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git diff:*), Bash(git log:*), Bash(git rev-parse:*), Bash(gh pr:*), Read, Glob, Grep, Agent, Write
 description: Code review the current branch against origin/master using 7 parallel review agents with confidence scoring.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Code Review
 

--- a/.claude/skills/collaborate/SKILL.md
+++ b/.claude/skills/collaborate/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/collaboration *), Bash(./claude/tools/collaboration), Read
 description: Cross-repo dispatch lifecycle — check, read, resolve, reply, push. Captain-only.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Cross-Repo Collaboration
 

--- a/.claude/skills/coord-commit/SKILL.md
+++ b/.claude/skills/coord-commit/SKILL.md
@@ -1,7 +1,16 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Read, Glob
 description: Commit coordination artifacts (handoffs, dispatches, seeds, config) without QG
 ---
+
+<!--
+  Permission note (flag #62, flag #63 / devex dispatch #171):
+  This skill intentionally does NOT set allowed-tools. Restricting to specific
+  git subcommand patterns silently blocks agents on permission prompts they
+  cannot see, and the principal cannot see which tool is being blocked either
+  (the permission visibility gap). Devex was stalled for hours on this trap.
+  Inherit from .claude/settings.json (Bash(*)) instead. See flag #63.
+-->
+
 
 # Coordination Commit
 

--- a/.claude/skills/crawl-sites/SKILL.md
+++ b/.claude/skills/crawl-sites/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Bash(./claude/tools/crawl-*:*), Bash(./claude/tools/config:*), Bash(source */claude/tools/lib/_provider-resolve:*), WebFetch
 description: Crawl and extract content from configured sites using the provider engine
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Crawl Sites
 

--- a/.claude/skills/define/SKILL.md
+++ b/.claude/skills/define/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Edit, Glob, Grep, Skill
 description: Drive toward a complete Product Vision & Requirements (PVR) using 1B1 protocol with completeness checklist.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Define — PVR Completeness
 

--- a/.claude/skills/deploy/SKILL.md
+++ b/.claude/skills/deploy/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Bash(./claude/tools/deploy-*:*), Bash(./claude/tools/config:*), Bash(source */claude/tools/lib/_provider-resolve:*)
 description: Deploy the project using the configured platform provider
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Deploy
 

--- a/.claude/skills/design/SKILL.md
+++ b/.claude/skills/design/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Edit, Glob, Grep, Skill
 description: Drive toward a complete Architecture & Design (A&D) using 1B1 protocol with completeness checklist.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Design — A&D Completeness
 

--- a/.claude/skills/diff-summary/SKILL.md
+++ b/.claude/skills/diff-summary/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git diff:*), Bash(git log:*), Read
 description: Classify git diffs as formatting-only vs substantive changes.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Diff Summary
 

--- a/.claude/skills/dispatch-read/SKILL.md
+++ b/.claude/skills/dispatch-read/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/dispatch *), Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch *), Read, Grep, Glob
 description: Read a dispatch and mark it as read — works from any branch or worktree
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Read Dispatch
 

--- a/.claude/skills/dispatch/SKILL.md
+++ b/.claude/skills/dispatch/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch *), Bash(bash claude/tools/dispatch *), Bash(./claude/tools/dispatch *), Read, Write
 description: Manage dispatches — list, read, fetch, reply, create, resolve
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Dispatch Management
 

--- a/.claude/skills/flag-triage/SKILL.md
+++ b/.claude/skills/flag-triage/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/flag *), Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch *), Bash(./claude/tools/flag *), Bash(./claude/tools/dispatch *), Read, Write
 description: Structured flag review — categorize, approve, dispose. Three-bucket triage for accumulated flags.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Flag Triage
 

--- a/.claude/skills/flag/SKILL.md
+++ b/.claude/skills/flag/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/flag *), Bash(bash claude/tools/flag *), Bash(./claude/tools/flag *)
 description: Quick-capture observations to a queue for later follow-up or 1B1 discussion
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Flag
 

--- a/.claude/skills/git-commit/SKILL.md
+++ b/.claude/skills/git-commit/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/stage-hash:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Bash(git commit:*), Read, Glob, Grep
 description: Git Commit Message Generator — QG-aware wrapper
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Git Commit — QG-Aware Wrapper
 

--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,7 +1,9 @@
 ---
-allowed-tools: Bash(bash ./claude/tools/handoff *), Read, Write
 description: Write a session handoff using the handoff tool — archive, write, verify
 ---
+
+<!-- Flag #62/#63: allowed-tools removed. Inherit Bash(*) from settings.json. -->
+
 
 # Session Handoff
 

--- a/.claude/skills/iteration-complete/SKILL.md
+++ b/.claude/skills/iteration-complete/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Read, Glob, Grep, Edit, Write, Agent, Skill
 description: Run the quality gate after completing an iteration — review, fix, test, report, auto-commit
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Iteration Complete
 

--- a/.claude/skills/phase-complete/SKILL.md
+++ b/.claude/skills/phase-complete/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Read, Glob, Grep, Edit, Write, Agent, Skill
 description: Run the full quality gate after completing an implementation phase — review, fix, test, report, commit
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Phase Complete — Quality Gate + Sprint Review
 

--- a/.claude/skills/plan-complete/SKILL.md
+++ b/.claude/skills/plan-complete/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Read, Glob, Grep, Edit, Write, Agent, Skill
 description: Complete a plan — final deep QG, finalize artifacts, produce Reference doc
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Plan Complete
 

--- a/.claude/skills/post-merge/SKILL.md
+++ b/.claude/skills/post-merge/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git rev-list:*), Bash(git tag:*), Bash(git branch:*), Bash(gh pr:*), Read, Glob, Skill
 description: Run after a PR is merged on GitHub. Verifies merge, merges origin into master, invokes /sync-all.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Post-Merge
 

--- a/.claude/skills/pr-prep/SKILL.md
+++ b/.claude/skills/pr-prep/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Read, Glob, Grep, Edit, Write, Agent, Skill
 description: Run a quality gate before creating a PR — review, fix, test, report, produce QGR receipt
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # PR Prep — Quality Gate Before PR Creation
 

--- a/.claude/skills/pr-respond/SKILL.md
+++ b/.claude/skills/pr-respond/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(gh pr:*), Bash(gh api:*), Read, Glob, Grep
 description: Fetch review comments on current PR, compose threaded replies, and resolve threads. Does NOT make code changes.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # PR Respond
 

--- a/.claude/skills/pre-phase-review/SKILL.md
+++ b/.claude/skills/pre-phase-review/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Glob, Grep, Agent, Edit, Write
 description: Review PVR, A&D, and Plan before starting a new phase — highlight findings, discuss decisions
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Pre-Phase Review
 

--- a/.claude/skills/preview/SKILL.md
+++ b/.claude/skills/preview/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Bash(./claude/tools/preview-*:*), Bash(./claude/tools/config:*), Bash(source */claude/tools/lib/_provider-resolve:*)
 description: Preview the current project using the configured infrastructure provider
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Preview
 

--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/stage-hash:*), Bash(./claude/tools/test-run:*), Bash(./claude/tools/commit-precheck:*), Bash(./claude/tools/skill-verify:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git add:*), Read, Glob, Grep, Edit, Write, Agent, Skill
 description: Run the quality gate — parallel agent review, fix cycle, test, report. Composable — called by /iteration-complete and /phase-complete.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Quality Gate — Composable Skill
 

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read
 description: DEPRECATED — use `git merge <target>` or `/sync` instead. Rebase is blocked by hookify.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Rebase (DEPRECATED)
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(gh pr:*), Bash(gh api:*), Bash(git diff:*), Bash(git log:*), Read, Glob, Grep
 description: Review a PR and post comments after approval. Does NOT make code changes.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Review PR
 

--- a/.claude/skills/sandbox-activate/SKILL.md
+++ b/.claude/skills/sandbox-activate/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(ln:*), Bash(ls:*), Bash(readlink:*), Bash(git rev-parse:*), Bash(git config:*), Glob, Read
 description: Activate a sandbox item by symlinking it to the Claude Code discovery location
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Activate
 

--- a/.claude/skills/sandbox-adopt/SKILL.md
+++ b/.claude/skills/sandbox-adopt/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Bash(mv:*), Bash(rm:*), Bash(ls:*), Bash(readlink:*), Bash(git add:*), Bash(git rev-parse:*), Glob, Grep
 description: Graduate a sandbox experiment to shared team-wide tooling
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Adopt
 

--- a/.claude/skills/sandbox-create/SKILL.md
+++ b/.claude/skills/sandbox-create/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Bash(ls:*), Bash(chmod:*), Bash(git config:*), Bash(git rev-parse:*), Glob, Grep
 description: Create a new experimental command, hook, rule, tool, or script in your sandbox
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Create
 

--- a/.claude/skills/sandbox-deactivate/SKILL.md
+++ b/.claude/skills/sandbox-deactivate/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(rm:*), Bash(ls:*), Bash(readlink:*), Glob
 description: Remove a sandbox symlink to deactivate an experimental item
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Deactivate
 

--- a/.claude/skills/sandbox-init/SKILL.md
+++ b/.claude/skills/sandbox-init/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Bash(mkdir:*), Bash(touch:*), Bash(cp:*), Bash(ln:*), Bash(ls:*), Bash(readlink:*), Bash(git config:*), Bash(git rev-parse:*), Glob
 description: Set up a new engineer's sandbox workspace under usr/
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Init
 

--- a/.claude/skills/sandbox-list/SKILL.md
+++ b/.claude/skills/sandbox-list/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(ls:*), Bash(readlink:*), Bash(git config:*), Glob, Read
 description: Show all sandbox items across engineers with activation status
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox List
 

--- a/.claude/skills/sandbox-status/SKILL.md
+++ b/.claude/skills/sandbox-status/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(readlink:*), Bash(ls:*), Glob
 description: Show all active sandbox symlinks and their health (OK or broken)
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Status
 

--- a/.claude/skills/sandbox-try/SKILL.md
+++ b/.claude/skills/sandbox-try/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(ln:*), Bash(ls:*), Bash(readlink:*), Bash(git rev-parse:*), Glob, Read
 description: Try another engineer's sandbox experiment by symlinking it locally
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sandbox Try
 

--- a/.claude/skills/secret/SKILL.md
+++ b/.claude/skills/secret/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/secret-* *), Bash(./claude/tools/secret-*), Bash(./claude/tools/secrets-scan*), Read
 description: Secret Management — set, get, list, delete, rotate, scan via configured provider
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Secret Management
 

--- a/.claude/skills/session-end/SKILL.md
+++ b/.claude/skills/session-end/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/handoff *), Bash(git status:*), Bash(git log:*), Bash(git branch:*)
 description: End a session cleanly — write handoff, warn on dirty state, report readiness
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Session End
 

--- a/.claude/skills/session-list/SKILL.md
+++ b/.claude/skills/session-list/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(ls:*), Bash(stat:*), Bash(wc:*), Read, Glob, Grep
 description: List past Claude Code sessions with metadata (date, branch, directory, size, first message)
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Session List
 

--- a/.claude/skills/session-read/SKILL.md
+++ b/.claude/skills/session-read/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Glob, Grep, Bash(wc:*), Bash(stat:*)
 description: Read a past session and produce a structured summary (messages, tool calls, files, decisions)
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Session Read
 

--- a/.claude/skills/session-resume/SKILL.md
+++ b/.claude/skills/session-resume/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash ./claude/tools/worktree-sync *), Bash(bash ./claude/tools/handoff *), Bash(bash ./claude/tools/dispatch *), Bash(git status:*), Bash(git log:*), Bash(git branch:*)
 description: Resume a worktree session — sync master, read handoff, check dispatches, report state
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Session Resume
 

--- a/.claude/skills/ship/SKILL.md
+++ b/.claude/skills/ship/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(./claude/tools/commit-precheck:*), Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git push:*), Bash(git rev-parse:*), Bash(gh pr:*), Read, Glob, Grep, Skill
 description: Quality-check, commit, push, and create/update PR in one flow.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Ship
 

--- a/.claude/skills/sync-all/SKILL.md
+++ b/.claude/skills/sync-all/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Bash(git rev-list:*), Bash(git worktree:*), Bash(git tag:*), Bash(git -C:*), Bash(git diff:*), Bash(./claude/tools/dispatch*), Read, Write, Glob, Grep, Edit
 description: Fetch, merge origin into master, merge worktree work into master, sync all worktrees. NEVER pushes.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sync All — Local Master Sync
 

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git fetch:*), Bash(git merge:*), Bash(git merge-base:*), Bash(git push:*), Bash(git status:*), Bash(git log:*), Bash(git rev-parse:*), Read
 description: Merge target into current branch and push to origin. The ONLY command that pushes.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Sync — Push to Origin
 

--- a/.claude/skills/transcript/SKILL.md
+++ b/.claude/skills/transcript/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Edit, Glob, Grep, Bash(date *), Bash(git branch *), Bash(git rev-parse *)
 description: Real-time conversation capture — records dialogue and decisions as they happen.
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Transcript — Conversation Capture
 

--- a/.claude/skills/upstream-port/SKILL.md
+++ b/.claude/skills/upstream-port/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/upstream-port *)
 description: Port files from monofolk to the-agency — auto path mapping, PR creation
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Upstream Port
 

--- a/.claude/skills/workstream-create/SKILL.md
+++ b/.claude/skills/workstream-create/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Edit, Bash(mkdir:*), Bash(mv:*), Bash(git rev-parse:*), Bash(git config:*), Bash(./claude/tools/agent-create:*), Glob, Grep
 description: Create a new workstream with scaffolded artifacts, agent registrations, and optional worktree
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Workstream Create
 

--- a/.claude/skills/worktree-create/SKILL.md
+++ b/.claude/skills/worktree-create/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Read, Write, Bash(git worktree:*), Bash(git branch:*), Bash(git rev-parse:*), Bash(git show-ref:*), Bash(./claude/tools/dependencies-install:*), Glob
 description: Create a new git worktree with dedicated branch and bootstrapped dev environment
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Create Worktree
 

--- a/.claude/skills/worktree-delete/SKILL.md
+++ b/.claude/skills/worktree-delete/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git worktree:*), Bash(git branch:*), Bash(git status:*), Bash(git rev-parse:*), Read, Glob
 description: Remove a git worktree and optionally delete its branch
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Delete Worktree
 

--- a/.claude/skills/worktree-list/SKILL.md
+++ b/.claude/skills/worktree-list/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(git worktree:*), Bash(git -C:*), Bash(git rev-parse:*), Bash(git status:*), Bash(ls:*), Read, Glob
 description: List all git worktrees with status info (branch, clean/dirty, deps)
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # List Worktrees
 

--- a/.claude/skills/worktree-sync/SKILL.md
+++ b/.claude/skills/worktree-sync/SKILL.md
@@ -1,7 +1,13 @@
 ---
-allowed-tools: Bash(bash $CLAUDE_PROJECT_DIR/claude/tools/worktree-sync *)
 description: Sync worktree with master — merge, copy settings, run sandbox-sync, report changes
 ---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
 
 # Worktree Sync
 

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "34.2",
+  "agency_version": "34.3",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/tools/worktree-sync
+++ b/claude/tools/worktree-sync
@@ -92,21 +92,30 @@ if [[ -z "$MAIN_CHECKOUT" ]] || [[ ! -d "$MAIN_CHECKOUT" ]]; then
     exit 1
 fi
 
+# Detect the main checkout's actual branch name — handles both 'main' and
+# 'master' conventions without hardcoding. Was the #65 bug: the tool
+# hardcoded 'master' everywhere and silently broke in any main-branch repo.
+MAIN_BRANCH=$(git -C "$MAIN_CHECKOUT" rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ -z "$MAIN_BRANCH" ]]; then
+    echo "worktree-sync: cannot determine main branch name from $MAIN_CHECKOUT" >&2
+    exit 1
+fi
+
 BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
-# --- Guard: not master ---
-if [[ "$BRANCH" == "master" || "$BRANCH" == "main" ]]; then
+# --- Guard: not on the main branch ---
+if [[ "$BRANCH" == "$MAIN_BRANCH" ]]; then
     if [[ "$AUTO_MODE" == true ]]; then
-        # Auto mode on master: soft skip, no error
+        # Auto mode on main: soft skip, no error
         if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
-            log_end "$RUN_ID" "success" 0 0 "skipped — on master"
+            log_end "$RUN_ID" "success" 0 0 "skipped — on $MAIN_BRANCH"
         fi
-        printf '{"systemMessage": "worktree-sync: skipped — on master"}'
+        printf '{"systemMessage": "worktree-sync: skipped — on %s"}' "$MAIN_BRANCH"
         exit 0
     else
-        echo "worktree-sync: on master — use /sync-all instead" >&2
+        echo "worktree-sync: on $MAIN_BRANCH — use /sync-all instead" >&2
         if [[ -n "$RUN_ID" ]] && type log_end &>/dev/null; then
-            log_end "$RUN_ID" "failure" 1 0 "on master"
+            log_end "$RUN_ID" "failure" 1 0 "on $MAIN_BRANCH"
         fi
         exit 1
     fi
@@ -134,18 +143,18 @@ fi
 PRE_MERGE_HEAD=$(git rev-parse HEAD 2>/dev/null)
 
 # --- Check if already up to date ---
-MERGE_BASE=$(git merge-base HEAD master 2>/dev/null || echo "")
-MASTER_HEAD=$(git rev-parse master 2>/dev/null || echo "")
+MERGE_BASE=$(git merge-base HEAD "$MAIN_BRANCH" 2>/dev/null || echo "")
+MAIN_HEAD=$(git rev-parse "$MAIN_BRANCH" 2>/dev/null || echo "")
 
-if [[ "$MERGE_BASE" == "$MASTER_HEAD" ]]; then
+if [[ "$MERGE_BASE" == "$MAIN_HEAD" ]]; then
     # Already up to date — skip merge, still sync settings + sandbox
     MERGED=false
     MERGE_MSG="already up to date"
     COMMITS=0
 else
-    # --- Merge master ---
+    # --- Merge main branch ---
     MERGED=true
-    MERGE_OUTPUT=$(git merge master 2>&1) || {
+    MERGE_OUTPUT=$(git merge "$MAIN_BRANCH" 2>&1) || {
         # Merge conflict — abort and restore. After this block runs the repo
         # is back at PRE_MERGE_HEAD with MERGE_HEAD cleared. The message has
         # to make that clear so the caller doesn't try to 'git merge --abort'
@@ -155,7 +164,7 @@ else
         git merge --abort 2>/dev/null || ABORT_OK=false
         CONFLICT_FILES=$(echo "$MERGE_OUTPUT" | grep "CONFLICT" || echo "(unknown)")
 
-        echo "worktree-sync: merge with master had conflicts — merge was automatically aborted." >&2
+        echo "worktree-sync: merge with $MAIN_BRANCH had conflicts — merge was automatically aborted." >&2
         echo "  Repo state: restored to pre-merge HEAD ($PRE_MERGE_HEAD)." >&2
         echo "  Conflict files:" >&2
         echo "$CONFLICT_FILES" | sed 's/^/    /' >&2
@@ -183,12 +192,12 @@ else
         fi
 
         if [[ "$AUTO_MODE" == true ]]; then
-            jq -n -c --arg msg "worktree-sync: merge conflict with master — merge was automatically aborted, repo restored. Review conflict files before retrying." '{"systemMessage": $msg}'
+            jq -n -c --arg msg "worktree-sync: merge conflict with $MAIN_BRANCH — merge was automatically aborted, repo restored. Review conflict files before retrying." '{"systemMessage": $msg}'
         fi
         exit 1
     }
     COMMITS=$(git rev-list "$PRE_MERGE_HEAD"..HEAD --count 2>/dev/null || echo "?")
-    MERGE_MSG="merged master ($COMMITS commits)"
+    MERGE_MSG="merged $MAIN_BRANCH ($COMMITS commits)"
 fi
 
 # --- Copy settings.json from main checkout ---

--- a/claude/workstreams/agency/references/gary-tan-durable-agents-20260409.md
+++ b/claude/workstreams/agency/references/gary-tan-durable-agents-20260409.md
@@ -1,0 +1,81 @@
+---
+type: reference
+source: Gary Tan (gstack)
+captured: 2026-04-09
+captured_by: the-agency/jordan/captain
+workstream: agency
+purpose: context for articles, book, framework methodology writing
+---
+
+# How I Get My Claw To Be A Durable AI Agent I Never Have To Instruct Twice
+
+Source: Gary Tan (@garrytan, gstack). Captured verbatim for reference. This is a philosophical sibling to our **telemetry-driven tool discovery** insight captured in `seed-telemetry-driven-tool-discovery-20260409.md` — both point at the same pattern from different angles.
+
+## The Prompt
+
+> Paste this into your OpenClaw's AGENTS.md or send it as a message:
+>
+> You are not allowed to do one-off work. If I ask you to do something and it's the kind of thing that will need to happen again, you must:
+>
+> 1. Do it manually the first time (3-10 items)
+> 2. Show me the output and ask if I like it
+> 3. If I approve, codify it into a SKILL.md file in workspace/skills/
+> 4. If it should run automatically, add it to cron with `openclaw cron add`
+>
+> Every skill must be MECE — each type of work has exactly one owner skill. No overlap, no gaps. Before creating a new skill, check if an existing one already covers it. If so, extend it instead.
+>
+> The test: if I have to ask you for something twice, you failed. The first time I ask is discovery. The second time means you should have already turned it into a skill running on a cron.
+>
+> When building a skill, follow this cycle:
+> - Concept: describe the process
+> - Prototype: run on 3-10 real items, no skill file yet
+> - Evaluate: review output with me, revise
+> - Codify: write SKILL.md (or extend existing)
+> - Cron: schedule if recurring
+> - Monitor: check first runs, iterate
+>
+> Every conversation where I say "can you do X" should end with X being a skill on a cron — not a memory of "he asked me to do X that one time."
+>
+> The system compounds. Build it once, it runs forever.
+
+## Why this matters to TheAgency
+
+Tan's framing is adjacent to but not identical to our **Friction → Telemetry → Tool → Block → Flow** loop. The differences are instructive:
+
+| Dimension | Tan's Durable Agents | TheAgency's Telemetry-Driven Discovery |
+|-----------|---------------------|----------------------------------------|
+| **Signal source** | The principal asking twice | The Bash tool log recording friction |
+| **Detection** | Human notices repetition | Telemetry mining finds patterns |
+| **Trigger** | "Don't make me ask twice" | "Every compound command is a request for a missing primitive" |
+| **Response** | Codify into skill + cron | Build tool + skill + hookify Triangle, block the workaround |
+| **Enforcement** | Promise / prompt instruction | Mechanical hookify block |
+| **Scale** | One human, one agent | Multi-agent fleet, multi-principal, multi-repo |
+| **MECE constraint** | Explicit (no overlap, no gaps) | Implicit (Triangle owns the capability) |
+
+## What we can borrow
+
+1. **"The first time is discovery; the second time is failure."** This is the better one-line framing of our friction-to-tool loop. Steal it for the README.
+2. **The skill lifecycle** (Concept → Prototype → Evaluate → Codify → Cron → Monitor) maps cleanly onto our Ladder (Document → Skill → Tool → Warn → Block) but emphasizes the Prototype → Evaluate step, which our Ladder underweights. Consider adding an explicit "Prototype (3-10 real items)" step to the Ladder documentation.
+3. **MECE constraint on skills.** We have this intuitively but not written down. Add a framework rule: before creating a new skill, check if an existing one can be extended. This prevents the skill-sprawl problem other frameworks hit.
+4. **Cron as first-class.** Tan has `openclaw cron add` as a fundamental primitive. We have `CronCreate` and `schedule` but haven't positioned them as "this is where durable work lives." Elevate cron in the framework story.
+
+## What we do that Tan doesn't mention
+
+1. **Mechanical enforcement via hookify** — Tan relies on agent compliance with the prompt. We block the anti-pattern at the tool level. Agent compliance is an unreliable base.
+2. **Telemetry as the signal source** — Tan relies on the principal noticing repetition. We mine the log. The principal can forget; the log cannot.
+3. **Triangle structure** (Tool + Skill + Hookify) — Tan has Skill + Cron. We add the Hookify layer and the Tool layer as distinct responsibilities. The separation of "the thing that does the work" (tool) from "the thing that teaches the agent to do the work" (skill) from "the thing that prevents the anti-pattern" (hookify) is a cleaner factoring.
+4. **Multi-agent fleet awareness** — Tan's model is single-agent. Ours has to work across a fleet where different agents have different capabilities and permissions.
+
+## Use for writing
+
+Direct quotes are usable with attribution. The comparison table is usable as structure for a section like "Two framings of the same insight."
+
+The article angle: **"The best framework insights are the ones that multiple people arrive at independently. Here are two."**
+
+The book angle: Tan's version is the **sound-bite version** (easy to copy-paste into any project). Ours is the **framework-level version** (requires investment in tool/skill/hookify infrastructure). Both are right for different contexts. The book should present Tan's prompt as the on-ramp for solo developers, and the full Triangle + Telemetry loop as the destination for teams running fleets.
+
+## Related artifacts
+
+- Seed: `claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md`
+- Flag #55: CLAUDE.md + README revision for telemetry-driven tool discovery (add a section referencing Tan)
+- Flag #54: compound command telemetry analysis workstream (the mining side)

--- a/tests/tools/worktree-sync.bats
+++ b/tests/tools/worktree-sync.bats
@@ -105,3 +105,92 @@ teardown() {
     # MERGE_HEAD must not exist — proves the tool aborted its own merge
     [[ ! -f "${WORKTREE_PATH}/.git/MERGE_HEAD" ]] && [[ ! -f "${MOCK_ROOT}/.git/worktrees/mock-worktree/MERGE_HEAD" ]]
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Issue #65 — main-branch repos (not just master)
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# The tool originally hardcoded 'master' throughout, which meant it silently
+# broke in any repo using 'main' as the default branch (including the-agency
+# itself). The fix detects MAIN_BRANCH from the main checkout's actual HEAD.
+# These tests exercise the main-branch path with a successful merge (no
+# conflict) to confirm the tool reads MAIN_BRANCH dynamically.
+
+setup_main_branch_repo() {
+    # Alternate setup: mock repo uses 'main' as default, feature branch is
+    # behind main by one non-conflicting commit.
+    export MAIN_MOCK_ROOT="${BATS_TEST_TMPDIR}/mock-main-branch"
+    mkdir -p "${MAIN_MOCK_ROOT}"
+    cd "${MAIN_MOCK_ROOT}"
+
+    git init --quiet --initial-branch=main
+    git config user.email "tester@example.invalid"
+    git config user.name "Tester"
+
+    echo "root" > README.md
+    git add README.md
+    git commit --quiet -m "initial"
+
+    # Feature branch at the root commit
+    git checkout --quiet -b devfeature
+
+    # Main advances with a non-conflicting new file
+    git checkout --quiet main
+    echo "new on main" > newfile.txt
+    git add newfile.txt
+    git commit --quiet -m "main: add newfile"
+
+    # Register devfeature as a worktree
+    export MAIN_WORKTREE_PATH="${BATS_TEST_TMPDIR}/mock-main-worktree"
+    git worktree add --quiet "${MAIN_WORKTREE_PATH}" devfeature
+}
+
+teardown_main_branch_repo() {
+    if [[ -d "${MAIN_MOCK_ROOT:-}" ]]; then
+        (cd "${MAIN_MOCK_ROOT}" && git worktree remove --force "${MAIN_WORKTREE_PATH}" 2>/dev/null || true)
+    fi
+}
+
+@test "worktree-sync: successfully merges 'main' branch (not just 'master')" {
+    # Skip the master-based setup for this test
+    if [[ -d "${MOCK_ROOT}" ]]; then
+        (cd "${MOCK_ROOT}" && git worktree remove --force "${WORKTREE_PATH}" 2>/dev/null || true)
+    fi
+    setup_main_branch_repo
+    cd "${MAIN_WORKTREE_PATH}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    teardown_main_branch_repo
+    assert_success
+    # Output should reference 'main', not 'master'
+    if echo "$output" | grep -qi 'master'; then
+        echo "Output references 'master' instead of 'main' — #65 regression:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+    # Output should confirm a merge happened
+    if ! echo "$output" | grep -qi 'merged\|up to date\|main'; then
+        echo "Output does not confirm main-branch merge:" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}
+
+@test "worktree-sync: detects MAIN_BRANCH dynamically from main checkout" {
+    # Same setup, different assertion — verify the tool's error path references
+    # the actual branch name, not a hardcoded 'master'.
+    if [[ -d "${MOCK_ROOT}" ]]; then
+        (cd "${MOCK_ROOT}" && git worktree remove --force "${WORKTREE_PATH}" 2>/dev/null || true)
+    fi
+    setup_main_branch_repo
+    # Invoke from the main checkout itself (should soft-skip in auto mode with 'main' in the message)
+    cd "${MAIN_MOCK_ROOT}"
+    run bash "${REPO_ROOT}/claude/tools/worktree-sync" --auto
+    teardown_main_branch_repo
+    assert_success
+    # The soft-skip message should mention 'main', not 'master'
+    if ! echo "$output" | grep -q 'main'; then
+        echo "Soft-skip message does not reference 'main':" >&2
+        echo "$output" >&2
+        return 1
+    fi
+}

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -2,8 +2,8 @@
 type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
-date: 2026-04-08
-trigger: end-of-day-33
+date: 2026-04-09
+trigger: end-of-day-34
 ---
 
 ## Identity
@@ -12,158 +12,157 @@ the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality g
 
 ## Current State
 
-**Day 33 complete.** Two releases shipped, one upstream contribution incorporated, one real-world agency-update test executed, first bug-found-and-filed via the new tooling loop. Local main is at `6cac2fa`, in sync with origin.
+**Day 34 complete. Biggest single day of the session so far.** Two releases shipped (34.1 + 34.2), meta-insight of the week captured, monofolk graduated to full-install, first full dogfood bug-found-filed-fixed-closed cycle executed, 13 new flags captured. Local main is at `1f54e79`, in sync with origin.
 
-## Shipped Today (Day 33)
+## Shipped Today (Day 34)
 
-### PR #53 — Day 33 R1 (MERGED)
+### PR #60 — Day 34.1 (MERGED)
 
-7 commits. Day 32 carry-over + Day 33 core work.
+Single feature release: **agency-version tool + statusline version display.**
 
-- **`agency-issue` v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1. Smoke-tested by filing [#52](https://github.com/the-agency-ai/the-agency/issues/52) using the tool itself
-- **`release-plan` v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern:** built then used to assemble its own release
-- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag)
-- **iscp-check v1.1.0** — delta suppression, stops the repeated "You have N" notifications
-- **6 seeds** — fleet-awareness, agency-issue, release-plan, silent-tool-calls (filed externally), granola carry-over, agent-mail-service
-- **3 pre-existing bugs fixed** — `.git/config bare=true`, `git-commit PROJECT_ROOT` unbound, `iscp-check.bats` stale version
+- `claude/tools/agency-version` — bash tool with verbs: `print` (default), `--statusline` (silent on missing), `--json`, `--help`
+- `claude/config/manifest.json` — new top-level `agency_version: "34.1"` field (single source of truth)
+- `claude/tools/statusline.sh` — renders `2.1.87 with Opus | 34.1 | the-agency (main) …`
+- 11 BATS tests, all green
+- Single commit: `118ae29`
 
-### PR #55 — merge-not-rebase (UPSTREAM, MERGED)
+### PR #63 — Day 34.2 (MERGED)
 
-Monofolk's contribution. Two hookify blocks (`block-raw-rebase`, `block-reset-to-origin`), four skill migrations (sync-all, sync, post-merge, rebase deprecated), `GIT-MERGE-NOT-REBASE.md` reference doc, CLAUDE-THEAGENCY.md update. Incorporated into our R2 same-day via `git merge origin/main`.
+Multi-fix release: **run-in Triangle + fixes #56, #57, #171 regression + telemetry-driven tool discovery seed.**
 
-### PR #54 — Day 33 R2 (MERGED)
+- **fix #56** (`c746d04`) — `agency update` now detects new top-level YAML keys in source `agency.yaml` and appends them to target with a comment marker. Dedupes duplicate keys. Verified end-to-end on `~/code/presence-detect` (43 → 124 lines, 9 missing sections added).
+- **fix #171 regression** (`2a62f8d`) — Gate 0 in `commit-precheck` hard-blocks any commit with `Test User <test@example.com>` attribution. Cleaned live `[user]` pollution from main's `.git/config` in same turn. Belt + suspenders alongside existing `test_helper.bash` unset guard.
+- **feat: run-in Triangle + fix #57** (`ac73ce9`) — new `claude/tools/run-in <dir> -- <cmd>` runs in subshell, parent CWD untouched. `/run-in` skill. `hookify.block-compound-bash` **wide block** on all compound patterns with educative WHY. 11 run-in BATS tests + 4 worktree-sync BATS tests (bug-exposing for #57). Seed: telemetry-driven tool discovery.
+- **34.2 version bump** (`bdab384`)
 
-13 commits on top of R1 + #55.
+### Issues closed today
+- #56 — agency update yaml section propagation (first full dogfood cycle via agency-issue)
+- #57 — worktree-sync misleading 'resolve manually' message
 
-- **iscp-check `--statusline` mode** + statusline.sh integration — silent periodic polling via Claude Code status line; `📬 Nd Mf` in footer when current agent has unread mail, silent when empty
-- **release-plan config-block pairing** — agency.yaml section changes fold into matching feature commits
-- **agency-issue BATS tests** (19) + arg-validation refactor (validate before gh auth check)
-- **release-plan BATS tests** (16)
-- **nit-add + nit-resolve** migrated to merge-based pull (were broken by new block-raw-rebase)
-- **Monofolk RFI reply** sent — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT (5 questions, options considered, reasoning)
-- **Worktree naming answered** (#169 → devex) — prefix collapse rule unblocks #166
-- **iscp statusline heads-up** (#170)
-- **Captain's log for Day 33** — 7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction
-- **PR lifecycle tool seed** — captured for future, on hold pending upstream work
+### Issues filed today
+- #58 — Docker CLI can't connect to daemon when Docker Desktop is running (dispatched to devex with standing autonomy directive)
 
-### Agency-update test (presence-detect)
+## The Meta-Insight of the Week
 
-Real-world dogfood test on `~/code/presence-detect` (5-day-old installation at 2.0.0 / `4d6f6683` → 2.0.0 / `6cac2fa9`).
+**"The Bash tool log is a list of the tools we haven't built yet."**
 
-**Backups created first:**
-- Filesystem copy at `~/code/presence-detect.backup-20260408-202749` (116 MB)
-- Git tag `agency-update-backup-20260408`
-- (Remote push not possible — no remote configured)
+Named the framework pattern that birthed run-in: **Friction → Telemetry → Tool → Block → Flow.** Every compound bash command is a request for a missing primitive. The telemetry already captures the request; we just need to mine it.
 
-**Dry-run summary:** +1085 new, ~66 modified, -1 deleted. Single deletion was benign (renamed hookify rule).
+Seed at `claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md`. Queued for CLAUDE.md + README-THEAGENCY + articles + book revision (flag #55). This is the thesis statement for "why TheAgency builds tools the way it builds tools."
 
-**Real update succeeded:**
-- All framework files propagated
-- `agency verify` 10/12 passes (2 deferred Figma providers)
-- All R1 + R2 + #55 content spot-checked and present downstream
-- Pre-existing uncommitted work preserved
+## monofolk Graduated
 
-**One bug found: [#56](https://github.com/the-agency-ai/the-agency/issues/56)** — `agency update` does not propagate new top-level YAML sections from `agency.yaml`. Only framework metadata is bumped. **Filed via `agency-issue` tool** (first real bug found-and-filed via the new tooling loop). **Captain will fix tomorrow morning and close via `agency-issue close`.**
+**The first external validation that the framework is mature enough to run production work without the sandbox.**
+
+- monofolk removed 32 sandbox symlinks and 47 personal hookify files
+- 15 agents, 13 worktrees, running overnight research fleet of 10 agents in parallel
+- Full Agency install as of today
+- 5-week sprint to May 15 NextGeneration go-live
+- Asked for diagnostic tooling — **we committed to a 4-wave delivery plan**:
+  - **Wave 1** (this week, Day 38-40): audit tool (#51) + worktree health diagnostics
+  - **Wave 2** (next week): stale artifact detection + hookify rule coverage report
+  - **Wave 3** (weeks 3-4): compound command telemetry mining (the meta-tool)
+  - **Wave 4** (week 5, before go-live): whatever Wave 3's telemetry mining surfaces
 
 ## Dispatches Sent Today
 
 | ID | Type | To | Subject |
 |----|------|-----|---------|
-| #149 | directive | devex | Day 33 work queue (4 items) |
-| #152 | review-response | devex | Item 3: accept main as-is |
-| #153 | review-response | devex | Item 1: SPEC-PROVIDER wrappers plan approved |
-| #157 | escalation | devex | ~~P0 git-commit bug~~ (downgraded in #162) |
-| #162 | dispatch | devex | P0 → P1 downgrade (sparse worktree confusion) |
-| #165 | directive | iscp | Peer-to-peer cross-repo dispatches + auto-CC |
-| #166 | directive | devex | Worktree naming convention |
-| #167 | directive | devex | Hookify noun-verb rename |
-| #168 | directive | devex | agent-create scaffolding with dispatch loops |
-| #169 | review-response | devex | Worktree naming = B (prefix collapse) |
-| #170 | dispatch | iscp | iscp-check --statusline heads-up |
+| #172 | review-response | devex | RE: #171 acknowledged, triaging |
+| #173 | review-response | devex | RE: #171 per-item unblock direction + back-to-work trigger |
+| #174 | directive | devex | DIRECTIVE: fix #58 docker socket + standing autonomy on full queue |
+| (collab) | dispatch | monofolk | RE: We're All-In — congratulations + graduation path queued |
+| (collab) | dispatch | monofolk | RE: agency update live — diagnostic tooling inventory + 4-wave roadmap |
 
-## Cross-Repo (Monofolk)
+#171 resolved. Devex has full standing autonomy authorization and does not need per-item approval.
 
-**Sent today:**
-- Reply to merge-not-rebase contribution — acknowledging, adopted, shipped into R2
-- Reply to SPEC-PROVIDER + SPEC-ENVIRONMENT RFI — full 1B1 answers with reasoning
-- R2 shipped dispatch — what's in it for monofolk, adoption notes, agency-update test results, #56 heads-up
+## Cross-Repo (monofolk)
 
-**No pending inbound.** Collaboration repo is clean on our side.
+- Inbound: 2 dispatches received and replied to (graduation + diagnostic tooling request)
+- Outbound: 2 replies pushed to `collaboration-monofolk` repo
+- No pending inbound
 
 ## Active Agents (background)
 
 | Agent | State | Notes |
 |-------|-------|-------|
-| devex | Queue: 4 items from #149, plus #166 (unblocked), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1 + R2 |
-| iscp | Phase 2 (per-agent inboxes plan approved). Received #170 + peer-to-peer directive (#165) | Needs to merge master for R1 + R2 |
-| mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
-| mdpal-cli | Own iteration | Needs to merge master |
+| devex | Standing autonomy. Queue: #58 docker fix + #149 items + #166/#167/#168 + #171 unblock sequence. Do not need approval on any item. | Needs to pick up main (R1+R2) on next session-resume. Manual merge likely required due to worktree-sync master/main bug (flag #65). |
+| iscp | Phase 2 work | Needs to pick up main. Manual merge required. |
+| mdpal-app / mdpal-cli | Own iterations | Not currently in active state. |
+
+## Captain Flags Captured Today (13 new, #53-#65)
+
+| # | Theme |
+|---|-------|
+| 53 | Docker socket self-heal (when Docker Desktop running but CLI can't connect) |
+| 54 | Compound command telemetry analysis workstream (the meta-tool that mines the log) |
+| 55 | CLAUDE.md + README revision for telemetry-driven tool discovery |
+| 56 | commit-precheck missing `end_run` event on failure (telemetry gap) |
+| 57 | Telemetry identity resolution broken (shows `testuser/unknown` instead of `jordan/captain`) |
+| 58 | `/why-did-this-fail` skill — query telemetry for failed run diagnostic |
+| 59 | Surface run IDs + exit codes on tool failure output |
+| 60 | Handoff tool investigation (why did commit 4bc05a1 not update blob?) |
+| 61 | RULE: We do NOT review on GitHub. PRs are shipping mechanism only. |
+| 62 | coord-commit allowed-tools frontmatter silently blocks agents (removed in fix) |
+| 63 | **Permission visibility gap** — agents can't see principal's permission prompts. File to Anthropic. |
+| 64 | Diagnostic tooling workstream (committed to monofolk) |
+| 65 | **worktree-sync hardcodes `master`** — breaks in main-branch repos. Blocks `/sync-all`. |
 
 ## Open Items
 
-### Tomorrow morning (immediate)
+### Tomorrow morning (Day 35 — highest priority)
 
-1. **Fix issue #56** — `agency update` YAML section migration. Investigate `claude/tools/lib/_agency-init`, implement three-way merge (preserve user values in existing sections, add new top-level sections from source with a comment). Test via re-running agency update on presence-detect. Close issue via `agency-issue close 56 --comment "Fixed in PR #NN"`.
-2. **Triage the 4 unfiled Anthropic Claude Code issues** from `usr/jordan/captain/anthropic-issues-to-file-20260406.md`. Verify #2 (brace expansion) is still relevant with current `Bash(*)` permissions. Close #4 (silent /feedback) in tracking doc. File #1 and #3 via `/feedback`.
+1. **Fix worktree-sync master/main bug (flag #65)** — pre-existing, blocking fleet sync. Detect `MAIN_BRANCH` from main checkout, replace all `master` references. File as agency-issue with bug-exposing test.
+2. **Fix coord-commit permission trap (flag #62)** — remove `allowed-tools` frontmatter, inherit `Bash(*)`. Audit all other skill frontmatter for the same pattern.
+3. **File permission visibility gap to Anthropic (flag #63)** — Claude Code feedback. Draft inline, principal approves.
+4. **Wave 1 diagnostic tools (committed to monofolk)** — audit tool (#51) + worktree health diagnostics. End-of-week target (Day 38-40).
 
-### Parked / deferred
+### KIV (when at laptop)
 
-- **Local presence-detect state** — left as-is with the agency-update diff uncommitted. Backups intact. Principal can commit when ready, after the #56 fix re-runs for the clean delta.
-- **PR lifecycle tool** — seed captured, on hold pending upstream work
-- **Fleet awareness `/define`** — seed ready, PVR not yet started
-- **Captain's log for #56 filing + #56 fix** — log tomorrow
-- **Pull-rebase hookify gap** — investigate whether `block-raw-rebase` pattern misses `git pull --rebase`
-- **`git-commit --staged` default when staging area non-empty** — small usability fix
+- PAT rotation — `.git/config` contains a GitHub token in the origin URL
+- `/compact-prep` B-prime build (session-end mode=compact flag)
+- CI/CD review (flag #52)
 
-### Dispatched to devex (their work)
+### Dispatched to devex (standing autonomy — they execute without approval)
 
-- #149 Item 2: Valueflow Phase 3
-- #149 Item 4: hookify rules from Day 32 friction
-- #166: worktree naming rule implementation
-- #167: hookify noun-verb rename
-- #168: agent-create scaffolding with dispatch loops
+- #58 docker socket fix
+- #149 full queue (Items 2, 4 + Valueflow Phase 3 + hookify rules)
+- #166 worktree naming
+- #167 hookify noun-verb rename
+- #168 agent-create scaffolding
+- #171 unblock sequence (merge conflict, handoff restore, stash cleanup)
+- Task #8 phase-complete SPEC-PROVIDER preview/deploy
 
-### Dispatched to iscp (their work)
+## Key Decisions Today
 
-- #165: peer-to-peer cross-repo dispatches + auto-CC to captains (protocol work)
-
-## Active Flags
-
-| ID | Flag | Status |
-|----|------|--------|
-| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
-
-## Key Decisions This Session
-
-1. **Bootstrap pattern confirmed twice** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done with `agency-issue` (R1) and `release-plan` (R1 + R2)
-2. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`
-3. **Worktree naming = prefix collapse** — unblocks devex #166
-4. **Dispatch loop convention is universal** — every agent, every session
-5. **Mailbox statusline = silent when empty** — icon only appears when current agent has unread mail (corrected from an earlier wrong interpretation)
-6. **SPEC-PROVIDER orthogonality confirmed** — environment and provider fully independent (RFI answer to monofolk)
-7. **First dogfood bug-found-and-filed loop completed** — issue #56 filed via agency-issue, will be closed via agency-issue after tomorrow's fix
-8. **Destructive operations require explicit authorization** — principal reminded captain to pause and confirm before push/merge/reset even when strategy is chosen. Going forward: strategy selection is NOT execution authorization.
+1. **Release format locked**: `{day}.{release}`, no `v` prefix, rapid-release discipline, one PR per release
+2. **Stacked PR hazard learned**: merging child PR before parent lands the child into parent's branch, not main. **Merge base-first, wait for auto-retarget, then merge child.**
+3. **Run-in Triangle shipped**: compound bash commands are hard-blocked framework-wide; `run-in` is the canonical replacement for the `cd X && cmd` pattern
+4. **Telemetry-driven tool discovery named and seeded** — will become framework-level methodology in README + CLAUDE.md + articles
+5. **Standing autonomy for devex**: explicit "don't wait for approval, just do it" directive; applies to all queued items
+6. **No reviews on GitHub** (flag #61): PRs are shipping mechanism only; review happens locally via `/captain-review`/`/code-review`/`/pr-prep`
+7. **monofolk diagnostic tooling 4-wave commitment** — concrete timeline for the fleet health roadmap
+8. **Permission visibility gap is structural**: the agent cannot see what the principal sees when approval prompts fire. Pre-approve trusted tools + file to Anthropic.
 
 ## Discipline Reminders
 
-- **Never rebase** — framework-wide block active (block-raw-rebase)
-- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin)
-- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; always pause and confirm before push/merge/close/delete
-- Use `/handoff` skill, never raw handoff tool
-- Use `/git-commit` (with `--staged` flag when pre-staging), never bare `git commit`
-- Run dispatch loop on session start (5m + 30m)
-- Cross-repo dispatches via collaboration repo, not direct
-- Per-agent attribution in all commits via the new email format
+- **NEVER review on GitHub.** PRs are shipping mechanism only.
+- **NEVER rebase** — framework-wide block active
+- **NEVER `reset --hard origin/*`** — framework-wide block active
+- **NEVER compound bash commands** — `&&`/`||`/`;`/`|`/`$(…)`/backticks all blocked by `hookify.block-compound-bash`. Use `run-in` for the `cd X && cmd` pattern; split into separate Bash calls otherwise.
+- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; pause and confirm before push/merge/close/delete
+- Use `/handoff` skill / `/git-commit` / etc — never raw tools
+- Dispatch loop (5m silent) running this session — will not survive compact; re-set on next session
+- Cross-repo dispatches via `collaboration` tool, not direct
 
 ## Next Action (start of next session)
 
 1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
-2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have acknowledged R2
-3. **Check for dispatches from devex/iscp/mdpal** — they may have picked up the merge
-4. **Tomorrow morning work:**
-   - Fix #56 (agency.yaml three-way merge)
-   - Triage + file Anthropic Claude Code backlog
-   - Day 34 R1 if more work surfaces
-5. **Captain's log** — append today's loop closing (#56 filed, fixed tomorrow) and anything new
+2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have picked up Day 34 and started sending feedback
+3. **Check devex / iscp / mdpal** for any inbound dispatches (probably pick-up acks for R1+R2 + #174)
+4. **Flag #65: worktree-sync master/main fix** — Wave 0, blocks fleet sync
+5. **Flag #62: coord-commit permission trap fix** — unblocks any future coord-commit invocations
+6. **Wave 1 diagnostic tooling kickoff** — audit tool (#51) + worktree health diagnostics, committed to monofolk for end-of-week
+7. **Captain's log** — append Day 35 kickoff
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260409-101856.md
+++ b/usr/jordan/captain/history/handoff-20260409-101856.md
@@ -1,0 +1,169 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-08
+trigger: end-of-day-33
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 33 complete.** Two releases shipped, one upstream contribution incorporated, one real-world agency-update test executed, first bug-found-and-filed via the new tooling loop. Local main is at `6cac2fa`, in sync with origin.
+
+## Shipped Today (Day 33)
+
+### PR #53 — Day 33 R1 (MERGED)
+
+7 commits. Day 32 carry-over + Day 33 core work.
+
+- **`agency-issue` v1** — thin gh wrapper with file/list/view/comment/close verbs. Designed via 10-question 1B1. Smoke-tested by filing [#52](https://github.com/the-agency-ai/the-agency/issues/52) using the tool itself
+- **`release-plan` v1** — heuristic-based release plan generator. Auto-detects day{N}-release-{M} branch, groups uncommitted files, pairs tool+skill+tests as feature commits. **Bootstrap pattern:** built then used to assemble its own release
+- **Dispatch loop convention** — documented in CLAUDE-THEAGENCY.md as canonical for every agent (5m silent + 30m visible nag)
+- **iscp-check v1.1.0** — delta suppression, stops the repeated "You have N" notifications
+- **6 seeds** — fleet-awareness, agency-issue, release-plan, silent-tool-calls (filed externally), granola carry-over, agent-mail-service
+- **3 pre-existing bugs fixed** — `.git/config bare=true`, `git-commit PROJECT_ROOT` unbound, `iscp-check.bats` stale version
+
+### PR #55 — merge-not-rebase (UPSTREAM, MERGED)
+
+Monofolk's contribution. Two hookify blocks (`block-raw-rebase`, `block-reset-to-origin`), four skill migrations (sync-all, sync, post-merge, rebase deprecated), `GIT-MERGE-NOT-REBASE.md` reference doc, CLAUDE-THEAGENCY.md update. Incorporated into our R2 same-day via `git merge origin/main`.
+
+### PR #54 — Day 33 R2 (MERGED)
+
+13 commits on top of R1 + #55.
+
+- **iscp-check `--statusline` mode** + statusline.sh integration — silent periodic polling via Claude Code status line; `📬 Nd Mf` in footer when current agent has unread mail, silent when empty
+- **release-plan config-block pairing** — agency.yaml section changes fold into matching feature commits
+- **agency-issue BATS tests** (19) + arg-validation refactor (validate before gh auth check)
+- **release-plan BATS tests** (16)
+- **nit-add + nit-resolve** migrated to merge-based pull (were broken by new block-raw-rebase)
+- **Monofolk RFI reply** sent — full 1B1 answers on SPEC-PROVIDER + SPEC-ENVIRONMENT (5 questions, options considered, reasoning)
+- **Worktree naming answered** (#169 → devex) — prefix collapse rule unblocks #166
+- **iscp statusline heads-up** (#170)
+- **Captain's log for Day 33** — 7 entries: 2 milestones, 2 builds, 1 decision, 3 learnings, 1 friction
+- **PR lifecycle tool seed** — captured for future, on hold pending upstream work
+
+### Agency-update test (presence-detect)
+
+Real-world dogfood test on `~/code/presence-detect` (5-day-old installation at 2.0.0 / `4d6f6683` → 2.0.0 / `6cac2fa9`).
+
+**Backups created first:**
+- Filesystem copy at `~/code/presence-detect.backup-20260408-202749` (116 MB)
+- Git tag `agency-update-backup-20260408`
+- (Remote push not possible — no remote configured)
+
+**Dry-run summary:** +1085 new, ~66 modified, -1 deleted. Single deletion was benign (renamed hookify rule).
+
+**Real update succeeded:**
+- All framework files propagated
+- `agency verify` 10/12 passes (2 deferred Figma providers)
+- All R1 + R2 + #55 content spot-checked and present downstream
+- Pre-existing uncommitted work preserved
+
+**One bug found: [#56](https://github.com/the-agency-ai/the-agency/issues/56)** — `agency update` does not propagate new top-level YAML sections from `agency.yaml`. Only framework metadata is bumped. **Filed via `agency-issue` tool** (first real bug found-and-filed via the new tooling loop). **Captain will fix tomorrow morning and close via `agency-issue close`.**
+
+## Dispatches Sent Today
+
+| ID | Type | To | Subject |
+|----|------|-----|---------|
+| #149 | directive | devex | Day 33 work queue (4 items) |
+| #152 | review-response | devex | Item 3: accept main as-is |
+| #153 | review-response | devex | Item 1: SPEC-PROVIDER wrappers plan approved |
+| #157 | escalation | devex | ~~P0 git-commit bug~~ (downgraded in #162) |
+| #162 | dispatch | devex | P0 → P1 downgrade (sparse worktree confusion) |
+| #165 | directive | iscp | Peer-to-peer cross-repo dispatches + auto-CC |
+| #166 | directive | devex | Worktree naming convention |
+| #167 | directive | devex | Hookify noun-verb rename |
+| #168 | directive | devex | agent-create scaffolding with dispatch loops |
+| #169 | review-response | devex | Worktree naming = B (prefix collapse) |
+| #170 | dispatch | iscp | iscp-check --statusline heads-up |
+
+## Cross-Repo (Monofolk)
+
+**Sent today:**
+- Reply to merge-not-rebase contribution — acknowledging, adopted, shipped into R2
+- Reply to SPEC-PROVIDER + SPEC-ENVIRONMENT RFI — full 1B1 answers with reasoning
+- R2 shipped dispatch — what's in it for monofolk, adoption notes, agency-update test results, #56 heads-up
+
+**No pending inbound.** Collaboration repo is clean on our side.
+
+## Active Agents (background)
+
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Queue: 4 items from #149, plus #166 (unblocked), #167 hookify rename, #168 agent-create scaffolding | Needs to merge master for R1 + R2 |
+| iscp | Phase 2 (per-agent inboxes plan approved). Received #170 + peer-to-peer directive (#165) | Needs to merge master for R1 + R2 |
+| mdpal-app | Phase 1A SwiftUI work | Needs to merge master |
+| mdpal-cli | Own iteration | Needs to merge master |
+
+## Open Items
+
+### Tomorrow morning (immediate)
+
+1. **Fix issue #56** — `agency update` YAML section migration. Investigate `claude/tools/lib/_agency-init`, implement three-way merge (preserve user values in existing sections, add new top-level sections from source with a comment). Test via re-running agency update on presence-detect. Close issue via `agency-issue close 56 --comment "Fixed in PR #NN"`.
+2. **Triage the 4 unfiled Anthropic Claude Code issues** from `usr/jordan/captain/anthropic-issues-to-file-20260406.md`. Verify #2 (brace expansion) is still relevant with current `Bash(*)` permissions. Close #4 (silent /feedback) in tracking doc. File #1 and #3 via `/feedback`.
+
+### Parked / deferred
+
+- **Local presence-detect state** — left as-is with the agency-update diff uncommitted. Backups intact. Principal can commit when ready, after the #56 fix re-runs for the clean delta.
+- **PR lifecycle tool** — seed captured, on hold pending upstream work
+- **Fleet awareness `/define`** — seed ready, PVR not yet started
+- **Captain's log for #56 filing + #56 fix** — log tomorrow
+- **Pull-rebase hookify gap** — investigate whether `block-raw-rebase` pattern misses `git pull --rebase`
+- **`git-commit --staged` default when staging area non-empty** — small usability fix
+
+### Dispatched to devex (their work)
+
+- #149 Item 2: Valueflow Phase 3
+- #149 Item 4: hookify rules from Day 32 friction
+- #166: worktree naming rule implementation
+- #167: hookify noun-verb rename
+- #168: agent-create scaffolding with dispatch loops
+
+### Dispatched to iscp (their work)
+
+- #165: peer-to-peer cross-repo dispatches + auto-CC to captains (protocol work)
+
+## Active Flags
+
+| ID | Flag | Status |
+|----|------|--------|
+| 34 | SECURITY: Bash(*) too broad pre-GTM | TODO (kept active per principal) |
+
+## Key Decisions This Session
+
+1. **Bootstrap pattern confirmed twice** — captain can build a tool and use it in the same session to assemble the release containing the tool. Done with `agency-issue` (R1) and `release-plan` (R1 + R2)
+2. **Merge-not-rebase discipline adopted same-day** — monofolk's PR #55 shipped the framework-wide rule, we applied it to R2 within minutes via `git merge origin/main`
+3. **Worktree naming = prefix collapse** — unblocks devex #166
+4. **Dispatch loop convention is universal** — every agent, every session
+5. **Mailbox statusline = silent when empty** — icon only appears when current agent has unread mail (corrected from an earlier wrong interpretation)
+6. **SPEC-PROVIDER orthogonality confirmed** — environment and provider fully independent (RFI answer to monofolk)
+7. **First dogfood bug-found-and-filed loop completed** — issue #56 filed via agency-issue, will be closed via agency-issue after tomorrow's fix
+8. **Destructive operations require explicit authorization** — principal reminded captain to pause and confirm before push/merge/reset even when strategy is chosen. Going forward: strategy selection is NOT execution authorization.
+
+## Discipline Reminders
+
+- **Never rebase** — framework-wide block active (block-raw-rebase)
+- **Never reset --hard origin/*** — framework-wide block active (block-reset-to-origin)
+- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; always pause and confirm before push/merge/close/delete
+- Use `/handoff` skill, never raw handoff tool
+- Use `/git-commit` (with `--staged` flag when pre-staging), never bare `git commit`
+- Run dispatch loop on session start (5m + 30m)
+- Cross-repo dispatches via collaboration repo, not direct
+- Per-agent attribution in all commits via the new email format
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
+2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have acknowledged R2
+3. **Check for dispatches from devex/iscp/mdpal** — they may have picked up the merge
+4. **Tomorrow morning work:**
+   - Fix #56 (agency.yaml three-way merge)
+   - Triage + file Anthropic Claude Code backlog
+   - Day 34 R1 if more work surfaces
+5. **Captain's log** — append today's loop closing (#56 filed, fixed tomorrow) and anything new
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/logs/captains-log-20260409.md
+++ b/usr/jordan/captain/logs/captains-log-20260409.md
@@ -1,0 +1,40 @@
+---
+type: captains-log
+date: 2026-04-09
+agent: jordan/captain
+---
+
+# Captain's Log — Thursday, April 9, 2026
+
+
+## 10:18:16 — milestone
+
+Day 34 shipped: 34.1 (agency-version tool + statusline) and 34.2 (run-in Triangle + fixes #56/#57/#171 regression). Two clean release PRs (#60, #63), both merged to main.
+
+## 10:18:20 — learning
+
+THE META-INSIGHT: the Bash tool log is a list of the tools we haven't built yet. Every compound bash command is a request for a missing primitive. Framework pattern: Friction → Telemetry → Tool → Block → Flow. Seed captured at claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md. Named the pattern that births run-in and will birth the next 20 Agency tools. Queued for CLAUDE.md + README + articles + book revision.
+
+## 10:18:24 — build
+
+run-in Triangle: claude/tools/run-in (subshell isolation, parent CWD untouched) + /run-in skill + hookify.block-compound-bash (wide block on &&/||/;/|/subshells/cd X && with educative WHY). 11 BATS tests green. First tool built under the telemetry-driven tool discovery discipline.
+
+## 10:18:33 — milestone
+
+monofolk graduated: sandbox removed, full Agency install. 15 agents, 13 worktrees. First external validation that framework is mature enough to run a production project without the safety net. Committed to a 5-week diagnostic tooling sprint: audit tool + worktree health (Wave 1 this week), stale artifact detection + hookify coverage (Wave 2 next week), compound command telemetry mining (Wave 3). Target: monofolk fully diagnostic-equipped by Day 45 before May 15 NextGeneration go-live.
+
+## 10:18:36 — milestone
+
+First full dogfood cycle complete: agency-issue tool was built yesterday; today it filed #56 (found on presence-detect update), fixed it (c746d04), verified end-to-end, and closed the issue — all via the tool itself. Same tool shipped #57, #58, closed #57 after red-green. The tool is working.
+
+## 10:18:41 — friction
+
+Devex was silently stalled today on a permission prompt inside coord-commit's restrictive allowed-tools frontmatter. They could not see the prompt from the principal's UI; I could not see the prompt from the agent side. Silent stall bug. Two flags: #62 (coord-commit fix — remove allowed-tools, inherit Bash(*)) and #63 (permission visibility gap — file to Anthropic as Claude Code feedback). Principal confirmed 'you don't see when I am asked for permission' is a structural gap.
+
+## 10:18:48 — decision
+
+Rapid-release discipline: Day.Release versioning (34.1, 34.2) where day = Agency workday, release = increment within day. No 'v' prefix. Each release = one PR. Stacked PRs work but REQUIRE merging base-first-and-wait-for-retarget or the child merges into parent instead of main (learned the hard way with PR #61 today).
+
+## 10:18:51 — observation
+
+13 new flags captured today (53-65). Major themes: permission visibility gap (62, 63), tool telemetry (56, 57, 58, 59), worktree-sync bugs (53, 65), diagnostic tooling workstream (64), CLAUDE.md revision queue (55), handoff forensics (60), GitHub CI/CD review (52 carryover), no-github-review rule (61).

--- a/usr/jordan/captain/logs/captains-log-20260409.md
+++ b/usr/jordan/captain/logs/captains-log-20260409.md
@@ -42,3 +42,7 @@ Rapid-release discipline: Day.Release versioning (34.1, 34.2) where day = Agency
 ## 10:21:32 — milestone
 
 Devex UNBLOCKED — all 6 unblock steps complete (#175). Main merged cleanly via 'git rm + git merge main'. Item 4 (handoff reverted) was a false alarm — startup reminder was showing a working-tree artifact, HEAD always had Day 33 content. Gate 0 confirmed working on devex side (test commit 'dbcd25b' authored correctly as Jordan, not Test User). Devex resuming Task #8 (/phase-complete for SPEC-PROVIDER preview/deploy). Standing autonomy on remaining queue.
+
+## 10:31:26 — build
+
+Knocked out #65 + #62 in one bundle commit (79805a3). #65: worktree-sync detects MAIN_BRANCH dynamically from main checkout (was hardcoded 'master' in 7 places), 6/6 BATS tests green including new main-branch coverage. #62: stripped allowed-tools frontmatter from 48 skill files via persistent helper at usr/jordan/captain/tools/strip-skill-allowed-tools. Defense-in-depth was illusory (global .claude/settings.json has Bash(*)); skill-level allowed-tools only created silent-stall traps. Script is re-runnable for future audits.

--- a/usr/jordan/captain/logs/captains-log-20260409.md
+++ b/usr/jordan/captain/logs/captains-log-20260409.md
@@ -38,3 +38,7 @@ Rapid-release discipline: Day.Release versioning (34.1, 34.2) where day = Agency
 ## 10:18:51 — observation
 
 13 new flags captured today (53-65). Major themes: permission visibility gap (62, 63), tool telemetry (56, 57, 58, 59), worktree-sync bugs (53, 65), diagnostic tooling workstream (64), CLAUDE.md revision queue (55), handoff forensics (60), GitHub CI/CD review (52 carryover), no-github-review rule (61).
+
+## 10:21:32 — milestone
+
+Devex UNBLOCKED — all 6 unblock steps complete (#175). Main merged cleanly via 'git rm + git merge main'. Item 4 (handoff reverted) was a false alarm — startup reminder was showing a working-tree artifact, HEAD always had Day 33 content. Gate 0 confirmed working on devex side (test commit 'dbcd25b' authored correctly as Jordan, not Test User). Devex resuming Task #8 (/phase-complete for SPEC-PROVIDER preview/deploy). Standing autonomy on remaining queue.

--- a/usr/jordan/captain/tools/strip-skill-allowed-tools
+++ b/usr/jordan/captain/tools/strip-skill-allowed-tools
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+#
+# What Problem: Every .claude/skills/*/SKILL.md file with an `allowed-tools`
+# frontmatter entry is a silent-stall trap. When an agent invokes that skill,
+# the allowed-tools scope OVERRIDES the global settings.json permissions
+# DOWNWARD, restricting what the skill can run. Any edge-case command the
+# skill needs that isn't in the pattern list triggers a permission prompt
+# that the agent cannot see and the principal cannot easily associate with
+# the stuck skill. Devex hit this inside coord-commit and silently stalled
+# for hours (dispatch #171 → flags #62, #63).
+#
+# How & Why: Scan all .claude/skills/*/SKILL.md files, find the allowed-tools
+# line inside the YAML frontmatter, remove it, and add a comment explaining
+# the removal so future readers understand the choice. Idempotent — can
+# re-run safely. Dry-run mode lists the files without modifying them. The
+# fix relies on .claude/settings.json already having Bash(*)/Read(**)/Edit(**)/
+# Write(**) globally, which the-agency does.
+#
+# Written: 2026-04-09 during captain Day 34 — skill allowed-tools audit
+
+import argparse
+import pathlib
+import re
+import sys
+
+SKILLS_DIR = pathlib.Path(".claude/skills")
+
+COMMENT_BLOCK = """
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
+"""
+
+
+def strip_allowed_tools(text: str) -> tuple[str, bool]:
+    """Return (new_text, modified). No-op if allowed-tools not present."""
+    lines = text.splitlines(keepends=True)
+    if not lines or not lines[0].startswith("---"):
+        return text, False
+
+    # Find closing of frontmatter
+    close_idx = None
+    for i in range(1, len(lines)):
+        if lines[i].startswith("---"):
+            close_idx = i
+            break
+    if close_idx is None:
+        return text, False
+
+    # Find the allowed-tools line(s) — could be single-line or continuation
+    new_frontmatter = []
+    removed = False
+    for line in lines[1:close_idx]:
+        if re.match(r"^allowed-tools\s*:", line):
+            removed = True
+            continue
+        new_frontmatter.append(line)
+
+    if not removed:
+        return text, False
+
+    rebuilt = "".join(
+        [lines[0]] + new_frontmatter + [lines[close_idx]] + [COMMENT_BLOCK] + lines[close_idx + 1 :]
+    )
+    return rebuilt, True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Strip allowed-tools from skill frontmatters")
+    parser.add_argument("--dry-run", action="store_true", help="List files that would change, do not modify")
+    parser.add_argument("--root", default=".", help="Project root (default: cwd)")
+    parser.add_argument("--only", nargs="*", help="Only process specific skill names (e.g. 'handoff dispatch')")
+    args = parser.parse_args()
+
+    root = pathlib.Path(args.root)
+    skills_dir = root / SKILLS_DIR
+    if not skills_dir.is_dir():
+        print(f"error: skills dir not found at {skills_dir}", file=sys.stderr)
+        return 2
+
+    skill_files = sorted(skills_dir.glob("*/SKILL.md"))
+    changed = 0
+    skipped = 0
+    for f in skill_files:
+        skill_name = f.parent.name
+        if args.only and skill_name not in args.only:
+            skipped += 1
+            continue
+        text = f.read_text()
+        new_text, modified = strip_allowed_tools(text)
+        if modified:
+            if args.dry_run:
+                print(f"WOULD STRIP: {f}")
+            else:
+                f.write_text(new_text)
+                print(f"stripped: {f}")
+            changed += 1
+
+    print(f"\n{'would change' if args.dry_run else 'changed'}: {changed}; untouched: {len(skill_files) - changed - skipped}; skipped by filter: {skipped}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Day 34 Release 3. Two fleet-level fixes bundled:

## What

### Fix #65 — worktree-sync main/master hardcoding

`worktree-sync` hardcoded `master` in 7 places, silently breaking in any repo using `main` as the default branch (including the-agency itself). This is why `/sync-all` was failing across the fleet — worktree agents have been manually running `git merge main` all along to work around it.

**Fix:** Detect `MAIN_BRANCH` dynamically from the main checkout at the start of the tool (`git -C $MAIN_CHECKOUT rev-parse --abbrev-ref HEAD`). Use that everywhere `master` was referenced.

**Tests:** 6/6 BATS green, including 2 new main-branch tests (successful merge + soft-skip message references dynamic branch name).

### Fix #62 — skill allowed-tools silent-stall trap

Every `.claude/skills/*/SKILL.md` file had an `allowed-tools` frontmatter entry that restricted Bash tool permissions DOWNWARD from the global `Bash(*)` in `.claude/settings.json`. When an agent invoked a skill, any Bash command outside the narrow pattern list triggered a silent permission prompt that **the agent could not see** and the principal could not easily associate with the stuck skill.

This is what blocked devex inside `coord-commit` for hours (dispatch #171). The defense-in-depth was illusory — agents could bypass the skill entirely and call bash directly.

**Fix:** Stripped `allowed-tools` from 48 skill files. Added explanatory comment to each with cross-references to flags #62 and #63. Global `.claude/settings.json` `Bash(*)` governs now.

**Tool:** Persistent helper at `usr/jordan/captain/tools/strip-skill-allowed-tools` (Python, idempotent, dry-run mode, re-runnable for future audits).

## Commits

| SHA | What |
|-----|------|
| `79805a3` | fix: #65 worktree-sync main/master + #62 skill allowed-tools trap |
| `2988325` | Day 34.3: bump agency_version to 34.3 |

## Meta-observation

Both fixes came from the same root cause: **invisible silent failures**. #65 silently broke worktree-sync in any main-branch repo — nobody noticed because agents worked around it manually. #62 silently blocked skill invocations — nobody noticed because neither agent nor principal could see the permission prompts. The same day, we also hit this pattern with dispatch #171 (misleading worktree-sync error message after conflict-abort, fixed in 34.2 as #57). This is a pattern — it deserves its own framework audit (flag #63 — permission visibility gap — queued for Anthropic feedback).

## Test plan

- [x] `bats tests/tools/worktree-sync.bats` — 6/6 green
- [x] `strip-skill-allowed-tools --dry-run` — lists 48 files correctly
- [x] Spot-check post-strip: `.claude/skills/dispatch/SKILL.md`, `.claude/skills/handoff/SKILL.md`, `.claude/skills/coord-commit/SKILL.md` — frontmatter clean, description preserved, comment added

## Related

- Resolves flag #65 (worktree-sync master/main)
- Resolves flag #62 (coord-commit permission trap)
- Related to flag #63 (permission visibility gap, queued for Anthropic)
- Related to dispatch #171 (devex blocker that surfaced #62)

🤖 Generated with [Claude Code](https://claude.com/claude-code)