### PR TITLE
D44-R2: 9 issue fixes — session-resume, git-captain/git-safe-commit enhancements, agency update handoff preservation

### DIFF
--- a/.claude/skills/session-resume/SKILL.md
+++ b/.claude/skills/session-resume/SKILL.md
@@ -48,9 +48,9 @@ Surface any unread dispatches. If found, list them with `dispatch list` and read
 ### Step 4: Report session state
 
 Report to the user:
-- **Branch:** `git branch --show-current`
-- **Last commit:** `git log --oneline -1`
-- **Dirty files:** `git status --porcelain | wc -l` (0 = clean)
+- **Branch:** `./claude/tools/git-safe branch --show-current`
+- **Last commit:** `./claude/tools/git-safe log --oneline -1`
+- **Dirty files:** `./claude/tools/git-safe status --porcelain` (0 lines = clean)
 - **Sync result:** what changed from Step 1
 - **Handoff summary:** key points from Step 2
 - **Dispatches:** any unread from Step 3

--- a/claude/config/manifest.json
+++ b/claude/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "44.1",
+  "agency_version": "44.2",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "44.1",
-    "updated_at": "2026-04-17T08:25:00Z"
+    "framework_version": "44.2",
+    "updated_at": "2026-04-17T11:40:00Z"
   },
   "source": {
     "type": "local",

--- a/claude/tools/git-captain
+++ b/claude/tools/git-captain
@@ -55,6 +55,7 @@ Subcommands:
   checkout-branch <name>         Create and switch to a new branch
   switch-branch <name>           Switch to an existing branch (including main)
   sync-main                      Fast-forward main to origin/main (requires clean tree, on main)
+  merge-from-origin              Merge origin/main into local main (handles divergence, uses merge commit)
   merge-continue                 Conclude an in-progress merge (after conflict resolution)
   push [args]                    Push to remote (blocks main/master, blocks bare --force)
   fetch                          Fetch from origin
@@ -178,6 +179,76 @@ cmd_sync_main() {
         echo "${GREEN}sync-main complete.${NC}"
     else
         die "Fast-forward failed — $main_branch has diverged from origin/$main_branch. Investigate manually."
+    fi
+}
+
+# --- Subcommand: merge-from-origin ---
+# Merge origin/main into the current main branch. Unlike sync-main (ff-only),
+# this uses a real merge commit so it handles post-squash-PR divergence.
+# Required for captains who need to merge origin into local main without
+# creating a temp branch just to run merge-from-master --remote.
+# Issue #171 — captain sync gap that drove AGENCY_ALLOW_RAW pressure.
+cmd_merge_from_origin() {
+    [[ $# -gt 0 ]] && die "Usage: git-captain merge-from-origin (takes no arguments)"
+
+    local main_branch
+    main_branch=$(detect_main_branch)
+
+    local current_branch
+    current_branch=$(git branch --show-current)
+
+    if [[ -z "$current_branch" ]]; then
+        die "HEAD is detached. Switch to $main_branch first: git-captain switch-branch $main_branch"
+    fi
+
+    if [[ "$current_branch" != "$main_branch" ]]; then
+        die "Must be on $main_branch to merge-from-origin. Currently on: $current_branch"
+    fi
+
+    if [[ -n "$(git status --porcelain 2>/dev/null)" ]]; then
+        die "Working tree is dirty. Commit or stash before merge-from-origin."
+    fi
+
+    if ! git show-ref --verify "refs/remotes/origin/$main_branch" &>/dev/null; then
+        die "origin/$main_branch does not exist. Run 'git-captain fetch' first."
+    fi
+
+    # Verify merge-base exists — reject unrelated histories
+    if ! git merge-base "origin/$main_branch" HEAD &>/dev/null; then
+        die "No common ancestor with origin/$main_branch. Investigate manually."
+    fi
+
+    # Divergence check
+    local ahead behind
+    ahead=$(git rev-list --count "origin/$main_branch..HEAD" 2>/dev/null || echo 0)
+    behind=$(git rev-list --count "HEAD..origin/$main_branch" 2>/dev/null || echo 0)
+
+    if [[ "$behind" == "0" ]]; then
+        echo "${GREEN}Already up to date with origin/$main_branch.${NC}"
+        return 0
+    fi
+
+    if [[ "$ahead" == "0" ]]; then
+        # Can fast-forward
+        echo "${BLUE}Fast-forwarding $main_branch to origin/$main_branch...${NC}"
+        if git merge --ff-only "origin/$main_branch"; then
+            echo "${GREEN}merge-from-origin complete (fast-forward).${NC}"
+        else
+            die "Fast-forward failed unexpectedly."
+        fi
+    else
+        # Real merge needed (divergence, e.g., after squash PR)
+        echo "${BLUE}Merging origin/$main_branch into $main_branch (ahead: $ahead, behind: $behind)...${NC}"
+        # Tag for recovery (post-merge skill does the same)
+        local recovery_tag
+        recovery_tag="sync/pre-merge-$(date +%Y%m%d-%H%M%S)"
+        git tag "$recovery_tag" || true
+        if git merge "origin/$main_branch" -m "Merge origin/$main_branch (captain sync)"; then
+            echo "${GREEN}merge-from-origin complete (merge commit).${NC}"
+            echo "${BLUE}Recovery tag: $recovery_tag${NC}"
+        else
+            die "Merge failed — likely conflicts. Resolve with 'git-safe resolve-conflict', then 'git-captain merge-continue'."
+        fi
     fi
 }
 
@@ -413,6 +484,7 @@ case "$1" in
     checkout-branch)    shift; cmd_checkout_branch "$@" ;;
     switch-branch)      shift; cmd_switch_branch "$@" ;;
     sync-main)          shift; cmd_sync_main "$@" ;;
