### PR TITLE
Day 35.1–35.2: Monitor-based dispatch + changelog awareness

### DIFF
--- a/.claude/skills/changelog-watch/SKILL.md
+++ b/.claude/skills/changelog-watch/SKILL.md
@@ -1,0 +1,46 @@
+# Changelog Watch
+
+Monitor Claude Code's changelog for new releases and features. Uses the Monitor tool to stream updates as they land.
+
+## When to use
+
+- At session start for continuous awareness of Claude Code changes
+- When you want to know about new features, breaking changes, or opportunities
+- Pairs with dispatch-monitor for full situational awareness
+
+## Instructions
+
+### Start watching
+
+Use the Monitor tool to run the changelog-monitor script in the background:
+
+```
+Monitor the Claude Code changelog for new releases. Run ./claude/tools/changelog-monitor in the background. When a new version is detected, summarize what changed and flag anything relevant to our workflow.
+```
+
+The script:
+- Polls the raw CHANGELOG.md from GitHub every 30 minutes (configurable with `--interval N`)
+- Only outputs when the changelog has actually changed (silent otherwise)
+- Extracts the latest entry automatically
+- State persisted in `~/.agency/changelog-monitor/` (survives session restarts)
+
+### When output arrives
+
+1. Read the changelog entry
+2. Evaluate relevance to TheAgency:
+   - New tools or features we should adopt?
+   - Breaking changes that affect our hooks/tools?
+   - Performance improvements we benefit from?
+   - Bug fixes for issues we've reported?
+3. If relevant: flag it to the principal, capture a seed if it warrants adoption
+4. If not relevant: note it silently, no output needed
+
+### Example discoveries this pattern would catch
+
+- Monitor tool (v2.1.98) — we adopted it within minutes of discovery
+- Remote Control improvements
+- Hook lifecycle changes
+- New MCP capabilities
+- Token pricing changes
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/monitor-dispatches/SKILL.md
+++ b/.claude/skills/monitor-dispatches/SKILL.md
@@ -1,0 +1,47 @@
+# Monitor Dispatches
+
+Set up event-driven dispatch monitoring using Claude Code's Monitor tool. Replaces the /loop polling pattern with real-time, token-efficient background monitoring.
+
+## When to use
+
+- At session start, instead of setting up `/loop 5m dispatch list`
+- When you want instant dispatch notification instead of 5-minute polling
+- Requires Claude Code v2.1.98+
+
+## Instructions
+
+### Start monitoring
+
+Use the Monitor tool to run the dispatch-monitor script in the background:
+
+```
+Monitor dispatches for me. Run ./claude/tools/dispatch-monitor --include-collab in the background. When output appears, read and respond to the dispatches.
+```
+
+The script:
+- Polls every 10 seconds (configurable with `--interval N`)
+- Only outputs when there ARE unread dispatches (completely silent otherwise)
+- With `--include-collab`, also checks cross-repo collaboration dispatches
+- Output is prefixed with `[DISPATCH]` or `[COLLAB]` for routing
+
+### When output arrives
+
+1. Parse the dispatch list from the Monitor output
+2. Read each unread dispatch with `./claude/tools/dispatch read <id>`
+3. Respond appropriately
+4. Resolve with `./claude/tools/dispatch resolve <id>` if no further action needed
+
+### Why this replaces /loop
+
+| Aspect | /loop polling | Monitor |
+|--------|--------------|---------|
+| Token cost | ~2,000 per check | ~10 per event |
+| Latency | 5 minutes | 10 seconds |
+| Blocking | Yes | No |
+| Daily cost | ~82,000 tokens | ~2,000 tokens |
+
+### Stop monitoring
+
+Ask Claude to stop the monitor, or it stops automatically when the session ends.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "35.1",
+  "agency_version": "35.2",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,10 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "34.4",
+  "agency_version": "35.1",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "2.0.0"
+    "framework_version": "2.0.0",
+    "updated_at": "2026-04-10T11:39:44Z"
   },
   "source": {
     "type": "local",

--- a/claude/tools/changelog-monitor
+++ b/claude/tools/changelog-monitor
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# What Problem: Claude Code ships updates frequently and we need to know
+# about new features, breaking changes, and opportunities (like the Monitor
+# tool itself) as they land. Currently we manually check the changelog or
+# hear about updates on X. We need automated, continuous awareness.
+#
+# How & Why: Polls the raw Claude Code CHANGELOG.md from GitHub every N
+# minutes (default 30). Compares against a local hash of the last-seen
+# version. When the changelog changes, outputs the new content for the
+# Monitor tool to stream to the agent. The agent then evaluates relevance
+# and surfaces what matters.
+#
+# Usage: With Monitor tool — "monitor Claude Code changelog for new releases"
+# Standalone: ./claude/tools/changelog-monitor [--interval N]
+#
+# Written: 2026-04-10 during captain session (35.2 — changelog awareness)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CHANGELOG_URL="https://raw.githubusercontent.com/anthropics/claude-code/main/CHANGELOG.md"
+STATE_DIR="${HOME}/.agency/changelog-monitor"
+HASH_FILE="${STATE_DIR}/last-hash"
+INTERVAL=1800  # 30 minutes default
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval)
+            INTERVAL="$2"
+            shift 2
+            ;;
+        --help|-h)
+            echo "Usage: changelog-monitor [--interval N]"
+            echo ""
+            echo "Polls Claude Code CHANGELOG.md for new entries."
+            echo "Only outputs when the changelog has changed since last check."
+            echo "Designed for use with Claude Code's Monitor tool."
+            echo ""
+            echo "Options:"
+            echo "  --interval N    Poll interval in seconds (default: 1800 = 30 min)"
+            echo "  --help          Show this help"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Ensure state directory exists
+mkdir -p "$STATE_DIR"
+
+# Initialize hash file if it doesn't exist
+if [[ ! -f "$HASH_FILE" ]]; then
+    echo "none" > "$HASH_FILE"
+fi
+
+while true; do
+    # Fetch changelog
+    CONTENT=$(curl -fsSL "$CHANGELOG_URL" 2>/dev/null || true)
+
+    if [[ -z "$CONTENT" ]]; then
+        sleep "$INTERVAL"
+        continue
+    fi
+
+    # Hash the content
+    CURRENT_HASH=$(echo "$CONTENT" | md5 2>/dev/null || echo "$CONTENT" | md5sum 2>/dev/null | cut -d' ' -f1)
+    LAST_HASH=$(cat "$HASH_FILE" 2>/dev/null || echo "none")
+
+    if [[ "$CURRENT_HASH" != "$LAST_HASH" ]]; then
+        # Changelog changed — extract the latest entry (everything before the second ## heading)
+        LATEST=$(echo "$CONTENT" | awk '/^## /{count++; if(count==2) exit} {print}')
+
+        echo "[CHANGELOG] Claude Code changelog updated!"
+        echo "$LATEST"
+        echo "[/CHANGELOG]"
+
+        # Save new hash
+        echo "$CURRENT_HASH" > "$HASH_FILE"
+    fi
+
+    sleep "$INTERVAL"
+done

--- a/claude/tools/dispatch-monitor
+++ b/claude/tools/dispatch-monitor
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# What Problem: Dispatch polling via /loop costs ~82,000 tokens/day and has
+# 5-minute latency. The Monitor tool (Claude Code v2.1.98+) can watch a
+# background script and react to output in real-time, but needs a script
+# that only outputs when there are actual dispatches to process.
+#
+# How & Why: Lightweight polling script designed as a Monitor tool backend.
+# Polls dispatch list every N seconds (default 10), only outputs when unread
+# dispatches exist (completely silent otherwise). The Monitor tool streams
+# each output line to the agent, who reacts immediately. Result: 96% token
+# savings, 10-second latency instead of 5 minutes.
+#
+# Usage: With Monitor tool — ask Claude to "monitor dispatches using dispatch-monitor"
+# Standalone: ./claude/tools/dispatch-monitor [--interval N] [--include-collab]
+#
+# Written: 2026-04-10 during captain session (Monitor tool adoption)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+INTERVAL=10
+INCLUDE_COLLAB=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --interval)
+            INTERVAL="$2"
+            shift 2
+            ;;
+        --include-collab)
+            INCLUDE_COLLAB=true
+            shift
+            ;;
+        --help|-h)
+            echo "Usage: dispatch-monitor [--interval N] [--include-collab]"
+            echo ""
+            echo "Lightweight polling script for use with Claude Code's Monitor tool."
+            echo "Only outputs when there are unread dispatches (silent otherwise)."
+            echo ""
+            echo "Options:"
+            echo "  --interval N        Poll interval in seconds (default: 10)"
+            echo "  --include-collab    Also check cross-repo collaboration dispatches"
+            echo "  --help              Show this help"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1" >&2
+            exit 1
+            ;;
+    esac
+done
+
+while true; do
+    # Check local dispatches
+    OUTPUT=$("$SCRIPT_DIR/dispatch" list --status unread 2>/dev/null || true)
+    if [[ -n "$OUTPUT" ]] && [[ "$OUTPUT" != "No dispatches found." ]]; then
+        echo "[DISPATCH] $OUTPUT"
+    fi
+
+    # Optionally check cross-repo collaboration
+    if [[ "$INCLUDE_COLLAB" == "true" ]]; then
+        COLLAB_OUTPUT=$("$SCRIPT_DIR/collaboration" check 2>/dev/null || true)
+        if [[ -n "$COLLAB_OUTPUT" ]]; then
+            echo "[COLLAB] $COLLAB_OUTPUT"
+        fi
+    fi
+
+    sleep "$INTERVAL"
+done

--- a/claude/workstreams/agency/seeds/seed-it-happened-and-breadcrumb-20260410.md
+++ b/claude/workstreams/agency/seeds/seed-it-happened-and-breadcrumb-20260410.md
@@ -1,0 +1,82 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-10
+subject: "This Happened!" + "Breadcrumb" — value-added services from The Agency
+---
+
+# This Happened! + Breadcrumb
+
+Two complementary value-added services from The Agency, designed to be human-friendly AND agent-friendly.
+
+## Breadcrumb — Distributed Trace Chain
+
+**What:** A correlation ID service using UUID7 identifiers that chain across service boundaries.
+
+**How it works:**
+- Every call gets a UUID7 identifier (time-ordered — sequence is embedded in the ID itself)
+- When a call crosses a service boundary, the receiving service adds its own UUID7 while preserving the parent
+- Chain: `UXCall_UUID7 → APICall1_UUID7 → ServiceCall2_UUID7 → ...`
+- All IDs go into logs at every level
+- UUID7's time-ordering means you can reconstruct sequence without a centralized clock
+
+**The pattern:**
+```
+User action → UI event (UUID7-A)
+  → API call (UUID7-A → UUID7-B)
+    → Database query (UUID7-A → UUID7-B → UUID7-C)
+    → External service (UUID7-A → UUID7-B → UUID7-D)
+```
+
+**Not new** — this is distributed tracing (OpenTelemetry trace/span IDs). What's different:
+- UUID7 instead of random trace IDs — time-ordered, sortable, no clock sync needed
+- Designed for both human and agent consumption
+- Integrated with "This Happened!" for end-to-end traceability from user report to root cause
+- Greenfield-friendly (monofolk bakes it in from day one)
+- Retrofit-friendly (add at API gateway layer for existing systems)
+
+**Name:** Breadcrumb — follow the trail from where you are back to where it started. Hansel and Gretel, but for distributed systems.
+
+## This Happened! — User Issue Reporting with Automatic State Capture
+
+**What:** A user-facing issue reporting mechanism that automatically captures runtime state at the moment the user reports a problem.
+
+**The name:** "This Happened!" — as in: no, it DID happen. Don't deny it. Here's what happened and where.
+
+**How it works:**
+- User hits a problem → taps "This Happened!" (or equivalent trigger)
+- System automatically captures:
+  - Current screen / UI state
+  - Recent user actions (last N interactions)
+  - In-flight API calls and their Breadcrumb trace IDs
+  - Device state (memory, network, OS version, app version)
+  - Relevant logs from the last N seconds
+  - Active feature flags / configuration
+- User can optionally add a note ("I was trying to...")
+- Everything gets bundled into a structured report
+- The Breadcrumb trail connects the report to the exact call chains that were executing
+
+**Why it matters:**
+- User doesn't have to describe what happened — the system already knows
+- Support doesn't have to ask "can you reproduce it?" — they have the trace
+- Agents can parse the structured data and diagnose automatically
+- The Breadcrumb chain means you go from "it's broken" → exact service → exact failure
+
+**Together:**
+- **This Happened!** captures the WHAT — runtime state, user context, the moment of impact
+- **Breadcrumb** traces the WHERE — the call chain across every service boundary
+- This Happened! automatically attaches the active Breadcrumb trails to every report
+- Support/agents follow the breadcrumbs from the user's "it happened" moment to root cause
+
+## Design Principles
+
+- **Human-friendly:** Whimsical names, clear UI, no jargon. A user taps "This Happened!" — they don't "file a JIRA ticket with reproduction steps."
+- **Agent-friendly:** Structured data, correlation IDs, machine-parseable reports. An agent reads the This Happened! report + Breadcrumb chain and diagnoses without asking for more context.
+- **Built for greenfield, retrofit for brownfield:** Monofolk bakes both in from day one. Existing systems can add Breadcrumb at the API gateway and This Happened! at the UI layer.
+- **Whimsical branding** — we have the kittens, we have the voice. These are Agency services, not enterprise middleware.
+
+## Status
+
+- **Breadcrumb:** Pattern defined. Implementing in monofolk from the ground up.
+- **This Happened!:** Concept captured. Needs PVR + A&D.
+- **Both:** Value-added services from The Agency — ship as part of the framework or as standalone packages.

--- a/claude/workstreams/agency/seeds/seed-monitor-tool-adoption-20260410.md
+++ b/claude/workstreams/agency/seeds/seed-monitor-tool-adoption-20260410.md
@@ -1,0 +1,66 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-10
+subject: "Monitor Tool — event-driven replacement for dispatch polling"
+---
+
+# Monitor Tool — Adopt for TheAgency
+
+## What It Is
+
+Claude Code v2.1.98+ introduces the **Monitor tool** — background scripts that stream events to the agent in real-time. Event-driven, not polling-based. Massive token savings.
+
+## How It Works
+
+- Claude writes a small script (bash, Python, etc.)
+- Spawns it as a background process
+- Each stdout line streams into the conversation as it arrives
+- Claude reacts between turns — non-blocking
+- Dies when the session ends
+
+## Why This Matters for Us
+
+### Current pattern: `/loop 5m dispatch list`
+- 288 checks/day × ~2,000 tokens/check = **~82,000 tokens/day**
+- 5-minute latency before agent sees new dispatch
+- Blocks conversation while polling
+
+### Proposed pattern: Monitor + dispatch polling script
+- Background script runs: `while true; do ./claude/tools/dispatch list --status unread 2>/dev/null | grep -v "No dispatches"; sleep 10; done`
+- Only streams output when there ARE dispatches
+- **~2,000 tokens/day** (per dispatch event, not per poll)
+- **10-second latency** instead of 5 minutes
+- Non-blocking — agent keeps working
+
+### Token savings: 96% reduction
+
+## Adoption Plan
+
+1. **Dispatch monitoring** — replace `/loop 5m dispatch list` with Monitor
+2. **Collaboration monitoring** — replace `/loop 10m collaboration check` with Monitor
+3. **Dev server watching** — Monitor build output for errors during implementation
+4. **Test watching** — Monitor test runs, react to failures in real-time
+5. **Deploy tracking** — Monitor Vercel/CI deploy status
+
+## Workshop Case Study
+
+This is a perfect case study for the Republic Poly workshop:
+
+> "We discovered this feature TODAY. Within minutes, we researched it, understood the implications, wrote a seed to adopt it, and planned the migration from our current polling to event-driven monitoring. That's AI Augmented Development in action — the OODA loop. Observe (new feature), Orient (how does it fit our system), Decide (adopt, replace polling), Act (seed, plan, implement)."
+
+Shows the live, iterative, responsive nature of working this way.
+
+## Implementation Notes
+
+- Requires Claude Code v2.1.98+
+- Monitor processes die with the session — need to restart on session start
+- Can be wrapped in a skill: `/monitor-dispatches`
+- Background script should be in `claude/tools/` (e.g., `dispatch-monitor`)
+- Replaces both the 5m fast-path and 30m nag loops
+
+## References
+
+- Claude Code v2.1.98 release notes
+- Claude Code Tools Reference — Monitor tool
+- Alistair's X post on Monitor tool launch

