### PR TITLE
D40-R4: hookify blocks now actually block — critical enforcement fix

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "40.3",
+  "agency_version": "40.4",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/hooks/block-raw-tools.sh
+++ b/claude/hooks/block-raw-tools.sh
@@ -38,8 +38,8 @@ if [[ "$COMMAND" =~ git-captain ]]; then
     # Resolve identity — if not captain, block
     agent_name=$(./claude/tools/agent-identity --field agent 2>/dev/null || echo "")
     if [[ "$agent_name" != "captain" ]]; then
-        printf '{"systemMessage":"BLOCKED: git-captain is captain-only. Agents use /git-safe for git operations.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
-        exit 0
+        printf '{"decision":"block","reason":"🚫 BLOCKED: git-captain is captain-only. Agents use /git-safe for git operations.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
+        exit 2
     fi
 fi
 
@@ -63,8 +63,8 @@ TRIMMED=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
 # Framework tools that call git internally are already exempted by the
 # ./claude/tools/ path check above.
 if [[ "$TRIMMED" =~ ^git[[:space:]] ]] || [[ "$TRIMMED" == "git" ]]; then
-    printf '{"systemMessage":"BLOCKED: Only safe git operations allowed. Use the git-safe family:\\n- /git-safe — status, log, diff, branch, show, blame, add, merge-from-master\\n- /git-safe-commit — commit with QG awareness\\n- /git-captain — captain only: push, fetch, tag, merge-to-master, checkout-branch, branch-delete\\n\\nIf you cannot do what you need with these, escalate to captain.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
-    exit 0
+    printf '{"decision":"block","reason":"🚫 BLOCKED: Only safe git operations allowed. Use the git-safe family:\\n- /git-safe — status, log, diff, branch, show, blame, add, merge-from-master\\n- /git-safe-commit — commit with QG awareness\\n- /git-captain — captain only: push, fetch, tag, merge-to-master, checkout-branch, branch-delete\\n\\nIf you cannot do what you need with these, escalate to captain.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
+    exit 2
 fi
 
 # Block raw cat — use Read tool

--- a/claude/hooks/block-raw-tools.sh
+++ b/claude/hooks/block-raw-tools.sh
@@ -33,21 +33,24 @@ if [[ -z "$COMMAND" ]]; then
     exit 0
 fi
 
-# Block git-captain for non-captain agents (belt-and-suspenders)
-if [[ "$COMMAND" =~ git-captain ]]; then
-    # Resolve identity — if not captain, block
-    agent_name=$(./claude/tools/agent-identity --field agent 2>/dev/null || echo "")
-    if [[ "$agent_name" != "captain" ]]; then
-        printf '{"decision":"block","reason":"🚫 BLOCKED: git-captain is captain-only. Agents use /git-safe for git operations.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
-        exit 2
-    fi
-fi
-
 # Allow framework tools to use whatever they need internally
 # (e.g., dispatch-monitor uses grep internally, that's fine)
+# MUST come before all content checks — tools are always exempt.
 if [[ "$COMMAND" =~ ^\./claude/tools/ ]] || [[ "$COMMAND" =~ ^\"?\$CLAUDE_PROJECT_DIR ]]; then
     printf '{}'
     exit 0
+fi
+
+# Block git-captain for non-captain agents (belt-and-suspenders)
+# Only match when git-captain is the COMMAND being invoked, not mentioned in args/strings
+TRIMMED_CMD=$(echo "$COMMAND" | sed 's/^[[:space:]]*//')
+if [[ "$TRIMMED_CMD" =~ ^git-captain([[:space:]]|$) ]] || [[ "$TRIMMED_CMD" =~ ^\./claude/tools/git-captain([[:space:]]|$) ]]; then
+    # Resolve identity — if not captain, block
+    agent_name=$(./claude/tools/agent-identity --field agent 2>/dev/null || echo "")
+    if [[ "$agent_name" != "captain" ]]; then
+        printf '{"decision":"block","reason":"BLOCKED: git-captain is captain-only. Agents use /git-safe for git operations.\\n\\n*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*"}'
+        exit 2
+    fi
 fi
 
 # Allow explicit opt-out (for legitimate edge cases)

--- a/claude/receipts/the-agency-jordan-captain-agency-hookify-block-fix-qgr-1e03e94-20260414-2043.md
+++ b/claude/receipts/the-agency-jordan-captain-agency-hookify-block-fix-qgr-1e03e94-20260414-2043.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: hookify-block-fix
+diff_base: origin/main
+hash_a: 1e03e940000000000000000000000000000000000000000000000000000000000
+hash_b: 98e4a79d7039c01d54303c9151603fe9badfd19bd496d2690bf3f427920264b6
+hash_c: 0d38215340f4029d5a8da972991b095c64a28de19e53dcc5a5c1d5be710426b4
+hash_d: 0d38215340f4029d5a8da972991b095c64a28de19e53dcc5a5c1d5be710426b4
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 1e03e940000000000000000000000000000000000000000000000000000000000
+date: 2026-04-14T20:43
+---
+
+# Receipt: pr-prep — hookify-block-fix
+
+## Chain of Trust
+- A (original): 1e03e94
+- B (findings): 98e4a79
+- C (triage): 0d38215
+- D (principal): 0d38215 — auto-approved — no principal 1B1
+- E (final): 1e03e94
+
+## Review Summary
+Bug fix: hookify blocks were warnings not blocks. 1 agent review, 2 low findings deferred.


### PR DESCRIPTION
## Summary

**CRITICAL BUG FIX:** `block-raw-tools.sh` git blocks used `systemMessage` + `exit 0` (shows message, allows execution) instead of `decision:block` + `exit 2` (hard block). All git commands ran despite showing "BLOCKED" messages. Enforcement was theater.

### Fixes
1. Git block: `systemMessage`+`exit 0` → `decision:block`+`exit 2`
2. Git-captain block: same fix
3. Tools exemption moved BEFORE all content checks (was after git-captain check)
4. Git-captain regex anchored to command start (was matching anywhere in command string, including heredoc content)

### Version
40.3 → 40.4

### QGR
Receipt signed: `the-agency-jordan-captain-agency-hookify-block-fix-qgr-1e03e94`
Chain: A(1e03e94)→B(98e4a79)→C(0d38215)→D=C(auto)→E(1e03e94)

## Test plan
- [ ] `git status` is blocked (hard block, not warning)
- [ ] `./claude/tools/git-safe status` works (tools exempt)
- [ ] Flag/commit messages containing "git-captain" don't trigger false positive
- [ ] Smoke test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)