### PR TITLE
D44-R1: dispatch-monitor Python rewrite + CI release-tag-check fix

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -52,20 +52,20 @@
     ],
     "PreToolUse": [
       {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/block-raw-tools.sh"
-          }
-        ]
-      },
-      {
         "matcher": "Skill",
         "hooks": [
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/ref-injector.sh"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/claude/hooks/block-raw-tools.sh"
           }
         ]
       },
@@ -138,15 +138,14 @@
     "allow": [
       "Bash(*)",
       "Edit(**)",
-      "Read(**)",
-      "Write(**)",
-      "Read(/tmp/**)",
-      "Write(/tmp/**)",
       "Edit(/tmp/**)",
+      "Edit(/var/folders/**)",
+      "Read(**)",
+      "Read(/tmp/**)",
       "Read(/var/folders/**)",
-      "Write(/var/folders/**)",
-      "Edit(/var/folders/**)"
+      "Write(**)",
+      "Write(/tmp/**)",
+      "Write(/var/folders/**)"
     ]
   }
 }
-

--- a/.github/workflows/release-tag-check.yml
+++ b/.github/workflows/release-tag-check.yml
@@ -55,17 +55,27 @@ jobs:
           echo "version=$v" >> "$GITHUB_OUTPUT"
           echo "Manifest version: v${v}"
 
-      - name: Assert release exists
+      - name: Assert release exists (with grace period)
         if: steps.ismerge.outputs.parents == '2'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           v="${{ steps.ver.outputs.version }}"
-          if ! gh release view "v${v}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
-            echo "::error file=claude/config/manifest.json::Merge commit $(git rev-parse --short HEAD) landed without release tag v${v}. Captain must run /post-merge to cut the release immediately. See issue #113."
-            exit 1
-          fi
-          echo "✓ Release v${v} present for merge commit $(git rev-parse --short HEAD)"
+          # /post-merge creates the release tag shortly after the merge lands.
+          # Poll for up to 120 seconds (12 × 10s) to avoid the race condition
+          # where this workflow fires before the tag exists. Issue #159.
+          for attempt in $(seq 1 12); do
+            if gh release view "v${v}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+              echo "✓ Release v${v} present for merge commit $(git rev-parse --short HEAD) (attempt ${attempt})"
+              exit 0
+            fi
+            if [[ "$attempt" -lt 12 ]]; then
+              echo "Release v${v} not found yet — waiting 10s (attempt ${attempt}/12)..."
+              sleep 10
+            fi
+          done
+          echo "::error file=claude/config/manifest.json::Merge commit $(git rev-parse --short HEAD) landed without release tag v${v} after 120s grace period. Captain must run /post-merge to cut the release. See issue #113."
+          exit 1
 
       - name: Skip (non-merge commit)
         if: steps.ismerge.outputs.parents != '2'

--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,24 @@ claude/agents/*/backups/archive/
 
 # Scheduled tasks lock (runtime state)
 .claude/scheduled_tasks.lock
+
+# --- The Agency framework-managed ignores ---
+# Managed by `agency init` / `agency update`. Append your project-specific
+# ignores above or below this block; leave these lines intact.
+
+# Tool telemetry (runtime logs, auto-appended — never commit)
+.claude/logs/
+
+# Agency service logs (but keep reviews for findings history)
+claude/logs/*
+!claude/logs/reviews/
+
+# Principal scratch (gitignored intentionally — used for drafts, tmp files)
+usr/*/tmp/
+usr/*/*/tmp/
+
+# Temporary agent/tool scratch
+.cache/
+*.tmp
+*.temp
+# --- End framework-managed ignores ---

--- a/claude/REFERENCE-PROVENANCE-HEADERS.md
+++ b/claude/REFERENCE-PROVENANCE-HEADERS.md
@@ -42,6 +42,39 @@ Every piece of code — scripts, tools, modules, classes, methods, functions —
 # Written: 2026-04-04 during captain session 18 (ISCP workstream creation)
 ```
 
+**Python tools** use the same pattern in a docstring:
+
+```python
+#!/usr/bin/env python3
+"""
+What Problem: Dispatch polling via /loop costs ~82,000 tokens/day and has
+5-minute latency. The Monitor tool can watch a background script and react
+to output in real-time, but the bash implementation requires bash 4+.
+
+How & Why: Python 3.9+ rewrite using stdlib only. Python gives us native
+set() for seen-ID tracking, proper subprocess error handling, and signal-
+based clean shutdown. No external dependencies.
+
+Written: 2026-04-17 D44 — first Python tool in the framework
+"""
+```
+
+### Language Choice for Tools
+
+Both bash and Python 3.9+ are valid languages for tools in `claude/tools/`.
+
+| Use bash when | Use Python when |
+|---------------|-----------------|
+| Thin wrappers around other tools | Data structures beyond arrays (sets, dicts) |
+| Git operations via git-safe | Long-running processes |
+| Simple file/path manipulation | Complex string parsing or JSON processing |
+| Interop with existing bash tools | Error handling needs try/except |
+| Shebang: `#!/usr/bin/env bash` | Shebang: `#!/usr/bin/env python3` |
+
+**Python constraints:** stdlib only (no pip/virtualenv). Python 3.9+ floor (matches macOS system Python). Use `from __future__ import annotations` for modern type hint syntax on 3.9.
+
+Templates: `claude/templates/TOOL.sh` (bash), `claude/templates/TOOL.py` (Python).
+
 The **What Problem** forces intent articulation. "What it does" is readable from the code. "What problem it solves" is not — and it's the thing that tells a future reader whether this code is still relevant.
 
 The **How & Why** captures the reasoning chain. When someone needs to change this code, they need to know not just what it does but why it does it *this way*. What alternatives were considered? What constraints drove the choice? This is the context that gets lost when code outlives the session that created it.

--- a/claude/config/agency.yaml
+++ b/claude/config/agency.yaml
@@ -48,10 +48,10 @@ commits:
 
 # Framework version tracking
 framework:
-  version: "2.0.0"
+  version: "43.4"
   installed_at: "2026-01-15T04:54:46+00:00"
