### PR TITLE
D41-R16: agency update --prune (opt-in orphan cleanup)

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "41.15",
+  "agency_version": "41.16",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/receipts/the-agency-jordan-captain-agency-captain-rgr-98a03f0-20260415-1221.md
+++ b/claude/receipts/the-agency-jordan-captain-agency-captain-rgr-98a03f0-20260415-1221.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: rgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: captain
+diff_base: origin/main
+hash_a: 98a03f0
+hash_b: 98a03f0
+hash_c: 98a03f0
+hash_d: 98a03f0
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 98a03f0
+date: 2026-04-15T12:21
+---
+
+# Receipt: pr-prep — captain
+
+## Chain of Trust
+- A (original): 98a03f0
+- B (findings): 98a03f0
+- C (triage): 98a03f0
+- D (principal): 98a03f0 — auto-approved — no principal 1B1
+- E (final): 98a03f0
+
+## Review Summary
+D41-R16: agency update --prune (opt-in orphan cleanup with protected paths)

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -17,6 +17,8 @@ RUN_ID=$(log_start "agency-update" "${AGENCY_ARGS[@]+"${AGENCY_ARGS[@]}"}" 2>/de
 VERBOSE=false
 DRY_RUN=false
 FORCE=false
+PRUNE=false              # D41-R16: opt-in rsync --delete for orphan cleanup
+YES=false                # D41-R16: bypass prune confirmation prompt
 TARGET_DIR=""
 FROM_GITHUB=""           # D41-R10 (monofolk hotfix): github ref to fetch from
 GITHUB_REPO_URL="https://github.com/the-agency-ai/the-agency.git"
@@ -34,6 +36,11 @@ Options:
   --verbose             Show detailed output
   --dry-run             Preview changes without applying
   --force               Proceed even if the working tree has uncommitted framework changes
+  --prune               Remove orphaned framework files (rsync --delete).
+                        Protects usr/, workstreams/, and paths in registry.json
+                        protected_paths. Prompts for confirmation before deleting
+                        unless --yes is passed. Default: off (purely additive sync).
+  --yes                 Skip the --prune confirmation prompt. No effect without --prune.
   --from-github [ref]   Shallow-clone the-agency from GitHub and use as source.
                         Optional ref: tag, branch, or commit (default: latest tag).
                         Examples:  --from-github
@@ -59,6 +66,8 @@ while [[ $# -gt 0 ]]; do
         --verbose) VERBOSE=true; shift ;;
         --dry-run) DRY_RUN=true; shift ;;
         --force) FORCE=true; shift ;;
+        --prune) PRUNE=true; shift ;;
+        --yes|-y) YES=true; shift ;;
         --from-github)
             # Optional ref follows the flag. If next arg is missing or starts
             # with `-` or matches a target-dir-like pattern, default to "latest".
