### PR TITLE
D41-R13: pr-merge Enforcement Triangle — safe PR merging (tool + skill + hookify)

### DIFF
--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -1,0 +1,126 @@
+---
+description: Merge a PR safely — true merge commit (never squash, never rebase), branch protection respected, --principal-approved gate for --admin override.
+---
+
+<!--
+  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
+  .claude/settings.json. Restricting to specific subcommand patterns at the
+  skill level silently blocks agents on permission prompts the agent cannot
+  see — see dispatch #171 for the devex incident that surfaced this trap.
+-->
+
+# PR Merge
+
+Safe wrapper for merging PRs. Always uses true merge commit (never squash,
+never rebase). Respects branch protection by default. Requires explicit
+principal authorization for `--admin` override.
+
+This skill exists because raw `gh pr merge` is too easy to misuse:
+- GitHub's UI nudges you toward squash (the wide button)
+- The `--squash` flag is one keystroke away from `--merge`
+- `--admin` bypasses branch protection silently
+- Without this discipline, the captain shipped 4 squash merges in one day
+
+## When to use
+
+- A PR is open, smoke check passes, principal has reviewed (or verbally OK'd
+  in chat), ready to land.
+- After resolving conflicts via `git-safe merge-from-master --remote` and
+  pushing the resolution.
+
+## When NOT to use
+
+- The PR has unresolved merge conflicts → resolve locally first.
+- The PR is in draft → mark as ready first.
+- You're trying to squash → ALWAYS use a real merge commit. Squash is banned.
+
+## Arguments
+
+- `$ARGUMENTS`: at minimum, the PR number. Optional flags:
+  - `--principal-approved` — captain attestation that principal verbally
+    OK'd the merge. ONLY way to enable `--admin` override. Logged for audit.
+  - `--delete-branch` — also delete remote branch after merge.
+  - `--dry-run` — preview without merging.
+
+## Steps
+
+### Step 1: Pre-flight
+
+1. Confirm the PR number (ask if missing).
+2. Confirm you're not on the PR's branch — captain merges from main or any
+   non-PR branch.
+3. If you're going to use `--principal-approved`, confirm the principal
+   has authorized in this conversation. Don't infer authorization.
+
+### Step 2: Invoke the tool
+
+```
+./claude/tools/pr-merge <N>
+```
+
+Or with explicit principal approval (only if they verbally OK'd):
+
+```
+./claude/tools/pr-merge <N> --principal-approved
+```
+
+### Step 3: Handle the outcome
+
+**On success:** report the merge URL and the next-steps (sync local main via
+`./claude/tools/_sync-main-ref` or wait for next captain `/post-merge`).
+
+**On branch-protection block (exit 3):** the tool prints the gate that's
+blocking. Two paths:
+- Ask the principal to `gh pr review <N> --approve` in GitHub UI, then
+  re-run.
+- If the principal has already authorized verbally in this conversation
+  but not in GitHub UI, re-run with `--principal-approved`.
+
+**On merge conflict (exit 1):** resolve locally first:
+
+```
+gh pr checkout <N>
+./claude/tools/git-safe merge-from-master --remote
+# resolve conflicts in working tree
+./claude/tools/git-safe add <files>
+./claude/tools/git-captain merge-continue
+./claude/tools/git-push <branch>
+# then retry
+./claude/tools/pr-merge <N>
+```
+
+### Step 4: Post-merge
+
+After a successful merge:
+- Sync local main: `./claude/tools/_sync-main-ref`
+- Create the GitHub release (if this is a release PR): `gh release create v<version> --target main --notes ...`
+- Notify fleet (if relevant): `/dispatch` to affected agents
+- Notify monofolk (if cross-repo relevant): `/collaborate send`
+
+## What this skill does NOT do
+
+- **Does not write commits** — merge happens server-side at GitHub.
+- **Does not delete the local branch** — that's the next captain's call.
+- **Does not auto-tag a release** — explicit `gh release create` afterward.
+- **Does not push** — the merge is server-side; you don't push the merge
+  commit.
+
+## Why never squash, never rebase
+
+Both rewrite history. The framework is built on visible, append-only history:
+- Branch commits are individually meaningful (QGRs, fixes, version bumps)
+- Merge commits create a permanent record of integration
+- `git log --graph` shows the actual flow
+- Bisecting works against real commits, not synthetic squash blobs
+
+The cost is heavier `git log` output. The benefit is you can SEE what
+happened and WHY, which is essential when fleet agents and adopters all
+have to read the same history.
+
+## Reference
+
+- Tool: `claude/tools/pr-merge`
+- Hookify: `claude/hookify/hookify.block-raw-gh-pr-merge.md` (blocks bare `gh pr merge`)
+- Discipline: `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "41.12",
+  "agency_version": "41.13",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/hookify/hookify.block-raw-gh-pr-merge.md
+++ b/claude/hookify/hookify.block-raw-gh-pr-merge.md
@@ -1,0 +1,27 @@
+---
+name: block-raw-gh-pr-merge
+enabled: true
+event: bash
+pattern: 'gh pr merge'
+action: block
+---
+
+🚫 BLOCKED: Raw `gh pr merge` is not allowed. Use `./claude/tools/pr-merge` (or `/pr-merge` skill) instead.
+
+Why: `gh pr merge` defaults nudge toward `--squash` (banned — same family as rebase, rewrites history). Captain shipped 4 squash merges on Day 41 by reaching for raw `gh pr merge`. The framework's principle is "merge, never rebase, never squash."
+
+The safe wrapper:
+- ALWAYS uses true merge commit (`--merge`)
+- Refuses `--squash` and `--rebase` flags explicitly
+- Defers to branch protection by default
+- Requires `--principal-approved` flag (not raw `--admin`) to bypass
+- Logs every override
+
+Usage:
+  ./claude/tools/pr-merge <PR>                       # standard merge
+  ./claude/tools/pr-merge <PR> --principal-approved  # captain attestation that principal verbally approved override
+  ./claude/tools/pr-merge <PR> --delete-branch       # also delete remote branch
+
+Skill: /pr-merge
+
+OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!

--- a/claude/receipts/the-agency-jordan-captain-agency-captain-rgr-fcc7aec-20260415-1148.md
+++ b/claude/receipts/the-agency-jordan-captain-agency-captain-rgr-fcc7aec-20260415-1148.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: rgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: captain
+diff_base: origin/main
+hash_a: fcc7aec
+hash_b: fcc7aec
+hash_c: fcc7aec
+hash_d: fcc7aec
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: fcc7aec
+date: 2026-04-15T11:48
+---
+
+# Receipt: pr-prep — captain
+
+## Chain of Trust
+- A (original): fcc7aec
+- B (findings): fcc7aec
+- C (triage): fcc7aec
+- D (principal): fcc7aec — auto-approved — no principal 1B1
+- E (final): fcc7aec
+
+## Review Summary
+D41-R13: pr-merge Enforcement Triangle (tool + skill + hookify) — closes squash discipline gap

--- a/claude/tools/pr-merge
+++ b/claude/tools/pr-merge
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# What Problem: Captain agents and adopters were merging PRs by reaching for
+# raw `gh pr merge` commands. GitHub's CLI defaults nudge toward `--squash`
+# (the wide button in the UI; one of three options at parity in the CLI).
+# Squash collapses N commits into 1 — semantically the same family as
+# rebase: history is rewritten/lost. The framework's principle is
+# "merge, never rebase" — and squash sits on the same forbidden side of
+# that line. Without a safe wrapper, captains slip into squash by habit.
+#
+# Worse: branch protection often requires reviewer approval that no agent
+# can give itself. The escape is `gh pr merge --admin` (bypass branch
+# protection). That bypass is sometimes legitimate (hotfix with verbal
+# principal authorization), sometimes a discipline failure. Without a
+# tool, the distinction collapses.
+#
+# How & Why: pr-merge wraps `gh pr merge` with three guarantees:
+#   1. ALWAYS uses --merge (true merge commit). Never --squash, never
+#      --rebase. Refuses if the caller passes --squash or --rebase.
+#   2. Defers to GitHub branch protection by default. If the PR is
+#      blocked by branch protection (review missing, required check
+#      failing), exits with a clear message naming the specific gate.
+#   3. --principal-approved opt-in flag is the ONLY way to invoke
+#      --admin override. Tool refuses --admin without it. The flag is
+#      a captain-internal signal that the principal verbally approved.
+#      Logged for telemetry.
+#
+# Companion: hookify rule blocks raw `gh pr merge` calls so agents are
+# routed through this tool. Skill /pr-merge wraps the tool with the
+# 1B1 prompt for the principal-approved flag.
+#
+# Usage:
+#   ./claude/tools/pr-merge <PR_NUMBER> [--principal-approved]
+#                                       [--delete-branch]
+#                                       [--dry-run] [--verbose]
+#
+# Examples:
+#   pr-merge 42                         # standard merge, requires gates pass
+#   pr-merge 42 --principal-approved    # bypasses branch protection (--admin)
+#   pr-merge 42 --delete-branch         # also delete remote branch after merge
+#
+# Written: 2026-04-15 (D41-R13 captain) — closes the discipline gap that let
+#          captain ship 4 squash merges in one day. Triangle: this tool,
+#          /pr-merge skill, block-raw-gh-pr-merge hookify rule.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# Source helpers
+[[ -f "$SCRIPT_DIR/lib/_log-helper" ]] && source "$SCRIPT_DIR/lib/_log-helper"
+if [[ -f "$SCRIPT_DIR/lib/_colors" ]]; then
+    source "$SCRIPT_DIR/lib/_colors"
+else
+    RED="" GREEN="" YELLOW="" BLUE="" NC=""
+fi
+
+TOOL_VERSION="1.0.0-20260415-d41r13"
+
+usage() {
+    cat <<'USAGE'
+pr-merge — Safe merge for the-agency PRs
+
+Usage:
+  pr-merge <pr-number> [--principal-approved] [--delete-branch]
+                       [--dry-run] [--verbose]
+
+Required:
+  <pr-number>             GitHub PR number to merge
+
+Options:
+  --principal-approved    Captain attestation that principal verbally OK'd
+                          the merge. ONLY way to enable --admin override.
+                          Logged for audit.
+  --delete-branch         Delete the remote branch after merge (default: keep)
+  --dry-run               Show what would happen, don't merge
+  --verbose               Detailed output
+  --help, -h              Show this help
+  --version               Show tool version
+
+Guarantees (cannot be disabled):
+  - Uses 'gh pr merge --merge' (true merge commit). Never --squash, never
+    --rebase. Refuses if caller passes either.
+  - Without --principal-approved: defers to branch protection. If gates fail,
+    exits with the specific gate that's blocking and instructions to fix.
+  - With --principal-approved: uses --admin to bypass branch protection.
+    Logged. Use only when principal has verbally authorized.
+
+Exit codes:
+  0 — merged
+  1 — merge failed (printed reason)
+  2 — bad usage / disallowed flag
+  3 — branch protection blocked, no --principal-approved
+USAGE
+}
+
+die() { echo "${RED}[ERROR]${NC} $*" >&2; exit 1; }
+log() { [[ "${VERBOSE:-false}" == "true" ]] && echo "${BLUE}[info]${NC} $*" || true; }
+
+# --- Parse args ---
+PR_NUMBER=""
+PRINCIPAL_APPROVED=false
+DELETE_BRANCH=false
+DRY_RUN=false
+VERBOSE=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --help|-h)             usage; exit 0 ;;
+        --version)             echo "pr-merge $TOOL_VERSION"; exit 0 ;;
+        --principal-approved)  PRINCIPAL_APPROVED=true; shift ;;
+        --delete-branch)       DELETE_BRANCH=true; shift ;;
+        --dry-run)             DRY_RUN=true; shift ;;
+        --verbose)             VERBOSE=true; shift ;;
+        --squash)              die "--squash is BANNED — pr-merge always uses true merge commit (merge-not-rebase discipline)" ;;
+        --rebase)              die "--rebase is BANNED — pr-merge always uses true merge commit (merge-not-rebase discipline)" ;;
+        --admin)               die "--admin is not allowed directly. Use --principal-approved if the principal has verbally authorized the override." ;;
+        -*)                    die "Unknown flag: $1 (run --help for usage)" ;;
+        *)
+            if [[ -z "$PR_NUMBER" ]]; then
+                PR_NUMBER="$1"
+            else
+                die "Unexpected positional arg: $1"
+            fi
+            shift
+            ;;
+    esac
+done
+
+# --- Validate ---
+[[ -z "$PR_NUMBER" ]] && { usage >&2; die "Missing <pr-number>"; }
+[[ ! "$PR_NUMBER" =~ ^[0-9]+$ ]] && die "PR number must be an integer (got: $PR_NUMBER)"
+
+command -v gh >/dev/null 2>&1 || die "gh CLI not found in PATH"
+
+# --- Telemetry ---
+RUN_ID=$(log_start "pr-merge" "$@" 2>/dev/null) || RUN_ID=""
+trap 'log_end "${RUN_ID:-}" "failure" $? 0 "Unexpected exit" 2>/dev/null || true' EXIT
+
+echo "${BLUE}pr-merge${NC} PR #$PR_NUMBER (run: ${RUN_ID:-none})"
+
+# --- Pre-flight: check PR exists + state ---
+PR_INFO=$(gh pr view "$PR_NUMBER" --json state,mergeable,mergeStateStatus,title 2>&1) || die "Could not view PR #$PR_NUMBER: $PR_INFO"
+
+PR_STATE=$(echo "$PR_INFO" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("state",""))' 2>/dev/null || echo "")
+PR_MERGEABLE=$(echo "$PR_INFO" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("mergeable",""))' 2>/dev/null || echo "")
+PR_STATUS=$(echo "$PR_INFO" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("mergeStateStatus",""))' 2>/dev/null || echo "")
+PR_TITLE=$(echo "$PR_INFO" | python3 -c 'import json,sys; print(json.load(sys.stdin).get("title",""))' 2>/dev/null || echo "")
+
+log "state=$PR_STATE mergeable=$PR_MERGEABLE status=$PR_STATUS"
+echo "  Title:  $PR_TITLE"
+echo "  State:  $PR_STATE  mergeable=$PR_MERGEABLE  status=$PR_STATUS"
+
+if [[ "$PR_STATE" != "OPEN" ]]; then
+    die "PR is not OPEN (state: $PR_STATE)"
+fi
+
+if [[ "$PR_MERGEABLE" == "CONFLICTING" ]]; then
+    die "PR has merge conflicts. Resolve locally first: git-safe merge-from-master --remote, fix, push, retry."
+fi
+
+# --- Build merge command ---
+MERGE_CMD=(gh pr merge "$PR_NUMBER" --merge)
+if [[ "$DELETE_BRANCH" == "true" ]]; then
+    MERGE_CMD+=(--delete-branch=true)
+else
+    MERGE_CMD+=(--delete-branch=false)
+fi
+
+if [[ "$PRINCIPAL_APPROVED" == "true" ]]; then
+    MERGE_CMD+=(--admin)
+    echo "  ${YELLOW}--principal-approved${NC} → using --admin (bypassing branch protection)"
+    log_info "PRINCIPAL_APPROVED used for PR #$PR_NUMBER" 2>/dev/null || true
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+    echo "  [dry-run] would run: ${MERGE_CMD[*]}"
+    trap - EXIT
+    log_end "$RUN_ID" "dry-run" 0 0 "Dry run for PR #$PR_NUMBER" 2>/dev/null || true
+    exit 0
+fi
+
+# --- Merge ---
+echo "  ${BLUE}Merging${NC}: ${MERGE_CMD[*]}"
+if MERGE_OUT=$("${MERGE_CMD[@]}" 2>&1); then
+    echo "${GREEN}✓ Merged${NC} PR #$PR_NUMBER"
+    [[ -n "$MERGE_OUT" ]] && echo "$MERGE_OUT"
+    trap - EXIT
+    log_end "$RUN_ID" "success" 0 0 "Merged PR #$PR_NUMBER" 2>/dev/null || true
+    exit 0
+else
+    # Check if the failure is branch-protection blocked
+    if echo "$MERGE_OUT" | grep -qiE "(blocked|requirement|branch protection|approving review)"; then
+        echo "" >&2
+        echo "${YELLOW}Branch protection is blocking the merge:${NC}" >&2
+        echo "$MERGE_OUT" >&2
+        echo "" >&2
+        echo "Two paths to proceed:" >&2
+        echo "  1. Get principal approval in GitHub UI (preferred):" >&2
+        echo "       gh pr review $PR_NUMBER --approve   # principal runs this" >&2
+        echo "       then re-run: pr-merge $PR_NUMBER" >&2
+        echo "  2. Override (only if principal has verbally authorized):" >&2
+        echo "       pr-merge $PR_NUMBER --principal-approved" >&2
+        trap - EXIT
+        log_end "$RUN_ID" "blocked" 3 0 "Branch protection blocked PR #$PR_NUMBER" 2>/dev/null || true
+        exit 3
+    fi
+    die "gh pr merge failed: $MERGE_OUT"
+fi

--- a/tests/tools/pr-merge.bats
+++ b/tests/tools/pr-merge.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+#
+# pr-merge tests — discipline enforcement for safe PR merging
+#
+# These tests verify the safety guarantees of pr-merge WITHOUT actually
+# calling GitHub. We assert on input validation, flag rejection, and help
+# output. End-to-end PR creation/merge is NOT covered here (would require
+# live GitHub state); covered by acceptance via use on the D41-R13 PR
+# itself ("dog-food" per principal directive).
+#
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/.." && pwd)"
+TOOL="${REPO_ROOT}/claude/tools/pr-merge"
+
+@test "pr-merge: --help works" {
+    run bash "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"pr-merge — Safe merge"* ]]
+    [[ "$output" == *"--principal-approved"* ]]
+    [[ "$output" == *"Never --squash"* ]]
+}
+
+@test "pr-merge: --version prints version" {
+    run bash "$TOOL" --version
+    [ "$status" -eq 0 ]
+    [[ "$output" == pr-merge\ * ]]
+}
+
+@test "pr-merge: rejects --squash explicitly" {
+    run bash "$TOOL" 42 --squash
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BANNED"* ]]
+    [[ "$output" == *"squash"* ]]
+}
+
+@test "pr-merge: rejects --rebase explicitly" {
+    run bash "$TOOL" 42 --rebase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"BANNED"* ]]
+    [[ "$output" == *"rebase"* ]]
+}
+
+@test "pr-merge: rejects raw --admin (must use --principal-approved)" {
+    run bash "$TOOL" 42 --admin
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"--admin is not allowed directly"* ]]
+    [[ "$output" == *"--principal-approved"* ]]
+}
+
+@test "pr-merge: rejects unknown flag" {
+    run bash "$TOOL" 42 --not-a-flag
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown flag"* ]]
+}
+
+@test "pr-merge: missing pr-number errors" {
+    run bash "$TOOL"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Missing"* ]]
+}
+
+@test "pr-merge: non-integer pr-number rejected" {
+    run bash "$TOOL" not-a-number
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"integer"* ]]
+}
+
+@test "pr-merge: rejects multiple positional args" {
+    run bash "$TOOL" 42 99
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unexpected positional arg"* ]]
+}


### PR DESCRIPTION
## Summary
Closes the discipline gap that let captain ship 4 squash merges in one day.

### Problem
Raw `gh pr merge` is too easy to misuse. GitHub UI nudges toward squash; `--squash` is one keystroke from `--merge`; `--admin` bypasses branch protection silently. Squash sits on the same forbidden side of the merge-not-rebase line — both rewrite history.

### Solution: full Enforcement Triangle
| Leg | File |
|---|---|
| **Tool** | `claude/tools/pr-merge` — refuses `--squash`/`--rebase`/`--admin` directly; requires `--principal-approved` flag (logged) for override |
| **Skill** | `.claude/skills/pr-merge/SKILL.md` — discoverable `/pr-merge` with 1B1 prompt for principal authorization |
| **Hookify** | `claude/hookify/hookify.block-raw-gh-pr-merge.md` — blocks raw `gh pr merge` with decision:block + exit 2 |

### Coverage
- 9 BATS tests pass (`tests/tools/pr-merge.bats`)
- E2E acceptance: **this PR will be merged using `./claude/tools/pr-merge` itself** (dog-food)

### Receipts
- RGR: `claude/receipts/the-agency-jordan-captain-agency-captain-rgr-fcc7aec-20260415-1148.md`

### Version
`agency_version`: 41.12 → 41.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)