-  updated_at: "2026-04-10T11:39:43+00:00"
-  source_commit: "200a5499392942df6c62faa61d7f3da71b18d14e"
+  updated_at: "2026-04-16T13:50:42+00:00"
+  source_commit: "d0b15b61f56341964e4f1de005e6bbc497bc8b1b"
 
 # Agent defaults
 agents:

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "43.4",
+  "agency_version": "44.1",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "43.4",
-    "updated_at": "2026-04-16T13:50:42Z"
+    "framework_version": "44.1",
+    "updated_at": "2026-04-17T08:25:00Z"
   },
   "source": {
     "type": "local",

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -4,8 +4,8 @@
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "2.0.0",
-    "updated_at": "2026-04-16T19:30:00Z"
+    "framework_version": "43.4",
+    "updated_at": "2026-04-16T13:50:42Z"
   },
   "source": {
     "type": "local",

--- a/claude/tools/dispatch-monitor
+++ b/claude/tools/dispatch-monitor
@@ -1,97 +1,185 @@
-#!/usr/bin/env bash
-# What Problem: Dispatch polling via /loop costs ~82,000 tokens/day and has
-# 5-minute latency. The Monitor tool (Claude Code v2.1.98+) can watch a
-# background script and react to output in real-time, but needs a script
-# that only outputs when there are actual dispatches to process.
-#
-# How & Why: Lightweight polling script designed as a Monitor tool backend.
-# Polls dispatch list every N seconds (default 10), only outputs when unread
-# dispatches exist (completely silent otherwise). The Monitor tool streams
-# each output line to the agent, who reacts immediately. Result: 96% token
-# savings, 10-second latency instead of 5 minutes.
-#
-# D43-R2: Added SEEN_IDS tracking to prevent stale-read loop (#144). Once a
-# dispatch ID is emitted, it never emits again — even if the DB query returns
-# it (e.g., because resolve/read didn't stick or identity shifted).
-#
-# Usage: With Monitor tool — ask Claude to "monitor dispatches using dispatch-monitor"
-# Standalone: ./claude/tools/dispatch-monitor [--interval N] [--include-collab]
-#
-# Written: 2026-04-10 during captain session (Monitor tool adoption)
-# Updated: 2026-04-16 D43-R2 — stale-read loop fix (#144)
+#!/usr/bin/env python3
+"""
+What Problem: Dispatch polling via /loop costs ~82,000 tokens/day and has
+5-minute latency. The Monitor tool (Claude Code v2.1.98+) can watch a
+background script and react to output in real-time, but needs a script
+that only outputs when there are actual dispatches to process.
 
-set -euo pipefail
+The original bash implementation used `declare -A` (associative arrays)
+for seen-ID tracking, which requires bash 4+. macOS ships bash 3.2
+(Apple won't distribute GPLv3), so the script fails on stock macOS.
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-INTERVAL=10
-INCLUDE_COLLAB=false
+How & Why: Python 3.9+ rewrite — first Python tool in the framework.
+Python gives us a native set() for seen-ID tracking (no bash version
+issues), proper subprocess error handling, and signal-based clean
+shutdown. Polls dispatch list every N seconds (default 10), only outputs
+when NEW unread dispatches exist (completely silent otherwise). The
+Monitor tool streams each stdout line to the agent.
 
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --interval)
-            INTERVAL="$2"
-            shift 2
-            ;;
-        --include-collab)
-            INCLUDE_COLLAB=true
-            shift
-            ;;
-        --help|-h)
-            echo "Usage: dispatch-monitor [--interval N] [--include-collab]"
-            echo ""
-            echo "Lightweight polling script for use with Claude Code's Monitor tool."
-            echo "Only outputs when there are unread dispatches (silent otherwise)."
-            echo ""
-            echo "Options:"
-            echo "  --interval N        Poll interval in seconds (default: 10)"
-            echo "  --include-collab    Also check cross-repo collaboration dispatches"
-            echo "  --help              Show this help"
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1" >&2
-            exit 1
-            ;;
-    esac
-done
+D43-R2 origin: SEEN_IDS tracking prevents stale-read loop (#144). Once
+a dispatch ID is emitted within a session, it never emits again — even
+if the DB query returns it (resolved dispatch re-appearing, identity
+shift, etc.). seen_ids is memory-only (lost on restart, by design —
+restart should re-surface currently-unread items).
 
-# Track IDs we've already surfaced to prevent the stale-read loop (#144).
-# Once an ID is emitted, it never emits again.
-declare -A SEEN_IDS
+Usage:
+    With Monitor tool: monitor dispatches using ./claude/tools/dispatch-monitor --include-collab
+    Standalone: ./claude/tools/dispatch-monitor [--interval N] [--include-collab]
 
-while true; do
-    # Check local dispatches
-    OUTPUT=$("$SCRIPT_DIR/dispatch" list --status unread 2>/dev/null || true)
-    if [[ -n "$OUTPUT" ]] && [[ "$OUTPUT" != "No dispatches found." ]]; then
-        # Filter out already-seen IDs
-        HAS_NEW=false
-        NEW_LINES=""
-        while IFS= read -r line; do
-            local_id=$(echo "$line" | awk '{print $1}')
-            if [[ "$local_id" =~ ^[0-9]+$ ]]; then
-                if [[ -z "${SEEN_IDS[$local_id]+_}" ]]; then
-                    SEEN_IDS[$local_id]=1
-                    HAS_NEW=true
-                    NEW_LINES+="$line"$'\n'
-                fi
-            else
-                NEW_LINES+="$line"$'\n'
-            fi
-        done <<< "$OUTPUT"
+Written: 2026-04-10 during captain session (Monitor tool adoption)
+Rewritten: 2026-04-17 D44 — Python rewrite (bash 3.2 compat, first Python tool)
+"""
 
-        if [[ "$HAS_NEW" == "true" ]]; then
-            echo "[DISPATCH] $NEW_LINES"
-        fi
-    fi
+from __future__ import annotations
 
-    # Optionally check cross-repo collaboration
-    if [[ "$INCLUDE_COLLAB" == "true" ]]; then
-        COLLAB_OUTPUT=$("$SCRIPT_DIR/collaboration" check 2>/dev/null || true)
-        if [[ -n "$COLLAB_OUTPUT" ]] && [[ -z "${SEEN_IDS[collab_${COLLAB_OUTPUT:0:40}]+_}" ]]; then
-            SEEN_IDS["collab_${COLLAB_OUTPUT:0:40}"]=1
-            echo "[COLLAB] $COLLAB_OUTPUT"
-        fi
-    fi
+import argparse
+import re
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Optional, Set, List
 
-    sleep "$INTERVAL"
-done
+# ── Constants ────────────────────────────────────────────────────────────────
+SCRIPT_DIR = Path(__file__).resolve().parent
+DISPATCH_TOOL = SCRIPT_DIR / "dispatch"
+COLLAB_TOOL = SCRIPT_DIR / "collaboration"
+MAX_SEEN_IDS = 10_000  # Cap to prevent unbounded growth in long sessions
+ID_PATTERN = re.compile(r"^\s*(\d+)\s")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="dispatch-monitor",
+        description=(
+            "Lightweight polling script for use with Claude Code's Monitor tool. "
+            "Only outputs when there are unread dispatches (silent otherwise)."
+        ),
+    )
+    parser.add_argument(
+        "--interval",
+        type=int,
+        default=10,
+        help="Poll interval in seconds (default: 10)",
+    )
+    parser.add_argument(
+        "--include-collab",
+        action="store_true",
+        help="Also check cross-repo collaboration dispatches",
+    )
+    return parser.parse_args()
+
+
+def run_command(cmd: list[str], timeout: int = 30) -> str:
+    """Run a subprocess, return stdout. Silent on failure (returns empty)."""
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+        return result.stdout.strip()
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        print(f"dispatch-monitor: {e}", file=sys.stderr, flush=True)
+        return ""
+
+
+def extract_id(line: str) -> int | None:
+    """Extract dispatch ID from a line. Returns None if not an ID line."""
+    match = ID_PATTERN.match(line)
+    if match:
+        return int(match.group(1))
+    return None
+
+
+def evict_oldest(seen: set[int], max_size: int) -> None:
+    """Evict oldest entries if set exceeds max size.
+
+    Since Python sets don't preserve insertion order in a recoverable way,
+    we just clear half when we hit the cap. Dispatch IDs are monotonically
+    increasing, so old IDs won't reappear — clearing is safe.
+    """
+    if len(seen) > max_size:
+        # Keep the higher (newer) IDs
+        sorted_ids = sorted(seen)
+        cutoff = len(sorted_ids) // 2
+        for old_id in sorted_ids[:cutoff]:
+            seen.discard(old_id)
+
+
+def check_dispatches(seen_ids: set[int]) -> None:
+    """Poll for unread dispatches and emit new ones."""
+    output = run_command([str(DISPATCH_TOOL), "list", "--status", "unread"])
+
+    if not output or output == "No dispatches found.":
+        return
+
+    new_lines: list[str] = []
+    has_new = False
+
+    for line in output.splitlines():
+        dispatch_id = extract_id(line)
+        if dispatch_id is not None:
+            if dispatch_id not in seen_ids:
+                seen_ids.add(dispatch_id)
+                has_new = True
+                new_lines.append(line)
+            # Skip already-seen IDs
+        else:
+            # Non-ID lines (headers, separators) — include with new dispatches
+            new_lines.append(line)
+
+    if has_new:
+        print(f"[DISPATCH] {chr(10).join(new_lines)}", flush=True)
+
+    evict_oldest(seen_ids, MAX_SEEN_IDS)
+
+
+def check_collab(seen_collab: set[str]) -> None:
+    """Poll for cross-repo collaboration dispatches."""
+    output = run_command([str(COLLAB_TOOL), "check"])
+
+    if not output:
+        return
+
+    # Key on first 40 chars to dedup (same pattern as bash version)
+    collab_key = output[:40]
+    if collab_key not in seen_collab:
+        seen_collab.add(collab_key)
+        print(f"[COLLAB] {output}", flush=True)
+
+
+def shutdown(signum: int, frame) -> None:
+    """Clean shutdown on SIGINT/SIGTERM."""
+    sys.exit(0)
+
+
+def main() -> None:
+    args = parse_args()
+
+    signal.signal(signal.SIGINT, shutdown)
+    signal.signal(signal.SIGTERM, shutdown)
+
+    seen_ids: set[int] = set()
+    seen_collab: set[str] = set()
+
+    print(
+        f"dispatch-monitor: polling every {args.interval}s"
+        + (" (with collab)" if args.include_collab else ""),
+        file=sys.stderr,
+        flush=True,
+    )
+
+    while True:
+        check_dispatches(seen_ids)
+
+        if args.include_collab:
+            check_collab(seen_collab)
+
+        time.sleep(args.interval)
+
+
+if __name__ == "__main__":
+    main()