@@ -255,15 +264,60 @@ _update_main() {
     log_step "Syncing framework files"
 
     # Use rsync in dry-run or real mode
-    # CRITICAL: NO --delete flag. Sync is ADDITIVE — add new files, update
-    # existing files, but NEVER delete files that only exist in the target.
+    #
+    # DEFAULT: NO --delete flag. Sync is ADDITIVE — add new files, update
+    # existing files, NEVER delete files that only exist in the target.
     # Project-specific tools (secret-local, provider tools, etc.) live in
-    # claude/tools/ alongside framework tools. --delete would destroy them.
-    # If a framework tool is renamed or removed, document it in release notes
-    # for manual cleanup — that's safer than destructive sync.
+    # claude/tools/ alongside framework tools. A blind --delete would destroy them.
+    #
+    # OPT-IN: --prune enables --delete with protected_paths enforced.
+    # Adopters run it explicitly when they want orphan cleanup. Confirmation
+    # prompt unless --yes. D41-R16 (monofolk request — opt-in adopter hygiene).
     local rsync_flags=("-rlpt")
     [[ "$VERBOSE" == "true" ]] && rsync_flags+=("-v")
     [[ "$DRY_RUN" == "true" ]] && rsync_flags+=("--dry-run")
+
+    # --- D41-R16: opt-in --prune (rsync --delete with protected paths) ---
+    if [[ "$PRUNE" == "true" ]]; then
+        # First pass: dry-run with --delete to preview what would be removed
+        local prune_preview
+        prune_preview=$(rsync -rlpt --dry-run --delete \
+            "${rsync_excludes[@]+"${rsync_excludes[@]}"}" \
+            --exclude "workstreams/" \
+            --exclude "usr/" \
+            --itemize-changes \
+            "$SOURCE_DIR/claude/" "$TARGET_DIR/claude/" 2>&1 | grep -E '^\*deleting' || true)
+
+        local prune_count
+        prune_count=$(echo "${prune_preview:-}" | grep -c '^\*deleting' || echo "0")
+
+        if [[ "$prune_count" -gt 0 ]]; then
+            echo ""
+            echo -e "${YELLOW}--prune: ${prune_count} orphan file(s) would be deleted from claude/:${NC}"
+            echo "$prune_preview" | head -20
+            [[ "$prune_count" -gt 20 ]] && echo "  ... and $((prune_count - 20)) more (use --verbose to see all)"
+            echo ""
+
+            if [[ "$DRY_RUN" == "true" ]]; then
+                echo "  [dry-run] no files will actually be deleted"
+            elif [[ "$YES" == "true" ]]; then
+                echo "  --yes: proceeding without prompt"
+                rsync_flags+=("--delete")
+            else
+                echo -en "  Delete these files? (yes/no) [default: no]: "
+                read -r prune_confirm
+                if [[ "$prune_confirm" == "yes" ]]; then
+                    rsync_flags+=("--delete")
+                    echo "  Proceeding with --delete."
+                else
+                    echo "  Aborting prune. Re-run without --prune, or with --yes to skip prompt."
+                    PRUNE=false
+                fi
+            fi
+        else
+            echo "  --prune: no orphan files found, nothing to delete."
+        fi
+    fi
 
     # Sync claude/ (excluding agency.yaml, protected paths, and workstreams)
     local rsync_output

--- a/tests/tools/agency-update.bats
+++ b/tests/tools/agency-update.bats
@@ -140,3 +140,66 @@ EOF
 # operate on the full porcelain output instead of the head-20 truncated
 # version — is a one-line refactor that the positive-assertion tests above
 # already exercise end-to-end.
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D41-R16: opt-in --prune (rsync --delete with protected paths)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency update: --help documents --prune and --yes" {
+    run_agency update --help
+    assert_success
+    assert_output_contains "--prune"
+    assert_output_contains "--yes"
+}
+
+@test "agency update: default (no --prune) does NOT delete orphaned target files" {
+    # Defensive regression test — forbids silent orphan deletion by default.
+    local root
+    root=$(setup_update_fixture)
+    # Orphan only in target, not in source
+    local orphan="$root/target/claude/tools/my-local-tool"
+    echo "#!/bin/bash" > "$orphan"
+
+    AGENCY_SOURCE="$root/source" run_agency update "$root/target" --force --yes
+    # The orphan must survive — default sync is additive only
+    [ -f "$orphan" ]
+}
+
+@test "agency update: --prune --dry-run previews deletions but does not delete" {
+    local root
+    root=$(setup_update_fixture)
+    local orphan="$root/target/claude/tools/my-local-tool"
+    echo "#!/bin/bash" > "$orphan"
+
+    AGENCY_SOURCE="$root/source" run_agency update "$root/target" --prune --dry-run --force
+    # Dry-run: orphan still exists
+    [ -f "$orphan" ]
+    # Prune preview should mention the orphan count or the dry-run note
+    [[ "$output" == *"--prune"* ]] || [[ "$output" == *"dry-run"* ]]
+}
+
+@test "agency update: --prune --yes deletes orphaned target files" {
+    local root
+    root=$(setup_update_fixture)
+    local orphan="$root/target/claude/tools/my-local-tool"
+    echo "#!/bin/bash" > "$orphan"
+
+    AGENCY_SOURCE="$root/source" run_agency update "$root/target" --prune --yes --force
+    # Orphan must be removed
+    [ ! -f "$orphan" ]
+}
+
+@test "agency update: --prune --yes preserves usr/ and workstreams/" {
+    local root
+    root=$(setup_update_fixture)
+    # Create adopter-owned files under usr/ (sandbox) and workstreams/ that
+    # don't exist in source — they must survive prune via the hard excludes.
+    mkdir -p "$root/target/usr/jordan/captain"
+    echo "handoff" > "$root/target/usr/jordan/captain/captain-handoff.md"
+    mkdir -p "$root/target/claude/workstreams/myproject"
+    echo "knowledge" > "$root/target/claude/workstreams/myproject/KNOWLEDGE.md"
+
+    AGENCY_SOURCE="$root/source" run_agency update "$root/target" --prune --yes --force
+    [ -f "$root/target/usr/jordan/captain/captain-handoff.md" ]
+    [ -f "$root/target/claude/workstreams/myproject/KNOWLEDGE.md" ]
+}


### PR DESCRIPTION
## Summary
Opt-in `--prune` flag adds rsync `--delete` for adopter hygiene while preserving their customizations.

### Change
- New flag: `agency update --prune [--yes]`
- Default behavior unchanged (purely additive sync)
- Preview pass + confirmation prompt before any deletion
- Protected paths from `registry.json` enforced
- Hard-excludes `usr/` and `workstreams/` (adopter-owned namespaces)

### Tests
13/13 BATS pass, including 5 new for --prune behavior + 1 defensive regression guard (default never deletes orphans).

### Version
41.15 → 41.16

🤖 Generated with [Claude Code](https://claude.com/claude-code)