### PR TITLE
feat: secret-local provider — macOS Keychain + Linux libsecret

### DIFF
--- a/claude/tools/secret-local
+++ b/claude/tools/secret-local
@@ -205,7 +205,11 @@ libsecret_set() {
     local svc
     svc=$(service_name "$key")
 
-    echo -n "$value" | secret-tool store --label="$svc" service "$svc" username "$key"
+    # Store with both the full service name (for get/delete) and a namespace
+    # attribute (for list). secret-tool search does exact match on attributes,
+    # so we need a common attribute across all secrets in a project.
+    echo -n "$value" | secret-tool store --label="$svc" \
+        service "$svc" username "$key" namespace "agency/${PROJECT}"
 }
 
 libsecret_get() {
@@ -225,10 +229,10 @@ libsecret_delete() {
 }
 
 libsecret_list() {
-    local prefix="agency/${PROJECT}/"
-
-    # secret-tool search returns attributes; filter for our namespace
-    secret-tool search --all service "agency/${PROJECT}" 2>/dev/null | \
+    # Search by the namespace attribute (common across all secrets in a project).
+    # secret-tool search does exact attribute match — the namespace attribute
+    # is set to "agency/{project}" on every secret in libsecret_set().
+    secret-tool search --all namespace "agency/${PROJECT}" 2>/dev/null | \
         grep "attribute.username" | \
         sed 's/.*= //' | \
         sort -u
@@ -285,7 +289,8 @@ cmd_set() {
     backend_set "$name" "$value"
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        printf '{"name":"%s","project":"%s","backend":"%s","status":"set"}\n' "$name" "$PROJECT" "$BACKEND"
+        jq -n --arg name "$name" --arg project "$PROJECT" --arg backend "$BACKEND" \
+            '{"name":$name,"project":$project,"backend":$backend,"status":"set"}'
     else
         echo -e "${GREEN}Secret set: $name (project=$PROJECT, backend=$BACKEND)${NC}"
     fi
@@ -311,7 +316,7 @@ cmd_get() {
     fi
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        printf '{"name":"%s","value":"%s"}\n' "$name" "$value"
+        jq -n --arg name "$name" --arg value "$value" '{"name":$name,"value":$value}'
     else
         echo "$value"
     fi
@@ -325,7 +330,8 @@ cmd_list() {
 
     if [[ -z "$secrets" ]]; then
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            echo '{"secrets":[],"project":"'"$PROJECT"'","backend":"'"$BACKEND"'"}'
+            jq -n --arg project "$PROJECT" --arg backend "$BACKEND" \
+                '{"secrets":[],"project":$project,"backend":$backend}'
         else
             echo "No secrets found (project=$PROJECT, backend=$BACKEND)"
         fi
@@ -333,19 +339,11 @@ cmd_list() {
     fi
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        local json_arr="["
-        local first=true
-        while IFS= read -r name; do
-            [[ -z "$name" ]] && continue
-            if [[ "$first" == "true" ]]; then
-                first=false
-            else
-                json_arr+=","
-            fi
-            json_arr+="\"$name\""
-        done <<< "$secrets"
-        json_arr+="]"
-        printf '{"secrets":%s,"project":"%s","backend":"%s"}\n' "$json_arr" "$PROJECT" "$BACKEND"
+        # Build JSON array safely via jq
+        local json_arr
+        json_arr=$(echo "$secrets" | jq -R 'select(length > 0)' | jq -s '.')
+        jq -n --argjson secrets "$json_arr" --arg project "$PROJECT" --arg backend "$BACKEND" \
+            '{"secrets":$secrets,"project":$project,"backend":$backend}'
     else
         echo "Secrets in project '$PROJECT' ($BACKEND):"
         echo ""
@@ -369,7 +367,7 @@ cmd_delete() {
     backend_delete "$name"
 
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        printf '{"name":"%s","project":"%s","status":"deleted"}\n' "$name" "$PROJECT"
+        jq -n --arg name "$name" --arg project "$PROJECT" '{"name":$name,"project":$project,"status":"deleted"}'
     else
         echo -e "${GREEN}Secret deleted: $name (project=$PROJECT)${NC}"
     fi
@@ -420,7 +418,7 @@ cmd_rotate() {
 
     if [[ "$verify" == "$new_value" ]]; then
         if [[ "$JSON_OUTPUT" == "true" ]]; then
-            printf '{"name":"%s","project":"%s","status":"rotated"}\n' "$name" "$PROJECT"
+            jq -n --arg name "$name" --arg project "$PROJECT" '{"name":$name,"project":$project,"status":"rotated"}'
         else
             echo -e "${GREEN}Secret rotated: $name (project=$PROJECT)${NC}"
         fi
@@ -477,7 +475,8 @@ cmd_scan() {
 
 cmd_platform() {
     if [[ "$JSON_OUTPUT" == "true" ]]; then
-        printf '{"platform":"%s","backend":"%s","project":"%s"}\n' "$PLATFORM" "$BACKEND" "$PROJECT"
+        jq -n --arg platform "$PLATFORM" --arg backend "$BACKEND" --arg project "$PROJECT" \
+            '{"platform":$platform,"backend":$backend,"project":$project}'
     else
         echo "Platform: $PLATFORM"
         echo "Backend:  $BACKEND"

--- a/claude/tools/secret-local
+++ b/claude/tools/secret-local
@@ -1,0 +1,572 @@
+#!/bin/bash
+# secret-local - CLI for local/machine-specific secrets via OS keychain
+#
+# What Problem: We need local secrets (machine passwords, infra creds, SSH keys,
+# API tokens that should never leave the machine) alongside shared secrets
+# (Doppler). The old secret-vault was a full REST service — overkill. This
+# provider talks directly to the OS keychain with no running service.
+#
+# How & Why: Auto-detects platform and uses the native credential store:
+# macOS → security CLI (login keychain), Linux → secret-tool (libsecret).
+# Both are unlocked when the user is logged in — no password prompts for
+# autonomous agents. Same interface as secret-doppler (set, get, list, delete,
+# rotate, scan). Namespaced under agency/{project}/{key} to avoid collision.
+#
+# Written: 2026-04-12 during devex session (local secrets provider build)
+#
+# Usage:
+#   ./claude/tools/secret-local <command> [options]
+#
+# Commands:
+#   set <name> <value>          Set a secret
+#   get <name>                  Get a secret value (plaintext)
+#   list                        List all secrets
+#   delete <name>               Delete a secret
+#   rotate <name>               Rotate a secret (get current, prompt for new, set, verify)
+#   scan                        Scan for leaked secrets in the codebase
+#   platform                    Show detected platform and backend
+#
+# Options:
+#   --project=<project>         Project namespace (default: auto-detect from repo)
+#   --json                      Output in JSON format
+#   --verbose                   Show detailed output
+#   -h, --help                  Show this help
+#   -v, --version               Show version
+#
+# Auto-detection:
+#   macOS  → security CLI (login keychain)
+#   Linux  → secret-tool CLI (libsecret / gnome-keyring)
+#
+# Namespace: agency/{project}/{key} — secrets from different projects don't collide.
+#
+# Examples:
+#   ./claude/tools/secret-local set ROUTER_PASSWORD myvalue --project=mycroft
+#   ./claude/tools/secret-local get ROUTER_PASSWORD --project=mycroft
+#   ./claude/tools/secret-local list --project=mycroft
+#   ./claude/tools/secret-local delete ROUTER_PASSWORD --project=mycroft
+#   ./claude/tools/secret-local rotate ROUTER_PASSWORD --project=mycroft
+#   ./claude/tools/secret-local platform
+
+set -euo pipefail
+
+# Source log helper for telemetry
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+    source "$SCRIPT_DIR/lib/_log-helper"
+fi
+RUN_ID=$(log_start "secret-local" "$@" 2>/dev/null) || true
+
+# Tool version
+TOOL_VERSION="1.0.0-20260412-000001"
+
+# Defaults
+VERBOSE=false
+JSON_OUTPUT=false
+PROJECT=""
+
+# Colors
+if [[ -f "$SCRIPT_DIR/lib/_colors" ]]; then
+    source "$SCRIPT_DIR/lib/_colors"
+else
+    RED="\033[0;31m" GREEN="\033[0;32m" YELLOW="\033[1;33m" BLUE="\033[0;34m" NC="\033[0m"
+fi
+
+# Logging functions (quiet by default)
+log_info() { [[ "$VERBOSE" == "true" ]] && echo -e "${GREEN}[INFO]${NC} $1" || true; }
+log_warn() { [[ "$VERBOSE" == "true" ]] && echo -e "${YELLOW}[WARN]${NC} $1" || true; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+log_step() { [[ "$VERBOSE" == "true" ]] && echo -e "${BLUE}[STEP]${NC} $1" || true; }
+verbose_echo() { [[ "$VERBOSE" == "true" ]] && echo "$@" || true; }
+
+# Detect repo root
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+
+# ─── Platform Detection ───
+
+PLATFORM=""
+BACKEND=""
+
+detect_platform() {
+    case "$(uname -s)" in
+        Darwin)
+            PLATFORM="macos"
+            if command -v security &>/dev/null; then
+                BACKEND="keychain"
+            else
+                log_error "macOS detected but 'security' CLI not found"
+                exit 1
+            fi
+            ;;
+        Linux)
+            PLATFORM="linux"
+            if command -v secret-tool &>/dev/null; then
+                BACKEND="libsecret"
+            else
+                log_error "Linux detected but 'secret-tool' not found"
+                echo "Install: sudo apt-get install libsecret-tools  (Debian/Ubuntu)" >&2
+                echo "         sudo dnf install libsecret            (Fedora)" >&2
+                exit 1
+            fi
+            ;;
+        *)
+            log_error "Unsupported platform: $(uname -s)"
+            echo "secret-local supports macOS (Keychain) and Linux (libsecret)" >&2
+            exit 1
+            ;;
+    esac
+    log_info "Platform: $PLATFORM, backend: $BACKEND"
+}
+
+# ─── Project Detection ───
+
+auto_detect_project() {
+    if [[ -n "$PROJECT" ]]; then
+        return
+    fi
+
+    # Try agency.yaml — look for project.name (not principals.name)
+    local agency_yaml="$REPO_ROOT/claude/config/agency.yaml"
+    if [[ -f "$agency_yaml" ]]; then
+        PROJECT=$(python3 -c "
+import re
+in_project = False
+with open('$agency_yaml') as f:
+    for line in f:
+        if re.match(r'^project:', line):
+            in_project = True
+            continue
+        if in_project and re.match(r'^\s+name:', line):
+            val = line.split(':', 1)[1].strip().strip('\"').strip(\"'\")
+            print(val)
+            break
+        if in_project and re.match(r'^\S', line):
+            break
+" 2>/dev/null || echo "")
+    fi
+
+    # Fallback: repo directory name
+    if [[ -z "$PROJECT" ]]; then
+        PROJECT=$(basename "$REPO_ROOT")
+    fi
+
+    log_info "Auto-detected project: $PROJECT"
+}
+
+# ─── Service Name (namespace) ───
+
+service_name() {
+    local key="${1:-}"
+    echo "agency/${PROJECT}/${key}"
+}
+
+# ─── macOS Keychain Backend ───
+
+keychain_set() {
+    local key="$1" value="$2"
+    local svc
+    svc=$(service_name "$key")
+
+    # Delete existing if present (security add fails on duplicate)
+    security delete-generic-password -s "$svc" -a "$key" >/dev/null 2>&1 || true
+
+    security add-generic-password -s "$svc" -a "$key" -w "$value" -T "" 2>/dev/null
+}
+
+keychain_get() {
+    local key="$1"
+    local svc
+    svc=$(service_name "$key")
+
+    security find-generic-password -s "$svc" -a "$key" -w 2>/dev/null
+}
+
+keychain_delete() {
+    local key="$1"
+    local svc
+    svc=$(service_name "$key")
+
+    security delete-generic-password -s "$svc" -a "$key" >/dev/null 2>&1
+}
+
+keychain_list() {
+    # Dump keychain and filter for our namespace prefix
+    local prefix="agency/${PROJECT}/"
+
+    security dump-keychain 2>/dev/null | grep -A4 "\"svce\"" | grep "$prefix" | \
+        sed 's/.*<blob>="//;s/"//' | \
+        sed "s|${prefix}||" | \
+        sort -u
+}
+
+# ─── Linux libsecret Backend ───
+
+libsecret_set() {
+    local key="$1" value="$2"
+    local svc
+    svc=$(service_name "$key")
+
+    echo -n "$value" | secret-tool store --label="$svc" service "$svc" username "$key"
+}
+
+libsecret_get() {
+    local key="$1"
+    local svc
+    svc=$(service_name "$key")
+
+    secret-tool lookup service "$svc" username "$key"
+}
+
+libsecret_delete() {
+    local key="$1"
+    local svc
+    svc=$(service_name "$key")
+
+    secret-tool clear service "$svc" username "$key"
+}
+
+libsecret_list() {
+    local prefix="agency/${PROJECT}/"
+
+    # secret-tool search returns attributes; filter for our namespace
+    secret-tool search --all service "agency/${PROJECT}" 2>/dev/null | \
+        grep "attribute.username" | \
+        sed 's/.*= //' | \
+        sort -u
+}
+
+# ─── Dispatch to Backend ───
+
+backend_set() {
+    case "$BACKEND" in
+        keychain)   keychain_set "$@" ;;
+        libsecret)  libsecret_set "$@" ;;
+    esac
+}
+
+backend_get() {
+    case "$BACKEND" in
+        keychain)   keychain_get "$@" ;;
+        libsecret)  libsecret_get "$@" ;;
+    esac
+}
+
+backend_delete() {
+    case "$BACKEND" in
+        keychain)   keychain_delete "$@" ;;
+        libsecret)  libsecret_delete "$@" ;;
+    esac
+}
+
+backend_list() {
+    case "$BACKEND" in
+        keychain)   keychain_list "$@" ;;
+        libsecret)  libsecret_list "$@" ;;
+    esac
+}
+
+# ─── Commands ───
+
+cmd_set() {
+    local name="${1:-}"
+    local value="${2:-}"
+
+    if [[ -z "$name" ]]; then
+        log_error "Usage: secret-local set <name> <value> [--project=<P>]"
+        exit 1
+    fi
+
+    if [[ -z "$value" ]]; then
+        log_error "Usage: secret-local set <name> <value> [--project=<P>]"
+        exit 1
+    fi
+
+    log_step "Setting secret '$name' in project '$PROJECT' ($BACKEND)"
+
+    backend_set "$name" "$value"
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        printf '{"name":"%s","project":"%s","backend":"%s","status":"set"}\n' "$name" "$PROJECT" "$BACKEND"
+    else
+        echo -e "${GREEN}Secret set: $name (project=$PROJECT, backend=$BACKEND)${NC}"
+    fi
+}
+
+cmd_get() {
+    local name="${1:-}"
+
+    if [[ -z "$name" ]]; then
+        log_error "Usage: secret-local get <name> [--project=<P>]"
+        exit 1
+    fi
+
+    log_step "Getting secret '$name' from project '$PROJECT' ($BACKEND)"
+
+    local value
+    value=$(backend_get "$name") || true
+
+    if [[ -z "$value" ]]; then
+        log_error "Secret not found: $name (project=$PROJECT, backend=$BACKEND)"
+        log_end "$RUN_ID" "failure" 1 0 "Get failed: $name" 2>/dev/null || true
+        exit 1
+    fi
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        printf '{"name":"%s","value":"%s"}\n' "$name" "$value"
+    else
+        echo "$value"
+    fi
+}
+
+cmd_list() {
+    log_step "Listing secrets in project '$PROJECT' ($BACKEND)"
+
+    local secrets
+    secrets=$(backend_list) || true
+
+    if [[ -z "$secrets" ]]; then
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            echo '{"secrets":[],"project":"'"$PROJECT"'","backend":"'"$BACKEND"'"}'
+        else
+            echo "No secrets found (project=$PROJECT, backend=$BACKEND)"
+        fi
+        return
+    fi
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        local json_arr="["
+        local first=true
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            if [[ "$first" == "true" ]]; then
+                first=false
+            else
+                json_arr+=","
+            fi
+            json_arr+="\"$name\""
+        done <<< "$secrets"
+        json_arr+="]"
+        printf '{"secrets":%s,"project":"%s","backend":"%s"}\n' "$json_arr" "$PROJECT" "$BACKEND"
+    else
+        echo "Secrets in project '$PROJECT' ($BACKEND):"
+        echo ""
+        while IFS= read -r name; do
+            [[ -z "$name" ]] && continue
+            echo "  $name"
+        done <<< "$secrets"
+    fi
+}
+
+cmd_delete() {
+    local name="${1:-}"
+
+    if [[ -z "$name" ]]; then
+        log_error "Usage: secret-local delete <name> [--project=<P>]"
+        exit 1
+    fi
+
+    log_step "Deleting secret '$name' from project '$PROJECT' ($BACKEND)"
+
+    backend_delete "$name"
+
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        printf '{"name":"%s","project":"%s","status":"deleted"}\n' "$name" "$PROJECT"
+    else
+        echo -e "${GREEN}Secret deleted: $name (project=$PROJECT)${NC}"
+    fi
+}
+
+cmd_rotate() {
+    local name="${1:-}"
+
+    if [[ -z "$name" ]]; then
+        log_error "Usage: secret-local rotate <name> [--project=<P>]"
+        exit 1
+    fi
+
+    log_step "Rotating secret '$name' in project '$PROJECT' ($BACKEND)"
+
+    # Get current value to verify it exists
+    local current
+    current=$(backend_get "$name") || true
+
+    if [[ -z "$current" ]]; then
+        log_error "Secret not found: $name (project=$PROJECT)"
+        exit 1
+    fi
+
+    verbose_echo "Current value retrieved (${#current} chars)"
+
+    # Prompt for new value
+    local new_value
+    if [[ -t 0 ]]; then
+        read -s -p "Enter new value for $name: " new_value
+        echo >&2
+    else
+        log_error "Cannot rotate interactively without a TTY"
+        exit 1
+    fi
+
+    if [[ -z "$new_value" ]]; then
+        log_error "New value cannot be empty"
+        exit 1
+    fi
+
+    # Set new value
+    backend_set "$name" "$new_value"
+
+    # Verify
+    local verify
+    verify=$(backend_get "$name") || true
+
+    if [[ "$verify" == "$new_value" ]]; then
+        if [[ "$JSON_OUTPUT" == "true" ]]; then
+            printf '{"name":"%s","project":"%s","status":"rotated"}\n' "$name" "$PROJECT"
+        else
+            echo -e "${GREEN}Secret rotated: $name (project=$PROJECT)${NC}"
+        fi
+    else
+        log_error "Verification failed after rotation for: $name"
+        exit 1
+    fi
+}
+
+cmd_scan() {
+    log_step "Scanning for leaked secrets..."
+
+    # Delegate to secrets-scan if available
+    if [[ -x "$SCRIPT_DIR/secrets-scan" ]]; then
+        "$SCRIPT_DIR/secrets-scan" "$@"
+        return $?
+    fi
+
+    # Fallback: basic scan
+    log_info "Running basic secret scan (install secrets-scan for comprehensive scanning)"
+
+    local found=0
+    local patterns=(
+        'AKIA[0-9A-Z]{16}'
+        'sk-[a-zA-Z0-9]{48}'
+        'ghp_[a-zA-Z0-9]{36}'
+        'ghu_[a-zA-Z0-9]{36}'
+        'dp\.pt\.[a-zA-Z0-9]{40,}'
+        'password\s*[:=]\s*["\x27][^"\x27]+'
+    )
+
+    for pattern in "${patterns[@]}"; do
+        local matches
+        matches=$(grep -rn --include="*.ts" --include="*.js" --include="*.json" --include="*.env" --include="*.yaml" --include="*.yml" -E "$pattern" "$REPO_ROOT" 2>/dev/null | grep -v node_modules | grep -v ".git/" | head -20 || true)
+        if [[ -n "$matches" ]]; then
+            if [[ $found -eq 0 ]]; then
+                echo -e "${RED}Potential secrets found:${NC}"
+                echo ""
+            fi
+            echo "$matches"
+            found=$((found + 1))
+        fi
+    done
+
+    if [[ $found -eq 0 ]]; then
+        echo -e "${GREEN}No leaked secrets detected${NC}"
+    else
+        echo ""
+        echo -e "${YELLOW}Review the findings above. False positives are possible.${NC}"
+        log_end "$RUN_ID" "failure" 1 0 "Secrets found: $found patterns" 2>/dev/null || true
+        exit 1
+    fi
+}
+
+cmd_platform() {
+    if [[ "$JSON_OUTPUT" == "true" ]]; then
+        printf '{"platform":"%s","backend":"%s","project":"%s"}\n' "$PLATFORM" "$BACKEND" "$PROJECT"
+    else
+        echo "Platform: $PLATFORM"
+        echo "Backend:  $BACKEND"
+        echo "Project:  $PROJECT"
+        case "$BACKEND" in
+            keychain)
+                echo "Store:    macOS login keychain"
+                echo "Prefix:   agency/${PROJECT}/"
+                ;;
+            libsecret)
+                echo "Store:    libsecret (gnome-keyring / KWallet)"
+                echo "Prefix:   agency/${PROJECT}/"
+                ;;
+        esac
+    fi
+}
+
+# ─── Option Parsing ───
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --version|-v)
+            echo "secret-local $TOOL_VERSION"
+            log_end "$RUN_ID" "success" 0 0 "Version check" 2>/dev/null || true
+            exit 0
+            ;;
+        --help|-h)
+            head -42 "$0" | tail -41 | sed 's/^# //' | sed 's/^#//'
+            log_end "$RUN_ID" "success" 0 0 "Help displayed" 2>/dev/null || true
+            exit 0
+            ;;
+        --verbose) VERBOSE=true; shift ;;
+        --json)    JSON_OUTPUT=true; shift ;;
+        --project=*) PROJECT="${1#*=}"; shift ;;
+        *) break ;;
+    esac
+done
+
+# ─── Main ───
+
+main() {
+    trap 'log_end "$RUN_ID" "failure" $? 0 "Unexpected exit" 2>/dev/null || true' EXIT
+
+    detect_platform
+    auto_detect_project
+
+    verbose_echo "secret-local [run: ${RUN_ID:-none}]"
+
+    COMMAND="${1:-}"
+    shift || true
+
+    # Parse remaining options
+    local positional_args=()
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --project=*) PROJECT="${1#*=}"; shift ;;
+            --json)      JSON_OUTPUT=true; shift ;;
+            --verbose)   VERBOSE=true; shift ;;
+            *)           positional_args+=("$1"); shift ;;
+        esac
+    done
+
+    case "$COMMAND" in
+        set)      cmd_set "${positional_args[@]+"${positional_args[@]}"}" ;;
+        get)      cmd_get "${positional_args[@]+"${positional_args[@]}"}" ;;
+        list)     cmd_list "${positional_args[@]+"${positional_args[@]}"}" ;;
+        delete)   cmd_delete "${positional_args[@]+"${positional_args[@]}"}" ;;
+        rotate)   cmd_rotate "${positional_args[@]+"${positional_args[@]}"}" ;;
+        scan)     cmd_scan "${positional_args[@]+"${positional_args[@]}"}" ;;
+        platform) cmd_platform ;;
+        ""|help|--help|-h)
+            head -42 "$0" | tail -41 | sed 's/^# //' | sed 's/^#//'
+            trap - EXIT
+            log_end "$RUN_ID" "success" 0 0 "Help displayed" 2>/dev/null || true
+            exit 0
+            ;;
+        *)
+            log_error "Unknown command: $COMMAND"
+            echo "Use: ./claude/tools/secret-local --help"
+            trap - EXIT
+            log_end "$RUN_ID" "failure" 1 0 "Unknown command" 2>/dev/null || true
+            exit 1
+            ;;
+    esac
+
+    trap - EXIT
+    verbose_echo "secret-local complete"
+    echo "✓"
+    log_end "$RUN_ID" "success" 0 0 "Command completed: $COMMAND" 2>/dev/null || true
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Local secrets provider for the `/secret` SPEC-PROVIDER system. Replaces the old `secret-vault` REST API service with direct OS keychain access. No running service needed.