--- a/claude/tools/dispatch-monitor
+++ b/claude/tools/dispatch-monitor
@@ -132,7 +132,8 @@ def check_dispatches(seen_ids: set[int]) -> None:
             new_lines.append(line)
 
     if has_new:
-        print(f"[DISPATCH] {chr(10).join(new_lines)}", flush=True)
+        joined = "\n".join(new_lines)
+        print(f"[DISPATCH] {joined}", flush=True)
 
     evict_oldest(seen_ids, MAX_SEEN_IDS)
 

--- a/claude/workstreams/agency/dispatch-monitor-ad-20260417.md
+++ b/claude/workstreams/agency/dispatch-monitor-ad-20260417.md
@@ -1,0 +1,154 @@
+---
+type: ad
+project: dispatch-monitor
+workstream: agency
+date: 2026-04-17
+status: draft
+author: the-agency/jordan/captain
+pvr: claude/workstreams/agency/dispatch-monitor-pvr-20260417.md
+---
+
+# dispatch-monitor — Architecture & Design
+
+## Overview
+
+Drop-in Python 3.9+ rewrite of `claude/tools/dispatch-monitor`. Replaces bash script that uses bash 4+ features (`declare -A`) unavailable on macOS. First Python tool in the framework — sets the pattern.
+
+## Architecture
+
+### Component Model
+
+```
+dispatch-monitor (Python 3.9+, stdlib only)
+  ├── main loop (poll, filter, emit)
+  ├── seen_ids: set[int]          — in-memory, lost on restart (by design)
+  ├── dispatch checker             — subprocess: ./claude/tools/dispatch list --status unread
+  ├── collab checker (optional)    — subprocess: ./claude/tools/collaboration check
+  └── stdout emitter               — line-buffered, [DISPATCH]/[COLLAB] prefixed
+```
+
+### Key Design Decisions
+
+**1. seen_ids is in-memory only (not persistent).**
+On restart, the monitor re-emits any currently-unread dispatches. This is correct — if the monitor crashed, the agent needs to see what's unread. The stale-read problem (#144) was dispatches re-surfacing within a single session due to query timing, not across restarts. Memory-only set solves this cleanly.
+
+**2. Subprocess calls to existing bash tools.**
+dispatch-monitor calls `dispatch list` and `collaboration check` as subprocesses. It does NOT reimplement their logic in Python. Those tools handle DB access, identity resolution, and formatting. This tool is purely a polling wrapper with deduplication.
+
+**3. stdout is the event stream, stderr for diagnostics.**
+The Monitor tool reads stdout lines as events. Diagnostic messages (startup, errors, polling status) go to stderr. This matches the Monitor tool contract.
+
+**4. Line-buffered stdout.**
+Python buffers stdout by default when not connected to a TTY (which is the case under Monitor). Must explicitly flush after every print or use `sys.stdout.reconfigure(line_buffering=True)` (Python 3.7+).
+
+**5. No telemetry integration.**
+Unlike most tools, dispatch-monitor is a long-running background process. Writing telemetry log_start/log_end per poll cycle would flood the log. Skip telemetry — the tool's value is in its stdout output, not its logs.
+
+## Interface
+
+```
+Usage: dispatch-monitor [--interval N] [--include-collab] [--help]
+
+Options:
+  --interval N        Poll interval in seconds (default: 10)
+  --include-collab    Also check cross-repo collaboration dispatches
+  --help              Show this help
+```
+
+Identical to the bash version. Drop-in replacement.
+
+## Implementation Details
+
+### Main Loop
+
+```python
+seen_ids: set[int] = set()
+
+while True:
+    # 1. Run dispatch list --status unread
+    output = run_dispatch_list()
+    
+    # 2. Parse output, extract IDs
+    new_lines = []
+    for line in output.splitlines():
+        dispatch_id = extract_id(line)
+        if dispatch_id and dispatch_id not in seen_ids:
+            seen_ids.add(dispatch_id)
+            new_lines.append(line)
+    
+    # 3. Emit if new
+    if new_lines:
+        print(f"[DISPATCH] {chr(10).join(new_lines)}", flush=True)
+    
+    # 4. Optional collab check
+    if include_collab:
+        collab_output = run_collab_check()
+        collab_key = hash(collab_output[:80])
+        if collab_output and collab_key not in seen_collab:
+            seen_collab.add(collab_key)
+            print(f"[COLLAB] {collab_output}", flush=True)
+    
+    # 5. Sleep
+    time.sleep(interval)
+```
+
+### ID Extraction
+
+Parse the first whitespace-delimited token from each line. If it's a digit string, it's a dispatch ID. Non-ID lines (headers, separators) are included with new dispatches but don't affect dedup.
+
+### Signal Handling
+
+```python
+import signal
+
+def shutdown(signum, frame):
+    sys.exit(0)
+
+signal.signal(signal.SIGINT, shutdown)
+signal.signal(signal.SIGTERM, shutdown)
+```
+
+### Error Handling
+
+Subprocess failures (dispatch tool not found, DB locked, permission error) are caught and silenced — `stderr` gets a diagnostic, but the loop continues. A transient failure shouldn't kill a session-length monitor.
+
+```python
+try:
+    result = subprocess.run([...], capture_output=True, text=True, timeout=30)
+except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+    print(f"dispatch-monitor: {e}", file=sys.stderr)
+    # Continue polling — transient failures are expected
+```
+
+### Script Resolution
+
+The dispatch tool path is resolved relative to the script's own location:
+
+```python
+SCRIPT_DIR = Path(__file__).resolve().parent
+DISPATCH_TOOL = SCRIPT_DIR / "dispatch"
+COLLAB_TOOL = SCRIPT_DIR / "collaboration"
+```
+
+## File Changes
+
+| File | Change |
+|------|--------|
+| `claude/tools/dispatch-monitor` | Replace bash with Python (same path, new shebang) |
+| `claude/REFERENCE-PROVENANCE-HEADERS.md` | Add Python tool guidance |
+
+## Testing
+
+- Verify Monitor tool integration (start, receive events, stop)
+- Verify stale-read prevention (same ID not emitted twice)
+- Verify silence when no dispatches
+- Verify `--include-collab` flag
+- Verify graceful handling of subprocess failures
+- Verify SIGINT/SIGTERM clean shutdown
+
+## What This Does NOT Cover
+
+- Rewriting other tools in Python
+- Adding pip/package management
+- Persistent seen_ids across restarts
+- Telemetry for the monitor itself

