### PR TITLE
D43-R4: agency update version display fix (closes #155)

### DIFF
--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "1.0",
-  "agency_version": "43.3",
+  "agency_version": "43.4",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -240,10 +240,9 @@ _update_main() {
     # --- Resolve versions ---
     local from_commit to_commit from_version to_version
     from_commit=$(grep '^  source_commit:' "$TARGET_DIR/claude/config/agency.yaml" 2>/dev/null | head -1 | sed 's/.*: *"\{0,1\}//' | sed 's/"\{0,1\} *$//' || echo "unknown")
-    from_version=$(grep '^  version:' "$TARGET_DIR/claude/config/agency.yaml" 2>/dev/null | head -1 | sed 's/.*: *"\{0,1\}//' | sed 's/"\{0,1\} *$//' || echo "unknown")
+    from_version=$(jq -r '.agency_version // "unknown"' "$TARGET_DIR/claude/config/manifest.json" 2>/dev/null || echo "unknown")
     to_commit=$(git -C "$SOURCE_DIR" rev-parse HEAD 2>/dev/null || echo "unknown")
-    to_version=$(grep '^  version:' "$SOURCE_DIR/claude/config/agency.yaml" 2>/dev/null | head -1 | sed 's/.*: *"\{0,1\}//' | sed 's/"\{0,1\} *$//' || echo "2.0.0")
-    to_version="${to_version:-2.0.0}"
+    to_version=$(jq -r '.agency_version // "unknown"' "$SOURCE_DIR/claude/config/manifest.json" 2>/dev/null || echo "unknown")
 
     echo ""
     echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260416-2053-4c857bd.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260416-2053-4c857bd.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: the-agency
+diff_base: origin/main
+hash_a: 4c857bdd4e73c72865e1057ed953093085e356d4c002f76a6bfb8ecae242a056
+hash_b: 4c857bdd4e73c72865e1057ed953093085e356d4c002f76a6bfb8ecae242a056
+hash_c: 4c857bdd4e73c72865e1057ed953093085e356d4c002f76a6bfb8ecae242a056
+hash_d: 4c857bdd4e73c72865e1057ed953093085e356d4c002f76a6bfb8ecae242a056
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 4c857bdd4e73c72865e1057ed953093085e356d4c002f76a6bfb8ecae242a056
+date: 2026-04-16T20:53
+---
+
+# Receipt: pr-prep — the-agency
+
+## Chain of Trust
+- A (original): 4c857bd
+- B (findings): 4c857bd
+- C (triage): 4c857bd
+- D (principal): 4c857bd — auto-approved — no principal 1B1
+- E (final): 4c857bd
+
+## Review Summary
+D43-R4: version display fix


### PR DESCRIPTION
## Summary

Reads `agency_version` from `manifest.json` instead of stale `framework.version` from `agency.yaml`. Now shows actual release version (e.g., 43.3 → 43.4) instead of forever-2.0.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)