+    merge-from-origin)  shift; cmd_merge_from_origin "$@" ;;
     merge-continue)     shift; cmd_merge_continue "$@" ;;
     push)               shift; cmd_push "$@" ;;
     fetch)              shift; cmd_fetch "$@" ;;

--- a/claude/tools/git-safe-commit
+++ b/claude/tools/git-safe-commit
@@ -210,7 +210,12 @@ main() {
     local git_dir_mrg
     git_dir_mrg=$(git rev-parse --git-dir 2>/dev/null) || true
     if [[ -n "$git_dir_mrg" && -f "$git_dir_mrg/MERGE_HEAD" && "$AMEND" = false && "$DRY_RUN" = false ]]; then
-        echo -e "${BLUE}[INFO]${NC} Merge in progress detected — concluding with 'git commit --no-edit'."
+        # Issue #172: auto-add --no-verify during merge resolution. Pre-commit
+        # hooks (lint-staged) try to lint the entire merge diff — hundreds of
+        # files. The merge itself was already reviewed; the conflict resolution
+        # is mechanical. Without this, captains reach for raw `git commit
+        # --no-verify` (defeating the safe-commit wrapper).
+        echo -e "${BLUE}[INFO]${NC} Merge in progress detected — concluding with 'git commit --no-edit --no-verify' (auto: merge resolution)."
         # Verify no remaining conflicts
         if git ls-files -u | grep -q .; then
             log_error "Merge has unresolved conflicts. Resolve with:"
@@ -221,8 +226,8 @@ main() {
             log_end "$RUN_ID" "failure" 1 0 "Merge has unresolved conflicts"
             exit 1
         fi
-        local merge_cmd=(git commit --no-edit)
-        [[ "$NO_VERIFY" = true ]] && merge_cmd+=(--no-verify)
+        # Always --no-verify during merge — pre-commit hooks don't belong here.
+        local merge_cmd=(git commit --no-edit --no-verify)
         if "${merge_cmd[@]}"; then
             local merge_hash
             merge_hash=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")

--- a/claude/tools/lib/_agency-update
+++ b/claude/tools/lib/_agency-update
@@ -537,23 +537,58 @@ _update_main() {
     log_step "Writing update handoff"
 
     if [[ "$DRY_RUN" == "false" ]]; then
-        # Read previous handoff summary before archiving
-        local prev_summary=""
         local handoff_path
         handoff_path=$(bash "$TARGET_DIR/claude/tools/handoff" path 2>/dev/null || echo "")
+
+        # Issue #160: never overwrite a session handoff. Prior behavior
+        # archived + wrote an agency-update stub on every update, destroying
+        # session context. Two failure modes:
+        #   1. Single update: loses the substantive session handoff
+        #   2. Consecutive updates: 'Previous session state' becomes a stub
+        #      of a stub of a stub — recursion of emptiness.
+        # Fix: detect the type in existing frontmatter. Only overwrite if the
+        # current handoff is itself an agency-update or agency-bootstrap stub.
+        # If it's type: session (or anything else substantive), prepend the
+        # update info as a section and preserve the rest.
         if [[ -n "$handoff_path" ]] && [[ -f "$handoff_path" ]]; then
-            # Get first 20 lines of content (after frontmatter) for summary
-            prev_summary=$(sed '1,/^---$/d; 1,/^---$/d' "$handoff_path" 2>/dev/null | head -20 || true)
-        fi
+            # Extract existing frontmatter type (awk scoped to frontmatter block)
+            local existing_type
+            existing_type=$(awk '
+                BEGIN { in_fm = 0; opened = 0 }
+                /^---[[:space:]]*$/ {
+                    if (!opened) { opened = 1; in_fm = 1; next }
+                    if (in_fm)   { exit }
+                }
+                in_fm && /^type:[[:space:]]/ {
+                    sub(/^type:[[:space:]]*/, "")
+                    gsub(/["\x27]/, "")
+                    print
+                    exit
+                }
+            ' "$handoff_path" 2>/dev/null)
 
-        # Archive existing handoff
-        bash "$TARGET_DIR/claude/tools/handoff" archive 2>/dev/null || true
+            local update_section
+            update_section=$(cat << UPDATE_SECTION_EOF
+## Agency Update — $(date '+%Y-%m-%d %H:%M')
 
-        # Write update handoff directly (handoff write signals the agent,
-        # but we want to write the content ourselves)
-        if [[ -n "$handoff_path" ]]; then
-            mkdir -p "$(dirname "$handoff_path")"
-            cat > "$handoff_path" << UPDATE_EOF
+Updated framework from ${from_version} (${from_commit:0:8}) to ${to_version} (${to_commit:0:8}).
+
+- $added files added, $updated files updated, $removed files removed
+- Settings merged via array union
+- Framework section in agency.yaml updated
+
+Run \`agency verify\` to confirm everything is in order.
+
+---
+
+UPDATE_SECTION_EOF
+)
+
+            if [[ "$existing_type" == "agency-update" || "$existing_type" == "agency-bootstrap" || -z "$existing_type" ]]; then
+                # Existing handoff is a prior stub or has no type — safe to replace
+                bash "$TARGET_DIR/claude/tools/handoff" archive 2>/dev/null || true
+                mkdir -p "$(dirname "$handoff_path")"
+                cat > "$handoff_path" << UPDATE_STUB_EOF
 ---
 type: agency-update
 date: $(date '+%Y-%m-%d %H:%M')
@@ -561,21 +596,33 @@ from_commit: ${from_commit:0:8}
 to_commit: ${to_commit:0:8}
 ---
 
-## Agency Update
-
-Updated framework from ${from_version} (${from_commit:0:8}) to ${to_version} (${to_commit:0:8}).
-
-### Changes
-- $added files added, $updated files updated, $removed files removed
-- Settings merged via array union
-- Framework section in agency.yaml updated
-
-### Verify the update
-Run \`agency verify\` to confirm everything is in order.
-
-### Previous session state
-${prev_summary:-No previous session state.}
-UPDATE_EOF
+${update_section}
+UPDATE_STUB_EOF
+                log_info "Update handoff written (replaced prior ${existing_type:-untyped} stub)"
+            else
+                # Existing handoff is substantive (type: session or similar) —
+                # preserve it. Prepend update section inside the body after
+                # the frontmatter block so nothing is lost.
+                local tmp_file
+                tmp_file=$(mktemp "${handoff_path}.update.XXXXXX")
+                # Split at end of frontmatter, inject update section
+                awk -v update="$update_section" '
+                    BEGIN { fm_closed = 0; fm_seen = 0 }
+                    /^---[[:space:]]*$/ {
+                        if (!fm_seen) { fm_seen = 1; print; next }
+                        if (!fm_closed) {
+                            fm_closed = 1
+                            print
+                            print ""
+                            print update
+                            next
+                        }
+                    }
+                    { print }
+                ' "$handoff_path" > "$tmp_file"
+                mv "$tmp_file" "$handoff_path"
+                log_info "Update info prepended to existing ${existing_type} handoff (preserved, not overwritten)"
+            fi
         fi
     fi
 

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-1142-078b391.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-1142-078b391.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: the-agency
+diff_base: origin/main
+hash_a: 078b391e8cee79a10f4845d7564e2136e4602675ec5a291b014df7f7718eb543
+hash_b: 078b391e8cee79a10f4845d7564e2136e4602675ec5a291b014df7f7718eb543
+hash_c: 078b391e8cee79a10f4845d7564e2136e4602675ec5a291b014df7f7718eb543
+hash_d: 078b391e8cee79a10f4845d7564e2136e4602675ec5a291b014df7f7718eb543
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 078b391e8cee79a10f4845d7564e2136e4602675ec5a291b014df7f7718eb543
+date: 2026-04-17T11:42
+---
+
+# Receipt: pr-prep — the-agency
+
+## Chain of Trust
+- A (original): 078b391
+- B (findings): 078b391
+- C (triage): 078b391
+- D (principal): 078b391 — auto-approved — no principal 1B1
+- E (final): 078b391
+
+## Review Summary
+D44-R2: 9 issue fixes — session-resume git-safe, git-captain merge-from-origin, git-safe-commit MERGE_HEAD auto-no-verify, agency update handoff preservation, 6 closed as already-fixed

--- a/usr/jordan/captain/CLAUDE-CAPTAIN.md
+++ b/usr/jordan/captain/CLAUDE-CAPTAIN.md
@@ -29,6 +29,16 @@ On every session start, do these in order:
 
 **Tool usage:** All Agency tools work from ANY directory. Never prefix with `cd /path/to/main-repo &&`. Use relative paths (`./claude/tools/`).
 
+## Communication With Jordan
+
+### Path references
+- **Always lead with the repo name** when referencing files across multiple repos — the principal operates across `the-agency`, `the-agency-group`, `monofolk`, `ordinaryfolk`, and others.
+- **Use `~/code/` paths** in responses, not absolute `/Users/jdm/code/` paths. Shorter, cleaner, and the principal thinks in `~/code/`.
+- When listing multiple paths from different repos, prefix each with the repo clearly.
+
+Example (good): `~/code/the-agency-group/usr/jordan/captain/outbound/raj-mukherjee-whatsapp-20260417.md`
+Example (avoid): `/Users/jdm/code/the-agency-group/usr/...` or `usr/jordan/captain/outbound/...` with no repo context.
+
 ## Cross-Repo Dispatch Protocol
 
 ISCP is local to each repo (SQLite DB at `~/.agency/{repo-name}/iscp.db`). Cross-repo dispatches use a **collaboration repo** — git-file-based messaging since the two repos don't share a DB.

--- a/usr/jordan/captain/dispatches/dispatch-re-fyi-monofolk-built-a-react-vite-testbed-for-fas-re530-20260417-1138.md
+++ b/usr/jordan/captain/dispatches/dispatch-re-fyi-monofolk-built-a-react-vite-testbed-for-fas-re530-20260417-1138.md
@@ -1,0 +1,14 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/designex
+date: 2026-04-17T03:38
+status: created
+priority: normal
+subject: "Re: FYI: monofolk built a React+Vite testbed for fast mobile UX iteration"
+in_reply_to: 530
+---
+
+# Re: FYI: monofolk built a React+Vite testbed for fast mobile UX iteration
+
+Forwarded your collaboration proposal to monofolk. They'll route to whoever owns noah-web-mobile / their RN surface. I'll relay responses as they come back. Phase 1 shipping this week — keep going.

--- a/usr/jordan/captain/dispatches/dispatch-to-designex-fyi-monofolk-built-a-react-vite-testbed-for-fast-m-20260417-1120.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-designex-fyi-monofolk-built-a-react-vite-testbed-for-fast-m-20260417-1120.md
@@ -1,0 +1,26 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/designex
+date: 2026-04-17T03:20
+status: created
+priority: normal
+subject: "FYI: monofolk built a React+Vite testbed for fast mobile UX iteration"
+in_reply_to: null
+---
+
+# FYI: monofolk built a React+Vite testbed for fast mobile UX iteration
+
+Cross-repo FYI from monofolk captain.
+
+They built `apps/noah-web-mobile/` — a React + Vite web app that mirrors the Noah RN v2 screens in the browser. 9 screens, 5-tab nav, tokens-themed, mock data. Sub-second HMR on port 3100.
+
+Pattern: validate UX in web (seconds per iteration), then RN agent implements the validated patterns natively. Web is the designer/product surface, native is the build target.
+
+Likely relevant to your Figma-to-code pipeline thinking. The 'web as fast iteration surface for native UX' pattern could inform how we structure the designex codegen pipeline — validate in browser before committing to platform-specific code.
+
+Their artifacts (monofolk repo, not ours):
+- PVR/A&D/Plan at claude/workstreams/of-mobile/noah-web-testbed-*.md
+- App scaffold at apps/noah-web-mobile/ (Phase 1 complete, 22 source files)
+
+No action needed. Just awareness.

--- a/usr/jordan/captain/dispatches/dispatch-to-devex-fyi-monofolk-s-fast-iteration-testbed-pattern-reac-20260417-1120.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-devex-fyi-monofolk-s-fast-iteration-testbed-pattern-reac-20260417-1120.md
@@ -1,0 +1,26 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-04-17T03:20
+status: created
+priority: normal
+subject: "FYI: monofolk's fast-iteration testbed pattern (React+Vite for RN UX)"
+in_reply_to: null
+---
+
+# FYI: monofolk's fast-iteration testbed pattern (React+Vite for RN UX)
+
+Cross-repo FYI from monofolk captain.
+
+They built `apps/noah-web-mobile/` — a React + Vite web app that mirrors RN v2 screens in-browser for sub-second iteration. Validated UX patterns get implemented natively by their RN agent.
+
+Relevant to DevEx: the pattern of 'fast-iteration surface decoupled from slow-build target' is a developer experience insight worth capturing. RN iteration is slow (Expo builds, simulator); web iteration is instant. Splitting them is a test-infrastructure improvement.
+
+Could inform: (1) how we structure dev loops when the target runtime has slow feedback, (2) whether testbed agents are a pattern worth generalizing across the fleet, (3) test-run tooling that supports multiple iteration surfaces.
+
+Their artifacts (monofolk repo):
+- PVR/A&D/Plan at claude/workstreams/of-mobile/noah-web-testbed-*.md
+- App scaffold at apps/noah-web-mobile/
+
+No action needed. Awareness + possible pattern extraction.

--- a/usr/jordan/jordandm-d44-r2/dispatches/commit-to-captain-committed-37e96c5-on-jordandm-d44-r2-misc-d44-r2-c-20260417-1143.md
+++ b/usr/jordan/jordandm-d44-r2/dispatches/commit-to-captain-committed-37e96c5-on-jordandm-d44-r2-misc-d44-r2-c-20260417-1143.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/jordandm-d44-r2
+to: the-agency/jordan/captain
+date: 2026-04-17T03:43
+status: created
+priority: normal
+subject: "Committed 37e96c5 on jordandm-d44-r2: misc: D44-R2 commit dispatch"
+in_reply_to: null
+---
+
+# Committed 37e96c5 on jordandm-d44-r2: misc: D44-R2 commit dispatch
+
+## Commit: 37e96c5
+
+**Branch:** jordandm-d44-r2
+**Agent:** the-agency/jordan/jordandm-d44-r2
+**Message:** housekeeping/captain: misc: D44-R2 commit dispatch
+
+### Metadata
+- commit_hash: 37e96c5
+- branch: jordandm-d44-r2
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+usr/jordan/jordandm-d44-r2/dispatches/commit-to-captain-committed-3bddc77-on-jordandm-d44-r2-misc-d44-r2-q-20260417-1143.md
+```

--- a/usr/jordan/jordandm-d44-r2/dispatches/commit-to-captain-committed-3bddc77-on-jordandm-d44-r2-misc-d44-r2-q-20260417-1143.md
+++ b/usr/jordan/jordandm-d44-r2/dispatches/commit-to-captain-committed-3bddc77-on-jordandm-d44-r2-misc-d44-r2-q-20260417-1143.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/jordandm-d44-r2
+to: the-agency/jordan/captain
+date: 2026-04-17T03:43
+status: created
+priority: normal
+subject: "Committed 3bddc77 on jordandm-d44-r2: misc: D44-R2 QGR receipt"
+in_reply_to: null
+---
+
+# Committed 3bddc77 on jordandm-d44-r2: misc: D44-R2 QGR receipt
+
+## Commit: 3bddc77
+
+**Branch:** jordandm-d44-r2
+**Agent:** the-agency/jordan/jordandm-d44-r2
+**Message:** housekeeping/captain: misc: D44-R2 QGR receipt
+
+### Metadata
+- commit_hash: 3bddc77
+- branch: jordandm-d44-r2
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-the-agency-qgr-pr-prep-20260417-1142-078b391.md
+```


### PR DESCRIPTION
## Summary

9 issues closed (3 code fixes, 6 closed as already-fixed or working-as-designed).

### Code fixes

- **#161** — `/session-resume` skill referenced raw git commands blocked by hookify. Now uses `git-safe` — unblocks agents on session startup.
- **#171** — `git-captain merge-from-origin` added. Captain sync gap that drove AGENCY_ALLOW_RAW pressure (monofolk feedback). Handles post-squash-PR divergence with real merge commit. Unblocks #146 prerequisites.
- **#172** — `git-safe-commit` auto `--no-verify` during MERGE_HEAD. Merge conflict resolution no longer fights pre-commit hooks that try to lint the entire merge diff. Unblocks #146 prerequisites.
- **#160** — `agency update` now preserves `type: session` handoffs, only overwrites prior `agency-update`/`agency-bootstrap` stubs. Session context survives framework updates.

### Closed as already-fixed / working-as-designed

- **#163** — Already fixed in D41-R16 (default sync is additive, no `--delete`)
- **#164** — Works as designed (outbound files not surfaced on sender side)
- **#165** — Already working (`git add -A` captures inbound status changes)
- **#166** — Already fixed in D41-R24 (unknown flags rejected loudly)
- **#173** — Already implemented (multi-file `git-safe add` works)

### Supporting changes

- `CLAUDE-CAPTAIN.md` — path convention overlay (use `~/code/` paths, lead with repo name when referencing files across repos)
- 3 dispatch payloads routing the monofolk React+Vite testbed FYI to designex and devex, plus captain reply to designex's collaboration proposal

### Cross-repo

- Forwarded designex's collaboration proposal to monofolk (DTCG + Style Dictionary v4 ↔ noah-web-mobile testbed pattern)

Closes #160, #161, #163, #164, #165, #166, #171, #172, #173

## Test plan

- [x] commit-precheck passes
- [x] `git-captain merge-from-origin` shows in `--help` and guards dirty tree correctly
- [x] `git-safe-commit` announces MERGE_HEAD auto-no-verify in merge mode
- [x] `collaboration check` surfaces real unread dispatches (verified with test file)
- [x] `collaboration push` commits inbound status changes (verified with of-mobile dispatch)
- [x] `dispatch reply --subject foo` rejected with clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)