--- a/claude/workstreams/agency/dispatch-monitor-plan-20260417.md
+++ b/claude/workstreams/agency/dispatch-monitor-plan-20260417.md
@@ -1,0 +1,41 @@
+---
+type: plan
+project: dispatch-monitor
+workstream: agency
+date: 2026-04-17
+status: active
+author: the-agency/jordan/captain
+pvr: claude/workstreams/agency/dispatch-monitor-pvr-20260417.md
+ad: claude/workstreams/agency/dispatch-monitor-ad-20260417.md
+mar: "Quick MAR — 3 agents (methodology-critic, practitioner, adopter-advocate)"
+---
+
+# dispatch-monitor — Implementation Plan
+
+## Scope
+
+Single-phase, 3 iterations. Small tool — no need for multi-phase.
+
+## Phase 1: Python Rewrite (3 iterations)
+
+### Iteration 1.1: Core rewrite
+- Replace `claude/tools/dispatch-monitor` with Python implementation
+- Main loop: poll, parse, dedup, emit
+- seen_ids as set with max 10,000 cap (LRU eviction via oldest-first discard)
+- Subprocess calls to dispatch list and collaboration check
+- Signal handling (SIGINT/SIGTERM)
+- Error handling (catch subprocess failures, continue polling)
+- Line-buffered stdout (flush=True on every print)
+- Provenance headers (What Problem / How & Why / Written)
+- CLI: --interval, --include-collab, --help
+
+### Iteration 1.2: CI fix + testing
+- Commit #159 release-tag-check polling fix (already coded)
+- Write/update dispatch-monitor tests
+- Verify Monitor tool integration manually
+
+### Iteration 1.3: Documentation + fleet notification
+- Update REFERENCE-PROVENANCE-HEADERS.md: Python is valid for tools
+- Update dependencies.yaml if needed (Python 3.9+ as required dep)
+- Brief migration note for release
+- Flag clear: Python tooling review item

