### PR TITLE
D43-R2: hotfix — agency update crash + lost commits from R1 (closes #151)

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "43.1",
+  "agency_version": "43.2",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/tools/agency
+++ b/claude/tools/agency
@@ -10,6 +10,7 @@
 #   verify [--verbose]                                         Health check
 #   whoami                                                     Show principal
 #   feedback "title" "description"                             Submit feedback
+#   deps [check|install]                                       Dependency management (macOS)
 #   version                                                    Show version info
 #   help                                                       Show this help
 #
@@ -47,6 +48,7 @@ Commands:
   update                    Sync framework to latest
   verify [--verbose]        Validate configuration
   whoami                    Show current principal
+  deps [check|install]      Dependency management (macOS brew)
   feedback "title" "desc"  Submit feedback
   version                   Show version info
   help                      Show this help
@@ -91,6 +93,10 @@ case "${1:-}" in
     whoami)
         shift; AGENCY_ARGS=("$@")
         source "$AGENCY_DIR/tools/lib/_agency-whoami"
+        ;;
+    deps)
+        shift; AGENCY_ARGS=("$@")
+        source "$AGENCY_DIR/tools/lib/_agency-deps"
         ;;
     feedback)
         shift; AGENCY_ARGS=("$@")

--- a/claude/tools/dispatch-monitor
+++ b/claude/tools/dispatch-monitor
@@ -10,10 +10,15 @@
 # each output line to the agent, who reacts immediately. Result: 96% token
 # savings, 10-second latency instead of 5 minutes.
 #
+# D43-R2: Added SEEN_IDS tracking to prevent stale-read loop (#144). Once a
+# dispatch ID is emitted, it never emits again — even if the DB query returns
+# it (e.g., because resolve/read didn't stick or identity shifted).
+#
 # Usage: With Monitor tool — ask Claude to "monitor dispatches using dispatch-monitor"
 # Standalone: ./claude/tools/dispatch-monitor [--interval N] [--include-collab]
 #
 # Written: 2026-04-10 during captain session (Monitor tool adoption)
+# Updated: 2026-04-16 D43-R2 — stale-read loop fix (#144)
 
 set -euo pipefail
 
@@ -50,17 +55,40 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Track IDs we've already surfaced to prevent the stale-read loop (#144).
+# Once an ID is emitted, it never emits again.
+declare -A SEEN_IDS
+
 while true; do
     # Check local dispatches
     OUTPUT=$("$SCRIPT_DIR/dispatch" list --status unread 2>/dev/null || true)
     if [[ -n "$OUTPUT" ]] && [[ "$OUTPUT" != "No dispatches found." ]]; then
-        echo "[DISPATCH] $OUTPUT"
+        # Filter out already-seen IDs
+        HAS_NEW=false
+        NEW_LINES=""
+        while IFS= read -r line; do
+            local_id=$(echo "$line" | awk '{print $1}')
+            if [[ "$local_id" =~ ^[0-9]+$ ]]; then
+                if [[ -z "${SEEN_IDS[$local_id]+_}" ]]; then
+                    SEEN_IDS[$local_id]=1
+                    HAS_NEW=true
+                    NEW_LINES+="$line"$'\n'
+                fi
+            else
+                NEW_LINES+="$line"$'\n'
+            fi
+        done <<< "$OUTPUT"
+
+        if [[ "$HAS_NEW" == "true" ]]; then
+            echo "[DISPATCH] $NEW_LINES"
+        fi
     fi
 
     # Optionally check cross-repo collaboration
     if [[ "$INCLUDE_COLLAB" == "true" ]]; then
         COLLAB_OUTPUT=$("$SCRIPT_DIR/collaboration" check 2>/dev/null || true)
-        if [[ -n "$COLLAB_OUTPUT" ]]; then
+        if [[ -n "$COLLAB_OUTPUT" ]] && [[ -z "${SEEN_IDS[collab_${COLLAB_OUTPUT:0:40}]+_}" ]]; then
+            SEEN_IDS["collab_${COLLAB_OUTPUT:0:40}"]=1
             echo "[COLLAB] $COLLAB_OUTPUT"
         fi
     fi