--- a/claude/workstreams/agency/seeds/seed-ooda-loop-structural-framework-20260410.md
+++ b/claude/workstreams/agency/seeds/seed-ooda-loop-structural-framework-20260410.md
@@ -1,0 +1,51 @@
+---
+type: dispatch
+from: monofolk/jordan/captain
+to: the-agency/jordan/captain
+date: 2026-04-10T16:23
+status: read
+priority: normal
+subject: "Follow-up: OODA Loop as TheAgency's structural framework"
+in_reply_to: new
+---
+
+# Follow-up: OODA Loop as TheAgency's structural framework
+
+Follow-up to the Process Intelligence dispatch sent earlier today.
+
+Jordan connected the dots: everything we are building — TheAgency, OF business process intelligence, the Celonis model — is OODA. Observe, Orient, Decide, Act. Boyd's loop.
+
+This should be a first-class concept in TheAgency, not just inspiration. Structural.
+
+## The Mapping
+
+- Observe: transcript mining, telemetry, QGRs, flag capture
+- Orient: hookify pattern matching, dispatch routing, MAR reviews
+- Decide: captain triage, 3-bucket disposition, principal approval
+- Act: agent execution, QG enforcement, tool automation, hookify block
+
+## Key Insight: The Closed Loop Gap
+
+Today we cycle OODA but with human gates between stages. The evolution:
+- Today: Human writes hookify rule after observing pattern in transcripts
+- Next: System suggests hookify rule from observed patterns, human approves
+- Future: System creates hookify rule automatically, human reviews after the fact
+
+Each step tightens the loop. Each step increases cycle speed. The one who cycles fastest wins.
+
+## OODA Maps to Everything
+
+- Valueflow stages map to OODA (Seed=Observe, Define/Design=Orient, Plan=Decide, Implement/Ship=Act)
+- Enforcement Ladder maps to OODA (Document=Observe, Skill=Orient, Tool/Hookify=Act)
+- The ladder IS the OODA loop applied to capability maturation
+
+## Two Products, Same Loop
+
+1. TheAgency — OODA for dev methodology (how software gets built)
+2. OF Process Intelligence — OODA for business operations (how healthcare/telehealth runs)
+
+Same architecture. Different domain.
+
+Full seed with detailed mappings is in monofolk at: usr/jordan/captain/research/seed-ooda-loop-theagency-20260410.md
+
+— The Admiral + Captain

--- a/claude/workstreams/agency/seeds/seed-process-intelligence-celonis-20260410.md
+++ b/claude/workstreams/agency/seeds/seed-process-intelligence-celonis-20260410.md
@@ -1,0 +1,56 @@
+---
+type: dispatch
+from: monofolk/jordan/captain
+to: the-agency/jordan/captain
+date: 2026-04-10T16:21
+status: read
+priority: normal
+subject: "Process Intelligence seed — Celonis interview + TheAgency trajectory"
+in_reply_to: new
+---
+
+# Process Intelligence seed — Celonis interview + TheAgency trajectory
+
+Jordan captured a BBC Business Daily interview with Alexander Rinke, co-CEO of Celonis ($13B process mining company). The interview sparked a strategic thread about where TheAgency is heading.
+
+## The Celonis Insight
+
+Celonis started as academic process mining — x-raying business processes to show how they actually work vs how people think they work. They evolved from observation to action: their platform now detects stuck processes and triggers AI agents to fix them automatically. $13B company. 15 years old. Started as a university project with 3 friends and $15K.
+
+Key quote from Rinke: The problem with AI is that AI does not know the context of each individual business. It is trained on a lot of public data, they are very smart, but as companies try to adopt them, these LLMs lack the business context about what is going on within the company and we provide that in a really unique way.
+
+## The TheAgency Parallel
+
+Jordan's observation: we are on the same trajectory at the development methodology layer.
+
+We have all three stages running today:
+1. Observe — transcript mining, telemetry, dispatch history, flag capture, QGRs
+2. Detect — hookify rules fire on patterns, QG review agents find issues, iscp-check surfaces unread mail
+3. Act — but mostly manual. The agent flags it, the human or captain decides.
+
+The gap is stage 3. Celonis closed it — their system detects the stuck process and triggers an AI agent to fix it. No human in the loop for known patterns.
+
+We have the pieces. Hookify rules block known bad patterns. Dispatch routes work to the right agent. QG runs automatically at boundaries. What we do not have yet is the closed loop — where observation of a pattern automatically creates the hookify rule, or automatically spins up the agent, or automatically adjusts the process.
+
+That is the jump from framework to platform. From developers use TheAgency to TheAgency runs itself and gets better.
+
+## Two Product Directions
+
+Jordan is also thinking about this for OF the business — not just for development methodology, but process intelligence tooling for OrdinaryFolk's business operations (orders, fulfillment, customer service, clinical workflows). Celonis for healthcare/telehealth. The same observe-detect-act loop applied to business processes, not just dev processes.
+
+## The Full Transcript
+
+Complete interview transcript (17 min, transcribed via Apple Notes from BBC MP3) is in monofolk at: usr/jordan/captain/research/seed-bbc-celonis-process-intelligence-20260410.md
+
+Key themes: bootstrapping without VC for 5 years, co-founder dynamics, Europe vs US capital, AI agents that act not just observe, Paulaner/Oktoberfest supply chain optimization.
+
+## What This Means for the-agency
+
+Consider this as input for the Valueflow evolution:
+- Valueflow today: documents the methodology, enforces it via hooks and rules
+- Valueflow next: observes how agents actually work (transcript mining, telemetry)
+- Valueflow future: detects patterns and automatically evolves the methodology
+
+Process intelligence for AI-augmented development. That is the product.
+
+— The Admiral + Captain

--- a/claude/workstreams/agency/seeds/workshop-bootstrap.sh
+++ b/claude/workstreams/agency/seeds/workshop-bootstrap.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# What Problem: Students at the Republic Polytechnic workshop need a fully
+# provisioned Ubuntu VM with Ghostty, Homebrew, Claude Code, and The Agency
+# framework. Without this script, setup takes 30+ minutes of manual steps
+# and students get stuck on different packages and configurations.
+#
+# How & Why: Single idempotent bootstrap script that installs everything in
+# order. Uses apt for system packages, Homebrew for CLI tools (matching our
+# macOS workflow — "no compromises"), and npm for Claude Code. Ghostty is
+# installed via apt PPA (Ubuntu 24.04+). Each section is guarded by
+# command-existence checks so re-running is safe.
+#
+# Written: 2026-04-10 during captain session (workshop VM prep)
+
+set -euo pipefail
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+step() { echo -e "\n${BOLD}${GREEN}▸ $1${NC}"; }
+warn() { echo -e "${YELLOW}⚠ $1${NC}"; }
+fail() { echo -e "${RED}✗ $1${NC}"; exit 1; }
+ok()   { echo -e "${GREEN}✓ $1${NC}"; }
+
+# ─── Pre-flight ──────────────────────────────────────────────────────────────
+
+step "Pre-flight checks"
+
+if [[ "$(id -u)" == "0" ]]; then
+    fail "Do not run this script as root. Run as your normal user (it will use sudo when needed)."
+fi
+
+if ! command -v apt-get &>/dev/null; then
+    fail "This script requires Ubuntu/Debian (apt-get not found)."
+fi
+
+ok "Running as $(whoami) on $(uname -m)"
+
+# ─── System packages ────────────────────────────────────────────────────────
+
+step "Installing system packages via apt"
+
+sudo apt-get update -qq
+
+PACKAGES=(
+    curl
+    wget
+    git
+    build-essential
+    jq
+    sqlite3
+    tree
+    unzip
+    ca-certificates
+    gnupg
+    lsb-release
+    software-properties-common
+    python3
+    python3-pip
+    ripgrep
+    fd-find
+)
+
+sudo apt-get install -y -qq "${PACKAGES[@]}"
+ok "System packages installed"
+
+# ─── Google Chrome ──────────────────────────────────────────────────────────
+
+step "Installing Google Chrome"
+
+if command -v google-chrome &>/dev/null || command -v google-chrome-stable &>/dev/null || command -v chromium-browser &>/dev/null; then
+    ok "Chrome/Chromium already installed"
+else
+    ARCH=$(dpkg --print-architecture)
+    if [[ "$ARCH" == "amd64" ]]; then
+        # Google Chrome available for x86_64
+        wget -q -O /tmp/google-chrome.deb "https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb"
+        sudo apt-get install -y -qq /tmp/google-chrome.deb
+        rm -f /tmp/google-chrome.deb
+        ok "Google Chrome installed"
+    else
+        # ARM64 — Chrome not available, use Chromium
+        sudo apt-get install -y -qq chromium-browser 2>/dev/null || sudo snap install chromium 2>/dev/null
+        ok "Chromium installed (Chrome not available for $ARCH)"
+    fi
+fi
+
+# ─── Homebrew ────────────────────────────────────────────────────────────────
+
+step "Installing Homebrew"
+
+if command -v brew &>/dev/null; then
+    ok "Homebrew already installed"
+else
+    NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+    # Add brew to PATH for this session and permanently
+    if [[ -d /home/linuxbrew/.linuxbrew ]]; then
+        eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
+        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.bashrc
+        echo 'eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"' >> ~/.profile
+    fi
+    ok "Homebrew installed"
+fi
+
+# ─── Node.js ─────────────────────────────────────────────────────────────────
+
+step "Installing Node.js"
+
+if command -v node &>/dev/null; then
+    ok "Node.js already installed ($(node --version))"
+else
+    # Use brew for Node.js — matches our macOS workflow
+    brew install node
+    ok "Node.js installed ($(node --version))"
+fi
+
+# ─── Claude Code ─────────────────────────────────────────────────────────────
+
+step "Installing Claude Code"
+
+if command -v claude &>/dev/null; then
+    ok "Claude Code already installed ($(claude --version 2>/dev/null || echo 'installed'))"
+else
+    npm install -g @anthropic-ai/claude-code
+    ok "Claude Code installed"
+fi
+
+# ─── Docker (optional) ──────────────────────────────────────────────────────
+
+step "Installing Docker"
+
+if command -v docker &>/dev/null; then
+    ok "Docker already installed"
+else
+    # Docker official install for Ubuntu
+    sudo install -m 0755 -d /etc/apt/keyrings
+    curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg 2>/dev/null
+    sudo chmod a+r /etc/apt/keyrings/docker.gpg
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
+        $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+        sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update -qq
+    sudo apt-get install -y -qq docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+    sudo usermod -aG docker "$USER"
+    ok "Docker installed (log out and back in for group to take effect)"
+fi
+
+# ─── GitHub CLI ──────────────────────────────────────────────────────────────
+
+step "Installing GitHub CLI"
+
+if command -v gh &>/dev/null; then
+    ok "GitHub CLI already installed ($(gh --version | head -1))"
+else
+    brew install gh
+    ok "GitHub CLI installed"
+fi
+
+# ─── The Agency ──────────────────────────────────────────────────────────────
+
+step "Setting up workshop workspace"
+
+mkdir -p ~/workshop
+cd ~/workshop
+
+if [[ ! -d ~/workshop/.git ]]; then
+    git init
+    ok "Workshop repo initialized"
+else
+    ok "Workshop repo already exists"
+fi
+
+# ─── Verification ────────────────────────────────────────────────────────────
+
+step "Verification"
+
+echo ""
+echo "Checking installed tools:"
+echo ""
+
+CHROME_CMD=""
+for c in google-chrome-stable google-chrome chromium-browser chromium; do
+    if command -v "$c" &>/dev/null; then CHROME_CMD="$c"; break; fi
+done
+
+if [[ -n "$CHROME_CMD" ]]; then
+    ok "browser — $CHROME_CMD"
+else
+    warn "browser — NOT FOUND (no Chrome or Chromium)"
+    ALL_OK=false
+fi
+
+TOOLS=(git node npm claude jq sqlite3 gh docker brew)
+ALL_OK=true
+
+for tool in "${TOOLS[@]}"; do
+    if command -v "$tool" &>/dev/null; then
+        VERSION=$("$tool" --version 2>/dev/null | head -1 || echo "installed")
+        ok "$tool — $VERSION"
+    else
+        warn "$tool — NOT FOUND"
+        ALL_OK=false
+    fi
+done
+
+echo ""
+
+if [[ "$ALL_OK" == "true" ]]; then
+    echo -e "${BOLD}${GREEN}════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BOLD}${GREEN}  ✓ Workshop environment ready!${NC}"
+    echo -e "${BOLD}${GREEN}════════════════════════════════════════════════════════════${NC}"
+    echo ""
+    echo "Pre-workshop setup is complete!"
+    echo ""
+    echo "At the workshop, we will:"
+    echo "  1. Open a terminal (Ctrl+Alt+T)"
+    echo "  2. Run: claude login  (opens Chrome for authentication)"
+    echo "  3. Run: cd ~/workshop && claude"
+    echo ""
+else
+    echo -e "${YELLOW}Some tools are missing — check the warnings above.${NC}"
+    echo "You can re-run this script safely to retry."
+fi