--- a/claude/workstreams/agency/dispatch-monitor-pvr-20260417.md
+++ b/claude/workstreams/agency/dispatch-monitor-pvr-20260417.md
@@ -1,0 +1,94 @@
+---
+type: pvr
+project: dispatch-monitor
+workstream: agency
+date: 2026-04-17
+status: draft
+author: the-agency/jordan/captain
+seeds:
+  - "1B1 discussion with principal on Python tooling strategy (2026-04-17)"
+  - "Issue #144 — dispatch-monitor stale-read loop"
+  - "dispatch-monitor bash 3.2 failure on macOS"
+---
+
+# dispatch-monitor — Python Rewrite PVR
+
+## Vision
+
+Rewrite `dispatch-monitor` from bash to Python 3.9+, establishing it as the first Python tool in the framework and setting the precedent that Python is a valid and encouraged language for Agency tools.
+
+## The Problem
+
+1. **dispatch-monitor is broken on macOS.** It uses `declare -A` (bash 4+ associative arrays) for SEEN_IDS tracking. macOS ships bash 3.2 (Apple won't ship GPLv3). The Monitor tool can't run it. All agent collaboration via dispatch monitoring is down fleet-wide.
+
+2. **Bash is the wrong language for this tool.** dispatch-monitor needs a set data structure (seen IDs), runs as a long-lived process, does string parsing, and would benefit from proper error handling. All of these are painful or impossible in bash 3.2.
+
+3. **No Python tools exist in the framework yet.** The TOOL.py template was created in D43 (#141) but has never been used for a shipped tool. There's no precedent for Python tools, and documentation doesn't clearly state Python is an option.
+
+## Target Users
+
+- **Captain agent** — primary consumer of dispatch notifications via Monitor tool
+- **Worktree agents** — receive dispatches from captain and other agents
+- **Adopter repos** — any repo running `agency update` gets this tool
+
+## Use Cases
+
+1. **UC1: Background dispatch monitoring** — Captain starts Monitor with dispatch-monitor at session start. Script polls every N seconds, only outputs when new unread dispatches exist. Monitor tool surfaces each output line to the agent.
+
+2. **UC2: Cross-repo collaboration monitoring** — With `--include-collab`, also checks the collaboration channel for cross-repo dispatches.
+
+3. **UC3: Stale-read prevention** — Once a dispatch ID has been surfaced, it never surfaces again, even if the underlying query returns it (resolved dispatch re-appearing, identity shift, etc.).
+
+4. **UC4: Standalone usage** — Can be run directly from CLI for debugging/testing without the Monitor tool.
+
+## Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| FR1 | Poll `dispatch list --status unread` every N seconds (default 10, configurable via `--interval`) |
+| FR2 | Only produce output when NEW unread dispatches exist (completely silent otherwise) |
+| FR3 | Track seen dispatch IDs in a set — once emitted, never emit again (stale-read prevention) |
+| FR4 | Optionally check cross-repo collaboration via `--include-collab` flag |
+| FR5 | Prefix output with `[DISPATCH]` or `[COLLAB]` for routing |
+| FR6 | Support `--help` flag with usage information |
+| FR7 | Use Python 3.9+ with no external dependencies (stdlib only) |
+| FR8 | Interoperate with existing JSONL telemetry (_log-helper format) |
+| FR9 | Flush stdout after every write (line-buffered for Monitor tool compatibility) |
+
+## Non-Functional Requirements
+
+| ID | Requirement |
+|----|-------------|
+| NFR1 | Zero external Python dependencies — stdlib only |
+| NFR2 | Memory-stable for long-running sessions (seen_ids set grows but dispatch IDs are small integers) |
+| NFR3 | Graceful handling of subprocess failures (dispatch tool not found, DB locked, etc.) |
+| NFR4 | Clean shutdown on SIGINT/SIGTERM |
+| NFR5 | Provenance headers following TOOL.py template pattern |
+| NFR6 | Python 3.9+ floor (matches macOS system Python) |
+
+## Constraints
+
+1. Must be a drop-in replacement — same CLI interface (`--interval N`, `--include-collab`, `--help`)
+2. Must work with the Monitor tool (stdout is the event stream, stderr for diagnostics)
+3. No pip install — stdlib only
+4. Shebang must be `#!/usr/bin/env python3` (resolves correctly on macOS and Linux)
+5. Must replace the existing bash script at `claude/tools/dispatch-monitor` (not a new path)
+
+## Success Criteria
+
+1. `dispatch-monitor --include-collab` runs successfully under the Monitor tool on macOS with system Python 3.9
+2. Stale-read prevention works (same dispatch ID never emitted twice)
+3. Silent when no new dispatches (zero output, no tokens consumed)
+4. All existing dispatch-monitor tests pass (update test expectations if needed)
+5. First Python tool shipped in `claude/tools/` — sets the precedent
+
+## Non-Goals
+
+- Rewriting other tools in Python (separate initiative, flagged for review)
+- Adding pip/virtualenv infrastructure
+- Changing the dispatch tool itself (this is just the monitor wrapper)
+- Python packaging or distribution concerns
+
+## Open Questions
+
+None — principal discussion resolved all questions (Python 3.9+, stdlib only, first tool, update docs).

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-0824-d5bb50c.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-0824-d5bb50c.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: the-agency
+diff_base: origin/main
+hash_a: 2a756efc36332a891fbae68c5c077a8bf7e7a472a29e8ace12d2c9f3bf1297f3
+hash_b: 2a756efc36332a891fbae68c5c077a8bf7e7a472a29e8ace12d2c9f3bf1297f3
+hash_c: 2a756efc36332a891fbae68c5c077a8bf7e7a472a29e8ace12d2c9f3bf1297f3
+hash_d: 2a756efc36332a891fbae68c5c077a8bf7e7a472a29e8ace12d2c9f3bf1297f3
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: d5bb50c550604bad0701fc015d8984d815f9191b32adeb195dca5ed92daec6ba
+date: 2026-04-17T08:24
+---
+
+# Receipt: pr-prep — the-agency
+
+## Chain of Trust
+- A (original): 2a756ef
+- B (findings): 2a756ef
+- C (triage): 2a756ef
+- D (principal): 2a756ef — auto-approved — no principal 1B1
+- E (final): d5bb50c
+
+## Review Summary
+D44-R1: dispatch-monitor Python rewrite + CI release-tag-check fix

--- a/tests/tools/test_dispatch_monitor.py
+++ b/tests/tools/test_dispatch_monitor.py
@@ -1,0 +1,139 @@
+"""
+Tests for dispatch-monitor (Python rewrite).
+
+Tests the core functions: ID extraction, seen-ID dedup, eviction.
+Does NOT test subprocess calls (those depend on the dispatch tool + DB).
+
+Written: 2026-04-17 D44 — dispatch-monitor Python rewrite
+"""
+
+import importlib.util
+import sys
+from pathlib import Path
+
+# Load dispatch-monitor as a module despite no .py extension.
+# Use SourceFileLoader directly — spec_from_file_location returns None
+# for files without .py extension.
+from importlib.machinery import SourceFileLoader
+
+_tool_path = str(Path(__file__).resolve().parent.parent.parent / "claude" / "tools" / "dispatch-monitor")
+_loader = SourceFileLoader("dispatch_monitor", _tool_path)
+_mod = _loader.load_module()
+
+extract_id = _mod.extract_id
+evict_oldest = _mod.evict_oldest
+ID_PATTERN = _mod.ID_PATTERN
+
+
+class TestExtractId:
+    def test_valid_id_line(self):
+        assert extract_id("519  commit   normal   resolved   ...") == 519
+
+    def test_valid_id_with_leading_spaces(self):
+        assert extract_id("  42  dispatch  normal  unread  ...") == 42
+
+    def test_header_line(self):
+        assert extract_id("ID   TYPE   PRI   STATUS   SUBJECT") is None
+
+    def test_separator_line(self):
+        assert extract_id("──────────────────────") is None
+
+    def test_empty_line(self):
+        assert extract_id("") is None
+
+    def test_no_dispatches_message(self):
+        assert extract_id("No dispatches found.") is None
+
+    def test_large_id(self):
+        assert extract_id("99999  commit  normal  unread  test") == 99999
+
+
+class TestEvictOldest:
+    def test_no_eviction_under_limit(self):
+        seen = {1, 2, 3}
+        evict_oldest(seen, 10)
+        assert seen == {1, 2, 3}
+
+    def test_eviction_at_limit(self):
+        seen = set(range(100))
+        evict_oldest(seen, 50)
+        # Should have evicted ~half (the lower IDs)
+        assert len(seen) <= 50
+        # Higher IDs should survive
+        assert 99 in seen
+        assert 98 in seen
+
+    def test_eviction_keeps_newer(self):
+        seen = {1, 2, 3, 100, 200, 300}
+        evict_oldest(seen, 3)
+        # Should keep the higher IDs
+        assert 300 in seen
+        assert 200 in seen
+        assert 100 in seen
+
+    def test_empty_set(self):
+        seen: set = set()
+        evict_oldest(seen, 10)
+        assert len(seen) == 0
+
+
+class TestDedup:
+    """Test the dedup logic that would happen in check_dispatches."""
+
+    def test_new_id_added(self):
+        seen = set()
+        line = "519  commit   normal   unread   test"
+        dispatch_id = extract_id(line)
+        assert dispatch_id == 519
+        assert dispatch_id not in seen
+        seen.add(dispatch_id)
+        assert dispatch_id in seen
+
+    def test_duplicate_rejected(self):
+        seen = {519}
+        line = "519  commit   normal   unread   test"
+        dispatch_id = extract_id(line)
+        assert dispatch_id in seen  # Should be filtered
+
+    def test_different_ids_both_accepted(self):
+        seen = set()
+        for line in [
+            "519  commit   normal   unread   test1",
+            "520  commit   normal   unread   test2",
+        ]:
+            dispatch_id = extract_id(line)
+            assert dispatch_id not in seen
+            seen.add(dispatch_id)
+        assert seen == {519, 520}
+
+
+if __name__ == "__main__":
+    # Simple test runner — no pytest dependency needed
+    import traceback
+
+    passed = 0
+    failed = 0
+    errors = []
+
+    for cls_name, cls in [
+        ("TestExtractId", TestExtractId),
+        ("TestEvictOldest", TestEvictOldest),
+        ("TestDedup", TestDedup),
+    ]:
+        for method_name in sorted(dir(cls)):
+            if not method_name.startswith("test_"):
+                continue
+            test_name = f"{cls_name}.{method_name}"
+            try:
+                getattr(cls(), method_name)()
+                passed += 1
+            except Exception:
+                failed += 1
+                errors.append((test_name, traceback.format_exc()))
+
+    for test_name, tb in errors:
+        print(f"FAIL: {test_name}")
+        print(tb)
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(1 if failed else 0)

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,10 +1,23 @@
 ---
-type: handoff
-agent: the-agency/jordan/captain
-workstream: housekeeping
-date: 2026-04-16
-trigger: session-end
+type: agency-update
+date: 2026-04-16 21:50
+from_commit: 200a5499
+to_commit: d0b15b61
 ---
+
+## Agency Update
+
+Updated framework from 43.4 (200a5499) to 43.4 (d0b15b61).
+
+### Changes
+- 0 files added, 0 files updated, 0 files removed
+- Settings merged via array union
+- Framework section in agency.yaml updated
+
+### Verify the update
+Run `agency verify` to confirm everything is in order.
+
+### Previous session state
 
 ## D43 Session End — 4 releases shipped
 
@@ -25,30 +38,3 @@ trigger: session-end
 
 - **#146** — Block AGENCY_ALLOW_RAW escape hatch (waiting on monofolk input)
 - **#150** — Linux deps support (apt/dnf) — future
-- **#157** — D-R format in version display — next release
-
-### Key decisions (D43)
-
-1. **No more raw git.** Principal directive: use tools and skills only. If the tool can't do it, build the capability. AGENCY_ALLOW_RAW escape hatch to be blocked (#146).
-2. **Always file issues.** Every bug gets an issue, even if fixed immediately. No silent fixes.
-3. **agency update must be zero-friction for adopters.** Auto-commit framework files, auto-verify, no manual git steps.
-4. **_sync-main-ref doesn't update working tree.** Post-merge flow needs `git checkout HEAD -- .` after `_sync-main-ref` to keep files in sync.
-5. **D-R format for version display** (#157) — next release.
-
-### Fleet status
-
-- 4 worktrees synced (devex, mdpal-app, mdpal-cli, mdslidepal-web)
-- 3 worktrees pending resolution (iscp, mdslidepal-mac, mock-and-mark — dispatched)
-- designex resolved merge conflict and shipping Phase 1.1
-
-### Behavioral notes for next session
-
-- NEVER suggest compact. Principal monitors via statusline.
-- NEVER use raw git. Use tools/skills. If blocked, build the tool.
-- Always file issues. Bug → issue → fix → close.
-- `git add -A` requires explicit principal approval every time.
-- Over/Over-and-out protocol for 1B1 discussions.
-
----
-
-*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,40 +1,30 @@
 ---
-type: agency-update
-date: 2026-04-16 21:50
-from_commit: 200a5499
-to_commit: d0b15b61
+type: session
+agent: the-agency/jordan/captain
+workstream: housekeeping
+date: 2026-04-17
+trigger: session-compact
 ---
 
-## Agency Update
+## D44 — dispatch-monitor Python rewrite + CI fix
 
-Updated framework from 43.4 (200a5499) to 43.4 (d0b15b61).
+### In progress
+- Executing full Valueflow flow: PVR → MAR → A&D → MAR → Plan → MAR → Implement
+- dispatch-monitor rewrite from bash to Python (first Python tool in framework)
+- #159 release-tag-check CI fix (polling grace period) — code done, not yet committed
 
-### Changes
-- 0 files added, 0 files updated, 0 files removed
-- Settings merged via array union
-- Framework section in agency.yaml updated
-
-### Verify the update
-Run `agency verify` to confirm everything is in order.
-
-### Previous session state
-
-## D43 Session End — 4 releases shipped
-
-### Releases
-
-| Release | PR | What |
-|---------|-----|------|
-| v43.1 | #145 | TOOL.sh/TOOL.py templates (#140 #141) + D42 doc sweep (65+ stale refs across 33 files) + README review (#142) + workshop pitch (#143) + CI fix (#148) |
-| v43.2 | #152 | Hotfix — agency update crash (#147) + dispatch-monitor stale-read (#144) + agency deps macOS (#135) + phantom test (#149) |
-| v43.3 | #154 | agency update auto-commit framework files + auto-verify |
-| v43.4 | #156 | agency update version display from manifest.json (#155) |
-
-### Issues closed: #134, #135, #140, #141, #142, #143, #144, #147, #148, #149, #151, #153, #155
-
-### Issues filed: #146, #147, #148, #149, #150, #151, #153, #155, #157
+### Context
+- 88% context at start — executing autonomously, no compaction
+- Principal directive: Python 3.9+ is valid for tooling, dispatch-monitor is first
+- Flagged: audit all tools for Python rewrite candidates
+- Flagged: update docs to make Python official
+- Dispatch fleet when done: Python is now an option
 
 ### Open issues
-
-- **#146** — Block AGENCY_ALLOW_RAW escape hatch (waiting on monofolk input)
-- **#150** — Linux deps support (apt/dnf) — future
+- #159 — CI fix (in this session)
+- #160 — agency update overwrites handoff
+- #157 — D-R version format
+- #146 — Block AGENCY_ALLOW_RAW
+- #158 — Captain monitors as proper tools
+- Duplicate /secret in presence-detect
+- jdm/jordan identity split

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -6,55 +6,48 @@ date: 2026-04-16
 trigger: session-end
 ---
 
-## D42 Session End — 8 releases shipped
+## D43 Session End — 4 releases shipped
 
 ### Releases
 
 | Release | PR | What |
 |---------|-----|------|
-| v42.1 | #129 | stage-hash bash + reset-soft + stash + hookify Bash wiring (closes #126 #128) |
-| v42.2 | #131 | hookify block-raw-gh-release + /secret dedup + block-raw-tools enforcement |
-| v42.3 | #132 | workstream content split — principal-scoped registrations, per-workstream receipts, git-safe mv/unstage/restore (closes #121 #130) |
-| v42.4 | #133 | migrate the-agency artifacts to new structure |
-| v42.5 | #136 | v1 tool retirement + root cleanup + repo structure overhaul |
-| v42.6 | #137 | .gitignore + CLAUDE.md + REFERENCE-TOOL-BUILDING.md |
-| v42.7 | #138 | plan-capture workstream-aware + agency-welcome + test fixtures |
-| v42.8 | #139 | version decouple (#122) + dependencies manifest (#135) + tool-create template |
+| v43.1 | #145 | TOOL.sh/TOOL.py templates (#140 #141) + D42 doc sweep (65+ stale refs across 33 files) + README review (#142) + workshop pitch (#143) + CI fix (#148) |
+| v43.2 | #152 | Hotfix — agency update crash (#147) + dispatch-monitor stale-read (#144) + agency deps macOS (#135) + phantom test (#149) |
+| v43.3 | #154 | agency update auto-commit framework files + auto-verify |
+| v43.4 | #156 | agency update version display from manifest.json (#155) |
 
-### Issues closed: #121, #122, #126, #128, #130, #135
+### Issues closed: #134, #135, #140, #141, #142, #143, #144, #147, #148, #149, #151, #153, #155
 
-### Issues filed: #135, #140, #141, #142, #143
+### Issues filed: #146, #147, #148, #149, #150, #151, #153, #155, #157
 
-### Stale working tree warning
+### Open issues
 
-Local working tree has stale files from pre-merge state. 4 files show as modified (plan-capture.py, TOOL.sh, pr-create, release-plan.bats) — these are the OLD versions from main before R7/R8 merged. Run `AGENCY_ALLOW_RAW=1 git checkout -- .` to restore from HEAD.
+- **#146** — Block AGENCY_ALLOW_RAW escape hatch (waiting on monofolk input)
+- **#150** — Linux deps support (apt/dnf) — future
+- **#157** — D-R format in version display — next release
 
-### Open issues for next session
+### Key decisions (D43)
 
-- **#140** — TOOL.sh template: complete logging/telemetry patterns
-- **#141** — Python tool template (TOOL.py)
-- **#142** — README-*.md content review (5 files need update)
-- **#143** — Workshop pitch for Mapletree REIT L&D
-- **#134** — workstream-create scaffold (monofolk report — likely stale SKILL.md)
-
-### Key structural decisions (D42)
-
-1. `.claude/agents/{P}/{A}.md` — principal-scoped, `claude --agent jordan/captain`
-2. `agent-bootstrap` retired — structural @import
-3. Receipt naming: `{org}-{principal}-{agent}-{ws}-{proj}-{type}-{boundary}-{date}-{hash}.md`
-4. Receipts at `claude/workstreams/{W}/qgr/` and `rgr/`
-5. `usr/{P}/{A}/` slim: tmp/, tools/, history/, history/flotsam/
-6. `project_version` decoupled from `agency_version`
-7. `claude/config/dependencies.yaml` — machine-readable deps manifest
-8. `git add -A` requires explicit principal approval every time
+1. **No more raw git.** Principal directive: use tools and skills only. If the tool can't do it, build the capability. AGENCY_ALLOW_RAW escape hatch to be blocked (#146).
+2. **Always file issues.** Every bug gets an issue, even if fixed immediately. No silent fixes.
+3. **agency update must be zero-friction for adopters.** Auto-commit framework files, auto-verify, no manual git steps.
+4. **_sync-main-ref doesn't update working tree.** Post-merge flow needs `git checkout HEAD -- .` after `_sync-main-ref` to keep files in sync.
+5. **D-R format for version display** (#157) — next release.
 
 ### Fleet status
 
-All agents dispatched on v42.3. Monofolk dispatched via collaboration.
+- 4 worktrees synced (devex, mdpal-app, mdpal-cli, mdslidepal-web)
+- 3 worktrees pending resolution (iscp, mdslidepal-mac, mock-and-mark — dispatched)
+- designex resolved merge conflict and shipping Phase 1.1
 
-### Repo root (clean)
+### Behavioral notes for next session
 
-apps/ CHANGELOG.md claude/ CLAUDE.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE README.md tests/ usr/
+- NEVER suggest compact. Principal monitors via statusline.
+- NEVER use raw git. Use tools/skills. If blocked, build the tool.
+- Always file issues. Bug → issue → fix → close.
+- `git add -A` requires explicit principal approval every time.
+- Over/Over-and-out protocol for 1B1 discussions.
 
 ---
 

--- a/usr/jordan/captain/dispatches/directive-to-iscp-python-3-9-is-now-official-for-tools-use-it-for-al-20260417-0819.md
+++ b/usr/jordan/captain/dispatches/directive-to-iscp-python-3-9-is-now-official-for-tools-use-it-for-al-20260417-0819.md
@@ -1,0 +1,28 @@
+---
+type: directive
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-04-17T00:19
+status: created
+priority: normal
+subject: "Python 3.9+ is now official for tools — use it for all future work"
+in_reply_to: null
+---
+
+# Python 3.9+ is now official for tools — use it for all future work
+
+Principal directive (D44):
+
+Python 3.9+ (stdlib only, no pip) is now a valid and encouraged language for framework tools. dispatch-monitor was rewritten from bash to Python today — first Python tool in claude/tools/. It's shipped and running.
+
+**For you specifically:**
+
+1. **All new tools you write should be Python 3.9+.** You own dispatch, flag, collaboration, iscp-check, iscp-migrate, agent-identity — these are prime candidates for Python (SQLite access, JSON parsing, set/dict data structures, proper error handling).
+
+2. **Review your existing tools for upgrade.** If any tool is fighting bash limitations (associative arrays, complex string parsing, error handling, long-running processes), consider rewriting in Python. dispatch-monitor hit declare -A (bash 4+) which broke on macOS — you may have similar landmines.
+
+3. **Constraints:** stdlib only. No pip, no virtualenv. Shebang: #!/usr/bin/env python3. Use 'from __future__ import annotations' for modern type hints on 3.9. Template at claude/templates/TOOL.py.
+
+4. **Reference:** REFERENCE-PROVENANCE-HEADERS.md now documents the bash vs Python decision table.
+
+This is not a request to rewrite everything now. It's a standing directive: Python first for new work, and upgrade existing tools when you're already touching them.

--- a/usr/jordan/captain/history/handoff-20260416-211136.md
+++ b/usr/jordan/captain/history/handoff-20260416-211136.md
@@ -1,0 +1,61 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: housekeeping
+date: 2026-04-16
+trigger: session-end
+---
+
+## D42 Session End — 8 releases shipped
+
+### Releases
+
+| Release | PR | What |
+|---------|-----|------|
+| v42.1 | #129 | stage-hash bash + reset-soft + stash + hookify Bash wiring (closes #126 #128) |
+| v42.2 | #131 | hookify block-raw-gh-release + /secret dedup + block-raw-tools enforcement |
+| v42.3 | #132 | workstream content split — principal-scoped registrations, per-workstream receipts, git-safe mv/unstage/restore (closes #121 #130) |
+| v42.4 | #133 | migrate the-agency artifacts to new structure |
+| v42.5 | #136 | v1 tool retirement + root cleanup + repo structure overhaul |
+| v42.6 | #137 | .gitignore + CLAUDE.md + REFERENCE-TOOL-BUILDING.md |
+| v42.7 | #138 | plan-capture workstream-aware + agency-welcome + test fixtures |
+| v42.8 | #139 | version decouple (#122) + dependencies manifest (#135) + tool-create template |
+
+### Issues closed: #121, #122, #126, #128, #130, #135
+
+### Issues filed: #135, #140, #141, #142, #143
+
+### Stale working tree warning
+
+Local working tree has stale files from pre-merge state. 4 files show as modified (plan-capture.py, TOOL.sh, pr-create, release-plan.bats) — these are the OLD versions from main before R7/R8 merged. Run `AGENCY_ALLOW_RAW=1 git checkout -- .` to restore from HEAD.
+
+### Open issues for next session
+
+- **#140** — TOOL.sh template: complete logging/telemetry patterns
+- **#141** — Python tool template (TOOL.py)
+- **#142** — README-*.md content review (5 files need update)
+- **#143** — Workshop pitch for Mapletree REIT L&D
+- **#134** — workstream-create scaffold (monofolk report — likely stale SKILL.md)
+
+### Key structural decisions (D42)
+
+1. `.claude/agents/{P}/{A}.md` — principal-scoped, `claude --agent jordan/captain`
+2. `agent-bootstrap` retired — structural @import
+3. Receipt naming: `{org}-{principal}-{agent}-{ws}-{proj}-{type}-{boundary}-{date}-{hash}.md`
+4. Receipts at `claude/workstreams/{W}/qgr/` and `rgr/`
+5. `usr/{P}/{A}/` slim: tmp/, tools/, history/, history/flotsam/
+6. `project_version` decoupled from `agency_version`
+7. `claude/config/dependencies.yaml` — machine-readable deps manifest
+8. `git add -A` requires explicit principal approval every time
+
+### Fleet status
+
+All agents dispatched on v42.3. Monofolk dispatched via collaboration.
+
+### Repo root (clean)
+
+apps/ CHANGELOG.md claude/ CLAUDE.md CODE_OF_CONDUCT.md CONTRIBUTING.md LICENSE README.md tests/ usr/
+
+---
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260416-215043.md
+++ b/usr/jordan/captain/history/handoff-20260416-215043.md
@@ -1,0 +1,54 @@
+---
+type: handoff
+agent: the-agency/jordan/captain
+workstream: housekeeping
+date: 2026-04-16
+trigger: session-end
+---
+
+## D43 Session End — 4 releases shipped
+
+### Releases
+
+| Release | PR | What |
+|---------|-----|------|
+| v43.1 | #145 | TOOL.sh/TOOL.py templates (#140 #141) + D42 doc sweep (65+ stale refs across 33 files) + README review (#142) + workshop pitch (#143) + CI fix (#148) |
+| v43.2 | #152 | Hotfix — agency update crash (#147) + dispatch-monitor stale-read (#144) + agency deps macOS (#135) + phantom test (#149) |
+| v43.3 | #154 | agency update auto-commit framework files + auto-verify |
+| v43.4 | #156 | agency update version display from manifest.json (#155) |
+
+### Issues closed: #134, #135, #140, #141, #142, #143, #144, #147, #148, #149, #151, #153, #155
+
+### Issues filed: #146, #147, #148, #149, #150, #151, #153, #155, #157
+
+### Open issues
+
+- **#146** — Block AGENCY_ALLOW_RAW escape hatch (waiting on monofolk input)
+- **#150** — Linux deps support (apt/dnf) — future
+- **#157** — D-R format in version display — next release
+
+### Key decisions (D43)
+
+1. **No more raw git.** Principal directive: use tools and skills only. If the tool can't do it, build the capability. AGENCY_ALLOW_RAW escape hatch to be blocked (#146).
+2. **Always file issues.** Every bug gets an issue, even if fixed immediately. No silent fixes.
+3. **agency update must be zero-friction for adopters.** Auto-commit framework files, auto-verify, no manual git steps.
+4. **_sync-main-ref doesn't update working tree.** Post-merge flow needs `git checkout HEAD -- .` after `_sync-main-ref` to keep files in sync.
+5. **D-R format for version display** (#157) — next release.
+
+### Fleet status
+
+- 4 worktrees synced (devex, mdpal-app, mdpal-cli, mdslidepal-web)
+- 3 worktrees pending resolution (iscp, mdslidepal-mac, mock-and-mark — dispatched)
+- designex resolved merge conflict and shipping Phase 1.1
+
+### Behavioral notes for next session
+
+- NEVER suggest compact. Principal monitors via statusline.
+- NEVER use raw git. Use tools/skills. If blocked, build the tool.
+- Always file issues. Bug → issue → fix → close.
+- `git add -A` requires explicit principal approval every time.
+- Over/Over-and-out protocol for 1B1 discussions.
+
+---
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260417-080500.md
+++ b/usr/jordan/captain/history/handoff-20260417-080500.md
@@ -1,0 +1,40 @@
+---
+type: agency-update
+date: 2026-04-16 21:50
+from_commit: 200a5499
+to_commit: d0b15b61
+---
+
+## Agency Update
+
+Updated framework from 43.4 (200a5499) to 43.4 (d0b15b61).
+
+### Changes
+- 0 files added, 0 files updated, 0 files removed
+- Settings merged via array union
+- Framework section in agency.yaml updated
+
+### Verify the update
+Run `agency verify` to confirm everything is in order.
+
+### Previous session state
+
+## D43 Session End — 4 releases shipped
+
+### Releases
+
+| Release | PR | What |
+|---------|-----|------|
+| v43.1 | #145 | TOOL.sh/TOOL.py templates (#140 #141) + D42 doc sweep (65+ stale refs across 33 files) + README review (#142) + workshop pitch (#143) + CI fix (#148) |
+| v43.2 | #152 | Hotfix — agency update crash (#147) + dispatch-monitor stale-read (#144) + agency deps macOS (#135) + phantom test (#149) |
+| v43.3 | #154 | agency update auto-commit framework files + auto-verify |
+| v43.4 | #156 | agency update version display from manifest.json (#155) |
+
+### Issues closed: #134, #135, #140, #141, #142, #143, #144, #147, #148, #149, #151, #153, #155
+
+### Issues filed: #146, #147, #148, #149, #150, #151, #153, #155, #157
+
+### Open issues
+
+- **#146** — Block AGENCY_ALLOW_RAW escape hatch (waiting on monofolk input)
+- **#150** — Linux deps support (apt/dnf) — future

--- a/usr/jordan/jordandm-d44-r1/dispatches/commit-to-captain-committed-cb1ab1d-on-jordandm-d44-r1-misc-d44-r1-q-20260417-0824.md
+++ b/usr/jordan/jordandm-d44-r1/dispatches/commit-to-captain-committed-cb1ab1d-on-jordandm-d44-r1-misc-d44-r1-q-20260417-0824.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/jordandm-d44-r1
+to: the-agency/jordan/captain
+date: 2026-04-17T00:24
+status: created
+priority: normal
+subject: "Committed cb1ab1d on jordandm-d44-r1: misc: D44-R1 QGR receipt"
+in_reply_to: null
+---
+
+# Committed cb1ab1d on jordandm-d44-r1: misc: D44-R1 QGR receipt
+
+## Commit: cb1ab1d
+
+**Branch:** jordandm-d44-r1
+**Agent:** the-agency/jordan/jordandm-d44-r1
+**Message:** housekeeping/captain: misc: D44-R1 QGR receipt
+
+### Metadata
+- commit_hash: cb1ab1d
+- branch: jordandm-d44-r1
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-0824-d5bb50c.md
+```


### PR DESCRIPTION
## Summary

- **dispatch-monitor rewritten from bash to Python 3.9+** — first Python tool in the framework. Fixes bash 3.2 incompatibility on macOS (declare -A requires bash 4+). Restores agent collaboration via dispatch monitoring. (#144 stale-read prevention preserved via Python set)
- **CI release-tag-check polling grace period** — workflow now polls up to 120s for the release tag before failing, fixing the race where /post-merge creates the tag after the workflow fires (#159)
- **REFERENCE-PROVENANCE-HEADERS.md updated** — Python 3.9+ is now official for framework tools, with language choice guidance table
- **14 Python unit tests** for dispatch-monitor core functions
- **Valueflow artifacts** — PVR, A&D, Plan for the dispatch-monitor rewrite
- **ISCP dispatch #521** — Python-first directive sent to ISCP agent

Closes #159

## Test plan

- [x] dispatch-monitor --help works on Python 3.9.6
- [x] dispatch-monitor runs silently when no unread dispatches
- [x] Monitor tool integration verified (persistent session monitor running)
- [x] 14 unit tests passing (extract_id, evict_oldest, dedup logic)
- [x] commit-precheck passes
- [x] QG review (2 parallel agents, findings triaged and fixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)