--- a/claude/tools/lib/_agency-deps
+++ b/claude/tools/lib/_agency-deps
@@ -1,0 +1,184 @@
+# What Problem: Framework dependencies (jq, sqlite3, gh, bats, etc.) are listed
+# in dependencies.yaml but there's no tool to check or install them. Fresh
+# adopters get cryptic failures when tools are missing.
+#
+# How & Why: Reads dependencies.yaml and checks each binary. On macOS, uses
+# brew to install missing ones. Reports status in a clear table.
+#
+# Usage: agency deps [check|install]
+#   check   — verify all deps, report missing (default)
+#   install — install missing deps via brew (macOS only for now)
+#
+# Written: 2026-04-16 during D43 session (issue #135)
+#
+# Inherits: set -euo pipefail, AGENCY_DIR, _log-helper, colors
+
+# --- Subcommand parsing ---
+DEPS_CMD="${AGENCY_ARGS[0]:-check}"
+DEPS_TIER="${AGENCY_ARGS[1]:-all}"  # all, required, testing, optional
+
+_deps_help() {
+    cat << 'HELP'
+agency deps — Dependency management
+
+Usage:
+  agency deps              Check all dependencies (default)
+  agency deps check        Same as above
+  agency deps install      Install missing dependencies via brew (macOS)
+  agency deps install required   Install only required tier
+  agency deps install testing    Install only testing tier
+
+Reads: claude/config/dependencies.yaml
+HELP
+}
+
+case "$DEPS_CMD" in
+    --help|-h) _deps_help; exit 0 ;;
+    check|install) ;;
+    *) echo "Unknown deps command: $DEPS_CMD" >&2; _deps_help >&2; exit 1 ;;
+esac
+
+# --- Locate dependencies.yaml ---
+PROJECT_ROOT="$(cd "$AGENCY_DIR/.." && pwd)"
+DEPS_FILE="$PROJECT_ROOT/claude/config/dependencies.yaml"
+
+if [[ ! -f "$DEPS_FILE" ]]; then
+    echo "Error: dependencies.yaml not found at $DEPS_FILE" >&2
+    exit 1
+fi
+
+# --- Parse dependencies.yaml (awk-based, no yq/python dependency) ---
+
+_parse_tier() {
+    local tier="$1"
+    awk -v tier="$tier:" '
+        BEGIN { in_tier = 0; current = "" }
+        /^[a-z]/ { in_tier = ($0 == tier) ? 1 : 0; next }
+        in_tier && /^  [a-z]/ {
+            gsub(/^  /, ""); gsub(/:.*/, "")
+            current = $0
+        }
+        in_tier && current != "" && /brew:/ {
+            val = $0
+            gsub(/.*brew: */, "", val)
+            gsub(/["'"'"']/, "", val)
+            gsub(/ *$/, "", val)
+            if (val != "null" && val != "") {
+                print current "|" val
+            } else {
+                print current "|MANUAL"
+            }
+            current = ""
+        }
+    ' "$DEPS_FILE"
+}
+
+# --- Check dependencies ---
+
+MISSING_BREW=()
+MISSING_MANUAL=()
+FOUND=0
+MISSING=0
+TOTAL=0
+
+_check_tier() {
+    local tier="$1"
+    local tier_label="$2"
+
+    local entries
+    entries=$(_parse_tier "$tier")
+    if [[ -z "$entries" ]]; then
+        return
+    fi
+
+    echo ""
+    echo -e "${BLUE}$tier_label${NC}"
+    echo "────────────────────────────────────────"
+
+    while IFS='|' read -r name brew; do
+        TOTAL=$((TOTAL + 1))
+        if command -v "$name" &>/dev/null; then
+            local ver
+            ver=$("$name" --version 2>/dev/null | head -1 | head -c 40) || ver="installed"
+            printf "  ${GREEN}✓${NC} %-20s %s\n" "$name" "$ver"
+            FOUND=$((FOUND + 1))
+        else
+            printf "  ${RED}✗${NC} %-20s %s\n" "$name" "(missing — brew: $brew)"
+            MISSING=$((MISSING + 1))
+            if [[ "$brew" == "MANUAL" ]]; then
+                MISSING_MANUAL+=("$name")
+            else
+                MISSING_BREW+=("$brew")
+            fi
+        fi
+    done <<< "$entries"
+}
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  Agency Dependency Check"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+if [[ "$DEPS_TIER" == "all" || "$DEPS_TIER" == "required" ]]; then
+    _check_tier "required" "Required"
+fi
+if [[ "$DEPS_TIER" == "all" || "$DEPS_TIER" == "testing" ]]; then
+    _check_tier "testing" "Testing"
+fi
+if [[ "$DEPS_TIER" == "all" || "$DEPS_TIER" == "optional" ]]; then
+    _check_tier "optional" "Optional"
+fi
+
+echo ""
+echo "────────────────────────────────────────"
+printf "  Total: %d | Found: %d | Missing: %d\n" "$TOTAL" "$FOUND" "$MISSING"
+
+if [[ $MISSING -eq 0 ]]; then
+    echo -e "  ${GREEN}All dependencies satisfied.${NC}"
+    echo ""
+    exit 0
+fi
+
+echo ""
+
+# --- Install missing (macOS only) ---
+
+if [[ "$DEPS_CMD" == "install" ]]; then
+    if [[ "$(uname -s)" != "Darwin" ]]; then
+        echo -e "${YELLOW}Install is macOS-only (brew) for now.${NC}"
+        echo "Linux support: see issue #150."
+        exit 1
+    fi
+
+    if ! command -v brew &>/dev/null; then
+        echo -e "${RED}Homebrew not found.${NC} Install it first:"
+        echo '  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"'
+        exit 1
+    fi
+
+    if [[ ${#MISSING_BREW[@]} -gt 0 ]]; then
+        echo -e "Installing via brew: ${MISSING_BREW[*]}"
+        brew install "${MISSING_BREW[@]}"
+        echo ""
+        echo -e "${GREEN}✓ Installed ${#MISSING_BREW[@]} package(s).${NC}"
+    fi
+
+    if [[ ${#MISSING_MANUAL[@]} -gt 0 ]]; then
+        echo ""
+        echo -e "${YELLOW}Manual install needed:${NC}"
+        for name in "${MISSING_MANUAL[@]}"; do
+            echo "  - $name (see dependencies.yaml for install instructions)"
+        done
+    fi
+else
+    if [[ ${#MISSING_BREW[@]} -gt 0 ]]; then
+        echo "  Install missing: agency deps install"
+        echo "  Or manually:     brew install ${MISSING_BREW[*]}"
+    fi
+    if [[ ${#MISSING_MANUAL[@]} -gt 0 ]]; then
+        echo "  Manual install needed: ${MISSING_MANUAL[*]}"
+    fi
+fi
+
+echo ""
+exit "$MISSING"

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -162,7 +162,7 @@ _update_main() {
     # D41-R10 (monofolk hotfix): --from-github takes precedence so adopters
     # without a local the-agency clone can update directly from origin.
     local SOURCE_DIR=""
-    local TMP_SOURCE_DIR=""   # Set if we shallow-cloned; teardown trap unsets
+    TMP_SOURCE_DIR=""   # NOT local — trap needs access after function exits
     if [[ -n "$FROM_GITHUB" ]]; then
         log_step "Fetching the-agency from GitHub (ref: $FROM_GITHUB)..."
         TMP_SOURCE_DIR=$(mktemp -d -t agency-source-XXXXXX)
@@ -553,6 +553,7 @@ _update_main() {
         # Write update handoff directly (handoff write signals the agent,
         # but we want to write the content ourselves)
         if [[ -n "$handoff_path" ]]; then
+            mkdir -p "$(dirname "$handoff_path")"
             cat > "$handoff_path" << UPDATE_EOF
 ---
 type: agency-update

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260416-2023-42ee83b.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260416-2023-42ee83b.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: the-agency
+diff_base: origin/main
+hash_a: 42ee83bd73594dcc9d3462e32c3bd2649f43bd08919ab078773ba74b7ab8d4f2
+hash_b: 42ee83bd73594dcc9d3462e32c3bd2649f43bd08919ab078773ba74b7ab8d4f2
+hash_c: 42ee83bd73594dcc9d3462e32c3bd2649f43bd08919ab078773ba74b7ab8d4f2
+hash_d: 42ee83bd73594dcc9d3462e32c3bd2649f43bd08919ab078773ba74b7ab8d4f2
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 42ee83bd73594dcc9d3462e32c3bd2649f43bd08919ab078773ba74b7ab8d4f2
+date: 2026-04-16T20:23
+---
+
+# Receipt: pr-prep — the-agency
+
+## Chain of Trust
+- A (original): 42ee83b
+- B (findings): 42ee83b
+- C (triage): 42ee83b
+- D (principal): 42ee83b — auto-approved — no principal 1B1
+- E (final): 42ee83b
+
+## Review Summary
+D43-R2 hotfix: agency update crash + dispatch-monitor + deps + test

--- a/tests/tools/agency-update.bats
+++ b/tests/tools/agency-update.bats
@@ -442,7 +442,6 @@ EOF
         diff-hash
         stage-hash
         commit-precheck
-        instruction-show
     )
     for tool in "${canonical_tools[@]}"; do
         [[ -f "$target/claude/tools/$tool" ]] || missing+=("$tool")


### PR DESCRIPTION
## Summary

Hotfix for commits lost when PR #145 auto-merged while additional pushes were in flight (#151).

Re-applies:
- **agency update --from-github crash fix** (#147): mkdir -p before handoff write + TMP_SOURCE_DIR scope fix
- **dispatch-monitor stale-read fix** (#144): SEEN_IDS tracking prevents infinite loop
- **agency deps check/install** (#135): macOS brew-based dependency management
- **phantom instruction-show test fix** (#149): removed nonexistent tool from canonical list

## Test plan

- [ ] `agency update --from-github --force` on presence-detect (was crashing)
- [ ] `agency update --from-github --force` on homekit-daikin-ac-bridge (was crashing)
- [ ] `agency deps check` reports installed/missing deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)