--- a/claude/workstreams/agency/seeds/workshop-outline-republic-poly-20260410.md
+++ b/claude/workstreams/agency/seeds/workshop-outline-republic-poly-20260410.md
@@ -1,0 +1,475 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-10
+subject: "AI Augmented Development Workshop — Republic Polytechnic — Outline"
+---
+
+# AI Augmented Development Workshop
+
+**Date:** Monday 14 April 2026, 10:00–17:00
+**Location:** Republic Polytechnic, Singapore
+**Participants:** ~20 lecturers
+**Format:** 6 hours working time (10:00 start, 1 hour lunch)
+
+---
+
+## Schedule Overview
+
+| Time | Block | Duration |
+|------|-------|----------|
+| 10:00–10:20 | Setup: Bootstrap + Claude Login + Remote Control | 20 min |
+| 10:20–11:00 | Part 1: The Sea Change | 40 min |
+| 11:00–11:45 | Part 2: Claude Code — The Tool | 45 min |
+| 11:45–12:15 | Part 3: TheAgency + Valueflow — The Methodology | 30 min |
+| 12:15–13:15 | **Lunch** | 60 min |
+| 13:15–14:45 | Part 4: Guided Build — Seed to Deploy | 90 min |
+| 14:45–15:25 | Elevator Pitches | 40 min |
+| 15:25–16:30 | Part 5: Independent Build | 65 min |
+| 16:30–17:00 | Show & Tell + Wrap | 30 min |
+
+---
+
+## Setup (10:00–10:20)
+
+**Goal:** Everyone connected and ready before any content starts.
+
+### Pre-work (done at home)
+- VMware Workstation installed
+- Ubuntu VM created and running
+- Claude Desktop installed on Windows and signed in
+
+### Workshop morning
+1. Boot VM, open GNOME Terminal
+2. Run the bootstrap script (installs Chrome, Homebrew, Node.js, Claude Code, Docker, GitHub CLI)
+3. `claude login` — opens browser for OAuth
+4. Launch two Claude Code instances with `remote-control`
+5. **Switch to Windows** — open Claude Desktop → Code tab
+6. Connect to the two Remote Control sessions from Code tab
+7. Done — all work happens in Claude Desktop from here
+
+**Key point:** The VM is infrastructure. Claude Desktop on Windows is their workspace.
+
+---
+
+## Part 1: The Sea Change (10:20–11:00)
+
+**Goal:** Set the frame. This is not a tool demo. This is a paradigm shift.
+
+### Opening Punch
+
+**Slide: "This is NOT Vibe Coding."**
+
+> "You may have heard the term 'Vibe Coding.' Gene Kim and Steve Yegge wrote a great book with that title, and there's excellent material in it that we'll draw on today. But I deliberately don't use that term. Vibe coding implies you just vibe and code comes out. What we're doing today is disciplined. It's engineering. It's building."
+
+**Slide: "Coding is dead."**
+
+> "We've thought for way too long that it's about being a coder. It's not. Coding is dead. What we are is builders. We build things. The tools change. The craft doesn't."
+
+**Slide: "We are builders."**
+
+### The Abstraction Ladder — My Career as the Model
+
+Walk through the history of abstraction, using personal history:
+
+| Era | Layer | What I did |
+|-----|-------|-----------|
+| 1980s | Hardware | Flipped switches on a front panel |
+| 1984 | Machine code | PM on MacsBug — Motorola 68K debugger for the Mac |
+| 1984 | Assembly | PM on MDS — Macintosh 68000 Development System |
+| 1986 | Assembly + HLL | PM on MPW — Macintosh Programmer's Workshop |
+| 1990s–2010s | High-level languages | C, C++, Java, JavaScript, through the decades |
+| 2020s | Frameworks | React, Next.js, NestJS |
+| 2025–now | AI Augmented | Claude Code + TheAgency |
+
+> "I was PM on the tools that built the Macintosh. The assembler. The debugger. The development environment. At a conference called MacHack — the legendary Mac developer conference that ran for 18 years, midnight keynotes, hack contests until 6 AM — there were three mantras. One of them was 'It's all Jordan's fault.' That's me. I've been at every level of this stack."
+
+> "Every time we moved up a layer, people said the previous layer was the 'real' programming. Assembly programmers looked down on C. C programmers looked down on Java. Everyone looks down on JavaScript. And now everyone says 'but can you code without AI?' It's the same argument every time. And it's wrong every time."
+
+**Slide: "Asking 'can you code without AI?' is like asking a React developer to write their OS in C."**
+
+### The Industry Sea Change
+
+- What's happened in the last year — the acceleration
+- AI changing all knowledge work (nod to Kim/Yegge Ch 5)
+- The classic tradeoff: Fast vs Good vs Cheap — pick two
+  - **With discipline, you can have all three.** That's the revolution.
+- Steve Yegge's levels — weave in naturally as reference points
+
+### Who Am I
+
+- Speaker bio — 4 decades, Apple/Adobe/Indeed/Yahoo, startups, Singapore
+- Head of Product & Technology at OrdinaryFolk (healthtech)
+- AI agents outnumber humans 6:1 on the team
+- Advisor on AI Augmented Development to Singapore Polytechnic, Open Government Products, others
+- The Christmas project story:
+  - Job interview challenge → built a full application Christmas Eve to New Year's Day
+  - 7 Claude agents running in parallel, 14 hours/day
+  - Cost: ~$200/month (Max 20 plan) vs $35K+ for equivalent human team
+  - "I landed with dry tanks at 93% utilization"
+
+### Domain Fluency + AI Beats Either Alone
+
+- Network configuration story — not an expert, but understood the problem
+- Could have written the diagnostic tools manually — given a week
+- Solved it in hours with Claude
+- **The skill that matters: understanding a problem and how to break it down**
+
+---
+
+## Part 2: Claude Code — The Tool (11:00–11:45)
+
+**Goal:** Understand what Claude Code is, why it's the right choice, and its key elements.
+
+### What Is Claude Code
+
+- A platform for defining and running AI agents, tuned for building software
+- Terminal-native, UNIX philosophy — extensible, composable, scriptable
+- Not an IDE — it's a command-line tool that works with ANY editor, ANY workflow
+- You own the toolchain — not waiting for Cursor/Windsurf to ship features
+
+### Why Claude Code Over Alternatives
+
+- **Multi-agent:** Multiple sessions working in parallel (vs Cursor's single-agent)
+- **Extensible:** UNIX philosophy — tools, hooks, MCP servers, skills
+- **Convention over configuration:** CLAUDE.md as the project constitution
+- **Full filesystem access:** Not sandboxed, not limited
+- **Terminal-native:** Composable with everything else in your workflow
+
+### ChatGPT / Cursor Compare & Contrast
+
+- ChatGPT: cut-and-paste doesn't work. No persistent context, no project awareness
+- Cursor: great single-agent workflow. But single agent. And you don't own the toolchain.
+- Claude Code: multi-agent, extensible, convention-driven, you own it
+
+### The Elements of Claude Code
+
+Walk through each with brief explanation:
+
+1. **CLAUDE.md** — standing instructions, project memory, the "working agreement"
+   - Hierarchy: `~/.claude/CLAUDE.md` → project root → subdirectories
+   - Agents read it on every session start — it's the constitution
+   - Every lesson learned becomes a standing instruction
+   - "This is where discipline lives"
+
+2. **Context Window** — what it is, why it matters
+   - Token economics: context tokens vs billable tokens
+   - The log dump analogy: "If I asked you to read a 50MB log dump, you'd lose every tree in the forest. And every token in that dump costs money."
+   - Managing context is THE critical skill
+
+3. **Tools** — Bash, Read, Write, Edit, Grep, Glob, Agent (subagents)
+
+4. **Plan Mode** — think before you act
+   - "Discuss → Plan → Review Plan → Revise → Implement"
+   - The cost of planning is low; the cost of rework is high
+
+5. **Hooks** — SessionStart, UserPromptSubmit, Stop
+   - Automation that fires at lifecycle events
+   - "Process as code — if it's not in a hook, it's a suggestion, not a rule"
+
+6. **Skills / Commands** — `/` discoverable actions
+
+7. **MCP Servers** — extending capabilities (browser, databases, APIs)
+
+8. **Compact** — what it is, why it happens, how to survive it
+   - Context window fills up → compact preserves key context
+   - Handoffs and standing instructions survive compacts
+
+9. **Remote Control** — connecting from Claude Desktop, browser, mobile
+   - "This is how you're working today — Claude Code runs in the VM, you control it from Desktop"
+
+### Anthropic's 4 Ds of AI Fluency
+
+1. **Delegation** — knowing what to hand off and what to keep
+2. **Description** — clearly communicating context, goals, constraints
+   - "AI can only build what you can describe"
+   - Pattern: What you want + Constraints + Success criteria
+   - Vague input → vague output. Specific input → specific output.
+3. **Discernment** — evaluating AI output, trust but verify
+   - Watch the log trail, interrupt when something looks wrong
+   - "Why haven't you looked at the logs?" story
+   - Career progression: directed contribution → independent contribution → work through others
+4. **Diligence** — you're responsible for what ships
+   - "AI ate my homework is not a valid excuse"
+
+### The Career Progression Analogy
+
+Map Claude Code capabilities to traditional SWE levels:
+
+| Level | SWE Equivalent | Claude Code Behavior |
+|-------|---------------|---------------------|
+| Apprentice | Intern / fresh hire | Without tuning — can create more work than value |
+| Journeyman | SWE → Senior SWE | With CLAUDE.md, good descriptions, quality gates |
+| Senior Journeyman | Senior SWE | With multi-agent review, autonomous iteration |
+| Master Craftsman | Principal SWE | With full Valueflow, running autonomously overnight |
+
+> "Without proper tuning, without the right approach — it's your intern. With discipline, it advances to your next level up fast."
+
+### Jamon Holmgren's 8 Practices (Validation from the Trenches)
+
+Quick reference — Jamon Holmgren (Founder/CTO, Infinite Red), paying $200+/mo:
+
+1. Excellent test suite — agent must run and fix tests
+2. Excellent docs — hand-written, agent keeps updated
+3. Curated codebase — small files, flat structure, well-named
+4. Review agents — Claude reviews Codex, Codex reviews Claude
+5. Well-written specs — hand-written, take your time
+6. Review every line of every change
+7. **Run agents at night — forces you to improve everything above** ← the ultimate discipline test
+8. Hand-write features sometimes — stay connected to the code
+
+> "His #7 is the key: if your system can't run autonomously while you sleep, your docs, tests, and specs aren't good enough yet."
+
+---
+
+## Part 3: TheAgency + Valueflow — The Methodology (11:45–12:15)
+
+**Goal:** The framework that makes disciplined AI augmented development repeatable.
+
+### The Problem
+
+- Claude Code is powerful but chaotic without structure
+- Context gets scattered across sessions
+- No framework for multi-step projects
+- Quality is inconsistent without gates
+- "Vibe coding chaos" — the Chapter 4 horror stories
+
+### What Is TheAgency
+
+- An open-source framework for when developers and AI agents work together
+- Convention over configuration (Rails model)
+- Agents with memory and identity
+- Structured collaboration — agents review each other, test each other
+- Context preservation across sessions (handoffs, CLAUDE.md, transcripts)
+
+### Born from the Trenches — Three Iterations
+
+1. **Christmas 2025** — the OrdinaryFolk build. 7 agents, 14 hours/day, discovered every friction point
+2. **January 2026** — agency-starter, first workshop (the one that broke), Agency Bench
+3. **February–April 2026** — TheAgency framework, Valueflow methodology, ISCP, Enforcement Triangle
+
+> "Every tool in the framework exists because I hit a wall and built something to get past it. This isn't theory. It's extracted from daily practice."
+
+### Valueflow — The AI SDLC
+
+```
+Idea → Seed → Research → Define (PVR) → Design (A&D) → Plan → Implement → Ship → Value
+```
+
+Walk through briefly:
+- **Seed** — captured starting point (an idea, a conversation, a problem)
+- **PVR** — Product Vision & Requirements (the what and why)
+- **A&D** — Architecture & Design (the how and why)
+- **Plan** — Phases × Iterations
+- **Implement** — Agents execute, QG at every boundary
+- **Ship** — PR, deploy, done
+
+### Quality Gates — The Discipline Layer
+
+- Multi-Agent Review (MAR) at every transition
+- 4 dimensions: correctness, design, security, testability
+- Red-green discipline: write a failing test, then fix
+- Binary triage: fix it or it's not an issue. No "low priority."
+- Quality Gate Report (QGR) documents everything
+
+### The Enforcement Triangle
+
+Every capability has three parts:
+1. **Tool** — does the work
+2. **Skill** — tells you when and how to use the tool
+3. **Hookify rule** — blocks the raw alternative
+
+> "If it's not enforced by code, it's a suggestion. And suggestions get ignored."
+
+### OODA — The Structural Pattern
+
+- Observe → Orient → Decide → Act
+- Maps to everything: Valueflow, Enforcement Ladder, captain triage
+- Inner loop (single iteration), middle loop (phase), outer loop (project)
+- The goal: tighten the loop. Faster cycles = better outcomes.
+
+### Live Case Study: The Monitor Tool (OODA in Real-Time)
+
+> "Let me show you something that happened TODAY while preparing this workshop."
+
+Story: During workshop prep, we discovered Claude Code's new Monitor tool (v2.1.98). Walk through what happened:
+
+1. **Observe** — Spotted the announcement on X while working
+2. **Orient** — Researched it: event-driven background scripts that replace polling. 96% token savings.
+3. **Decide** — This replaces our dispatch polling system. Wrote an adoption seed immediately.
+4. **Act** — Planned the migration, will implement this weekend
+
+> "From discovery to adoption plan in minutes. The methodology finds and adopts improvements continuously. It improves itself. That's what an AIADLC gives you."
+
+This demonstrates:
+- The OODA loop in practice, not theory
+- How seeds work — capture → research → decide → act
+- Why discipline matters — without the framework, this discovery gets lost in a chat window
+- The methodology is alive — it evolves as you use it
+
+### Three Experience Pillars
+
+- **UX** — User Experience (traditional)
+- **PX** — Principal Experience (the human directing agents)
+- **AX** — Agentic Experience (the agents themselves)
+- Most tools favor one side. We treat both equally.
+
+---
+
+## LUNCH (12:15–13:15)
+
+---
+
+## Part 4: Guided Build — Seed to Deploy (13:15–14:45)
+
+**Goal:** Walk everyone through a complete Valueflow cycle, step by step, building a real project that deploys to Vercel.
+
+### The Toy Project: Personal Page + Mini-Blog
+
+**Seed:** "Build a personal page that introduces you, with a mini-blog where you can write posts. Deploy it to Vercel."
+
+- About me section
+- Mini-blog with 2-3 posts
+- **Stretch goal:** AI-powered Q&A section (requires Anthropic API key)
+- Next.js + local markdown for blog posts → Vercel deploy
+
+### Prerequisites (handled by bootstrap)
+- Node.js, npm, git installed
+- GitHub account (they'll need this for Vercel deploy)
+- Vercel account (free hobby tier — sign up during this section)
+
+### Step-by-Step Walkthrough
+
+Everyone works together, guided by Jordan. Their captain (from the workshop CLAUDE.md) knows the curriculum and guides 1:1.
+
+**Step 1: The Seed (5 min)**
+- "Tell your captain: I want to build a personal page with a mini-blog. Here's my name and a sentence about me."
+- Captain acknowledges, asks clarifying questions (teaching the Description skill)
+
+**Step 2: PVR (15 min)**
+- Captain guides them through defining what they want
+- What pages? What features? What does success look like?
+- Captain produces a PVR document
+- Teach: "This is the Description from the 4 Ds in action"
+
+**Step 3: A&D (10 min)**
+- Captain proposes: Next.js, Tailwind, markdown files for blog posts
+- Brief discussion of why these choices
+- Captain produces A&D document
+- Teach: "Your agent just did architecture. You reviewed it. That's Discernment."
+
+**Step 4: Plan (10 min)**
+- Captain breaks it into iterations:
+  1. Project scaffold + about page
+  2. Blog listing + individual post pages
+  3. Styling and polish
+  4. Vercel deploy
+  5. (Stretch) AI Q&A section
+- Captain produces a plan
+- Teach: "This is Plan Mode. Think before you act."
+
+**Step 5: Execute Iterations 1-3 (30 min)**
+- Captain executes, students watch and review
+- Teach verification: "Watch what it's doing. If something looks wrong, hit Escape and ask why."
+- After each iteration: review, approve, move to next
+- Teach: "This is the OODA loop in action — observe, orient, decide, act"
+
+**Step 6: Deploy to Vercel (15 min)**
+- Sign up for Vercel (free)
+- Connect GitHub repo
+- Captain handles the deploy configuration
+- Everyone has a live URL
+
+**Step 7: Celebrate (5 min)**
+- Everyone shares their URL in the chat
+- "You just went from idea to deployed website through a structured methodology in 90 minutes."
+
+---
+
+## Elevator Pitches (14:45–15:25)
+
+**Goal:** Each participant shares their seed idea for the independent build.
+
+- 20 participants × 2 minutes max
+- Jordan enforces the cutoff
+- Format: "I want to build [X] because [Y]"
+- Brief feedback from Jordan on each: scope check, feasibility, suggestions
+
+---
+
+## Part 5: Independent Build (15:25–16:30)
+
+**Goal:** They take their own idea through Valueflow with their captain, while Jordan floats.
+
+- Each student has their seed from the elevator pitch
+- Their captain (in the workshop CLAUDE.md) knows Valueflow and guides them
+- Jordan floats between students, gives suggestions, unblocks issues
+- Goal: get to at least a running local version, ideally deployed
+
+### Collaboration Setup
+
+- All students' captains are configured to collaborate with Jordan's captain
+- Jordan can see what everyone is working on
+- If a student gets stuck, their captain can escalate to Jordan's captain
+
+---
+
+## Show & Tell + Wrap (16:30–17:00)
+
+**Goal:** Celebrate what was built, reinforce key learnings, point to next steps.
+
+### Show & Tell (20 min)
+- Volunteers demo what they built (URL or screen share)
+- Brief applause, brief feedback
+
+### Key Takeaways (5 min)
+1. **This is NOT Vibe Coding** — it's disciplined, it's engineering, it's building
+2. **Context is everything** — CLAUDE.md, handoffs, managed context
+3. **Description drives quality** — AI can only build what you can describe
+4. **Trust but verify** — the career progression from apprentice to master
+5. **Quality gates matter** — every issue fixed, red-green, no broken windows
+6. **The abstraction continues** — you're the next generation of builders
+
+### What's Next
+- TheAgency is open source — https://github.com/the-agency-ai/the-agency
+- Keep the VM — it's your development environment now
+- Join the community (links)
+- Workshop materials stay in the repo they cloned
+- Jordan's contact info for follow-up
+
+### Closing
+
+> "40 years ago, I was flipping switches on a front panel. Today you deployed a website by having a conversation with an AI agent. The tools changed. The craft didn't. You are builders. Go build."
+
+---
+
+## Workshop Artifacts to Prepare
+
+| Artifact | Status | Notes |
+|----------|--------|-------|
+| Setup guide (GDoc) | ✅ Done | Sent to participants |
+| Bootstrap script | ✅ Tested | `workshop-bootstrap.sh` |
+| Workshop start script | 📝 Draft | Needs redraft for Remote Control + Desktop flow |
+| Workshop repo | ❌ TODO | `the-agency-ai/aiad-workshop` — CLAUDE.md + CAPTAIN.md |
+| `agency init` tested on repo | ❌ TODO | Verify init layers cleanly over workshop content |
+| Slides / keynote | ❌ TODO | Key slides identified in outline |
+| Toy project spec | 📝 In outline | Personal page + mini-blog |
+| Vercel deploy tested | ❌ TODO | Verify flow works end-to-end |
+| Collaboration config | ❌ TODO | Students → Jordan captain connection |
+| Jamon Holmgren quote slide | ❌ TODO | 8 practices, permission to cite |
+| Monitor tool adoption | ❌ TODO | Implement this weekend — replace dispatch polling |
+| Monitor case study slide | ❌ TODO | OODA live example for Part 3 |
+
+---
+
+## Source Materials
+
+All workshop content drawn from:
+- Jordan's workshop transcripts (Jan 9, Jan 10, Jan 15, Mar 14, Apr 3, Apr 4, Apr 6, Apr 9, Apr 10)
+- Vibe Coding by Gene Kim & Steve Yegge (book analysis)
+- Anthropic's 4 Ds framework
+- MacHack history / "It's All Jordan's Fault"
+- MacsBug, MDS, MPW product history
+- Jamon Holmgren's 8 practices (X post)
+- OODA Loop / Process Intelligence dispatches from monofolk
+- TheAgency framework documentation

--- a/claude/workstreams/agency/seeds/workshop-setup-guide-20260410.md
+++ b/claude/workstreams/agency/seeds/workshop-setup-guide-20260410.md
@@ -1,0 +1,126 @@
+---
+type: seed
+workstream: agency
+date: 2026-04-10
+subject: Workshop VM Setup Guide — Republic Polytechnic
+---
+
+# AI Augmented Development Workshop — Setup Guide
+
+## Workshop: AI Augmented Development with Claude Code
+**Date:** Monday 14 April 2026
+**Location:** Republic Polytechnic
+
+---
+
+## What You Need
+
+### 1. VMware Workstation Pro (free)
+
+**Download:** https://support.broadcom.com/group/ecx/productdownloads?subfamily=VMware+Workstation+Pro
+
+- Create a free Broadcom account if you don't have one
+- Download **VMware Workstation Pro** for Windows
+- Install with default settings
+
+### 2. Ubuntu 24.04.4 Desktop ISO (x86_64)
+
+**Download:** https://releases.ubuntu.com/24.04.4/ubuntu-24.04.4-desktop-amd64.iso
+
+- ~5.8 GB download
+- This is the **AMD64** (x86_64) version — the standard one for Windows/Intel/AMD machines
+
+### 3. Claude Desktop (on your Windows machine)
+
+**Download:** https://claude.ai/download
+
+- Install the Windows version
+- Sign up for a free account if you don't have one
+- This runs on your Windows host, not inside the VM
+
+### 4. Anthropic Account
+
+- You will log in to Claude Code via the browser at the workshop
+- You do NOT need to set this up in advance — we'll walk through it together
+
+---
+
+## Step-by-Step: Create the VM
+
+### Step 1: Create a new VM in VMware Workstation
+
+1. Open VMware Workstation
+2. **File → New Virtual Machine** (or Ctrl+N)
+3. Select **Typical** configuration → Next
+4. **Installer disc image file (iso)** → Browse to your downloaded `ubuntu-24.04.4-desktop-amd64.iso` → Next
+5. Enter your name, username, and password — your choice, just remember them!
+6. VM name: `Agency-Workshop` → Next
+7. Disk size: **40 GB**, store as single file → Next
+8. Click **Customize Hardware**:
+   - **Memory:** 4096 MB (4 GB)
+   - **Processors:** 4
+   - **Network:** NAT (default)
+9. Click **Close** then **Finish**
+
+### Step 2: Install Ubuntu
+
+The VM will boot from the ISO automatically. The installer has several screens — here's exactly what to do at each one:
+
+1. **Accessibility** — skip this unless you need it. Just close it.
+2. **Install Ubuntu** — click **Install Ubuntu** (not "Try Ubuntu")
+3. **Update installer?** — the installer may offer to update itself. Click **Update installer**, wait for it to finish, then **relaunch the installer**. This is normal — you'll start from step 1 again.
+4. **Language & Keyboard** — pick your language and keyboard layout, click **Next**
+5. **Internet connection** — select **Use wired connection** (this is the VMware virtual network adapter — it's correct). Click **Next**
+6. **Type of installation** — select **Interactive installation**. Click **Next**
+7. **Default or Extended?** — select **Default installation**. Click **Next**
+8. **Proprietary software** — leave both checkboxes **unchecked** (you don't need GPU drivers or media codecs for this workshop). Click **Next**
+9. **Disk setup** — select **Erase disk and install Ubuntu** (this is safe — it only erases the virtual disk, not your real hard drive!). Click **Next**
+10. **Create your account** — enter your name, username, and password. Your choice — just remember them! Uncheck "Require my password to log in" if you want auto-login for convenience. Click **Next**
+11. **Timezone** — select your timezone. Click **Next**
+12. **Review your choices** — confirm everything looks right. Click **Install**
+13. **Wait** ~10 minutes for the installation to complete
+14. Click **Restart Now** when prompted
+15. Press **Enter** when asked to remove installation media
+
+### Step 3: First Boot & Run the Bootstrap Script
+
+After Ubuntu boots and you log in:
+
+1. Open a terminal: **press Ctrl+Alt+T**
+2. Run this command:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/the-agency-ai/the-agency/main/claude/workstreams/agency/seeds/workshop-bootstrap.sh | bash
+```
+
+3. The script will install everything you need:
+   - Google Chrome browser
+   - Homebrew, Node.js, Git, jq, sqlite3, and other dev tools
+   - Claude Code
+   - Docker & GitHub CLI
+
+4. **When it finishes**, it will show a verification checklist. All items should show ✓.
+
+**That's it for pre-workshop setup.** We'll do Claude Code login and workspace creation together at the start of the workshop.
+
+---
+
+## Troubleshooting
+
+**VM won't start / slow performance:**
+- Make sure **virtualization** is enabled in your BIOS/UEFI settings (VT-x / AMD-V)
+- Close other heavy applications
+- Try reducing VM memory to 3072 MB if your machine has only 8 GB RAM
+
+**No internet in the VM:**
+- Check VMware's virtual network: **Edit → Virtual Network Editor**
+- Make sure NAT is configured
+- Try switching network adapter to **Bridged** mode
+
+**Bootstrap script fails:**
+- Make sure you have internet connectivity: `ping google.com`
+- Run the script again — it's idempotent (safe to re-run)
+- If a specific package fails, note the error and ask at the workshop
+
+**"Curl not found":**
+- Run `sudo apt update && sudo apt install -y curl` first, then re-run the bootstrap command

--- a/claude/workstreams/agency/seeds/workshop-start.sh
+++ b/claude/workstreams/agency/seeds/workshop-start.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# What Problem: On workshop morning, students need to go from "VM running" to
+# "two Claude Code sessions with Remote Control, ready for Chrome connection"
+# in one script. Without this, it's 10+ manual steps and someone always gets
+# stuck on one of them.
+#
+# How & Why: Single script that runs the bootstrap (idempotent), handles
+# claude login (interactive pause), creates workspace, and launches two
+# Claude Code sessions in separate terminal windows with remote-control.
+# Uses gnome-terminal for new windows — simplest for non-sysadmin users.
+#
+# Written: 2026-04-10 during captain session (workshop VM prep)
+
+set -euo pipefail
+
+# ─── Colors ──────────────────────────────────────────────────────────────────
+
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+BOLD='\033[1m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+step() { echo -e "\n${BOLD}${GREEN}▸ $1${NC}"; }
+warn() { echo -e "${YELLOW}⚠ $1${NC}"; }
+fail() { echo -e "${RED}✗ $1${NC}"; exit 1; }
+ok()   { echo -e "${GREEN}✓ $1${NC}"; }
+info() { echo -e "${CYAN}  $1${NC}"; }
+
+# ─── Step 1: Quick tool check ───────────────────────────────────────────────
+
+step "Checking tools"
+
+MISSING=()
+for tool in git node npm jq sqlite3 docker brew; do
+    if ! command -v "$tool" &>/dev/null; then
+        MISSING+=("$tool")
+    fi
+done
+
+# Check for Claude Code specifically
+if ! command -v claude &>/dev/null; then
+    MISSING+=("claude")
+fi
+
+# Check for any browser
+BROWSER=""
+for b in google-chrome-stable google-chrome chromium-browser chromium firefox; do
+    if command -v "$b" &>/dev/null; then BROWSER="$b"; break; fi
+done
+if [[ -z "$BROWSER" ]]; then
+    MISSING+=("browser")
+fi
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    warn "Missing tools: ${MISSING[*]}"
+    echo ""
+    echo "Run the bootstrap script first:"
+    echo "  curl -fsSL https://raw.githubusercontent.com/the-agency-ai/the-agency/main/claude/workstreams/agency/seeds/workshop-bootstrap.sh | bash"
+    echo ""
+    fail "Cannot continue without required tools."
+fi
+
+ok "All tools present"
+ok "Browser: $BROWSER"
+ok "Claude Code: $(claude --version 2>/dev/null || echo 'installed')"
+
+# ─── Step 2: Claude Code login ──────────────────────────────────────────────
+
+step "Claude Code login"
+
+# Check if already logged in
+if claude --version &>/dev/null 2>&1; then
+    # Try a quick check — if claude can run, auth might be cached
+    echo "Checking authentication..."
+fi
+
+echo ""
+echo -e "${BOLD}${CYAN}═══════════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${CYAN}  Claude Code will open a browser window for login.${NC}"
+echo -e "${BOLD}${CYAN}  Log in with the account provided at the workshop.${NC}"
+echo -e "${BOLD}${CYAN}═══════════════════════════════════════════════════════════${NC}"
+echo ""
+
+claude login
+
+echo ""
+ok "Login complete"
+
+# ─── Step 3: Create workspace ───────────────────────────────────────────────
+
+step "Setting up workspace"
+
+mkdir -p ~/workshop
+cd ~/workshop
+
+if [[ ! -d .git ]]; then
+    git init
+    git config user.name "Workshop Student"
+    git config user.email "student@workshop.local"
+    ok "Workshop repo initialized"
+else
+    ok "Workshop repo already exists"
+fi
+
+# ─── Step 4: Launch Claude Code sessions ────────────────────────────────────
+
+step "Launching Claude Code sessions"
+
+echo ""
+echo -e "${BOLD}Launching two Claude Code sessions with Remote Control...${NC}"
+echo ""
+
+# Launch Session 1
+gnome-terminal --title="Claude Code — Session 1" -- bash -c '
+    cd ~/workshop
+    echo "═══════════════════════════════════════════════"
+    echo "  Claude Code — Session 1"
+    echo "  Remote Control will be enabled automatically"
+    echo "═══════════════════════════════════════════════"
+    echo ""
+    claude --remote-control
+    exec bash
+' &
+
+sleep 2
+
+# Launch Session 2
+gnome-terminal --title="Claude Code — Session 2" -- bash -c '
+    cd ~/workshop
+    echo "═══════════════════════════════════════════════"
+    echo "  Claude Code — Session 2"
+    echo "  Remote Control will be enabled automatically"
+    echo "═══════════════════════════════════════════════"
+    echo ""
+    claude --remote-control
+    exec bash
+' &
+
+sleep 2
+
+# ─── Step 5: Instructions ──────────────────────────────────────────────────
+
+echo ""
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}${GREEN}  ✓ Workshop environment is ready!${NC}"
+echo -e "${BOLD}${GREEN}════════════════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "${BOLD}Two Claude Code sessions are running in separate windows.${NC}"
+echo ""
+echo -e "${BOLD}To connect from Chrome on your Windows machine:${NC}"
+echo ""
+echo "  1. Open Chrome on Windows"
+echo "  2. Go to: ${CYAN}claude.ai/code${NC}"
+echo "  3. Each Claude Code window shows a QR code or session code"
+echo "  4. Scan or enter the code in Chrome to connect"
+echo ""
+echo -e "${BOLD}You now have:${NC}"
+echo "  • Claude Desktop on Windows — for research and chat"
+echo "  • Two Claude Code sessions — for hands-on coding"
+echo "  • Remote Control — Chrome controls the Claude Code sessions"
+echo ""
+echo -e "${BOLD}${CYAN}Happy building! 🚀${NC}"
+echo ""

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -2,67 +2,153 @@
 type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
-date: 2026-04-09
-trigger: break-2000sgt
+date: 2026-04-10
+trigger: mid-session-context-preservation
 ---
 
-## Resume after 0200 SGT
+## Current Session — Day 35 Captain
 
-### Immediate on resume
+### Active Work: Workshop Invites (1B1)
 
-1. **PR #69 (D34-R5)** — open, awaiting approval. 813/813 tests green + ISCP merge unblock. Approve → merge → `/post-merge 69`.
-2. **ISO download** — Ubuntu 24.04.4 ARM64 desktop downloading to `~/Downloads/ubuntu-24.04.4-desktop-arm64.iso`. Should be done. Verify: `ls -lh ~/Downloads/ubuntu-24.04.4-desktop-arm64.iso` — expect ~3.3 GB.
-3. **Create VM** in Fusion from the ISO → bootstrap script → agency init → snapshot → OVA. Workshop is Monday.
+Writing personalized WhatsApp invites for the Republic Poly workshop. 1B1 through the list.
 
-### Day 34 shipped (on origin)
+**Sent:**
+1. ✅ Abel Ang — Chairperson RP, arranged Jordan's SOI Advisory Board seat
+2. ✅ Kiren Kumar — DCEO IMDA, long relationship since Indeed/EDB days
+3. ✅ Agrim Singh / Sherry Jian — AI dev community leaders in SG, follow-up to X invite
+4. ✅ Alwyn, OGP — DevRel + Senior SWE, decade-long relationship, offered OGP session pro bono
+5. ✅ Sonjia, OGP — Lead PM, Jordan got her Indeed secondment from NRF, offered OGP session pro bono
+6. ✅ Andrew McGlinchey — ex-Indeed product partner, been on the whole journey, tried V1
 
-- **34.1** (PR #60) — agency-version tool + statusline
-- **34.2** (PR #63) — run-in Triangle + fixes #56/#57/#171
-- **34.3** (PR #66) — worktree-sync main/master fix + skill allowed-tools audit (48 files)
-- **34.4** (PR #67) — agency-health v1 (3-dimensional fleet health)
-- **34.5** (PR #69) — 27 test failures killed + schema skip guard + scaled timeout [PENDING MERGE]
+**Remaining:**
+7. Hongyi, OGP — need context
+8. Eliot, OGP — need context
+9. Hygin, OGP — need context
+10. Janson Seah, StaffAny — need context
+11. Dr Lim Woo Lip, SVP/CTO Cyber, ST Engineering — need context
+12. Mr Lim Thian Chin, CRO & Senior Director, GovTech — need context
+13. Dr Forest Tan, Associate Professor, SIT — need context
+14. David Alfred, Drew & Napier — need context
+15. Sherwyn Goh — need context
+16. Gail Lau — need context
+17. Peng Ong — need context
+18. Lin Yang — need context
+19. Shanyl Ong — need context
+20. Nicole Zhu — need context
+21. Luke Ong — need context
+22. Michael Cheng — need context
 
-### Fleet state
+**Base template** (finalized):
+- Opening: "I want to invite you to something this coming Monday."
+- Pro bono workshop at RP, AI Augmented Development with Claude Code
+- Beyond Vibe Coding: structured, disciplined building of software with AI
+- AIADLC through TheAgency methodology and Valueflow
+- Three takeaways: grounding, hands-on experience, framework
+- Accessible — you don't need a technical background
+- Short notice — nominate someone if can't attend
+- BYOAP — ~$100 for Claude Code subscription
+- Venue details + directions + Phyllis Ling contact
 
-- **devex** — standing autonomy, crushed tasks #8-#13. docker-heal shipped. Worktree naming, hookify rename, agent-create dispatch loops all in progress.
-- **iscp** — blocked on merge until #69 lands. Has 3 conflict files to resolve (flag, _iscp-db, flag.bats). Direction sent via #183/#184/#197/#199. Standing autonomy.
-- **mdpal-app** — worktree in weird split state (1449 deletions). Dispatched #181 for agent diagnosis. Stub handoff created.
-- **mdpal-cli** — synced to main, .agency-agent created, stub handoff created.
-- **mock-and-mark** — worktree created, identity set, settings synced. Ready for reactivation session. Jordan: "fix it, launching soon."
+### Also Pending: Anthropic License Outreach (Batch 2)
 
-### Monofolk
-
-- Graduated to full-install (sandbox removed)
-- Agency-health v1 committed to them as Wave 1 diagnostic tool
-- PR workflow converging (D#-R# naming, no-squash, captain builds PRs)
-- pr-build tool coming from them (upstream contribution)
-- Dropbox tool design routed to iscp (#177)
-- Awaiting their reply on QGR location alignment + D-counter retroactive question
+Jordan sent messages to Boris (Claude Code creator), Thariq, and Agrim/Sherry asking for 25-30 Max 20x licenses for two weeks. Need to draft additional outreach via LinkedIn and Twitter to more Anthropic folks.
 
 ### Workshop — Monday 2026-04-14 at Republic Polytechnic
 
-- Ubuntu 24.04 LTS ARM64 VM in VMware Workstation Pro (free)
-- Ghostty + brew + Docker + Claude Code + agency init
-- ISO downloading. Next: create VM, run bootstrap, snapshot, export OVA
-- Students get OVA, open Ghostty, `claude login`, `cd ~/workshop`, `claude`
-- "No compromises. As close to macOS as we can get."
+**Full outline written:** `claude/workstreams/agency/seeds/workshop-outline-republic-poly-20260410.md`
 
-### Principles locked today
+**Schedule:**
+- 10:00–10:20: Setup (bootstrap + login + remote control to Desktop)
+- 10:20–11:00: Part 1 — The Sea Change (NOT Vibe Coding, coding is dead, builder identity, abstraction ladder, MacHack, Christmas project)
+- 11:00–11:45: Part 2 — Claude Code (elements, CLAUDE.md, 4 Ds, career progression, Jamon's 8 practices)
+- 11:45–12:15: Part 3 — TheAgency + Valueflow (methodology, born from trenches, QG, OODA, Monitor tool case study)
+- 12:15–13:15: Lunch
+- 13:15–14:45: Part 4 — Guided Build (personal page + mini-blog → Vercel deploy)
+- 14:45–15:25: Elevator Pitches (20 × 2 min)
+- 15:25–16:30: Part 5 — Independent Build (you float)
+- 16:30–17:00: Show & Tell + Wrap
 
-- **No broken windows.** If we use it or have used it, it gets included.
-- **No compromises** on the workshop experience.
-- **Be the Man Who Was Too Lazy to Fail** — invest in tools, not heroic manual execution.
-- **Rapid release discipline** — D#-R# naming, no squash, one PR per release.
-- **Standing autonomy** — agents execute without per-step approval.
-- **No reviews on GitHub** — PRs are shipping mechanism only.
-- **Ban raw git writes** (flag #83, pending 1B1 on scope).
+**Key framing:**
+- "This is NOT Vibe Coding." / "Coding is dead." / "We are builders."
+- Abstraction ladder using Jordan's career: switches → MacsBug → MDS → MPW → AI
+- MacHack mantras: "It's all Jordan's fault", "Sleep is for the weak and sickly", "72 Hours Caffeine and Code"
+- Steve Yegge's 8 levels woven in (not dedicated block)
+- Monitor tool as live OODA case study
 
-### Open flags (31 total, key ones)
+**Student setup:**
+- VM runs Claude Code with remote-control
+- Students work from Claude Desktop Code tab on Windows
+- Captain bootstrap CLAUDE.md knows the curriculum, acts as tutor
+- Students' captains collaborate with Jordan's captain
+- Repo: clone → `agency init` → captain wakes up knowing the workshop
 
-- #55 CLAUDE.md revision (rich material ready)
-- #69 create-tool input validation (all *-create tools)
-- #78 session naming issues (needs 1B1)
-- #82 agency verify reads dependencies.yaml
-- #83 ban raw git writes (needs 1B1)
+**Toy project:** Personal page + mini-blog, deploy to Vercel. AI Q&A stretch goal.
+
+### Workshop Artifacts
+
+| Artifact | Status |
+|----------|--------|
+| Setup guide (GDoc) | ✅ Sent to participants |
+| Bootstrap script | ✅ Tested on ARM64 VM |
+| Workshop outline | ✅ Written |
+| Experience doc | ✅ Written with action log + manifest |
+| Workshop start script | 📝 Needs redraft for Remote Control + Desktop flow |
+| Workshop repo | ❌ TODO — `the-agency-ai/aiad-workshop` |
+| Captain bootstrap CLAUDE.md | ❌ TODO |
+| Slides / keynote | ❌ TODO |
+| Vercel deploy tested | ❌ TODO |
+| Monitor tool adoption | ❌ TODO — implement this weekend |
+
+### VM State
+
+- Fusion VM running at `~/Virtual Machines.localized/TheAgency-Workshop-Ubuntu-64-bit-ARM.vmwarevm/`
+- IP: 192.168.1.115 (bridged mode), SSH working with key auth
+- Passwordless sudo configured, lock screen disabled
+- **3 snapshots:** clean-install, pre-bootstrap, post-bootstrap
+- All tools verified green: chromium, git, node, npm, claude, jq, sqlite3, gh, docker, brew
+- Ghostty dropped (no Linux packages — students use GNOME Terminal)
+
+### Seeds Captured Today
+
+- `seed-it-happened-and-breadcrumb-20260410.md` — "This Happened!" + "Breadcrumb" value-added services
+- `seed-monitor-tool-adoption-20260410.md` — Monitor tool replaces dispatch polling, 96% token savings
+- `seed-ooda-loop-structural-framework-20260410.md` — from monofolk, OODA as structural pattern
+- `seed-process-intelligence-celonis-20260410.md` — from monofolk, Celonis interview + trajectory
+- `workshop-outline-republic-poly-20260410.md` — full workshop outline
+- `workshop-setup-guide-20260410.md` — student setup guide
+- `workshop-bootstrap.sh` — tested bootstrap script
+- `workshop-start.sh` — workshop morning script (needs redraft)
+
+### Dispatches Sent Today
+
+- **#200** to the-agency/jordan/devex — SPEC:PROVIDER for NestJS + React/Next.js
+- **Collaboration** to monofolk/captain — query on "This Happened!" prior discussion
+- **Collaboration** to monofolk/devex — SPEC:PROVIDER directive, coordinate with the-agency/devex
+
+### Earlier Today
+
+- ✅ PR #69 merged (D34-R5 — 27 test failures killed)
+- ✅ `pr-build` tool landed from upstream (monofolk contribution)
+- Architecture mistake: ARM64 ISO can't build x86 OVA → pivoted to bootstrap script model
+- VMX hand-crafted failures: lsilogic, e1000e, PCIe bridges — documented in experience report
+
+### Dispatch Loops Running
+
+| Loop | Interval | Job ID |
+|------|----------|--------|
+| Dispatch fast-path | 5m | e6f02feb |
+| Dispatch nag | 30m | 49fafcb4 |
+| Collaboration | 10m | 10e370af |
+
+### Content Knowledge (not in files, in session context)
+
+- MacHack: "It's all Jordan's fault" — conference mantra, Jordan was Apple rep
+- MacsBug: Motorola 68K debugger, Jordan was PM
+- MDS: Macintosh 68000 Development System (1984), Jordan was PM
+- MPW: Macintosh Programmer's Workshop (1986), Jordan was PM
+- "72 Hours Caffeine and Code" — MacHack mantra, Jordan jokes "that was my original plan but I got overruled"
+- Jamon Holmgren's 8 practices (X post) — validation from the trenches
+- Workshop is two-day format for Anthropic license ask, but one-day delivery this Monday
+- Boris + Thariq outreach for 25-30 Max 20x licenses
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -3,32 +3,32 @@ type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
 date: 2026-04-10
-trigger: mid-session-context-preservation
+trigger: mid-session-context-preservation-2
 ---
 
-## Current Session — Day 35 Captain
+## Current Session — Day 35 Captain (continued)
 
 ### Active Work: Workshop Invites (1B1)
 
-Writing personalized WhatsApp invites for the Republic Poly workshop. 1B1 through the list.
+Writing personalized WhatsApp invites for the Republic Poly workshop. Date correction: **Monday 13 April** (not 14th — caught by Eliot).
 
 **Sent:**
-1. ✅ Abel Ang — Chairperson RP, arranged Jordan's SOI Advisory Board seat
-2. ✅ Kiren Kumar — DCEO IMDA, long relationship since Indeed/EDB days
-3. ✅ Agrim Singh / Sherry Jian — AI dev community leaders in SG, follow-up to X invite
-4. ✅ Alwyn, OGP — DevRel + Senior SWE, decade-long relationship, offered OGP session pro bono
-5. ✅ Sonjia, OGP — Lead PM, Jordan got her Indeed secondment from NRF, offered OGP session pro bono
-6. ✅ Andrew McGlinchey — ex-Indeed product partner, been on the whole journey, tried V1
+1. ✅ Abel Ang — Chairperson RP. In US, can't attend. Wants future session. "You give me a day, I will give you AI Augmented Development!"
+2. ✅ Kiren Kumar — DCEO IMDA. Linked to prior discussion about doing workshop for his team.
+3. ✅ Agrim Singh / Sherry Jian — AI dev community leaders. Follow-up to X invite.
+4. ✅ Alwyn, OGP — DevRel + SWE. Offered OGP session pro bono.
+5. ✅ Sonjia, OGP — Lead PM. Pre-messaged about OrdinaryFolk results. Offered OGP session pro bono.
+6. ✅ Andrew McGlinchey — ex-Indeed partner. In Korea, nominating Deepak (friend). Wants next one.
+7. ✅ Hongyi, OGP — Director. Personal message about OrdinaryFolk results (19 features, 3M LOC). Offered OGP session. "Want to share it with you when we both can make it happen."
+8. ✅ Eliot, OGP — SWE. S10 connection. Offered to bring it to OGP. Busy Mon/Tue but "you were right about Claude Code." Caught date error.
+9. ✅ Hygin, OGP — COO. Non-technical but TheAgency + Valueflow could be a win. Married to Lynette (ex-Indeed).
+10. ✅ Janson Seah — CEO StaffAny. "Try before you buy" framing. Bring new CTO.
 
-**Remaining:**
-7. Hongyi, OGP — need context
-8. Eliot, OGP — need context
-9. Hygin, OGP — need context
-10. Janson Seah, StaffAny — need context
-11. Dr Lim Woo Lip, SVP/CTO Cyber, ST Engineering — need context
-12. Mr Lim Thian Chin, CRO & Senior Director, GovTech — need context
-13. Dr Forest Tan, Associate Professor, SIT — need context
-14. David Alfred, Drew & Napier — need context
+**Remaining (date corrected to Monday 13 April):**
+11. Dr Lim Woo Lip — SVP/CTO Cyber, ST Engineering — need context
+12. Mr Lim Thian Chin — CRO & Senior Director, GovTech — need context
+13. Dr Forest Tan — Associate Professor, SIT — need context
+14. David Alfred — Drew & Napier — need context
 15. Sherwyn Goh — need context
 16. Gail Lau — need context
 17. Peng Ong — need context
@@ -37,100 +37,53 @@ Writing personalized WhatsApp invites for the Republic Poly workshop. 1B1 throug
 20. Nicole Zhu — need context
 21. Luke Ong — need context
 22. Michael Cheng — need context
+23. Dorcas Tan — IMDA, Cluster Director, works for Kiren — need context
+24. Deepak — Andrew's nominee, will reach out via WhatsApp
 
-**Base template** (finalized):
-- Opening: "I want to invite you to something this coming Monday."
-- Pro bono workshop at RP, AI Augmented Development with Claude Code
-- Beyond Vibe Coding: structured, disciplined building of software with AI
-- AIADLC through TheAgency methodology and Valueflow
-- Three takeaways: grounding, hands-on experience, framework
-- Accessible — you don't need a technical background
-- Short notice — nominate someone if can't attend
-- BYOAP — ~$100 for Claude Code subscription
-- Venue details + directions + Phyllis Ling contact
+**Also pending: Anthropic license outreach (Batch 2)** — LinkedIn + Twitter to more Anthropic folks for 25-30 Max 20x licenses.
 
-### Also Pending: Anthropic License Outreach (Batch 2)
+### Base Invite Template (finalized)
 
-Jordan sent messages to Boris (Claude Code creator), Thariq, and Agrim/Sherry asking for 25-30 Max 20x licenses for two weeks. Need to draft additional outreach via LinkedIn and Twitter to more Anthropic folks.
+Key elements:
+- "I want to invite you to something this coming Monday."
+- AI Augmented Development with Claude Code workshop (pro bono) at RP
+- AIADLC, TheAgency methodology, Valueflow
+- "Think of it as beyond Vibe Coding: structured, disciplined building of software with AI."
+- Three takeaways: grounding, hands-on, framework
+- "you don't need a technical background"
+- Short notice — nominate someone
+- BYOAP ~$100 for Claude Code subscription
+- PS: TheAgency + Valueflow open source link
+- Venue details + directions after PS
+- **DATE: Monday 13 April** (corrected)
 
-### Workshop — Monday 2026-04-14 at Republic Polytechnic
+### Workshop Outline
 
-**Full outline written:** `claude/workstreams/agency/seeds/workshop-outline-republic-poly-20260410.md`
+Full outline at: `claude/workstreams/agency/seeds/workshop-outline-republic-poly-20260410.md`
 
-**Schedule:**
-- 10:00–10:20: Setup (bootstrap + login + remote control to Desktop)
-- 10:20–11:00: Part 1 — The Sea Change (NOT Vibe Coding, coding is dead, builder identity, abstraction ladder, MacHack, Christmas project)
-- 11:00–11:45: Part 2 — Claude Code (elements, CLAUDE.md, 4 Ds, career progression, Jamon's 8 practices)
-- 11:45–12:15: Part 3 — TheAgency + Valueflow (methodology, born from trenches, QG, OODA, Monitor tool case study)
-- 12:15–13:15: Lunch
-- 13:15–14:45: Part 4 — Guided Build (personal page + mini-blog → Vercel deploy)
-- 14:45–15:25: Elevator Pitches (20 × 2 min)
-- 15:25–16:30: Part 5 — Independent Build (you float)
-- 16:30–17:00: Show & Tell + Wrap
+**Key dates/corrections:**
+- Workshop is **Monday 13 April** (not 14th)
+- 10:00-17:00, 1 hour lunch
 
 **Key framing:**
-- "This is NOT Vibe Coding." / "Coding is dead." / "We are builders."
-- Abstraction ladder using Jordan's career: switches → MacsBug → MDS → MPW → AI
+- "This is NOT Vibe Coding" / "Coding is dead" / "We are builders"
+- Abstraction ladder: switches → MacsBug → MDS → MPW → AI
 - MacHack mantras: "It's all Jordan's fault", "Sleep is for the weak and sickly", "72 Hours Caffeine and Code"
-- Steve Yegge's 8 levels woven in (not dedicated block)
-- Monitor tool as live OODA case study
+- 4 Ds, career progression, OODA, Monitor tool case study
+- Toy project: personal page + mini-blog → Vercel deploy
 
 **Student setup:**
-- VM runs Claude Code with remote-control
-- Students work from Claude Desktop Code tab on Windows
-- Captain bootstrap CLAUDE.md knows the curriculum, acts as tutor
-- Students' captains collaborate with Jordan's captain
-- Repo: clone → `agency init` → captain wakes up knowing the workshop
-
-**Toy project:** Personal page + mini-blog, deploy to Vercel. AI Q&A stretch goal.
-
-### Workshop Artifacts
-
-| Artifact | Status |
-|----------|--------|
-| Setup guide (GDoc) | ✅ Sent to participants |
-| Bootstrap script | ✅ Tested on ARM64 VM |
-| Workshop outline | ✅ Written |
-| Experience doc | ✅ Written with action log + manifest |
-| Workshop start script | 📝 Needs redraft for Remote Control + Desktop flow |
-| Workshop repo | ❌ TODO — `the-agency-ai/aiad-workshop` |
-| Captain bootstrap CLAUDE.md | ❌ TODO |
-| Slides / keynote | ❌ TODO |
-| Vercel deploy tested | ❌ TODO |
-| Monitor tool adoption | ❌ TODO — implement this weekend |
-
-### VM State
-
-- Fusion VM running at `~/Virtual Machines.localized/TheAgency-Workshop-Ubuntu-64-bit-ARM.vmwarevm/`
-- IP: 192.168.1.115 (bridged mode), SSH working with key auth
-- Passwordless sudo configured, lock screen disabled
-- **3 snapshots:** clean-install, pre-bootstrap, post-bootstrap
-- All tools verified green: chromium, git, node, npm, claude, jq, sqlite3, gh, docker, brew
-- Ghostty dropped (no Linux packages — students use GNOME Terminal)
-
-### Seeds Captured Today
-
-- `seed-it-happened-and-breadcrumb-20260410.md` — "This Happened!" + "Breadcrumb" value-added services
-- `seed-monitor-tool-adoption-20260410.md` — Monitor tool replaces dispatch polling, 96% token savings
-- `seed-ooda-loop-structural-framework-20260410.md` — from monofolk, OODA as structural pattern
-- `seed-process-intelligence-celonis-20260410.md` — from monofolk, Celonis interview + trajectory
-- `workshop-outline-republic-poly-20260410.md` — full workshop outline
-- `workshop-setup-guide-20260410.md` — student setup guide
-- `workshop-bootstrap.sh` — tested bootstrap script
-- `workshop-start.sh` — workshop morning script (needs redraft)
-
-### Dispatches Sent Today
-
-- **#200** to the-agency/jordan/devex — SPEC:PROVIDER for NestJS + React/Next.js
-- **Collaboration** to monofolk/captain — query on "This Happened!" prior discussion
-- **Collaboration** to monofolk/devex — SPEC:PROVIDER directive, coordinate with the-agency/devex
+- VM + Claude Code with remote-control → Claude Desktop Code tab on Windows
+- Workshop repo: clone → agency init → captain wakes up knowing curriculum
 
 ### Earlier Today
 
-- ✅ PR #69 merged (D34-R5 — 27 test failures killed)
-- ✅ `pr-build` tool landed from upstream (monofolk contribution)
-- Architecture mistake: ARM64 ISO can't build x86 OVA → pivoted to bootstrap script model
-- VMX hand-crafted failures: lsilogic, e1000e, PCIe bridges — documented in experience report
+- ✅ PR #69 merged
+- ✅ VM built, tested, bootstrapped — 3 snapshots (clean-install, pre-bootstrap, post-bootstrap)
+- ✅ Presence-detect synced to agency 34.4 (1,057 files, committed f3dba8c)
+- ✅ Seeds captured: This Happened + Breadcrumb, Monitor tool, OODA, Process Intelligence
+- ✅ Dispatches sent: #200 to devex (SPEC:PROVIDER), monofolk collab (This Happened query + SPEC:PROVIDER)
+- ✅ Workshop outline, setup guide, bootstrap script, start script all written
 
 ### Dispatch Loops Running
 
@@ -139,16 +92,5 @@ Jordan sent messages to Boris (Claude Code creator), Thariq, and Agrim/Sherry as
 | Dispatch fast-path | 5m | e6f02feb |
 | Dispatch nag | 30m | 49fafcb4 |
 | Collaboration | 10m | 10e370af |
-
-### Content Knowledge (not in files, in session context)
-
-- MacHack: "It's all Jordan's fault" — conference mantra, Jordan was Apple rep
-- MacsBug: Motorola 68K debugger, Jordan was PM
-- MDS: Macintosh 68000 Development System (1984), Jordan was PM
-- MPW: Macintosh Programmer's Workshop (1986), Jordan was PM
-- "72 Hours Caffeine and Code" — MacHack mantra, Jordan jokes "that was my original plan but I got overruled"
-- Jamon Holmgren's 8 practices (X post) — validation from the trenches
-- Workshop is two-day format for Anthropic license ask, but one-day delivery this Monday
-- Boris + Thariq outreach for 25-30 Max 20x licenses
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -3,166 +3,66 @@ type: handoff
 agent: the-agency/jordan/captain
 workstream: agency
 date: 2026-04-09
-trigger: end-of-day-34
+trigger: break-2000sgt
 ---
 
-## Identity
+## Resume after 0200 SGT
 
-the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+### Immediate on resume
 
-## Current State
+1. **PR #69 (D34-R5)** — open, awaiting approval. 813/813 tests green + ISCP merge unblock. Approve → merge → `/post-merge 69`.
+2. **ISO download** — Ubuntu 24.04.4 ARM64 desktop downloading to `~/Downloads/ubuntu-24.04.4-desktop-arm64.iso`. Should be done. Verify: `ls -lh ~/Downloads/ubuntu-24.04.4-desktop-arm64.iso` — expect ~3.3 GB.
+3. **Create VM** in Fusion from the ISO → bootstrap script → agency init → snapshot → OVA. Workshop is Monday.
 
-**Day 34 complete. Biggest single day of the session so far.** Two releases shipped (34.1 + 34.2), meta-insight of the week captured, monofolk graduated to full-install, first full dogfood bug-found-filed-fixed-closed cycle executed, 13 new flags captured. Local main is at `1f54e79`, in sync with origin.
+### Day 34 shipped (on origin)
 
-## Shipped Today (Day 34)
+- **34.1** (PR #60) — agency-version tool + statusline
+- **34.2** (PR #63) — run-in Triangle + fixes #56/#57/#171
+- **34.3** (PR #66) — worktree-sync main/master fix + skill allowed-tools audit (48 files)
+- **34.4** (PR #67) — agency-health v1 (3-dimensional fleet health)
+- **34.5** (PR #69) — 27 test failures killed + schema skip guard + scaled timeout [PENDING MERGE]
 
-### PR #60 — Day 34.1 (MERGED)
+### Fleet state
 
-Single feature release: **agency-version tool + statusline version display.**
+- **devex** — standing autonomy, crushed tasks #8-#13. docker-heal shipped. Worktree naming, hookify rename, agent-create dispatch loops all in progress.
+- **iscp** — blocked on merge until #69 lands. Has 3 conflict files to resolve (flag, _iscp-db, flag.bats). Direction sent via #183/#184/#197/#199. Standing autonomy.
+- **mdpal-app** — worktree in weird split state (1449 deletions). Dispatched #181 for agent diagnosis. Stub handoff created.
+- **mdpal-cli** — synced to main, .agency-agent created, stub handoff created.
+- **mock-and-mark** — worktree created, identity set, settings synced. Ready for reactivation session. Jordan: "fix it, launching soon."
 
-- `claude/tools/agency-version` — bash tool with verbs: `print` (default), `--statusline` (silent on missing), `--json`, `--help`
-- `claude/config/manifest.json` — new top-level `agency_version: "34.1"` field (single source of truth)
-- `claude/tools/statusline.sh` — renders `2.1.87 with Opus | 34.1 | the-agency (main) …`
-- 11 BATS tests, all green
-- Single commit: `118ae29`
+### Monofolk
 
-### PR #63 — Day 34.2 (MERGED)
+- Graduated to full-install (sandbox removed)
+- Agency-health v1 committed to them as Wave 1 diagnostic tool
+- PR workflow converging (D#-R# naming, no-squash, captain builds PRs)
+- pr-build tool coming from them (upstream contribution)
+- Dropbox tool design routed to iscp (#177)
+- Awaiting their reply on QGR location alignment + D-counter retroactive question
 
-Multi-fix release: **run-in Triangle + fixes #56, #57, #171 regression + telemetry-driven tool discovery seed.**
+### Workshop — Monday 2026-04-14 at Republic Polytechnic
 
-- **fix #56** (`c746d04`) — `agency update` now detects new top-level YAML keys in source `agency.yaml` and appends them to target with a comment marker. Dedupes duplicate keys. Verified end-to-end on `~/code/presence-detect` (43 → 124 lines, 9 missing sections added).
-- **fix #171 regression** (`2a62f8d`) — Gate 0 in `commit-precheck` hard-blocks any commit with `Test User <test@example.com>` attribution. Cleaned live `[user]` pollution from main's `.git/config` in same turn. Belt + suspenders alongside existing `test_helper.bash` unset guard.
-- **feat: run-in Triangle + fix #57** (`ac73ce9`) — new `claude/tools/run-in <dir> -- <cmd>` runs in subshell, parent CWD untouched. `/run-in` skill. `hookify.block-compound-bash` **wide block** on all compound patterns with educative WHY. 11 run-in BATS tests + 4 worktree-sync BATS tests (bug-exposing for #57). Seed: telemetry-driven tool discovery.
-- **34.2 version bump** (`bdab384`)
+- Ubuntu 24.04 LTS ARM64 VM in VMware Workstation Pro (free)
+- Ghostty + brew + Docker + Claude Code + agency init
+- ISO downloading. Next: create VM, run bootstrap, snapshot, export OVA
+- Students get OVA, open Ghostty, `claude login`, `cd ~/workshop`, `claude`
+- "No compromises. As close to macOS as we can get."
 
-### Issues closed today
-- #56 — agency update yaml section propagation (first full dogfood cycle via agency-issue)
-- #57 — worktree-sync misleading 'resolve manually' message
+### Principles locked today
 
-### Issues filed today
-- #58 — Docker CLI can't connect to daemon when Docker Desktop is running (dispatched to devex with standing autonomy directive)
+- **No broken windows.** If we use it or have used it, it gets included.
+- **No compromises** on the workshop experience.
+- **Be the Man Who Was Too Lazy to Fail** — invest in tools, not heroic manual execution.
+- **Rapid release discipline** — D#-R# naming, no squash, one PR per release.
+- **Standing autonomy** — agents execute without per-step approval.
+- **No reviews on GitHub** — PRs are shipping mechanism only.
+- **Ban raw git writes** (flag #83, pending 1B1 on scope).
 
-## The Meta-Insight of the Week
+### Open flags (31 total, key ones)
 
-**"The Bash tool log is a list of the tools we haven't built yet."**
-
-Named the framework pattern that birthed run-in: **Friction → Telemetry → Tool → Block → Flow.** Every compound bash command is a request for a missing primitive. The telemetry already captures the request; we just need to mine it.
-
-Seed at `claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md`. Queued for CLAUDE.md + README-THEAGENCY + articles + book revision (flag #55). This is the thesis statement for "why TheAgency builds tools the way it builds tools."
-
-## monofolk Graduated
-
-**The first external validation that the framework is mature enough to run production work without the sandbox.**
-
-- monofolk removed 32 sandbox symlinks and 47 personal hookify files
-- 15 agents, 13 worktrees, running overnight research fleet of 10 agents in parallel
-- Full Agency install as of today
-- 5-week sprint to May 15 NextGeneration go-live
-- Asked for diagnostic tooling — **we committed to a 4-wave delivery plan**:
-  - **Wave 1** (this week, Day 38-40): audit tool (#51) + worktree health diagnostics
-  - **Wave 2** (next week): stale artifact detection + hookify rule coverage report
-  - **Wave 3** (weeks 3-4): compound command telemetry mining (the meta-tool)
-  - **Wave 4** (week 5, before go-live): whatever Wave 3's telemetry mining surfaces
-
-## Dispatches Sent Today
-
-| ID | Type | To | Subject |
-|----|------|-----|---------|
-| #172 | review-response | devex | RE: #171 acknowledged, triaging |
-| #173 | review-response | devex | RE: #171 per-item unblock direction + back-to-work trigger |
-| #174 | directive | devex | DIRECTIVE: fix #58 docker socket + standing autonomy on full queue |
-| (collab) | dispatch | monofolk | RE: We're All-In — congratulations + graduation path queued |
-| (collab) | dispatch | monofolk | RE: agency update live — diagnostic tooling inventory + 4-wave roadmap |
-
-#171 resolved. Devex has full standing autonomy authorization and does not need per-item approval.
-
-## Cross-Repo (monofolk)
-
-- Inbound: 2 dispatches received and replied to (graduation + diagnostic tooling request)
-- Outbound: 2 replies pushed to `collaboration-monofolk` repo
-- No pending inbound
-
-## Active Agents (background)
-
-| Agent | State | Notes |
-|-------|-------|-------|
-| devex | Standing autonomy. Queue: #58 docker fix + #149 items + #166/#167/#168 + #171 unblock sequence. Do not need approval on any item. | Needs to pick up main (R1+R2) on next session-resume. Manual merge likely required due to worktree-sync master/main bug (flag #65). |
-| iscp | Phase 2 work | Needs to pick up main. Manual merge required. |
-| mdpal-app / mdpal-cli | Own iterations | Not currently in active state. |
-
-## Captain Flags Captured Today (13 new, #53-#65)
-
-| # | Theme |
-|---|-------|
-| 53 | Docker socket self-heal (when Docker Desktop running but CLI can't connect) |
-| 54 | Compound command telemetry analysis workstream (the meta-tool that mines the log) |
-| 55 | CLAUDE.md + README revision for telemetry-driven tool discovery |
-| 56 | commit-precheck missing `end_run` event on failure (telemetry gap) |
-| 57 | Telemetry identity resolution broken (shows `testuser/unknown` instead of `jordan/captain`) |
-| 58 | `/why-did-this-fail` skill — query telemetry for failed run diagnostic |
-| 59 | Surface run IDs + exit codes on tool failure output |
-| 60 | Handoff tool investigation (why did commit 4bc05a1 not update blob?) |
-| 61 | RULE: We do NOT review on GitHub. PRs are shipping mechanism only. |
-| 62 | coord-commit allowed-tools frontmatter silently blocks agents (removed in fix) |
-| 63 | **Permission visibility gap** — agents can't see principal's permission prompts. File to Anthropic. |
-| 64 | Diagnostic tooling workstream (committed to monofolk) |
-| 65 | **worktree-sync hardcodes `master`** — breaks in main-branch repos. Blocks `/sync-all`. |
-
-## Open Items
-
-### Tomorrow morning (Day 35 — highest priority)
-
-1. **Fix worktree-sync master/main bug (flag #65)** — pre-existing, blocking fleet sync. Detect `MAIN_BRANCH` from main checkout, replace all `master` references. File as agency-issue with bug-exposing test.
-2. **Fix coord-commit permission trap (flag #62)** — remove `allowed-tools` frontmatter, inherit `Bash(*)`. Audit all other skill frontmatter for the same pattern.
-3. **File permission visibility gap to Anthropic (flag #63)** — Claude Code feedback. Draft inline, principal approves.
-4. **Wave 1 diagnostic tools (committed to monofolk)** — audit tool (#51) + worktree health diagnostics. End-of-week target (Day 38-40).
-
-### KIV (when at laptop)
-
-- PAT rotation — `.git/config` contains a GitHub token in the origin URL
-- `/compact-prep` B-prime build (session-end mode=compact flag)
-- CI/CD review (flag #52)
-
-### Dispatched to devex (standing autonomy — they execute without approval)
-
-- #58 docker socket fix
-- #149 full queue (Items 2, 4 + Valueflow Phase 3 + hookify rules)
-- #166 worktree naming
-- #167 hookify noun-verb rename
-- #168 agent-create scaffolding
-- #171 unblock sequence (merge conflict, handoff restore, stash cleanup)
-- Task #8 phase-complete SPEC-PROVIDER preview/deploy
-
-## Key Decisions Today
-
-1. **Release format locked**: `{day}.{release}`, no `v` prefix, rapid-release discipline, one PR per release
-2. **Stacked PR hazard learned**: merging child PR before parent lands the child into parent's branch, not main. **Merge base-first, wait for auto-retarget, then merge child.**
-3. **Run-in Triangle shipped**: compound bash commands are hard-blocked framework-wide; `run-in` is the canonical replacement for the `cd X && cmd` pattern
-4. **Telemetry-driven tool discovery named and seeded** — will become framework-level methodology in README + CLAUDE.md + articles
-5. **Standing autonomy for devex**: explicit "don't wait for approval, just do it" directive; applies to all queued items
-6. **No reviews on GitHub** (flag #61): PRs are shipping mechanism only; review happens locally via `/captain-review`/`/code-review`/`/pr-prep`
-7. **monofolk diagnostic tooling 4-wave commitment** — concrete timeline for the fleet health roadmap
-8. **Permission visibility gap is structural**: the agent cannot see what the principal sees when approval prompts fire. Pre-approve trusted tools + file to Anthropic.
-
-## Discipline Reminders
-
-- **NEVER review on GitHub.** PRs are shipping mechanism only.
-- **NEVER rebase** — framework-wide block active
-- **NEVER `reset --hard origin/*`** — framework-wide block active
-- **NEVER compound bash commands** — `&&`/`||`/`;`/`|`/`$(…)`/backticks all blocked by `hookify.block-compound-bash`. Use `run-in` for the `cd X && cmd` pattern; split into separate Bash calls otherwise.
-- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; pause and confirm before push/merge/close/delete
-- Use `/handoff` skill / `/git-commit` / etc — never raw tools
-- Dispatch loop (5m silent) running this session — will not survive compact; re-set on next session
-- Cross-repo dispatches via `collaboration` tool, not direct
-
-## Next Action (start of next session)
-
-1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
-2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have picked up Day 34 and started sending feedback
-3. **Check devex / iscp / mdpal** for any inbound dispatches (probably pick-up acks for R1+R2 + #174)
-4. **Flag #65: worktree-sync master/main fix** — Wave 0, blocks fleet sync
-5. **Flag #62: coord-commit permission trap fix** — unblocks any future coord-commit invocations
-6. **Wave 1 diagnostic tooling kickoff** — audit tool (#51) + worktree health diagnostics, committed to monofolk for end-of-week
-7. **Captain's log** — append Day 35 kickoff
+- #55 CLAUDE.md revision (rich material ready)
+- #69 create-tool input validation (all *-create tools)
+- #78 session naming issues (needs 1B1)
+- #82 agency verify reads dependencies.yaml
+- #83 ban raw git writes (needs 1B1)
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/directive-spec-provider-needed-nestjs-react-next-js-applicat-20260410-1619.md
+++ b/usr/jordan/captain/dispatches/directive-spec-provider-needed-nestjs-react-next-js-applicat-20260410-1619.md
@@ -1,0 +1,29 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-10T08:19
+status: created
+priority: normal
+subject: "SPEC:PROVIDER needed: NestJS + React/Next.js application scaffolding"
+in_reply_to: null
+---
+
+# SPEC:PROVIDER needed: NestJS + React/Next.js application scaffolding
+
+Jordan directive: We need a SPEC:PROVIDER setup that allows us to easily create backend and frontend applications in the-agency repo.
+
+**Stack:**
+- **Backend:** NestJS
+- **Frontend:** React + Next.js
+
+**What we need:**
+- SPEC:PROVIDER wrappers that scaffold new NestJS services and React/Next.js apps
+- Standard project structure, build config, dev server setup
+- Integration with the agency framework (CLAUDE.md, hooks, tools)
+
+This is for building value-added services like 'This Happened!' (user issue reporting) and 'Breadcrumb' (distributed tracing) as actual running applications, not just CLI tools.
+
+Priority: soon. Jordan wants to start building these services in the-agency repo.
+
+Coordinate with monofolk/devex if they have existing SPEC:PROVIDER patterns for these stacks.

--- a/usr/jordan/captain/history/handoff-20260409-195346.md
+++ b/usr/jordan/captain/history/handoff-20260409-195346.md
@@ -1,0 +1,168 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-09
+trigger: end-of-day-34
+---
+
+## Identity
+
+the-agency/jordan/captain — Captain. Coordination, dispatch routing, quality gates, PR lifecycle. First up, last down.
+
+## Current State
+
+**Day 34 complete. Biggest single day of the session so far.** Two releases shipped (34.1 + 34.2), meta-insight of the week captured, monofolk graduated to full-install, first full dogfood bug-found-filed-fixed-closed cycle executed, 13 new flags captured. Local main is at `1f54e79`, in sync with origin.
+
+## Shipped Today (Day 34)
+
+### PR #60 — Day 34.1 (MERGED)
+
+Single feature release: **agency-version tool + statusline version display.**
+
+- `claude/tools/agency-version` — bash tool with verbs: `print` (default), `--statusline` (silent on missing), `--json`, `--help`
+- `claude/config/manifest.json` — new top-level `agency_version: "34.1"` field (single source of truth)
+- `claude/tools/statusline.sh` — renders `2.1.87 with Opus | 34.1 | the-agency (main) …`
+- 11 BATS tests, all green
+- Single commit: `118ae29`
+
+### PR #63 — Day 34.2 (MERGED)
+
+Multi-fix release: **run-in Triangle + fixes #56, #57, #171 regression + telemetry-driven tool discovery seed.**
+
+- **fix #56** (`c746d04`) — `agency update` now detects new top-level YAML keys in source `agency.yaml` and appends them to target with a comment marker. Dedupes duplicate keys. Verified end-to-end on `~/code/presence-detect` (43 → 124 lines, 9 missing sections added).
+- **fix #171 regression** (`2a62f8d`) — Gate 0 in `commit-precheck` hard-blocks any commit with `Test User <test@example.com>` attribution. Cleaned live `[user]` pollution from main's `.git/config` in same turn. Belt + suspenders alongside existing `test_helper.bash` unset guard.
+- **feat: run-in Triangle + fix #57** (`ac73ce9`) — new `claude/tools/run-in <dir> -- <cmd>` runs in subshell, parent CWD untouched. `/run-in` skill. `hookify.block-compound-bash` **wide block** on all compound patterns with educative WHY. 11 run-in BATS tests + 4 worktree-sync BATS tests (bug-exposing for #57). Seed: telemetry-driven tool discovery.
+- **34.2 version bump** (`bdab384`)
+
+### Issues closed today
+- #56 — agency update yaml section propagation (first full dogfood cycle via agency-issue)
+- #57 — worktree-sync misleading 'resolve manually' message
+
+### Issues filed today
+- #58 — Docker CLI can't connect to daemon when Docker Desktop is running (dispatched to devex with standing autonomy directive)
+
+## The Meta-Insight of the Week
+
+**"The Bash tool log is a list of the tools we haven't built yet."**
+
+Named the framework pattern that birthed run-in: **Friction → Telemetry → Tool → Block → Flow.** Every compound bash command is a request for a missing primitive. The telemetry already captures the request; we just need to mine it.
+
+Seed at `claude/workstreams/agency/seeds/seed-telemetry-driven-tool-discovery-20260409.md`. Queued for CLAUDE.md + README-THEAGENCY + articles + book revision (flag #55). This is the thesis statement for "why TheAgency builds tools the way it builds tools."
+
+## monofolk Graduated
+
+**The first external validation that the framework is mature enough to run production work without the sandbox.**
+
+- monofolk removed 32 sandbox symlinks and 47 personal hookify files
+- 15 agents, 13 worktrees, running overnight research fleet of 10 agents in parallel
+- Full Agency install as of today
+- 5-week sprint to May 15 NextGeneration go-live
+- Asked for diagnostic tooling — **we committed to a 4-wave delivery plan**:
+  - **Wave 1** (this week, Day 38-40): audit tool (#51) + worktree health diagnostics
+  - **Wave 2** (next week): stale artifact detection + hookify rule coverage report
+  - **Wave 3** (weeks 3-4): compound command telemetry mining (the meta-tool)
+  - **Wave 4** (week 5, before go-live): whatever Wave 3's telemetry mining surfaces
+
+## Dispatches Sent Today
+
+| ID | Type | To | Subject |
+|----|------|-----|---------|
+| #172 | review-response | devex | RE: #171 acknowledged, triaging |
+| #173 | review-response | devex | RE: #171 per-item unblock direction + back-to-work trigger |
+| #174 | directive | devex | DIRECTIVE: fix #58 docker socket + standing autonomy on full queue |
+| (collab) | dispatch | monofolk | RE: We're All-In — congratulations + graduation path queued |
+| (collab) | dispatch | monofolk | RE: agency update live — diagnostic tooling inventory + 4-wave roadmap |
+
+#171 resolved. Devex has full standing autonomy authorization and does not need per-item approval.
+
+## Cross-Repo (monofolk)
+
+- Inbound: 2 dispatches received and replied to (graduation + diagnostic tooling request)
+- Outbound: 2 replies pushed to `collaboration-monofolk` repo
+- No pending inbound
+
+## Active Agents (background)
+
+| Agent | State | Notes |
+|-------|-------|-------|
+| devex | Standing autonomy. Queue: #58 docker fix + #149 items + #166/#167/#168 + #171 unblock sequence. Do not need approval on any item. | Needs to pick up main (R1+R2) on next session-resume. Manual merge likely required due to worktree-sync master/main bug (flag #65). |
+| iscp | Phase 2 work | Needs to pick up main. Manual merge required. |
+| mdpal-app / mdpal-cli | Own iterations | Not currently in active state. |
+
+## Captain Flags Captured Today (13 new, #53-#65)
+
+| # | Theme |
+|---|-------|
+| 53 | Docker socket self-heal (when Docker Desktop running but CLI can't connect) |
+| 54 | Compound command telemetry analysis workstream (the meta-tool that mines the log) |
+| 55 | CLAUDE.md + README revision for telemetry-driven tool discovery |
+| 56 | commit-precheck missing `end_run` event on failure (telemetry gap) |
+| 57 | Telemetry identity resolution broken (shows `testuser/unknown` instead of `jordan/captain`) |
+| 58 | `/why-did-this-fail` skill — query telemetry for failed run diagnostic |
+| 59 | Surface run IDs + exit codes on tool failure output |
+| 60 | Handoff tool investigation (why did commit 4bc05a1 not update blob?) |
+| 61 | RULE: We do NOT review on GitHub. PRs are shipping mechanism only. |
+| 62 | coord-commit allowed-tools frontmatter silently blocks agents (removed in fix) |
+| 63 | **Permission visibility gap** — agents can't see principal's permission prompts. File to Anthropic. |
+| 64 | Diagnostic tooling workstream (committed to monofolk) |
+| 65 | **worktree-sync hardcodes `master`** — breaks in main-branch repos. Blocks `/sync-all`. |
+
+## Open Items
+
+### Tomorrow morning (Day 35 — highest priority)
+
+1. **Fix worktree-sync master/main bug (flag #65)** — pre-existing, blocking fleet sync. Detect `MAIN_BRANCH` from main checkout, replace all `master` references. File as agency-issue with bug-exposing test.
+2. **Fix coord-commit permission trap (flag #62)** — remove `allowed-tools` frontmatter, inherit `Bash(*)`. Audit all other skill frontmatter for the same pattern.
+3. **File permission visibility gap to Anthropic (flag #63)** — Claude Code feedback. Draft inline, principal approves.
+4. **Wave 1 diagnostic tools (committed to monofolk)** — audit tool (#51) + worktree health diagnostics. End-of-week target (Day 38-40).
+
+### KIV (when at laptop)
+
+- PAT rotation — `.git/config` contains a GitHub token in the origin URL
+- `/compact-prep` B-prime build (session-end mode=compact flag)
+- CI/CD review (flag #52)
+
+### Dispatched to devex (standing autonomy — they execute without approval)
+
+- #58 docker socket fix
+- #149 full queue (Items 2, 4 + Valueflow Phase 3 + hookify rules)
+- #166 worktree naming
+- #167 hookify noun-verb rename
+- #168 agent-create scaffolding
+- #171 unblock sequence (merge conflict, handoff restore, stash cleanup)
+- Task #8 phase-complete SPEC-PROVIDER preview/deploy
+
+## Key Decisions Today
+
+1. **Release format locked**: `{day}.{release}`, no `v` prefix, rapid-release discipline, one PR per release
+2. **Stacked PR hazard learned**: merging child PR before parent lands the child into parent's branch, not main. **Merge base-first, wait for auto-retarget, then merge child.**
+3. **Run-in Triangle shipped**: compound bash commands are hard-blocked framework-wide; `run-in` is the canonical replacement for the `cd X && cmd` pattern
+4. **Telemetry-driven tool discovery named and seeded** — will become framework-level methodology in README + CLAUDE.md + articles
+5. **Standing autonomy for devex**: explicit "don't wait for approval, just do it" directive; applies to all queued items
+6. **No reviews on GitHub** (flag #61): PRs are shipping mechanism only; review happens locally via `/captain-review`/`/code-review`/`/pr-prep`
+7. **monofolk diagnostic tooling 4-wave commitment** — concrete timeline for the fleet health roadmap
+8. **Permission visibility gap is structural**: the agent cannot see what the principal sees when approval prompts fire. Pre-approve trusted tools + file to Anthropic.
+
+## Discipline Reminders
+
+- **NEVER review on GitHub.** PRs are shipping mechanism only.
+- **NEVER rebase** — framework-wide block active
+- **NEVER `reset --hard origin/*`** — framework-wide block active
+- **NEVER compound bash commands** — `&&`/`||`/`;`/`|`/`$(…)`/backticks all blocked by `hookify.block-compound-bash`. Use `run-in` for the `cd X && cmd` pattern; split into separate Bash calls otherwise.
+- **Explicit authorization for destructive ops** — strategy choice is not execution go-ahead; pause and confirm before push/merge/close/delete
+- Use `/handoff` skill / `/git-commit` / etc — never raw tools
+- Dispatch loop (5m silent) running this session — will not survive compact; re-set on next session
+- Cross-repo dispatches via `collaboration` tool, not direct
+
+## Next Action (start of next session)
+
+1. **Run dispatch loop + nag loop** on startup (5m silent + 30m visible)
+2. **Check collaboration** (`./claude/tools/collaboration check`) — monofolk may have picked up Day 34 and started sending feedback
+3. **Check devex / iscp / mdpal** for any inbound dispatches (probably pick-up acks for R1+R2 + #174)
+4. **Flag #65: worktree-sync master/main fix** — Wave 0, blocks fleet sync
+5. **Flag #62: coord-commit permission trap fix** — unblocks any future coord-commit invocations
+6. **Wave 1 diagnostic tooling kickoff** — audit tool (#51) + worktree health diagnostics, committed to monofolk for end-of-week
+7. **Captain's log** — append Day 35 kickoff
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260410-185036.md
+++ b/usr/jordan/captain/history/handoff-20260410-185036.md
@@ -1,0 +1,68 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: agency
+date: 2026-04-09
+trigger: break-2000sgt
+---
+
+## Resume after 0200 SGT
+
+### Immediate on resume
+
+1. **PR #69 (D34-R5)** — open, awaiting approval. 813/813 tests green + ISCP merge unblock. Approve → merge → `/post-merge 69`.
+2. **ISO download** — Ubuntu 24.04.4 ARM64 desktop downloading to `~/Downloads/ubuntu-24.04.4-desktop-arm64.iso`. Should be done. Verify: `ls -lh ~/Downloads/ubuntu-24.04.4-desktop-arm64.iso` — expect ~3.3 GB.
+3. **Create VM** in Fusion from the ISO → bootstrap script → agency init → snapshot → OVA. Workshop is Monday.
+
+### Day 34 shipped (on origin)
+
+- **34.1** (PR #60) — agency-version tool + statusline
+- **34.2** (PR #63) — run-in Triangle + fixes #56/#57/#171
+- **34.3** (PR #66) — worktree-sync main/master fix + skill allowed-tools audit (48 files)
+- **34.4** (PR #67) — agency-health v1 (3-dimensional fleet health)
+- **34.5** (PR #69) — 27 test failures killed + schema skip guard + scaled timeout [PENDING MERGE]
+
+### Fleet state
+
+- **devex** — standing autonomy, crushed tasks #8-#13. docker-heal shipped. Worktree naming, hookify rename, agent-create dispatch loops all in progress.
+- **iscp** — blocked on merge until #69 lands. Has 3 conflict files to resolve (flag, _iscp-db, flag.bats). Direction sent via #183/#184/#197/#199. Standing autonomy.
+- **mdpal-app** — worktree in weird split state (1449 deletions). Dispatched #181 for agent diagnosis. Stub handoff created.
+- **mdpal-cli** — synced to main, .agency-agent created, stub handoff created.
+- **mock-and-mark** — worktree created, identity set, settings synced. Ready for reactivation session. Jordan: "fix it, launching soon."
+
+### Monofolk
+
+- Graduated to full-install (sandbox removed)
+- Agency-health v1 committed to them as Wave 1 diagnostic tool
+- PR workflow converging (D#-R# naming, no-squash, captain builds PRs)
+- pr-build tool coming from them (upstream contribution)
+- Dropbox tool design routed to iscp (#177)
+- Awaiting their reply on QGR location alignment + D-counter retroactive question
+
+### Workshop — Monday 2026-04-14 at Republic Polytechnic
+
+- Ubuntu 24.04 LTS ARM64 VM in VMware Workstation Pro (free)
+- Ghostty + brew + Docker + Claude Code + agency init
+- ISO downloading. Next: create VM, run bootstrap, snapshot, export OVA
+- Students get OVA, open Ghostty, `claude login`, `cd ~/workshop`, `claude`
+- "No compromises. As close to macOS as we can get."
+
+### Principles locked today
+
+- **No broken windows.** If we use it or have used it, it gets included.
+- **No compromises** on the workshop experience.
+- **Be the Man Who Was Too Lazy to Fail** — invest in tools, not heroic manual execution.
+- **Rapid release discipline** — D#-R# naming, no squash, one PR per release.
+- **Standing autonomy** — agents execute without per-step approval.
+- **No reviews on GitHub** — PRs are shipping mechanism only.
+- **Ban raw git writes** (flag #83, pending 1B1 on scope).
+
+### Open flags (31 total, key ones)
+
+- #55 CLAUDE.md revision (rich material ready)
+- #69 create-tool input validation (all *-create tools)
+- #78 session naming issues (needs 1B1)
+- #82 agency verify reads dependencies.yaml
+- #83 ban raw git writes (needs 1B1)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/workshop-vm-experience-20260410.md
+++ b/usr/jordan/captain/workshop-vm-experience-20260410.md
@@ -1,0 +1,316 @@
+---
+type: reference
+date: 2026-04-10
+subject: Workshop VM Build — Experience Report
+---
+
+# Workshop VM Build — Experience Report
+
+## Context
+
+Building a Ubuntu 24.04 VM for the Republic Polytechnic workshop (Monday 14 April 2026). Goal was to script the entire process via VMware Fusion CLI (`vmrun`, `vmware-vdiskmanager`, `ovftool`). Target: students on Windows x86 machines with VMware Workstation Pro.
+
+## Architecture Mistake
+
+Downloaded `ubuntu-24.04.4-desktop-arm64.iso` (3.3 GB) — correct for our Apple Silicon Mac but **wrong for the students**. They're on Windows x86 machines. An ARM64 OVA won't run on x86 VMware Workstation. Can't cross-build either — Fusion on Apple Silicon cannot run x86 guests (no emulation, no Rosetta passthrough for VMs).
+
+**Resolution:** Pivoted to a bootstrap script model. Students create their own x86 VM from `ubuntu-24.04.4-desktop-amd64.iso`, then run our bootstrap script inside it. We test the script on our ARM64 VM — the script is architecture-independent.
+
+## Hand-Crafted VMX Failures
+
+Attempted to create the VM entirely via CLI with a hand-written `.vmx` file. Failed three times:
+
+### Failure 1: `lsilogic` not supported on ARM64
+
+```
+The device type "lsilogic" specified for "scsi0" is not supported by VMware Fusion 25.0.0.
+```
+
+**Fix:** ARM64 requires NVMe, not SCSI. Changed to `nvme0.present = "TRUE"`.
+
+### Failure 2: `e1000e` PCIe slot conflict
+
+```
+No PCIe slot available for Ethernet0. Remove Ethernet0 and try again.
+```
+
+Initially thought `e1000e` wasn't supported on ARM64, switched to `vmxnet3`. Same error. The real issue was **missing PCIe bridge configuration**, not the NIC type. Fusion's wizard-created VMX has `e1000e` and it works fine.
+
+### Failure 3: VMX panic — "monitor not available"
+
+```
+E1000PCI: failed to register e1000e device.
+PANIC: Unexpected signal: 11.
+Panic: monitor not available, skipping monitor coredump.
+```
+
+Cascading failure from the PCIe slot issue. Without proper bridge entries, devices can't register, the VMX process panics.
+
+### Root Cause: Missing PCIe Bridge Entries
+
+Fusion's wizard generates **6 PCIe bridge entries** that are required for ARM64 VMs:
+
+```
+pciBridge0.present = "TRUE"
+pciBridge4.present = "TRUE"
+pciBridge4.virtualDev = "pcieRootPort"
+pciBridge4.functions = "8"
+pciBridge5.present = "TRUE"
+pciBridge5.virtualDev = "pcieRootPort"
+pciBridge5.functions = "8"
+pciBridge6.present = "TRUE"
+pciBridge6.virtualDev = "pcieRootPort"
+pciBridge6.functions = "8"
+pciBridge7.present = "TRUE"
+pciBridge7.virtualDev = "pcieRootPort"
+pciBridge7.functions = "8"
+```
+
+Without these, no PCIe device (NIC, USB, SATA, NVMe) can claim a slot. The error message ("No PCIe slot available") is accurate but misleading — it's not a slot numbering conflict, it's a missing bus topology.
+
+Additionally, Fusion auto-assigns `pciSlotNumber` values and writes them back to the `.vmx` on first boot. Hand-assigning slot numbers is futile — Fusion overwrites them. The correct approach is to provide the bridge entries and let Fusion assign slots.
+
+### Other Required Entries
+
+Fusion's wizard also adds `vmci0.present`, `hpet0.present`, and `sound.*` entries. The `vmci0` (Virtual Machine Communication Interface) and `hpet0` (High Precision Event Timer) may not be strictly required but are part of the standard ARM64 VM profile.
+
+## What Works: Fusion GUI Wizard + CLI Post-Config
+
+The working approach:
+
+1. **Fusion GUI wizard** creates the VM with correct hardware profile (~2 min)
+2. **CLI post-config** via `.vmx` edits: attach ISO, bump CPUs/RAM/disk
+3. **`vmrun start`** boots the VM
+4. **`vmrun snapshot`** for rollback points
+5. **`ovftool`** for OVA export
+
+The wizard handles the platform-specific hardware topology that's underdocumented for ARM64. Everything after creation is scriptable.
+
+## ARM64 VMX Template (for future scripting)
+
+If we ever need to create ARM64 VMs from scratch via CLI, this is the minimum viable `.vmx`:
+
+```
+.encoding = "UTF-8"
+config.version = "8"
+virtualHW.version = "22"
+virtualHW.productCompatibility = "hosted"
+
+# PCIe bridges — REQUIRED for ARM64
+pciBridge0.present = "TRUE"
+pciBridge4.present = "TRUE"
+pciBridge4.virtualDev = "pcieRootPort"
+pciBridge4.functions = "8"
+pciBridge5.present = "TRUE"
+pciBridge5.virtualDev = "pcieRootPort"
+pciBridge5.functions = "8"
+pciBridge6.present = "TRUE"
+pciBridge6.virtualDev = "pcieRootPort"
+pciBridge6.functions = "8"
+pciBridge7.present = "TRUE"
+pciBridge7.virtualDev = "pcieRootPort"
+pciBridge7.functions = "8"
+
+vmci0.present = "TRUE"
+hpet0.present = "TRUE"
+firmware = "efi"
+guestOS = "arm-ubuntu-64"
+numvcpus = "4"
+memsize = "4096"
+
+# Disk — NVMe required for ARM64
+nvme0.present = "TRUE"
+nvme0:0.present = "TRUE"
+nvme0:0.fileName = "disk.vmdk"
+
+# CD/DVD
+sata0.present = "TRUE"
+sata0:0.present = "TRUE"
+sata0:0.deviceType = "cdrom-image"
+sata0:0.fileName = "/path/to/ubuntu.iso"
+sata0:0.startConnected = "TRUE"
+
+# Network — e1000e works on ARM64 (with bridges)
+ethernet0.present = "TRUE"
+ethernet0.connectionType = "nat"
+ethernet0.virtualDev = "e1000e"
+ethernet0.addressType = "generated"
+
+# USB
+usb.present = "TRUE"
+usb_xhci.present = "TRUE"
+
+# Misc
+tools.syncTime = "TRUE"
+displayName = "My ARM64 VM"
+```
+
+## Action Log — VM Test Build
+
+| # | Action | Result |
+|---|--------|--------|
+| 1 | Downloaded `ubuntu-24.04.4-desktop-arm64.iso` (3.3 GB) | ✅ Complete |
+| 2 | Hand-crafted .vmx — `lsilogic` disk controller | ❌ Not supported on ARM64 |
+| 3 | Switched to NVMe disk | ❌ PCIe slot error for Ethernet0 |
+| 4 | Switched NIC from `e1000e` to `vmxnet3` | ❌ Same PCIe slot error |
+| 5 | Diagnosed root cause: missing PCIe bridge entries | 💡 Key learning |
+| 6 | Realized ARM64 OVA can't run on x86 student machines | 💡 Pivoted to bootstrap script model |
+| 7 | Created VM via Fusion GUI wizard | ✅ Correct hardware profile |
+| 8 | Post-configured: 4 CPUs, 4GB RAM, 40GB disk, attached ISO | ✅ vmx edits + vdiskmanager |
+| 9 | Booted VM, walked through Ubuntu installer | ✅ Captured every screen |
+| 10 | Installer offered "Update installer" mid-wizard | 💡 Captured for guide — requires relaunch |
+| 11 | Ubuntu installed, rebooted, snapshot "clean-install" | ✅ Rollback point |
+| 12 | Installed open-vm-tools + openssh-server | ✅ Clipboard + SSH access |
+| 13 | Switched to bridged networking for SSH | ✅ IP: 192.168.1.115 |
+| 14 | Added SSH key, set up passwordless sudo | ✅ Remote access working |
+| 15 | Disabled lock screen, screensaver, idle sleep | ✅ gsettings |
+| 16 | Snapshot "pre-bootstrap" | ✅ Second rollback point |
+| 17 | Ran bootstrap script — system packages | ✅ All installed |
+| 18 | Bootstrap — Google Chrome | ❌ No ARM64 .deb — fell back to Chromium snap |
+| 19 | Bootstrap — Ghostty | ❌ No PPA, no snap, no flatpak, no .deb for Linux |
+| 20 | Decision: drop Ghostty, use default GNOME Terminal | ✅ Simpler for students |
+| 21 | Bootstrap — Homebrew | ✅ Installed |
+| 22 | Bootstrap — Node.js (via system, not brew) | ✅ v25.9.0 |
+| 23 | Bootstrap — Claude Code | ✅ v2.1.100 |
+| 24 | Bootstrap — Docker | ✅ Installed |
+| 25 | Bootstrap — GitHub CLI | ✅ v2.89.0 |
+| 26 | Fixed: `CHROME_CMD` unbound variable in verification | ✅ Script bug |
+| 27 | Fixed: Chrome install — architecture-aware (amd64→Chrome, arm64→Chromium) | ✅ Script fix |
+
+## Software Manifest
+
+### Host Machine (Students — Windows x86)
+
+| Software | Version | Source |
+|----------|---------|--------|
+| VMware Workstation Pro | Latest (free) | https://support.broadcom.com/group/ecx/productdownloads?subfamily=VMware+Workstation+Pro |
+| Claude Desktop | Latest | https://claude.ai/download |
+
+### VM — Ubuntu 24.04.4 Desktop
+
+#### Pre-installed (Ubuntu default)
+| Software | Purpose |
+|----------|---------|
+| Firefox | Default browser (pre-installed) |
+| GNOME Terminal | Default terminal |
+| Python 3.12 | System Python |
+
+#### Installed by bootstrap script — system packages (apt)
+| Package | Purpose |
+|---------|---------|
+| curl | HTTP client |
+| wget | HTTP downloads |
+| git | Version control |
+| build-essential | C/C++ compiler toolchain |
+| jq | JSON processor |
+| sqlite3 | Database (used by ISCP) |
+| tree | Directory visualization |
+| unzip | Archive extraction |
+| ca-certificates | TLS certificates |
+| gnupg | GPG for package signing |
+| lsb-release | OS identification |
+| software-properties-common | PPA management |
+| python3-pip | Python package manager |
+| ripgrep | Fast search (rg) |
+| fd-find | Fast file finder (fd) |
+
+#### Installed by bootstrap script — applications
+| Software | Version (tested) | Install method | Purpose |
+|----------|-----------------|----------------|---------|
+| Google Chrome | Latest | apt (.deb from Google) | Browser for OAuth (x86 only) |
+| Chromium | 146.x | snap (ARM64 fallback) | Browser for OAuth (ARM64 only) |
+| Homebrew | Latest | Official installer | Package manager (macOS parity) |
+| Node.js | v25.9.0 | brew | JavaScript runtime |
+| Claude Code | v2.1.100 | npm (`@anthropic-ai/claude-code`) | AI coding assistant |
+| Docker CE | Latest | Official Docker repo | Container runtime |
+| GitHub CLI | v2.89.0 | brew | GitHub operations |
+| open-vm-tools | Latest | apt | VMware guest integration |
+| openssh-server | Latest | apt | SSH access |
+
+### NOT Installed (dropped)
+| Software | Reason |
+|----------|--------|
+| Ghostty | No prebuilt packages for Linux. No PPA, snap, flatpak, or .deb. Build-from-source requires Zig compiler — too complex for workshop. Students use GNOME Terminal instead. |
+
+## Workshop Runtime Architecture
+
+### Student Setup
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│  Windows Host                                                │
+│                                                              │
+│  ┌─────────────────────────┐                                 │
+│  │  Chrome                 │                                 │
+│  │  └─ claude.ai/code      │───── outbound HTTPS ──────┐    │
+│  │     (Remote Control UI) │                            │    │
+│  └─────────────────────────┘                            │    │
+│                                                         │    │
+│  ┌─────────────────────────┐                            │    │
+│  │  Claude Desktop         │                            │    │
+│  │  (research / chat)      │                            │    │
+│  └─────────────────────────┘                            │    │
+│                                                         │    │
+│  ┌──────────────────────────────────────────────────┐   │    │
+│  │  Ubuntu VM (VMware Workstation, NAT)             │   │    │
+│  │                                                  │   │    │
+│  │  ┌─────────────────┐  ┌─────────────────┐       │   │    │
+│  │  │ GNOME Terminal  │  │ GNOME Terminal  │       │   │    │
+│  │  │ claude session 1│  │ claude session 2│       │   │    │
+│  │  │ /remote-control │  │ /remote-control │       │   │    │
+│  │  └────────┬────────┘  └────────┬────────┘       │   │    │
+│  │           │                    │                 │   │    │
+│  └───────────┼────────────────────┼─────────────────┘   │    │
+│              │                    │                      │    │
+└──────────────┼────────────────────┼──────────────────────┘    │
+               │                    │                           │
+               └─── outbound HTTPS ─┴───── Anthropic relay ────┘
+                    (port 443 only)        servers
+```
+
+### Networking
+
+- **VM network mode: NAT** — simplest, works everywhere, no bridging needed
+- **Remote Control** goes through Anthropic's relay servers — both the browser (claude.ai/code) and the CLI (Claude Code in VM) connect **outbound** to Anthropic. They never talk to each other directly.
+- **No inbound ports** need to be opened on the VM or the host
+- **Port 443 (HTTPS)** is the only requirement — outbound from both host and VM
+
+### How Remote Control Works
+
+1. Student opens **two GNOME Terminal windows** in the VM
+2. In each, runs `claude` then `/remote-control` (or `claude --remote-control`)
+3. Claude Code displays a QR code or URL
+4. Student opens **Chrome on Windows host** → navigates to `claude.ai/code`
+5. Scans QR code or enters the session code
+6. Chrome tab now controls the Claude Code session in the VM
+7. Repeat for second session in another Chrome tab
+
+### Why This Setup
+
+- **Claude Desktop on Windows** — for research, chat, general Claude usage (no coding)
+- **Claude Code in VM** — for hands-on coding, agency framework, terminal access
+- **Remote Control bridge** — lets them see and interact with Claude Code sessions from the comfortable Chrome UI while the actual execution happens in the Linux VM
+- **Two sessions** — one for the main project, one for exploration/experiments
+
+## Deliverables Produced
+
+1. **Workshop Setup Guide** — `claude/workstreams/agency/seeds/workshop-setup-guide-20260410.md`
+   - Students download VMware Workstation + Ubuntu AMD64 ISO + Claude Desktop
+   - Create VM via Workstation wizard, install Ubuntu
+   - Detailed installer walk-through (every screen documented)
+   - Bootstrap script runs at the workshop, not at home
+
+2. **Bootstrap Script** — `claude/workstreams/agency/seeds/workshop-bootstrap.sh`
+   - Idempotent, architecture-independent
+   - Installs: Chrome/Chromium, Homebrew, Node.js, Claude Code, Docker, GitHub CLI
+   - Tested on ARM64 VM
+
+## Lessons
+
+- **ARM64 VMware is underdocumented.** The PCIe bridge requirement is not in any official VMware CLI docs. You discover it by diffing a wizard-created VMX against a hand-crafted one.
+- **Fusion overwrites your .vmx.** It auto-assigns PCI slots, UUIDs, and adds entries on every boot attempt. Fighting it is pointless — let the wizard or Fusion itself handle hardware topology.
+- **Architecture matters for VM distribution.** OVA built on ARM can't run on x86. The bootstrap script model (students build their own VM, script provisions it) is more portable than shipping an image.
+- **"Too Lazy to Fail" applies here.** The bootstrap script is the durable artifact. The VM image was a one-shot; the script is reusable, testable, and architecture-independent.
+- **Ghostty is macOS-only in practice.** No prebuilt Linux packages. Drop it for Linux workshops — GNOME Terminal is fine for Claude Code.
+- **Google Chrome has no ARM64 Linux .deb.** Use Chromium as fallback. Script needs architecture-aware branching.
+- **Ubuntu installer has a mid-wizard "update installer" prompt** that restarts the wizard. Must be documented for non-sysadmin users.


### PR DESCRIPTION
## Summary

- **35.1** — `dispatch-monitor` tool + `/monitor-dispatches` skill: event-driven dispatch watching via Claude Code's Monitor tool. Replaces `/loop 5m` polling with 10-second latency background monitoring. 96% token savings (~82K → ~2K tokens/day).
- **35.2** — `changelog-monitor` tool + `/changelog-watch` skill: automated Claude Code changelog watching. Polls CHANGELOG.md every 30 min, streams new entries for agent evaluation. Drives conversations about new features and adoption opportunities.

Also includes:
- Workshop outline, setup guide, bootstrap script, start script for Republic Poly (13 April)
- Seeds: This Happened! + Breadcrumb, Monitor tool adoption, OODA structural framework, Process Intelligence (Celonis)
- Dispatch #200 to devex (SPEC:PROVIDER for NestJS + React/Next.js)
- VM experience report with full action log and software manifest
- Handoffs

## Test plan

- [ ] `./claude/tools/dispatch-monitor --help` shows usage
- [ ] `./claude/tools/dispatch-monitor` runs silently when no unread dispatches
- [ ] `./claude/tools/changelog-monitor --help` shows usage
- [ ] `./claude/tools/agency-version` shows 35.2
- [ ] `/monitor-dispatches` skill discoverable
- [ ] `/changelog-watch` skill discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)