- Auto-detects platform: macOS (`security` CLI / Keychain) or Linux (`secret-tool` / libsecret)
- Same interface as `secret-doppler`: set, get, list, delete, rotate, scan
- Namespaced under `agency/{project}/{key}` — no collisions
- Login keychain unlocks with user session — no password prompts for autonomous agents

## Origin

Built by monofolk/jordan/devex. Mycroft needed local credential storage for network/sysadmin operations (Linksys router passwords, SSH keys). Doppler is for shared secrets; this is for machine-specific credentials that should never leave the machine.

## Relationship to secret-vault

`secret-vault` was the old REST API service that wrapped macOS Keychain. `secret-local` is the direct replacement — same backing store (Keychain), no service layer. `secret-vault` should be deprecated in favor of `secret-local` as the 'local' provider in the SPEC-PROVIDER dispatch.

## Test plan

- [ ] `secret-local set test-key` — prompts for value, stores in Keychain
- [ ] `secret-local get test-key` — retrieves value
- [ ] `secret-local list` — shows all agency-namespaced secrets
- [ ] `secret-local delete test-key` — removes from Keychain
- [ ] `secret-local platform` — reports macOS or Linux
- [ ] Verify namespace: secrets stored under `agency/{project}/{key}` service field

🤖 Generated with [Claude Code](https://claude.com/claude-code)