### PR TITLE
jordandm-D41-R22: agent-bootstrap shift crash + multi-principal.bats coverage assertion (closes #115)

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "41.21",
+  "agency_version": "41.22",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "2.0.0",
-    "updated_at": "2026-04-15T18:00:00Z"
+    "updated_at": "2026-04-15T18:30:00Z"
   },
   "source": {
     "type": "local",

--- a/claude/receipts/the-agency-jordan-captain-housekeeping-d41-r22-rgr-497abad-20260415-1811.md
+++ b/claude/receipts/the-agency-jordan-captain-housekeeping-d41-r22-rgr-497abad-20260415-1811.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: rgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: housekeeping
+project: d41-r22
+diff_base: origin/main
+hash_a: 497abad73cbd44b5aa18f8e6e27b2a7168c7ce2afe5929f89851bbac41b86015
+hash_b: d955a035ade29e885cd5f0b56acb0927d2bf29837dacb5b9431bd30670b7533c
+hash_c: 3e72750097c6b9d87e18e51fbff72cc0d8cfd38848f369e501e595297f017379
+hash_d: 3e72750097c6b9d87e18e51fbff72cc0d8cfd38848f369e501e595297f017379
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 497abad73cbd44b5aa18f8e6e27b2a7168c7ce2afe5929f89851bbac41b86015
+date: 2026-04-15T18:11
+---
+
+# Receipt: pr-prep — d41-r22
+
+## Chain of Trust
+- A (original): 497abad
+- B (findings): d955a03
+- C (triage): 3e72750
+- D (principal): 3e72750 — auto-approved — no principal 1B1
+- E (final): 497abad
+
+## Review Summary
+D41-R22: agent-bootstrap shift crash + multi-principal.bats coverage assertion (closes #115)

--- a/claude/tools/agent-bootstrap
+++ b/claude/tools/agent-bootstrap
@@ -68,7 +68,14 @@ verbose=false
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --agent)
-            agent_override="${2:-}"
+            # D41-R22 (issue #115 bug 1): under set -euo pipefail, `shift 2`
+            # crashes when --agent is the last arg with no value following.
+            # Validate before consuming.
+            if [[ $# -lt 2 ]]; then
+                echo "agent-bootstrap: --agent requires a value" >&2
+                exit 2
+            fi
+            agent_override="$2"
             shift 2
             ;;
         --path)

--- a/tests/tools/multi-principal.bats
+++ b/tests/tools/multi-principal.bats
@@ -336,9 +336,27 @@ teardown() {
     # include runtime principal resolution.
     run grep -l "agent-bootstrap" "$REPO_ROOT/.claude/agents/"*.md
     assert_success
-    local count
-    count=$(grep -l "agent-bootstrap" "$REPO_ROOT/.claude/agents/"*.md | wc -l | tr -d ' ')
-    [[ "$count" -ge "9" ]]
+    # D41-R22 (issue #115 bug 2): ratio-based coverage instead of fixed
+    # threshold. Catches regressions where any single agent loses
+    # agent-bootstrap, regardless of how many agents the repo has.
+    local total covered
+    total=$(ls "$REPO_ROOT/.claude/agents/"*.md 2>/dev/null | grep -v -i 'README' | wc -l | tr -d ' ')
+    covered=$(grep -l "agent-bootstrap" "$REPO_ROOT/.claude/agents/"*.md 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$covered" -ne "$total" ]]; then
+        echo "agent-bootstrap coverage: $covered/$total (must be 100%)"
+        false
+    fi
+}
+
+@test "agent-bootstrap --agent with no value: clean error, no shift crash (issue #115 bug 1)" {
+    cd "$MOCK_REPO"
+    export USER="jdm"
+    # Trailing --agent with no value would crash under set -euo pipefail
+    # (shift 2 with one arg). D41-R22 fix: validate before shifting.
+    run "$MOCK_REPO/claude/tools/agent-bootstrap" --agent
+    assert_failure
+    [[ "$status" -eq "2" ]]
+    [[ "$output" == *"--agent requires a value"* ]] || [[ "$stderr" == *"--agent requires a value"* ]]
 }
 
 @test "agent-bootstrap honors CLAUDE_AGENT_NAME env fallback when agent-identity is unavailable" {


### PR DESCRIPTION
## Summary

Closes #115 — two D41-R19 follow-up bugs found by monofolk during their R19 adoption. Both have proposed fixes inline in the issue; applied verbatim.

## Bug 1 — \`agent-bootstrap --agent\` crashes when value is missing

\`claude/tools/agent-bootstrap\` parsed \`--agent\` with \`shift 2\` unconditionally. Under \`set -euo pipefail\`, if \`--agent\` is the last arg, \`shift 2\` exits non-zero and crashes silently.

**Fix:** validate \`$# -ge 2\` before shifting; print clean error + exit 2 otherwise.

## Bug 2 — \`multi-principal.bats\` agent-bootstrap coverage threshold is stale

The subagent-anchor test asserted \`count >= 9\` (number of agents in the-agency). Monofolk has 17 — passes either way, but a regression where half lose \`agent-bootstrap\` would also pass. Weak assertion.

**Fix:** ratio-based — count total non-README agent .md files, count those containing \`agent-bootstrap\`, assert equality. Catches regressions where ANY agent loses the startup step regardless of repo size.

## Tests

- New regression test for bug 1 (\`agent-bootstrap --agent with no value: clean error, no shift crash\`)
- Existing subagent-anchor rewritten as ratio-based coverage check
- **24/24 BATS green**

## Files

- \`claude/tools/agent-bootstrap\` — \`--agent\` arg parsing validates value before shift
- \`tests/tools/multi-principal.bats\` — new bug-1 anchor + ratio-based coverage assertion
- \`claude/config/manifest.json\` — 41.21 → 41.22

🤖 Generated with [Claude Code](https://claude.com/claude-code)