### PR TITLE
jordandm-D41-R26: agency init dir-level copies for hooks/agents/commands/REFERENCE-*/README-* (R25 audit follow-up)

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "41.25",
+  "agency_version": "41.26",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "2.0.0",
-    "updated_at": "2026-04-15T20:30:00Z"
+    "updated_at": "2026-04-15T21:00:00Z"
   },
   "source": {
     "type": "local",

--- a/claude/receipts/the-agency-jordan-captain-housekeeping-d41-r26-rgr-0ff2233-20260415-2030.md
+++ b/claude/receipts/the-agency-jordan-captain-housekeeping-d41-r26-rgr-0ff2233-20260415-2030.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: rgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: housekeeping
+project: d41-r26
+diff_base: origin/main
+hash_a: 0ff223323c2f4e74e7a5114a9838000ef0d6f9334a4c0c1acfb67b43c30db17f
+hash_b: 02660c87bffba60d5f2549fcd8660a2274854bb224f160e9f5e578064c740e5f
+hash_c: bb6343e98fd6023240d2fbf6697d206c85d19beafffaf8e13f69aeba2c3f7a1f
+hash_d: bb6343e98fd6023240d2fbf6697d206c85d19beafffaf8e13f69aeba2c3f7a1f
+hash_d_source: "auto-approved — audit follow-up"
+hash_e: 0ff223323c2f4e74e7a5114a9838000ef0d6f9334a4c0c1acfb67b43c30db17f
+date: 2026-04-15T20:30
+---
+
+# Receipt: pr-prep — d41-r26
+
+## Chain of Trust
+- A (original): 0ff2233
+- B (findings): 02660c8
+- C (triage): bb6343e
+- D (principal): bb6343e — auto-approved — audit follow-up
+- E (final): 0ff2233
+
+## Review Summary
+D41-R26: agency init dir-level copies for hooks/agents/commands/REFERENCE-*/README-*

--- a/claude/tools/lib/_agency-init
+++ b/claude/tools/lib/_agency-init
@@ -276,11 +276,15 @@ _init_main() {
         exit 1
     fi
 
-    # Commands
-    cp "$AGENCY_SOURCE/.claude/commands/discuss.md" "$TARGET_DIR/.claude/commands/" 2>/dev/null || true
-    for cmd in secret.md agency-help.md agency-welcome.md agency-tutorial.md agency-bug.md agency-nit.md agency-request.md changelog.md; do
-        [[ -f "$AGENCY_SOURCE/.claude/commands/$cmd" ]] && cp "$AGENCY_SOURCE/.claude/commands/$cmd" "$TARGET_DIR/.claude/commands/"
-    done
+    # Commands — D41-R26: directory-level copy (was hardcoded list that
+    # missed new commands added post-freeze)
+    if [[ -d "$AGENCY_SOURCE/.claude/commands" ]]; then
+        local cmd_file
+        for cmd_file in "$AGENCY_SOURCE/.claude/commands/"*.md; do
+            [[ -f "$cmd_file" ]] || continue
+            cp "$cmd_file" "$TARGET_DIR/.claude/commands/"
+        done
+    fi
 
     # Skills
     if [[ -d "$AGENCY_SOURCE/.claude/skills" ]]; then
@@ -302,8 +306,23 @@ _init_main() {
 
     mkdir -p "$TARGET_DIR/claude"
     [[ -f "$AGENCY_SOURCE/claude/CLAUDE-THEAGENCY.md" ]] && cp "$AGENCY_SOURCE/claude/CLAUDE-THEAGENCY.md" "$TARGET_DIR/claude/"
-    [[ -f "$AGENCY_SOURCE/claude/README-THEAGENCY.md" ]] && cp "$AGENCY_SOURCE/claude/README-THEAGENCY.md" "$TARGET_DIR/claude/"
-    [[ -f "$AGENCY_SOURCE/claude/README-GETTINGSTARTED.md" ]] && cp "$AGENCY_SOURCE/claude/README-GETTINGSTARTED.md" "$TARGET_DIR/claude/"
+
+    # README-*.md — D41-R26: copy ALL top-level README files from framework
+    # (was hardcoded list missing README-ENFORCEMENT.md + README-SAFE-TOOLS.md +
+    # README-RECEIPT-INFRASTRUCTURE.md + more as they're added)
+    local readme_file
+    for readme_file in "$AGENCY_SOURCE/claude/"README-*.md; do
+        [[ -f "$readme_file" ]] && cp "$readme_file" "$TARGET_DIR/claude/"
+    done
+
+    # REFERENCE-*.md — D41-R26: the 39 framework reference docs are the
+    # authoritative guidance layer. Old code tried to copy /claude/docs/*.md
+    # which doesn't exist — these live at /claude/REFERENCE-*.md instead.
+    # Every ref-injected skill assumes these are present.
+    local ref_file
+    for ref_file in "$AGENCY_SOURCE/claude/"REFERENCE-*.md; do
+        [[ -f "$ref_file" ]] && cp "$ref_file" "$TARGET_DIR/claude/"
+    done
 
     # Config
     mkdir -p "$TARGET_DIR/claude/config"
@@ -353,25 +372,45 @@ telemetry:
   providers: ["jsonl"]
 YAML_EOF
 
-    # Docs
-    mkdir -p "$TARGET_DIR/claude/docs"
-    for doc in QUALITY-GATE.md DEVELOPMENT-METHODOLOGY.md CODE-REVIEW-LIFECYCLE.md FEEDBACK-FORMAT.md PR-LIFECYCLE.md TELEMETRY.md; do
-        [[ -f "$AGENCY_SOURCE/claude/docs/$doc" ]] && cp "$AGENCY_SOURCE/claude/docs/$doc" "$TARGET_DIR/claude/docs/"
-    done
+    # Docs — legacy /claude/docs/ path (kept as no-op fallback; content
+    # lives at /claude/REFERENCE-*.md now, copied above in Step 3).
+    if [[ -d "$AGENCY_SOURCE/claude/docs" ]]; then
+        mkdir -p "$TARGET_DIR/claude/docs"
+        local doc_file
+        for doc_file in "$AGENCY_SOURCE/claude/docs/"*.md; do
+            [[ -f "$doc_file" ]] && cp "$doc_file" "$TARGET_DIR/claude/docs/"
+        done
+    fi
 
-    # Agents
-    for agent in project-manager reviewer-code reviewer-design reviewer-scorer reviewer-security reviewer-test cos captain; do
-        if [[ -d "$AGENCY_SOURCE/claude/agents/$agent" ]]; then
-            mkdir -p "$TARGET_DIR/claude/agents/$agent"
-            cp "$AGENCY_SOURCE/claude/agents/$agent/agent.md" "$TARGET_DIR/claude/agents/$agent/"
-        fi
-    done
+    # Agents — D41-R26: directory-level copy of ALL agent classes + their
+    # agent.md class docs. Old hardcoded list missed iscp, tech-lead,
+    # platform-specialist, researcher, and ~10 others. Every agent class
+    # that ships gets copied now.
+    if [[ -d "$AGENCY_SOURCE/claude/agents" ]]; then
+        mkdir -p "$TARGET_DIR/claude/agents"
+        local agent_dir agent_name
+        for agent_dir in "$AGENCY_SOURCE/claude/agents"/*/; do
+            [[ -d "$agent_dir" ]] || continue
+            agent_name=$(basename "$agent_dir")
+            mkdir -p "$TARGET_DIR/claude/agents/$agent_name"
+            # Copy all .md files in the agent dir (agent.md + any KNOWLEDGE.md etc)
+            local af
+            for af in "$agent_dir"*.md; do
+                [[ -f "$af" ]] && cp "$af" "$TARGET_DIR/claude/agents/$agent_name/"
+            done
+        done
+    fi
 
-    # Hooks
-    mkdir -p "$TARGET_DIR/claude/hooks"
-    for hook in ref-injector.sh session-handoff.sh quality-check.sh plan-capture.sh branch-freshness.sh tool-telemetry.sh ghostty-status.sh; do
-        [[ -f "$AGENCY_SOURCE/claude/hooks/$hook" ]] && cp "$AGENCY_SOURCE/claude/hooks/$hook" "$TARGET_DIR/claude/hooks/"
-    done
+    # Hooks — D41-R26: directory-level copy. Old hardcoded list missed
+    # block-raw-tools.sh (CRITICAL — hookify enforcement layer) and
+    # idle-mail-check.sh. New hooks auto-install with no list maintenance.
+    if [[ -d "$AGENCY_SOURCE/claude/hooks" ]]; then
+        mkdir -p "$TARGET_DIR/claude/hooks"
+        local hook_file
+        for hook_file in "$AGENCY_SOURCE/claude/hooks/"*.sh; do
+            [[ -f "$hook_file" ]] && cp "$hook_file" "$TARGET_DIR/claude/hooks/"
+        done
+    fi
     chmod +x "$TARGET_DIR/claude/hooks/"*.sh 2>/dev/null || true
 
     # Hookify rules

--- a/tests/tools/agency-update.bats
+++ b/tests/tools/agency-update.bats
@@ -486,6 +486,150 @@ EOF
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# D41-R26: regression anchors for THREE more frozen lists beyond R25's tools
+# (agents, hooks, commands, REFERENCE-*, README-*). If any future PR
+# re-hardcodes any of these, these tests fail loud.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency init: installs ALL hooks (not hardcoded subset) — D41-R26" {
+    local target="${BATS_TEST_TMPDIR}/init-hooks"
+    mkdir -p "$target"
+    cd "$target"
+    git init --quiet --initial-branch=main
+    git -c user.name=t -c user.email=t@t commit --quiet --allow-empty -m "init" --no-verify
+
+    AGENCY_SOURCE="$REPO_ROOT" run "$REPO_ROOT/claude/tools/agency" init --principal tester
+    assert_success
+
+    # These hooks were MISSING from the old hardcoded list — now must be present
+    local missing=()
+    local canonical_hooks=(
+        block-raw-tools.sh      # CRITICAL — hookify enforcement
+        idle-mail-check.sh
+        ref-injector.sh
+        session-handoff.sh
+        quality-check.sh
+    )
+    for hook in "${canonical_hooks[@]}"; do
+        [[ -f "$target/claude/hooks/$hook" ]] || missing+=("$hook")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Missing hooks after agency init: ${missing[*]}"
+        false
+    fi
+}
+
+@test "agency init: installs ALL agent classes (not hardcoded 8) — D41-R26" {
+    local target="${BATS_TEST_TMPDIR}/init-agents"
+    mkdir -p "$target"
+    cd "$target"
+    git init --quiet --initial-branch=main
+    git -c user.name=t -c user.email=t@t commit --quiet --allow-empty -m "init" --no-verify
+
+    AGENCY_SOURCE="$REPO_ROOT" run "$REPO_ROOT/claude/tools/agency" init --principal tester
+    assert_success
+
+    # Old hardcoded list had 8 classes. Framework has ~21. Assert the ones
+    # that were previously missing are now present.
+    local missing=()
+    local canonical_agents=(
+        captain
+        cos
+        project-manager
+        reviewer-code
+        reviewer-design
+        reviewer-scorer
+        reviewer-security
+        reviewer-test
+        iscp
+        tech-lead
+    )
+    for agent in "${canonical_agents[@]}"; do
+        [[ -f "$target/claude/agents/$agent/agent.md" ]] || missing+=("$agent")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Missing agent classes after agency init: ${missing[*]}"
+        false
+    fi
+
+    # Also: count should match framework's count (dir-level copy)
+    local framework_count=$(ls -d "$REPO_ROOT/claude/agents/"*/ 2>/dev/null | wc -l | tr -d ' ')
+    local target_count=$(ls -d "$target/claude/agents/"*/ 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$target_count" -lt "$framework_count" ]]; then
+        echo "Agent count mismatch: framework has $framework_count, target has $target_count"
+        false
+    fi
+}
+
+@test "agency init: installs ALL REFERENCE-*.md docs — D41-R26" {
+    local target="${BATS_TEST_TMPDIR}/init-refs"
+    mkdir -p "$target"
+    cd "$target"
+    git init --quiet --initial-branch=main
+    git -c user.name=t -c user.email=t@t commit --quiet --allow-empty -m "init" --no-verify
+
+    AGENCY_SOURCE="$REPO_ROOT" run "$REPO_ROOT/claude/tools/agency" init --principal tester
+    assert_success
+
+    # REFERENCE-* docs must all ship — ref-injector depends on them
+    local framework_refs=$(ls "$REPO_ROOT/claude/"REFERENCE-*.md 2>/dev/null | wc -l | tr -d ' ')
+    local target_refs=$(ls "$target/claude/"REFERENCE-*.md 2>/dev/null | wc -l | tr -d ' ')
+
+    # Target must match framework count (directory-level copy)
+    if [[ "$target_refs" -ne "$framework_refs" ]]; then
+        echo "REFERENCE-*.md count mismatch: framework has $framework_refs, target has $target_refs"
+        false
+    fi
+
+    # At least a few canonical refs must be present by name
+    local canonical_refs=(REFERENCE-QUALITY-GATE.md REFERENCE-AGENT-DISCIPLINE.md REFERENCE-ISCP-PROTOCOL.md)
+    local missing=()
+    for ref in "${canonical_refs[@]}"; do
+        [[ -f "$target/claude/$ref" ]] || missing+=("$ref")
+    done
+    if [[ ${#missing[@]} -gt 0 ]]; then
+        echo "Missing canonical REFERENCE docs: ${missing[*]}"
+        false
+    fi
+}
+
+@test "agency init: installs ALL README-*.md docs — D41-R26" {
+    local target="${BATS_TEST_TMPDIR}/init-readmes"
+    mkdir -p "$target"
+    cd "$target"
+    git init --quiet --initial-branch=main
+    git -c user.name=t -c user.email=t@t commit --quiet --allow-empty -m "init" --no-verify
+
+    AGENCY_SOURCE="$REPO_ROOT" run "$REPO_ROOT/claude/tools/agency" init --principal tester
+    assert_success
+
+    local framework_readmes=$(ls "$REPO_ROOT/claude/"README-*.md 2>/dev/null | wc -l | tr -d ' ')
+    local target_readmes=$(ls "$target/claude/"README-*.md 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$target_readmes" -ne "$framework_readmes" ]]; then
+        echo "README-*.md count mismatch: framework has $framework_readmes, target has $target_readmes"
+        false
+    fi
+}
+
+@test "agency init: installs ALL commands — D41-R26" {
+    local target="${BATS_TEST_TMPDIR}/init-cmds"
+    mkdir -p "$target"
+    cd "$target"
+    git init --quiet --initial-branch=main
+    git -c user.name=t -c user.email=t@t commit --quiet --allow-empty -m "init" --no-verify
+
+    AGENCY_SOURCE="$REPO_ROOT" run "$REPO_ROOT/claude/tools/agency" init --principal tester
+    assert_success
+
+    local framework_cmds=$(ls "$REPO_ROOT/.claude/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
+    local target_cmds=$(ls "$target/.claude/commands/"*.md 2>/dev/null | wc -l | tr -d ' ')
+    if [[ "$target_cmds" -ne "$framework_cmds" ]]; then
+        echo "Commands count mismatch: framework has $framework_cmds, target has $target_cmds"
+        false
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # D41-R20: post-merge skill enforces release verification
 # ─────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Follow-up to R25 hotfix. R25 fixed the tools/libs frozen-list. Audit revealed **four MORE frozen lists** in \`_agency-init\` that were leaving adopters with incomplete installs.

### Found by audit

| Area | Old state | Framework reality | Missing from fresh inits |
|---|---|---|---|
| Tools | hardcoded ~30 | 60+ | ✅ Fixed in R25 |
| **Agents** | hardcoded 8 classes | 21+ | **13 missing** — iscp, tech-lead, platform-specialist, researcher, etc. |
| **Hooks** | hardcoded 7 | 9 | **2 missing** — \`block-raw-tools.sh\` (CRITICAL — hookify enforcement!) + \`idle-mail-check.sh\` |
| **Commands** | hardcoded 9 | 10 | brittle (missed new commands post-freeze) |
| **Docs** | pointed at wrong path \`/claude/docs/\` | 39 \`REFERENCE-*.md\` files | **all 39 missing** — ref-injector had nothing to inject |
| **READMEs** | hardcoded 2 | 5 | \`README-ENFORCEMENT.md\`, \`README-SAFE-TOOLS.md\`, \`README-RECEIPT-INFRASTRUCTURE.md\` |

### Fix

Directory-level copy for every one. Same pattern as R25's tools fix:

\`\`\`bash
for item in \"\$AGENCY_SOURCE/claude/hooks/\"*.sh; do cp ...
for dir in \"\$AGENCY_SOURCE/claude/agents/\"*/; do ...
for cmd in \"\$AGENCY_SOURCE/.claude/commands/\"*.md; do cp ...
for readme in \"\$AGENCY_SOURCE/claude/\"README-*.md; do cp ...
for ref in \"\$AGENCY_SOURCE/claude/\"REFERENCE-*.md; do cp ...
\`\`\`

Zero maintenance burden on future additions — new hook, new agent, new REFERENCE doc, new command all auto-install on fresh \`agency init\`.

## Tests

5 new regression anchors — one per category — asserting canonical items are installed AND count matches framework.

\`\`\`
ok 1 agency init: installs ALL hooks (not hardcoded subset) — D41-R26
ok 2 agency init: installs ALL agent classes (not hardcoded 8) — D41-R26
ok 3 agency init: installs ALL REFERENCE-*.md docs — D41-R26
ok 4 agency init: installs ALL README-*.md docs — D41-R26
ok 5 agency init: installs ALL commands — D41-R26
\`\`\`

Plus R25's 2 anchors still green.

## Impact

Future \`agency init --from-github\` produces a COMPLETE install. No more silently-missing enforcement hooks, orphaned ref-injector paths, or missing agent classes.

Existing adopter repos (e.g. homekit-daikin-ac-bridge, monofolk) can catch up via \`./claude/tools/agency update --from-github\` which already uses rsync (directory-level).

## Files

- \`claude/tools/lib/_agency-init\` — Step 2 commands, Step 3 agents/hooks/docs all converted to dir-level
- \`tests/tools/agency-update.bats\` — 5 new regression anchors
- \`claude/config/manifest.json\` — 41.25 → 41.26

🤖 Generated with [Claude Code](https://claude.com/claude-code)