### PR TITLE
v2 skill methodology — consolidated package (supersedes #294-323)

### DIFF
--- a/.claude/skills/captain-release/SKILL.md
+++ b/.claude/skills/captain-release/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: captain-release
+description: Captain-only. Quality-check, commit, push, create PR, and cut a release in one flow. The "code is ready" command for captain-owned branches. Every PR is a release. Formerly `/release` — v2 rename to captain-actor-verb.
+agency-skill-version: 2
+when_to_use: Captain has staged coordination work on a captain-* branch and wants to land it as a PR + release. NEVER from master. NEVER from a worktree agent branch (agents use /pr-submit → /pr-captain-land). NEVER auto-invoked.
+argument-hint: "[--no-push] [--no-pr] <commit description>"
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-QUALITY-GATE.md
+  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+---
+
+<!--
+  allowed-tools omitted — inherits Bash(*). This skill composes many
+  tools (commit-precheck, git-safe-commit, git-push, pr-create, Edit,
+  Read for manifest.json) plus Skill invocations (/pr-prep, /git-safe-commit).
+  Inherit Bash(*) rather than enumerate at subcommand level (flag #62/#63
+  / devex dispatch #171).
+-->
+
+# captain-release
+
+Captain's one-flow release command for captain-owned branches (captain-*). Runs quality-check → commit → push → create PR → version-bump → summary. Every PR is a release.
+
+**Name pattern:** `captain-` actor prefix (captain-only), `release` verb. Grouped with `captain-log`, `captain-review` in the captain family.
+
+## Why this exists
+
+When captain has staged coordination work (a framework fix, a refactor, a doc update) on a captain-* branch, that work needs to land as a PR with proper QG + release tagging + version bump. Without one cohesive command, each step gets skipped or done out of order. `captain-release` bundles the full flow.
+
+Agents use a different path: `/pr-submit` → captain's `/pr-captain-land`. That's the agent-owned-work flow. `captain-release` is for captain-owned work (framework fixes, REFERENCE doc updates, captain-* coord artifacts).
+
+## Required reading
+
+Before proceeding, Read the files listed in `required_reading:` frontmatter.
+
+## Usage
+
+```
+/captain-release <commit description>
+/captain-release --no-push <description>
+/captain-release --no-pr <description>
+```
+
+## Preconditions
+
+- Captain NOT on master. Running on master aborts — never push directly to master; always PR.
+- Working tree has staged or uncommitted changes relevant to this release.
+- A QGR receipt exists for the current state (via prior `/pr-prep` or `/quality-gate`).
+
+## Flow / Steps
+
+### Step 1: Pre-flight
+
+1. Check current branch. If master, **abort**.
+2. Show `git status` + `git diff --stat HEAD`.
+3. If no changes, inform user and stop.
+
+### Step 2: Quality gate
+
+Run `./claude/tools/commit-precheck`. Verify formatting, linting, tests pass. If fails, stop and report.
+
+### Step 3: Commit
+
+Invoke `/git-safe-commit` with the commit description from `<arguments>`. Produces a commit on the captain-* branch.
+
+### Step 4: Push (unless `--no-push`)
+
+1. Show commits that will be pushed.
+2. Ask for confirmation.
+3. `./claude/tools/git-push --force-with-lease <branch>`.
+
+### Step 5: PR (unless `--no-pr` and push happened)
+
+1. Check if PR exists: `gh pr view <branch>`.
+2. If exists: report URL.
+3. If not: `./claude/tools/pr-create --title "..." --body "..."`.
+
+**Never raw `gh pr create`.** The pr-create tool validates a QGR receipt before allowing PR creation.
+
+### Step 6: Version bump
+
+1. Parse PR title for release version (D#-R# → version #.# OR monofolk_version increment).
+2. Update `claude/config/manifest.json`: bump appropriate version field + `updated_at`.
+3. Commit the bump via `/git-safe-commit --no-work-item`.
+4. Push: `./claude/tools/git-push <branch>`.
+
+### Step 7: Summary
+
+```
+Release complete:
+  Committed: <commit-hash> <message>
+  Version: <old> → <new>
+  Pushed: origin/<branch>
+  PR: <url> (or skipped)
+  Post-merge: run /pr-captain-post-merge after PR merges on GitHub
+```
+
+## Failure modes
+
+- **On master**: abort (never push directly to master).
+- **commit-precheck fails**: stop, report which check failed; captain fixes + retries.
+- **push rejected**: probably branch protection or force-with-lease race; captain investigates.
+- **pr-create rejected (no QGR)**: run `/pr-prep` to produce a receipt, retry.
+- **version bump already done on branch**: skill detects (manifest diff), skips Step 6 bump.
+
+## What this does NOT do
+
+- **Does not merge the PR** — that's `/pr-captain-merge`.
+- **Does not run post-merge** — that's `/pr-captain-post-merge` after GitHub merges the PR.
+- **Does not push master** — master is pushed only via merged PRs.
+- **Does not land agent-owned work** — for that, agent uses `/pr-submit` → captain uses `/pr-captain-land`.
+
+## Captain-only — four-layer defense
+
+1. `disable-model-invocation: true` — Claude can't auto-invoke.
+2. `paths: []` — no auto-activation.
+3. Name contains `captain-` — scope visible in listing.
+4. Step 1 precondition — captain must be on a captain-* branch, not master or agent branch.
+
+## Status
+
+`active` (v2, refactored from legacy `release` 2026-04-19).
+
+## Related
+
+- `/pr-captain-merge` — merge step after PR is reviewed
+- `/pr-captain-post-merge` — release step after merge
+- `/pr-captain-land` — alternative flow when landing agent-owned work
+- `/pr-prep` — QG before this skill runs
+- `/git-safe-commit` — underlying commit tool
+- `claude/tools/pr-create` — underlying PR creation tool
+- `claude/tools/commit-precheck` — QG precheck
+- the-agency#296 — PR lifecycle ownership
+- the-agency#315 — V1→V2 migration
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/captain-release/assets/README.md
+++ b/.claude/skills/captain-release/assets/README.md
@@ -1,0 +1,5 @@
+# assets/
+
+Empty by design. `captain-release` has no user-facing templates or static assets — PR descriptions are captain-authored per-release; the version-bump manifest edit is a direct JSON update.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/.claude/skills/captain-release/examples.md
+++ b/.claude/skills/captain-release/examples.md
@@ -1,0 +1,128 @@
+# captain-release — examples
+
+## Happy-path examples
+
+### Full flow — captain lands framework fix
+
+Captain on `captain-framework-fix` branch with staged changes:
+
+```
+/captain-release fix: resolve worktree-sync MAIN_BRANCH bug + add regression test
+```
+
+Expected flow: commit-precheck green → commit → push → PR created → version bumped 1.9 → 2.0 → summary printed.
+
+### Stage without pushing
+
+```
+/captain-release --no-push misc: consolidate QGR receipts for pending PRs
+```
+
+Result: commit lands locally; no push. Captain pushes later manually.
+
+### Push without PR
+
+```
+/captain-release --no-pr draft: initial sketch for REFERENCE-FOO.md
+```
+
+Result: commit + push to origin; no PR yet. Captain opens PR later.
+
+---
+
+## Edge-case examples
+
+### On master (abort)
+
+Captain accidentally runs from master:
+
+```
+/captain-release misc: whatever
+```
+
+Expected:
+```
+ABORT: never run /captain-release from master.
+  Create a captain-* branch first: git-captain checkout-branch captain-<topic>
+```
+
+Exit 1.
+
+### commit-precheck fails
+
+Formatter finds issues:
+
+```
+/captain-release feat: add REFERENCE-ESTIMATION.md
+```
+
+Expected:
+```
+STOP: commit-precheck failed — formatter reports 3 unformatted files.
+  Run 'oxfmt' to fix, then re-run /captain-release.
+```
+
+Exit 1. No commit.
+
+### No changes to release
+
+Captain runs the skill with nothing to commit:
+
+```
+/captain-release misc: whatever
+```
+
+Expected:
+```
+Nothing to release — working tree clean and no staged changes.
+  If you meant to commit earlier work, use /git-safe-commit directly.
+```
+
+Exit 0. No-op.
+
+---
+
+## Integration examples
+
+### Typical captain workflow
+
+```
+git-captain checkout-branch captain-ref-doc-update
+# ... edits ...
+/pr-prep "captain: REFERENCE update for X"
+/captain-release docs(REFERENCE): update X with Y
+# ... PR gets reviewed ...
+/pr-captain-merge <N>
+/pr-captain-post-merge <N>
+```
+
+Four skills, complete end-to-end.
+
+### Compared to agent workflow
+
+Agent:
+```
+/pr-prep "<agent-scope>"
+/git-push <branch>
+/pr-submit --scope "<one-liner>"
+```
+
+Captain:
+```
+/pr-captain-land <agent-branch>
+```
+
+`captain-release` is not used in the agent-owned path.
+
+### Batched coord commits before release
+
+Captain wants three coord artifacts in one PR:
+
+```
+git-safe-commit "housekeeping: capture QGR for #110" --no-work-item
+git-safe-commit "housekeeping: archive handoff pre-compact" --no-work-item
+git-safe-commit "housekeeping: file flag #68 details" --no-work-item
+/captain-release housekeeping: consolidated coord from session X
+```
+
+The earlier three commits are already on the branch. `/captain-release` commits whatever's left (usually empty at this point), push, PR, bump. The PR description references all four commits.

--- a/.claude/skills/captain-release/reference.md
+++ b/.claude/skills/captain-release/reference.md
@@ -1,0 +1,40 @@
+# captain-release — unique protocol
+
+## Version-bump parsing rules
+
+Resolution order:
+
+1. **D#-R# pattern** in PR title → map to `agency_version` or `monofolk_version` per repo convention
+2. **Release-type tag in PR body** (e.g., `Release-Type: minor`) → semver bump
+3. **Default** → increment the primary version field (`monofolk_version` in monofolk, `agency_version` in the-agency)
+
+The bump happens AFTER the PR is created (Step 6) so the PR's diff shows the actual substance, and the version bump is a follow-up commit on the same branch.
+
+## `--no-push` / `--no-pr` semantics
+
+- `--no-push` skips Steps 4, 5, 6 entirely. Captain has a local commit only. Useful when captain wants to stage multiple commits before pushing.
+- `--no-pr` keeps push (Step 4) but skips PR creation (Step 5). Captain intends to open the PR manually via different flow.
+- Both flags can be combined; effectively just runs Steps 1-3 (commit).
+
+## Differences from `/pr-captain-land`
+
+| Aspect | `/captain-release` | `/pr-captain-land` |
+|---|---|---|
+| Branch origin | captain creates the work on a captain-* branch | agent creates work on agent branch, submits via /pr-submit |
+| QG responsibility | captain runs /pr-prep before /captain-release | agent runs /pr-prep before /pr-submit |
+| Version bump | captain does it in this skill's Step 6 | captain does it in /pr-captain-land's Step 4 |
+| PR creation | captain-authored description (this skill) | captain-authored description wrapping agent's scope |
+| Merge | separate subsequent `/pr-captain-merge` invocation | included as Step 7 of /pr-captain-land |
+| Release creation | separate subsequent `/pr-captain-post-merge` | included as Step 8 of /pr-captain-land |
+
+Rule of thumb: use `/captain-release` for captain-authored work. Use `/pr-captain-land` when captain is landing an agent's prepared branch.
+
+## Recovery flows
+
+- **commit-precheck fails after captain has already committed**: edit files, re-stage, `git commit --amend` (captain-authorized via git-safe-commit), re-run.
+- **Push rejected on force-with-lease**: someone else pushed to the captain-* branch (rare — captain owns it). Fetch, inspect, decide: rebase-equivalent via `git-safe merge-from-master` or abort.
+- **pr-create blocks on QGR mismatch**: diff-hash drifted since QG receipt was signed. Re-run `/pr-prep`. Common after captain's coord commits on master between QG and PR create.
+
+## Release-tag-check interaction
+
+The `release-tag-check` GitHub Actions workflow requires every merge commit on master to have a matching release tag. `captain-release` doesn't create the release tag — that's `/pr-captain-post-merge`'s job after merge. But `captain-release` DOES ensure the version-bump commit is present on the branch, which is the precondition for `/pr-captain-post-merge` to derive the tag correctly.

--- a/.claude/skills/captain-release/scripts/README.md
+++ b/.claude/skills/captain-release/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts/
+
+Empty by design. `captain-release` is pure orchestration — composes `commit-precheck` + `/git-safe-commit` + `/git-push` + `pr-create` + `Edit`/`Read` for manifest.json. No skill-specific scripts needed.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/.claude/skills/captain-sync-all/SKILL.md
+++ b/.claude/skills/captain-sync-all/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: captain-sync-all
+description: Captain-only. Fetch, merge origin into master, merge unique worktree work into master, and sync all worktrees. The daily rhythm command. NEVER pushes to remote. NEVER rebases. NEVER resets to origin. Formerly `/sync-all` — v2 rename to captain-actor-verb.
+agency-skill-version: 2
+when_to_use: Captain on master in main checkout, starting a captain session or after a PR has merged (to propagate to the fleet). NEVER from a worktree. NEVER auto-invoked.
+argument-hint: ""
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - claude/REFERENCE-WORKTREE-DISCIPLINE.md
+  - claude/REFERENCE-SAFE-TOOLS.md
+---
+
+<!--
+  allowed-tools omitted — inherits Bash(*). Composes git-captain +
+  git-safe + dispatch + worktree-sync across every worktree. Too broad
+  to restrict at subcommand level (flag #62/#63 caveat).
+-->
+
+# captain-sync-all
+
+Captain's daily master-sync rhythm command. Reconciles master with origin, merges any unique worktree work into master (with confirmation), and syncs every worktree to the updated master. **Never pushes.** Push is a separate concern (merged PRs land on master server-side).
+
+**Name pattern:** `captain-` actor prefix (captain-only) + `sync-all` (compound noun-verb, the action). Grouped with `captain-release`, `captain-log`, `captain-review` in the captain family.
+
+## Why this exists
+
+Captain is the single coordination point for master state across the fleet. After a PR lands on GitHub or after captain-side coord commits, the local master + every worktree's local view of master must be reconciled. Without this skill, each worktree drifts independently and sync-pain accumulates.
+
+**Never pushes.** Pushing from master is structurally banned by the framework. PR-merged commits reach origin/master via GitHub's merge; local sync pulls those down.
+
+**Never rebases, never resets to origin.** Per `REFERENCE-GIT-MERGE-NOT-REBASE.md`, all sync uses true merge commits.
+
+## Required reading
+
+Before proceeding, Read the files listed in `required_reading:` frontmatter.
+
+## Usage
+
+```
+/captain-sync-all
+```
+
+No arguments. Skill is fully automatic; prompts for confirmation before merging worktree work into master.
+
+## Preconditions
+
+- Captain on master (or main) in main checkout. NOT a worktree.
+- Working tree clean. No uncommitted changes on master.
+
+## Flow / Steps
+
+### Step 1: Safety checks
+
+1. Confirm on master in main checkout.
+2. Confirm clean working tree.
+
+### Step 2: Fetch origin
+
+```
+./claude/tools/git-captain fetch
+```
+
+### Step 3: Divergence detection + reconcile
+
+Check divergence:
+
+```
+git log --oneline origin/master..master    # local-only commits
+git log --oneline master..origin/master    # remote-only commits
+```
+
+**If diverged (both sides > 0 — typical after PR merge + local coord commits):**
+
+1. Verify merge-base exists: `git merge-base origin/master HEAD`. If fails, ABORT with recovery hint.
+2. Tag for recovery: `git tag sync/pre-merge-$(date +%Y%m%d-%H%M%S)`.
+3. Merge: `./claude/tools/git-captain merge-from-origin` (produces merge commit).
+4. If conflicts: halt, show files, ask principal to resolve.
+
+**If behind only:** `./claude/tools/git-captain merge-from-origin` fast-forwards.
+
+**Never `git reset --hard origin/master`. Never `git rebase origin/master`.**
+
+### Step 4: Enumerate worktrees
+
+For each worktree, determine: branch name, clean/dirty status, commits ahead of master.
+
+### Step 5: Merge worktree work (with confirmation)
+
+For each worktree with commits ahead of master:
+
+- Show the commits.
+- Ask principal for confirmation.
+- If yes: `git merge <branch> --no-ff`.
+
+### Step 5b: Dispatch main-updated
+
+If any worktree work merged into master in Step 5, dispatch `main-updated` to all agents with worktrees:
+
+```
+./claude/tools/dispatch create --type main-updated --to <repo>/<principal>/<agent> --subject "Main updated — new work merged"
+```
+
+Agents see this on their next `iscp-check` / `/session-resume`.
+
+### Step 6: Sync worktrees to master
+
+For each worktree: `git -C <worktree-path> merge master`. Picks up new master content.
+
+### Step 7: Report
+
+Present status table:
+
+```
+Sync complete:
+
+Worktree          Branch              Status    Merged    Synced
+-----------------------------------------------------------------
+fix-auth          fix-auth            clean     3 commits yes
+proto-tooling     proto/tooling       dirty     skipped   yes
+```
+
+### Step 8: Update handoff
+
+Light update to captain handoff: "what synced, what was merged into master, any worktrees skipped."
+
+## Failure modes
+
+- **Not on master**: abort with clear error.
+- **Dirty working tree**: abort; asks principal to commit or stash.
+- **Merge-base missing**: abort (usually force-push or filter-repo incident); principal decides recovery.
+- **Step 3 merge conflict**: halt; principal resolves, captain re-runs skill.
+- **Worktree merge conflict in Step 5**: report, skip that worktree, continue with others. Principal resolves later.
+- **Worktree sync conflict in Step 6**: report that worktree as NOT synced. Agent will resolve on their next /session-resume.
+
+## What this does NOT do
+
+- **Does not push.** Push happens via PR merges server-side.
+- **Does not rebase.** All sync uses merge commits.
+- **Does not reset to origin.** Preserves local history.
+- **Does not force-sync**: conflicts halt the process; no forced resolution.
+- **Does not write commits on worktree branches** (other than merge-master commits).
+
+## Captain-only — four-layer defense
+
+1. `disable-model-invocation: true` — Claude can't auto-invoke.
+2. `paths: []` — no auto-activation.
+3. Name contains `captain-`.
+4. Step 1 precondition — must be on master in main checkout.
+
+## Status
+
+`active` (v2, refactored from legacy `sync-all` 2026-04-19).
+
+## Related
+
+- `/pr-captain-post-merge` — invokes this as Step 5 after a merge
+- `/sync` — agent-side push skill (different scope entirely)
+- `/worktree-sync` — single-worktree sync (agent-side; this skill calls it across all worktrees)
+- `claude/tools/git-captain` — safe captain-side git operations
+- `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- `claude/REFERENCE-WORKTREE-DISCIPLINE.md` — worktree model
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/captain-sync-all/SKILL.md
+++ b/.claude/skills/captain-sync-all/SKILL.md
@@ -3,7 +3,7 @@ name: captain-sync-all
 description: Captain-only. Fetch, merge origin into master, merge unique worktree work into master, and sync all worktrees. The daily rhythm command. NEVER pushes to remote. NEVER rebases. NEVER resets to origin. Formerly `/sync-all` — v2 rename to captain-actor-verb.
 agency-skill-version: 2
 when_to_use: Captain on master in main checkout, starting a captain session or after a PR has merged (to propagate to the fleet). NEVER from a worktree. NEVER auto-invoked.
-argument-hint: ""
+argument-hint: "(no args)"
 paths: []
 disable-model-invocation: true
 required_reading:

--- a/.claude/skills/captain-sync-all/assets/README.md
+++ b/.claude/skills/captain-sync-all/assets/README.md
@@ -1,0 +1,5 @@
+# assets/
+
+Empty by design. `captain-sync-all` has no templates or static assets — the sync report is generated dynamically from `git worktree list` output.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/.claude/skills/captain-sync-all/examples.md
+++ b/.claude/skills/captain-sync-all/examples.md
@@ -1,0 +1,168 @@
+# captain-sync-all — examples
+
+## Happy-path examples
+
+### Session-start sync
+
+Captain starts morning session. Overnight PR merged on GitHub.
+
+```
+/captain-sync-all
+```
+
+Expected flow: fetch → divergence detected → tag recovery → merge origin/master → enumerate worktrees → no local-only worktree commits to merge → sync worktrees to new master → report + handoff update.
+
+### Sync with worktree work to land
+
+Captain session, `devex` worktree has 3 commits not yet in master (captain may have forgotten to run this after devex's PR merged):
+
+```
+/captain-sync-all
+```
+
+Expected: Step 5 prompts:
+```
+Worktree 'devex' has 3 commits ahead of master:
+  abc1234 feat(devex): X
+  def5678 fix(devex): Y
+  ghi9012 docs(devex): Z
+Merge into master? [y/N]
+```
+
+Captain says yes → merges with `--no-ff` → `main-updated` dispatch fires → Step 6 propagates.
+
+### All clean, no work
+
+No remote changes, no worktree drift:
+
+```
+/captain-sync-all
+```
+
+Expected:
+```
+Sync complete:
+  Master: at origin/master (e47ce53a)
+  Worktrees: all in sync (17/17)
+  Dispatches sent: 0
+```
+
+Size: S, fast pass, no-op in terms of state change.
+
+---
+
+## Edge-case examples
+
+### Captain not on master
+
+```
+/captain-sync-all
+```
+
+Expected:
+```
+ABORT: captain must be on master (currently on captain-fix-foo).
+  Switch: git-captain switch-branch master
+```
+
+Exit 1.
+
+### Dirty tree
+
+```
+/captain-sync-all
+```
+
+Expected:
+```
+ABORT: master working tree is dirty (2 uncommitted files).
+  Commit or stash before sync:
+    M claude/REFERENCE-X.md
+    ?? usr/jordan/captain/dispatches/new-one.md
+```
+
+Exit 1.
+
+### Step 3 merge conflict
+
+Captain's local master has a coord commit that conflicts with origin/master:
+
+```
+/captain-sync-all
+```
+
+Expected:
+```
+ABORT: merge origin/master conflicted:
+  CONFLICT (content): claude/REFERENCE-SKILLS-INDEX.md
+  
+Resolve manually:
+  git status
+  # edit conflicted files
+  git-safe add claude/REFERENCE-SKILLS-INDEX.md
+  git-captain merge-continue
+  # re-run /captain-sync-all
+```
+
+Exit 1. Working tree left mid-merge for resolution.
+
+### Step 6 worktree sync conflict
+
+Worktree `folio` has local changes that conflict with the newly-merged master:
+
+```
+/captain-sync-all
+```
+
+Expected:
+```
+Step 6: folio sync conflicted (CONFLICT in apps/folio/config.ts).
+  Not synced. Agent will resolve on next /session-resume.
+  Dispatch sent to folio agent noting the pending conflict.
+...
+Sync complete:
+  Worktrees synced: 16/17
+  Pending agent resolution: folio
+```
+
+Exit 0 (soft failure — captain did its job; agent owns conflict).
+
+---
+
+## Integration examples
+
+### Daily captain rhythm
+
+```
+# morning
+/session-resume
+/captain-sync-all           # reconcile with overnight activity
+# ... work ...
+/pr-captain-merge <N>
+/pr-captain-post-merge <N>  # internally calls /captain-sync-all at Step 5
+# ... more work ...
+/session-end
+/captain-sync-all           # optional: leave things tidy for tomorrow
+```
+
+### After a fleet-wide framework change
+
+Captain lands PR #110 that modifies `.claude/settings.json`:
+
+```
+/pr-captain-post-merge 110
+# → includes /captain-sync-all → fleet worktrees pick up settings.json
+```
+
+Every agent's next `/session-resume` copies the updated settings (via `worktree-sync`'s settings-copy step).
+
+### Manual run after a squash PR on GitHub
+
+External collaborator's PR was squash-merged on GitHub. Captain is unaware of the change:
+
+```
+git-captain fetch     # hmm, origin/master has new commits
+/captain-sync-all     # reconcile
+```
+
+Step 3 detects diverge (local has coord commits; origin has squash commits); merge-commit resolution preserves both.

--- a/.claude/skills/captain-sync-all/reference.md
+++ b/.claude/skills/captain-sync-all/reference.md
@@ -1,0 +1,58 @@
+# captain-sync-all — unique protocol
+
+## Recovery tag convention
+
+Before any master merge, Step 3 tags the pre-merge state:
+
+```
+git tag sync/pre-merge-YYYYMMDD-HHMMSS
+```
+
+These tags accumulate but are cheap (just refs). Captain can prune manually if needed. Tag enables roll-back if the subsequent merge goes sideways:
+
+```
+git reset --hard sync/pre-merge-YYYYMMDD-HHMMSS  # ONLY before the merge is pushed anywhere
+```
+
+**Never roll back after a push / after any worktree has picked up the merge.** At that point the merge is shared history.
+
+## Worktree merge order
+
+Step 5 merges each worktree's work into master SEQUENTIALLY. Order: whatever `git worktree list` returns (typically alphabetical by path). If worktree A introduces conflicts with worktree B when both merge into master, captain resolves A first (as it appears first), then B's merge may conflict against A's newly-merged content.
+
+This is rare because worktree agents work in different workstream directories. When it happens, captain holds 1B1 with the two agents about which should land first.
+
+## `main-updated` dispatch semantics
+
+Sent to every worktree agent after a merge in Step 5. The dispatch type is `main-updated` (legacy name; some docs call it `master-updated`). Agents' `/session-resume` checks for unread dispatches and surfaces the notification.
+
+The dispatch itself is lightweight: just "main-updated, merged X from branch Y." Agents pick up the actual content via `git merge master` (Step 6 of this skill propagates it automatically) or on their next `/session-resume`.
+
+## Step 6 failure semantics
+
+If a worktree's `git merge master` (Step 6) fails with conflict:
+
+- The worktree is left with unresolved conflict markers.
+- Skill reports it as NOT synced.
+- Agent resolves on their next `/session-resume` via `worktree-sync --auto` or manual conflict resolution.
+- Captain does NOT resolve agent conflicts (that's their workstream; they know their content).
+
+## Invocation from `/pr-captain-post-merge`
+
+When `/pr-captain-post-merge` runs as part of PR land flow, it invokes `/captain-sync-all` at Step 5. In that composition:
+
+- Steps 1-2 are fast (captain already clean on master).
+- Step 3 merge-from-origin picks up the just-merged PR.
+- Steps 4-7 propagate to fleet.
+- Step 8 (handoff) is included.
+
+## Frequency
+
+Captain runs `/captain-sync-all` at:
+
+- **Session start** — to reconcile with any overnight/external PR merges.
+- **After each PR land** (automatic via `/pr-captain-post-merge`).
+- **Session end** — optional; ensures next session starts clean.
+- **On demand** when captain notices worktree drift (agent reports "merge conflict on session-resume").
+
+Typical frequency: 2-5x per active captain session.

--- a/.claude/skills/captain-sync-all/scripts/README.md
+++ b/.claude/skills/captain-sync-all/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts/
+
+Empty by design. `captain-sync-all` composes `git-captain fetch` + `git-captain merge-from-origin` + per-worktree `git merge master` + `dispatch create`. No skill-specific scripts needed.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/.claude/skills/iteration-complete/SKILL.md
+++ b/.claude/skills/iteration-complete/SKILL.md
@@ -1,83 +1,185 @@
 ---
-description: Run the quality gate after completing an iteration — review, fix, test, report, auto-commit
+name: iteration-complete
+description: Run the quality gate after completing an iteration — review, fix, test, report, auto-commit. No principal approval needed (iteration boundary is auto-approved). Auto-emits a structured dispatch to captain so the small-batch-cadence daemon can pick up for PR landing.
+agency-skill-version: 2
+when_to_use: After completing an iteration of work inside a phase. For phase boundaries use /phase-complete. For final plan delivery use /plan-complete. For pre-PR gating of accumulated work use /pr-prep.
+argument-hint: "<phase.iter>: <description> [--base <ref>]"
+paths:
+  - .claude/worktrees/**
+required_reading:
+  - claude/REFERENCE-QUALITY-GATE.md
+  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--
-  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
-  .claude/settings.json. Restricting to specific subcommand patterns at the
-  skill level silently blocks agents on permission prompts the agent cannot
-  see — see dispatch #171 for the devex incident that surfaced this trap.
+  allowed-tools intentionally omitted — inherits Bash(*) from
+  .claude/settings.json. Subcommand-level restriction silently blocked
+  fleet agents (flag #62/#63; devex dispatch #171). This skill composes
+  dispatch, diff-hash, receipt-sign, git-safe, git-safe-commit, and
+  Skill invocations — too broad to enumerate at subcommand level without
+  regression risk. Inherit Bash(*).
 -->
 
-# Iteration Complete
+# iteration-complete
 
-Run this after completing each iteration. Invokes `/quality-gate` for the review+fix cycle, then auto-commits — no principal approval needed.
+Run this after completing each iteration of work. Invokes `/quality-gate` for the review+fix cycle, auto-commits on green (no principal approval at iteration boundaries), and emits a structured dispatch to captain so the small-batch-cadence daemon can pick up for PR landing.
 
-## Arguments
+## Why this exists
 
-- $ARGUMENTS: Description of what was completed. Must include boundary type and phase-iteration (e.g., "iteration-complete 1.2: parser edge cases"). If empty or missing phase-iteration, ask the user before proceeding.
+Iteration boundaries are the smallest formal commit-and-review unit in the-agency's valueflow work stream. Without a dedicated skill, agents skip the quality gate, forget the receipt-sign step, or let the commit drift from the plan file. `iteration-complete` bundles all five responsibilities (QG run → QGR receipt → auto-commit → plan update → handoff update + dispatch to captain) so iteration-end is single-invocation and auditable.
 
-## Steps
+Auto-commit (no principal approval) is specifically for iteration boundaries — they're small, bounded units where the QG + receipt is sufficient attestation. Phase and plan boundaries use sister skills with principal approval gates.
 
-### Step 1: Preconditions
+## Required reading
 
-1. If `$ARGUMENTS` is empty, ask the user what was completed before proceeding.
-2. Run `git diff --stat HEAD` and `git status`. If no changed files, tell the user "Nothing to gate — no changes since last commit" and stop.
-3. Identify the plan file in `docs/plans/` that this work belongs to. If none exists, note "no plan file" — the commit message will omit the Plan: line.
+Before proceeding, Read the files listed in `required_reading:` frontmatter. `REFERENCE-QUALITY-GATE.md` is the protocol the invoked `/quality-gate` skill runs. `REFERENCE-RECEIPT-INFRASTRUCTURE.md` explains the five-hash chain that signs the iteration's QGR receipt.
 
-### Step 2: Determine the prior-iteration base ref
+## Usage
 
-The QG's Hash A/Hash E diff is computed against the **prior iteration commit** (or the phase-start commit if this is the first iteration in the phase). Determine it as follows, in order:
+```
+/iteration-complete <phase.iter>: <description> [--base <ref>]
+```
 
-1. **Read the plan file** in `docs/plans/` (or `claude/workstreams/*/`) for an iteration history / status table. The most recent prior iteration's commit SHA is the base. Many plans record this under "Quality Gate Reports" or a status table.
-2. **Grep git log** for the prior iteration's commit: `git log --oneline --grep="Phase <P>\\." | head` — e.g., for iteration 1.3, the base is the SHA of the commit titled "Phase 1.2: ...". If this is iteration X.1 (first iteration in the phase), use the phase-start tag / commit (e.g., `v{phase}.0` or the commit titled "Phase <P-1>: ..." if no tag).
-3. **Fallback:** `HEAD~1` — use only if steps 1 and 2 yield nothing, and note this in the handoff update as a fallback used.
+Examples:
+- `/iteration-complete 1.2: parser edge cases`
+- `/iteration-complete 1.3: error handling --base abc1234`
 
-Capture the SHA/ref as `$BASE_REF`.
+- `<phase.iter>`: numeric identifier (phase.iteration), e.g., `1.2`
+- `<description>`: one-line summary
+- `--base <ref>` (optional): override baseline for QG diff-hash; resolved automatically if omitted
+
+If invoked with empty arguments, ask what was completed before proceeding.
+
+## Preconditions
+
+- Changed files present (`git status` non-empty).
+- On a worktree branch (not master — this skill is worktree-only).
+- Prior iteration's commit identifiable (or explicit `--base` passed). First iteration in a phase uses the phase-start commit.
+- A plan file should exist under `docs/plans/` or `claude/workstreams/*/`. If absent, skill proceeds with a "no plan file" note in the commit; handoff captures the omission.
+
+## Flow / Steps
+
+### Step 1: Preflight
+
+1. If args empty, ask what was completed.
+2. `git status` + `git diff --stat HEAD`. If empty, report "Nothing to gate" and stop.
+3. Identify plan file.
+
+### Step 2: Determine prior-iteration base ref
+
+QG's Hash A / Hash E diff is computed against the prior iteration commit (or phase-start commit for first iteration). Resolution order:
+
+1. Read plan file for iteration history / status table; use the last iteration's commit SHA.
+2. Grep git log for the prior-iteration commit: `git log --oneline --grep="Phase <P>\\."`. If this is X.1, use phase-start tag/commit.
+3. Fallback: `HEAD~1`. Note fallback usage in handoff.
+
+Capture as `$BASE_REF`.
 
 ### Step 3: Run the quality gate
 
-Invoke `/quality-gate` via the Skill tool, passing arguments that include both the boundary description AND the base ref:
-
 ```
-iteration-complete 1.2: parser edge cases --base <BASE_REF>
+/quality-gate iteration-complete <phase.iter>: <description> --base <BASE_REF>
 ```
 
-For example: `iteration-complete 1.2: parser edge cases --base abc1234`.
+Leading `iteration-complete <phase.iter>` tells QG the boundary type (used in receipt filename). `--base` tells QG the baseline for Hash A/E via `diff-hash --base`.
 
-The leading `iteration-complete <phase-iter>` tells `/quality-gate` the boundary type (used in the receipt filename). The `--base <ref>` tells `/quality-gate` what baseline to use for Hash A / Hash E via `diff-hash --base`.
+Full QG protocol runs: parallel review → consolidate → bug-exposing tests → fix → coverage tests → confirm clean → present QGR → sign receipt (five-hash chain at `claude/workstreams/{W}/qgr/`). Iteration-complete is auto-approved — Hash D = Hash C.
 
-This runs the full QG protocol: parallel agent review → consolidate → bug-exposing tests → fix → coverage tests → confirm clean → present QGR → sign receipt via `receipt-sign` (five-hash chain, written to `claude/workstreams/{W}/qgr/`). Iteration-complete is auto-approved — Hash D = Hash C.
+Wait for receipt signed before proceeding.
 
-Wait for the QGR to be presented and the receipt signed before proceeding.
+### Step 4: Commit (auto)
 
-### Step 4: Commit automatically
+No approval. Commit automatically after clean QGR.
 
-At iteration boundaries, no approval is needed. Commit automatically after a clean QGR.
+Use `/git-safe-commit` with the full structured commit message from the QGR's "Proposed Commit" section.
 
-Use `/git-safe-commit` via the Skill tool. Pass it the full structured commit message from the QGR's "Proposed Commit" section. The message must follow the format from the injected `quality-gate.md` reference.
+### Step 5: Update plan file
 
-### Step 5: Update the plan
+Append to the plan under "Quality Gate Reports":
 
-After committing, update the plan file in `docs/plans/` to reflect:
+- What was done
+- What QG found + fixed
+- Plan changes (scope, reordering, new findings)
+- Iteration status-table row
 
-- What was done in this commit (iteration/phase status change)
-- What the quality gate found (bugs fixed, test gaps closed)
-- Any changes to the plan itself (scope adjustments, reordering, new findings)
-- Iteration-level status table for multi-iteration phases
-- **Append the full QGR** (all three tables + summary) under a "Quality Gate Reports" section. Each iteration gets its own subsection. This is required — the plan is the living record.
+Append the full QGR (all tables + summary). The plan is the living record.
 
 ### Step 6: Update handoff
 
-Locate the handoff file for this project (glob `usr/*/*/handoff.md` or `usr/*/captain/handoff.md`). Update with:
+Update the worktree handoff file (`usr/*/*/handoff.md` or `usr/*/captain/handoff.md`):
 
-- Current phase and iteration status
-- What was just committed (summary, not full QGR)
-- What's next (next iteration or phase-complete)
-- Any decisions made or context that would help a fresh session continue
+- Current phase + iteration status
+- What just committed (summary, not full QGR)
+- What's next
+- Context for fresh-session continuation
 
-### Note
+### Step 7: Emit iteration-complete dispatch to captain
 
-This command handles iteration boundaries only. At phase boundaries, use `/phase-complete` instead — it runs a deep QG, requires principal approval, and lands on master.
+Structured dispatch for captain's auto-ship daemon. Must run AFTER the commit (Step 4) so `commit_hash` is current.
 
-After completing this iteration, move to the next iteration. When all iterations in a phase are done, run `/phase-complete`.
+Capture:
+- `ITERATION_SLUG` (e.g., "1.2")
+- `PHASE_NUM`
+- `BRANCH` = `git branch --show-current`
+- `COMMIT_HASH` = the Step 4 commit
+- `SUMMARY` = first line of commit message
+- `RECEIPT_PATH` = QGR receipt path from Step 3
+
+Emit:
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch create \
+  --to {repo}/{principal}/captain \
+  --type iteration-complete \
+  --subject "Iteration {ITERATION_SLUG} complete on {BRANCH}" \
+  --body "<yaml body — see below>"
+```
+
+Body:
+
+```yaml
+event: iteration-complete
+iteration: {ITERATION_SLUG}
+phase: {PHASE_NUM}
+branch: {BRANCH}
+commit_hash: {COMMIT_HASH}
+summary: {SUMMARY}
+qgr_receipt: {RECEIPT_PATH}
+emitted_at: {ISO-8601 timestamp}
+```
+
+Cascade isolation: export `AGENCY_SKILL_BYPASS_CASCADE=1` at skill start and unset at end if running multiple commits within the skill.
+
+## Failure modes
+
+- **No changes to gate** (Step 1): skill stops cleanly with "Nothing to gate" message. Not an error.
+- **QG fails** (Step 3): fix-and-retry per QG protocol — the gate itself handles findings, no special iteration-complete handling needed.
+- **Commit fails** (Step 4): usually a pre-commit hook (lint-staged, oxfmt). Fix the blocking issue; re-run from Step 4 (QG already passed; no need to re-run Step 3).
+- **Plan file missing** (Step 5): skill notes "no plan file" and continues. Handoff records the gap.
+- **Dispatch emission fails** (Step 7): skill warns but exits 0 — the commit itself is the authoritative record; dispatch is notification. Captain catches the omission via other mechanisms (handoff read, manual check).
+
+## What this does NOT do
+
+- **Does not land on master** — iteration-complete is a worktree-side boundary. Phase boundary + pr-submit + captain's pr-captain-land land on master.
+- **Does not require principal approval** — iteration boundaries are auto-approved; the QG + receipt is sufficient attestation.
+- **Does not run deep QG** — the QG here is iteration-scoped (diff against prior iteration). Phase and plan boundaries run deeper variants.
+- **Does not squash prior iteration commits** — those stay individually visible in history; squash happens (if at all) at phase boundary.
+
+## Status
+
+`active` (v2, body retrofit from Arguments/Steps pattern to 9-section structure 2026-04-19).
+
+## Related
+
+- `/quality-gate` — the core QG protocol this skill invokes in Step 3
+- `/phase-complete` — sibling skill for phase boundaries (deep QG + principal approval)
+- `/plan-complete` — sibling skill for plan delivery (final deep QG + A&D)
+- `/pr-prep` — pre-PR gating for accumulated work
+- `/pr-submit` — agent's hand-off to captain for PR landing (runs AFTER iteration-complete when ready to ship)
+- `claude/tools/receipt-sign` — signs the five-hash receipt
+- `claude/tools/dispatch` — emits the Step 7 notification
+- `claude/workstreams/captain/small-batch-cadence-*.md` — design for the auto-ship daemon that consumes Step 7's dispatch
+- the-agency#298 — skill refactor recommendation
+- the-agency#315 — V1→V2 migration
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/iteration-complete/assets/README.md
+++ b/.claude/skills/iteration-complete/assets/README.md
@@ -1,0 +1,3 @@
+# assets/
+
+TODO: describe or note empty

--- a/.claude/skills/iteration-complete/examples.md
+++ b/.claude/skills/iteration-complete/examples.md
@@ -1,0 +1,7 @@
+# iteration-complete — examples
+
+## Happy-path
+
+## Edge-case
+
+## Integration

--- a/.claude/skills/iteration-complete/reference.md
+++ b/.claude/skills/iteration-complete/reference.md
@@ -1,0 +1,3 @@
+# iteration-complete — unique protocol
+
+TODO: fill or note empty

--- a/.claude/skills/iteration-complete/scripts/README.md
+++ b/.claude/skills/iteration-complete/scripts/README.md
@@ -1,0 +1,3 @@
+# scripts/
+
+TODO: describe or note empty

--- a/.claude/skills/phase-complete/SKILL.md
+++ b/.claude/skills/phase-complete/SKILL.md
@@ -1,97 +1,203 @@
 ---
-description: Run the full quality gate after completing an implementation phase — review, fix, test, report, commit
+name: phase-complete
+description: Run the full deep quality gate after completing an implementation phase — review, fix, test, report, squash-commit. Principal approval REQUIRED before commit (phase boundary is NOT auto-approved). Auto-emits phase-complete dispatch to captain for PR landing.
+agency-skill-version: 2
+when_to_use: After completing a full phase of work — all iterations in the phase closed. For iteration boundaries within a phase use /iteration-complete. For final plan delivery use /plan-complete.
+argument-hint: "<phase>: <description>"
+paths:
+  - .claude/worktrees/**
+required_reading:
+  - claude/REFERENCE-QUALITY-GATE.md
+  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--
-  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
-  .claude/settings.json. Restricting to specific subcommand patterns at the
-  skill level silently blocks agents on permission prompts the agent cannot
-  see — see dispatch #171 for the devex incident that surfaced this trap.
+  allowed-tools intentionally omitted — inherits Bash(*). See sibling
+  iteration-complete for full rationale (flag #62/#63; devex dispatch #171;
+  the-agency#298 refactor caveat). Broad tool surface makes subcommand-level
+  narrowing brittle.
 -->
 
-# Phase Complete — Quality Gate + Sprint Review
+# phase-complete
 
-Run this after completing each implementation phase. Invokes `/quality-gate` for the review+fix cycle, then presents results for principal approval before committing. Do not proceed to the next phase until the gate passes and the user approves.
+Run this after completing each implementation phase (the collection of iterations that delivered a logical unit of work). Runs the full deep quality gate, presents results for principal approval (Sprint Review), commits the squash-rollup of iterations on approval, and emits a dispatch to captain for PR landing.
 
-## Arguments
+## Why this exists
 
-- $ARGUMENTS: Description of what was completed. Must include boundary type and phase (e.g., "phase-complete 1: types and parser"). If empty or missing phase number, ask the user before proceeding.
+Phases are larger boundary events than iterations — a full sub-deliverable (parser + lexer + AST; or data model + migration + seed; etc.). The QG at this boundary is deeper than iteration-complete's (full phase scope, not just since-last-iteration). Principal approval is REQUIRED — phases are the Sprint-Review moment where the principal decides whether the body of work is good enough to carry forward. Without a dedicated skill, phases drift into ad-hoc "I think we're done" claims; `/phase-complete` enforces the gate + approval + squash + dispatch in sequence.
 
-## Steps
+Squash discipline matters at phase boundaries: iterations are individually meaningful during development but collapse to a single phase-commit in the durable record so master history stays readable. Iterations remain in reflog / tags if anyone needs to replay them.
 
-### Step 1: Preconditions
+## Required reading
 
-1. If `$ARGUMENTS` is empty, ask the user what was completed before proceeding.
-2. Run `git diff --stat HEAD` and `git status`. If no changed files, tell the user "Nothing to gate — no changes since last commit" and stop.
-3. Identify the plan file in `docs/plans/` that this work belongs to. If none exists, note "no plan file" — the commit message will omit the Plan: line.
+Read the files listed in `required_reading:` frontmatter. `REFERENCE-QUALITY-GATE.md` is the deep QG protocol. `REFERENCE-RECEIPT-INFRASTRUCTURE.md` covers the five-hash receipt chain signed at Step 4.
+
+## Usage
+
+```
+/phase-complete <phase>: <description>
+```
+
+Example: `/phase-complete 1: types and parser`
+
+- `<phase>`: numeric phase identifier (e.g., `1`)
+- `<description>`: one-line summary of what the phase delivered
+
+If invoked with empty args, ask what was completed before proceeding.
+
+## Preconditions
+
+- On a worktree branch (not master).
+- Changed files present OR prior iteration commits within this phase (both acceptable — Step 2 squash handles the multi-iteration case).
+- Plan file identifiable (phase info, iteration history, phase-start tag preferred).
+- Principal available for Sprint Review (Step 5 blocks on their approval; do not phase-complete when principal is offline unless you're OK waiting).
+- 1B1 transcript file path known (or willing to start one mid-skill — QG's Hash D uses the transcript hash for phase/plan boundaries; auto-approval only applies at iteration boundary).
+
+## Flow / Steps
+
+### Step 1: Preflight
+
+1. If args empty, ask what was completed.
+2. `git status` + `git diff --stat HEAD`. Combined with prior-phase iteration commits, there should be something to gate. Empty = stop.
+3. Identify the plan file.
 
 ### Step 2: Squash iterations (if applicable)
 
-If this phase had multiple iterations committed separately, squash them into a single phase commit before running the gate. Use `git reset --soft` to the commit before the first iteration, then re-stage all changes.
+If this phase had multiple iterations committed separately:
+
+```
+git reset --soft <commit-before-first-iteration-in-this-phase>
+```
+
+Then re-stage all changes. They're now uncommitted, ready for a single phase commit in Step 6.
 
 If only one commit or no prior iteration commits, skip this step.
 
-### Step 3: Determine the phase-start base ref
+### Step 3: Determine phase-start base ref
 
-The QG's Hash A/Hash E diff is computed against the **phase-start tag** (or commit). Determine as follows, in order:
+The deep QG diff is computed against the phase-start tag/commit. Resolution order:
 
-1. **Read the plan file** in `docs/plans/` (or `claude/workstreams/*/`) for a phase-start tag — most plans record `tag: v<phase>.0` or similar on the phase header (e.g., Phase 1 starts at `v40.1`).
-2. **Check for a git tag** matching the phase: `git tag --list 'v*' --sort=-v:refname | head` — use the tag that marks the start of this phase.
-3. **Fallback:** `git merge-base main HEAD` — the divergence point from master. Note in the handoff if fallback was used.
+1. Read plan file for `tag: v<phase>.0` or similar in phase header (e.g., Phase 1 starts at `v40.1`).
+2. `git tag --list 'v*' --sort=-v:refname | head` — use the tag marking this phase's start.
+3. Fallback: `git merge-base main HEAD`. Note in handoff if fallback was used.
 
-Capture the tag/SHA as `$BASE_REF`.
+Capture as `$BASE_REF`.
 
-### Step 4: Run the quality gate
-
-Invoke `/quality-gate` via the Skill tool, passing arguments that include both the boundary description AND the base ref:
+### Step 4: Run the deep quality gate
 
 ```
-phase-complete 1: types and parser --base <BASE_REF>
+/quality-gate phase-complete <phase>: <description> --base <BASE_REF>
 ```
 
-For example: `phase-complete 1: types and parser --base v40.1`.
+Full QG protocol — parallel review → consolidate → bug-exposing tests → fix → coverage tests → confirm clean → present QGR → sign receipt (five-hash chain at `claude/workstreams/{W}/qgr/`).
 
-The leading `phase-complete <phase>` tells `/quality-gate` the boundary type (used in the receipt filename). The `--base <ref>` tells `/quality-gate` what baseline to use for Hash A / Hash E via `diff-hash --base`.
+Scope: **full phase's work** (all changes since `$BASE_REF`). Deeper than iteration-level.
 
-This runs the full QG protocol: parallel agent review → consolidate → bug-exposing tests → fix → coverage tests → confirm clean → present QGR → sign receipt via `receipt-sign` (five-hash chain, written to `claude/workstreams/{W}/qgr/`).
+**Phase-complete requires principal 1B1** — pass the 1B1 transcript path to `/quality-gate` so Step 10 records Hash D as the transcript hash (NOT auto-approved like iteration-complete).
 
-The QG is scoped to the **full phase's work** (all changes since divergence from master, or since the last phase commit). This is a deep review — broader scope than the iteration-level gate.
+Wait for QGR presented + receipt signed before proceeding.
 
-Phase-complete requires principal 1B1 — capture the 1B1 transcript path so `/quality-gate` Step 10 can record Hash D as the transcript hash (not auto-approved).
+### Step 5: Sprint Review — wait for approval
 
-Wait for the QGR to be presented and the receipt signed before proceeding.
-
-### Step 5: Sprint Review — Wait for approval
-
-Present the QGR and proposed commit message to the user. This is a Sprint Review — the principal reviews the body of work.
+Present the QGR + proposed commit message to the principal. This IS the Sprint Review.
 
 **Do not commit without explicit principal approval.**
 
-If the principal requests changes, make them and re-run the relevant QG steps.
+If principal requests changes:
+- Make the changes
+- Re-run the relevant QG step(s)
+- Re-present
+
+Loop until approval.
 
 ### Step 6: Commit with approval
 
-Once approved, re-run `git status` to capture any new files written during the QG fix cycle (bug-exposing tests, coverage tests). Use `/git-safe-commit` via the Skill tool, staging all relevant files. Pass it the full structured commit message from the QGR's "Proposed Commit" section.
+Once approved, `git status` to capture any QG-phase-added files (bug-exposing tests, coverage tests). Use `/git-safe-commit` via Skill tool, staging all relevant files. Pass the full structured commit message from the QGR's "Proposed Commit" section. Message leads with `Phase <N>: <description>` per framework convention.
 
-### Step 7: Update the plan
+### Step 7: Update plan file
 
-After committing, update the plan file in `docs/plans/` to reflect:
+Under "Quality Gate Reports":
 
-- What was done in this phase (phase status change)
-- What the quality gate found (bugs fixed, test gaps closed)
-- Any changes to the plan itself (scope adjustments, reordering, new findings)
-- **Append the full QGR** under a "Quality Gate Reports" section. Each phase gets its own subsection.
+- Phase status change (e.g., "Phase 1: complete")
+- What QG found + fixed
+- Plan changes
+- Append full QGR
 
 ### Step 8: Update handoff
 
-Locate the handoff file for this project (glob `usr/*/*/handoff.md` or `usr/*/captain/handoff.md`). Update with:
+Update worktree handoff:
 
 - Phase completion status
-- What was committed (summary of the phase's work)
-- What's next (next phase, or plan-complete if this was the last phase)
-- Key decisions, trade-offs, or context from this phase
-- Any open items or known issues carried forward
+- What was committed (phase summary)
+- What's next (next phase, or `/plan-complete` if last phase)
+- Key decisions / trade-offs / open items
 
-### Note: Multi-iteration phases
+### Step 9: Emit phase-complete dispatch to captain
 
-If this phase had multiple iterations that were each committed separately, the phase-complete commit should squash the iteration commits into a single phase commit. Step 2 handles this — use `git reset --soft` to combine them before running the gate.
+Structured dispatch for captain's auto-ship daemon.
+
+Capture:
+- `PHASE_SLUG`
+- `BRANCH`
+- `COMMIT_HASH` (Step 6 commit)
+- `SUMMARY`
+- `RECEIPT_PATH`
+
+Emit:
+
+```
+bash $CLAUDE_PROJECT_DIR/claude/tools/dispatch create \
+  --to {repo}/{principal}/captain \
+  --type phase-complete \
+  --subject "Phase {PHASE_SLUG} complete on {BRANCH}" \
+  --body "<yaml body>"
+```
+
+Body:
+
+```yaml
+event: phase-complete
+phase: {PHASE_SLUG}
+branch: {BRANCH}
+commit_hash: {COMMIT_HASH}
+summary: {SUMMARY}
+qgr_receipt: {RECEIPT_PATH}
+emitted_at: {ISO-8601 timestamp}
+```
+
+Cascade isolation: `AGENCY_SKILL_BYPASS_CASCADE=1` in environment.
+
+## Failure modes
+
+- **Nothing to gate** (Step 1): skill stops cleanly.
+- **Squash conflicts** (Step 2): rare (reset --soft doesn't conflict), but if the pre-phase state is unclear, skill halts — principal investigates.
+- **QG fails** (Step 4): fix-and-retry per QG protocol.
+- **Principal rejects at Sprint Review** (Step 5): make changes, re-run relevant QG steps, re-present. No time limit on this loop.
+- **Commit fails after approval** (Step 6): pre-commit hook (lint-staged, oxfmt). Fix the blocking issue, re-run from Step 6 (QG stays valid).
+- **Dispatch emission fails** (Step 9): warn, exit 0. Commit is the authoritative record.
+
+## What this does NOT do
+
+- **Does not auto-approve** — principal 1B1 + explicit approval required. Iteration boundaries auto-approve; phase boundaries do not.
+- **Does not push or open a PR** — that's captain's job via `/pr-captain-land` after consuming the Step 9 dispatch (or direct via `/pr-submit`).
+- **Does not squash across phases** — squash is within-phase only. Prior phases stay as distinct commits.
+- **Does not bump manifest versions** — versioning happens at PR-landing time (captain's flow).
+
+## Status
+
+`active` (v2, body retrofit from Arguments/Steps pattern to 9-section structure 2026-04-19).
+
+## Related
+
+- `/quality-gate` — deep QG protocol invoked in Step 4
+- `/iteration-complete` — sibling skill for iteration boundaries (auto-approved, lighter QG)
+- `/plan-complete` — sibling skill for plan delivery (final deep QG + A&D)
+- `/pr-submit` — agent's hand-off to captain; runs after phase-complete when ready to land
+- `/pr-captain-land` — captain's counterpart; consumes Step 9's dispatch
+- `claude/tools/receipt-sign` — signs the five-hash receipt at phase boundary
+- `claude/workstreams/captain/small-batch-cadence-*.md` — auto-ship daemon design
+- the-agency#296 — PR lifecycle ownership
+- the-agency#298 — skill refactor recommendation
+- the-agency#315 — V1→V2 migration (this skill's retrofit lives in Tier 1)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/phase-complete/assets/README.md
+++ b/.claude/skills/phase-complete/assets/README.md
@@ -1,0 +1,3 @@
+# assets/
+
+TODO: describe or note empty

--- a/.claude/skills/phase-complete/examples.md
+++ b/.claude/skills/phase-complete/examples.md
@@ -1,0 +1,7 @@
+# phase-complete — examples
+
+## Happy-path
+
+## Edge-case
+
+## Integration

--- a/.claude/skills/phase-complete/reference.md
+++ b/.claude/skills/phase-complete/reference.md
@@ -1,0 +1,3 @@
+# phase-complete — unique protocol
+
+TODO: fill or note empty

--- a/.claude/skills/phase-complete/scripts/README.md
+++ b/.claude/skills/phase-complete/scripts/README.md
@@ -1,0 +1,3 @@
+# scripts/
+
+TODO: describe or note empty

--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -1,0 +1,247 @@
+---
+name: pr-captain-land
+description: Captain-only. Land an agent's prepared branch — switch, verify receipt, bump monofolk_version, create PR, watch CI, merge, release, notify agent. The single-writer serialization point for monofolk_version and PR creation. Companion to /pr-submit (the-agency#296 Phase 1 pilot). The `captain-` qualifier in the name signals scope at a glance (complements paths + disable-model-invocation enforcement).
+agency-skill-version: 2
+when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. NEVER auto-invoked (disable-model-invocation + empty paths).
+argument-hint: "<agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - claude/REFERENCE-SAFE-TOOLS.md
+---
+
+<!--
+  allowed-tools intentionally omitted — inherits Bash(*) from
+  .claude/settings.json. Subcommand-level restriction silently blocked
+  fleet agents (flag #62/#63; devex dispatch #171). This skill composes
+  git-safe, git-captain, git-push, git-safe-commit, pr-create,
+  pr-captain-merge, gh-release, dispatch, diff-hash, and gh — tool-level
+  narrow restriction would work but needs maintenance. Inherit Bash(*).
+  Defense in depth is layered via disable-model-invocation + paths: [] +
+  captain- name + runtime precondition (see "Captain-only — four-layer
+  defense" below).
+-->
+
+# pr-captain-land
+
+Captain-side skill that lands an agent's prepared branch as a merged PR + GitHub release + fleet notification. Companion to `/pr-submit`. This is the single-writer serialization point for `monofolk_version` and PR creation — eliminates the version-bump and receipt-hash races the pre-v2 distributed model created.
+
+**Name pattern:** `pr-` prefix groups with the PR skill family (so `/pr<tab>` autocomplete shows the full kit). `captain-` qualifier flags captain-only scope in the skill listing without requiring the reader to open SKILL.md.
+
+## Why this exists
+
+Per the-agency#296 — one captain, one writer, one serialization point. Every PR, every version bump, every release goes through this skill when driven by an agent's `/pr-submit`.
+
+Pre-v2 (distributed PR ownership) failure modes this skill eliminates:
+
+- Agent A and agent B both run `/pr-prep` + `/pr-create` concurrently → both bump `monofolk_version` → one loses, the other's release tag is wrong.
+- Captain lands a coord commit on master between an agent's `/pr-prep` and that agent's `/pr-create` → the receipt's diff-hash no longer matches → `pr-create` blocks with a confusing error.
+- Agent opens PR with a one-line body → fleet reviewers can't tell what changed without diving into diff.
+
+Captain-owned: captain is serialized by definition (one captain), captain re-verifies the receipt at the moment of landing, captain authors a fleet-aware PR body that references agent + scope + receipt.
+
+## Required reading
+
+Before running, Read the files listed in `required_reading:` frontmatter.
+
+- `REFERENCE-CODE-REVIEW-LIFECYCLE.md` — end-to-end PR flow
+- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — five-hash chain, receipt re-verification semantics
+- `REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline (`pr-captain-merge` enforces)
+- `REFERENCE-SAFE-TOOLS.md` — the safe-tool family this skill composes
+
+This skill's `reference.md` is the step-by-step land protocol with failure-mode recovery.
+
+## Usage
+
+```
+/pr-captain-land <agent-branch>
+/pr-captain-land <agent-branch> --dry-run
+/pr-captain-land <agent-branch> --title "Custom PR title"
+/pr-captain-land <agent-branch> --no-release
+```
+
+- `<agent-branch>`: **required.** The branch that `/pr-submit` identified.
+- `--dry-run`: walk the preflight + preview the PR body; no mutation.
+- `--title`: override the default PR title (which derives from the agent's scope).
+- `--no-release`: skip Step 8 (release creation). Used when landing a PR that explicitly shouldn't cut a release (rare).
+
+## Preconditions
+
+The script enforces **all** of these before any mutation; any failure exits non-zero with a clear error and no state change:
+
+1. Running in the **main checkout** (first entry of `git worktree list`). Not in a `.claude/worktrees/` path.
+2. Current branch is `master` or `main`.
+3. Master tree is clean (`git status --porcelain` empty).
+4. `<agent-branch>` exists on origin (`git ls-remote --heads origin <agent-branch>` non-empty).
+5. `<agent-branch>` passes safe-name validation: regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
+6. Diff-hash of `<agent-branch>` vs `origin/master` matches a QGR receipt at `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
+
+Any failure → zero mutation, clean error message, exit 1.
+
+## Flow / Steps
+
+The script at `scripts/pr-captain-land` walks these nine steps. Full failure-mode detail is in `reference.md`.
+
+### Step 1: Preflight
+
+Verify all six preconditions. If any fail, exit 1.
+
+### Step 2: Switch to agent branch
+
+```
+./claude/tools/git-captain switch-branch <agent-branch>
+```
+
+Main checkout is now on agent's branch.
+
+### Step 3: Verify receipt against current state
+
+```
+./claude/tools/diff-hash --base origin/master --json
+```
+
+Find receipt at `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`. If missing, agent's state drifted — switch back to master, exit 1, tell agent to re-run `/pr-prep` + `/pr-submit`.
+
+### Step 4: Bump `monofolk_version`
+
+Read `claude/config/manifest.json`. Bump minor (e.g., `1.8 → 1.9`). Refresh `updated_at` to current UTC timestamp.
+
+**Security note:** version-bump is done via Python env-var substitution (`MANIFEST=... NEW_VER=... python3 -c '...os.environ[...]...'`), **not** f-string interpolation. This blocks code-injection via adversarial branch names. (Fix landed in `ccf054ad` per MAR finding F-SEC-1 / CRITICAL-3.)
+
+Commit via `git-safe-commit`:
+
+```
+chore(manifest): bump monofolk_version {old} → {new} for PR landing (captain)
+```
+
+Push to origin.
+
+### Step 5: Create PR
+
+```
+./claude/tools/pr-create --title "<title>" --body "<captain-authored fleet-aware body>"
+```
+
+Title derives from agent's `--scope` or `--title` override. Body wraps agent's scope with:
+
+- "Captain-landed PR via `pr-captain-land` (the-agency#296 Phase 1)"
+- Branch, receipt path, diff-hash, version bump
+- "Release `v{new}` will follow on merge"
+
+### Step 6: Switch back to master
+
+```
+./claude/tools/git-captain switch-branch master
+```
+
+Captain sits on master during the CI-wait phase. Avoids any accidental commit on the PR branch.
+
+### Step 7: Watch CI
+
+Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Only gates on `lint-and-test`.
+
+| State | Action |
+|---|---|
+| SUCCESS | proceed to Step 8 |
+| FAILURE | exit 1 — agent must fix + push + resubmit |
+| PENDING / IN_PROGRESS | wait 20s, poll again |
+
+Max 30 attempts = 10 minutes. On timeout, exit 1.
+
+`deploy-preview-backend` is environmental flake and ignored by this skill.
+
+### Step 8: Merge + release
+
+Merge:
+
+```
+./claude/tools/pr-merge {pr-num} --principal-approved
+```
+
+True merge commit — never squash, never rebase (enforced by `pr-captain-merge` / underlying `pr-merge`).
+
+Sync master:
+
+```
+./claude/tools/git-captain fetch
+./claude/tools/git-captain merge-from-origin
+```
+
+Release (unless `--no-release`):
+
+```
+./claude/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+```
+
+Release notes: captain-authored, references PR number + agent.
+
+### Step 9: Dispatch agent
+
+```
+./claude/tools/dispatch create \
+  --to <agent-address> \
+  --type master-updated \
+  --subject "PR #{num} landed — v{new} released" \
+  --body "<PR URL, release URL, version bump, Phase 1 pilot feedback request>"
+```
+
+Agent picks up on next `/session-resume` or via dispatch monitor.
+
+## Failure modes
+
+- **Preflight fails** (Step 1): exit 1, no mutation. Captain resolves (switch to main checkout, clean tree, ensure branch exists, verify agent submitted).
+- **Branch-name validation fails** (Step 1.5): rare — injection attempt or malformed branch. Exit 1. Agent renames.
+- **Receipt mismatch** (Step 3): master drifted. Exit 1 with switch-back-to-master. Agent re-runs `/pr-prep` + `/pr-submit`.
+- **Version-bump push fails** (Step 4): concurrent captain activity or branch-protection edge. Switch back to master, exit 1. Captain investigates.
+- **`pr-create` blocks on receipt** (Step 5): re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
+- **CI failure** (Step 7): version-bump commit stays on agent's branch; agent can fix + push + resubmit via `/pr-submit`. Version doesn't re-bump on retry (captain detects current == target).
+- **CI timeout** (Step 7): exit 1, captain investigates manually.
+- **Merge fails** (Step 8): likely branch-protection edge. Captain falls back to manual `/pr-captain-merge <num> --principal-approved`.
+- **Release creation fails** (Step 8): merge succeeded, release failed. Warn captain, suggest manual `gh release create`. Skill returns 0 because merge is the primary outcome. (MAR follow-up H13 tracks stricter semantics.)
+- **Dispatch emission fails** (Step 9): warn, exit 0. Merge + release are the authoritative record; dispatch is notification.
+
+## What this does NOT do
+
+- **Does not write code.** Agent's branch is the substance; captain lands it as-is (plus the version-bump).
+- **Does not modify agent's existing commits.** Only appends the version-bump commit.
+- **Does not squash or rebase.** `pr-captain-merge` enforces true merge commit per framework discipline.
+- **Does not auto-retry on failure.** Failures need captain attention; no silent retries that mask real issues.
+- **Does not fire from an agent context.** Four-layer defense (below) makes this impossible.
+
+## Captain-only — four-layer defense
+
+Defense in depth against accidental invocation from the wrong context:
+
+1. **`disable-model-invocation: true`** in frontmatter — Claude cannot auto-invoke. Captain must explicitly type the command.
+2. **`paths: []`** (intentionally empty) — no file-path auto-activation. (Contrast with `pr-submit` which has `paths: [.claude/worktrees/**]`.)
+3. **Name contains `captain-`** — any human or agent browsing the skill list sees scope at a glance.
+4. **Runtime precondition** — script's Step 1 refuses unless in main checkout on master.
+
+Any single layer failing is caught by the next. All four must fail simultaneously for an unauthorized invocation to land a PR.
+
+## Status
+
+`active` (v2, agency-skill-version 2 from birth — Phase 1 pilot for the-agency#296). Scripts hardened in `ccf054ad` per MAR findings (Python env-var substitution + branch-name validation). Ready for fleet-wide dogfood on next agent PRs.
+
+## Related
+
+- `/pr-submit` — agent-side companion; this skill consumes its dispatch
+- `/pr-captain-merge` — the merge primitive this skill calls at Step 8
+- `/pr-prep` — the QG-before-PR-create that signs the receipt this skill re-verifies
+- `/pr-captain-post-merge` — alternative entry for post-merge tasks (release + fleet-notify) when landing was done manually
+- `claude/tools/pr-create` — PR creation tool (receipt-aware)
+- `claude/tools/pr-merge` — safe-merge primitive (underlies `/pr-captain-merge`)
+- `claude/tools/gh-release` — release creation wrapper
+- `claude/tools/dispatch` — ISCP dispatch tool
+- `claude/tools/diff-hash` — receipt-matching hash
+- `reference.md` — full step-by-step protocol + recovery flows
+- `examples.md` — happy-path + failure-mode examples
+- the-agency#296 — PR lifecycle ownership design
+- the-agency#298 — skill refactor recommendation
+- the-agency#314 — upstream package MAR summary (this skill's scripts hardened there)
+- the-agency#315 — V1→V2 migration master issue
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-captain-land/assets/README.md
+++ b/.claude/skills/pr-captain-land/assets/README.md
@@ -1,0 +1,14 @@
+# assets/
+
+Empty by design. `pr-captain-land` generates all its output dynamically:
+
+- PR title from agent scope (or `--title` override)
+- PR body composed from branch/SHA/hash/receipt/version-bump at runtime
+- Release notes composed from PR # + agent identity + version diff
+- Dispatch body composed from merge outcome
+
+No static templates needed.
+
+Bundle structure requires this directory (v2 spec §5); this README explains the intentional emptiness so audit tooling doesn't flag it as drift.
+
+If future extensions need a PR body template (e.g., for cross-repo releases where the body must conform to a partner's issue format), they land here.

--- a/.claude/skills/pr-captain-land/examples.md
+++ b/.claude/skills/pr-captain-land/examples.md
@@ -1,0 +1,184 @@
+# pr-captain-land — examples
+
+## Happy-path examples
+
+### Captain lands agent's PR end-to-end
+
+Captain is on master, main checkout, tree clean. Agent dispatched `/pr-submit` for branch `jordan-devex-d12-r3`:
+
+```
+/pr-captain-land jordan-devex-d12-r3
+```
+
+Expected flow:
+
+```
+[pr-captain-land] Preflight OK: main-checkout=ok, branch=master, tree=clean, remote-branch=exists, receipt=found
+[pr-captain-land] Switched to jordan-devex-d12-r3
+[pr-captain-land] Receipt verified: hash 8b4c2e1 matches qgr-pr-prep-20260419-1430-8b4c2e1.md
+[pr-captain-land] Bumping monofolk_version 1.9 → 1.10
+[pr-captain-land] Pushed chore(manifest) commit to origin/jordan-devex-d12-r3
+[pr-captain-land] Created PR #118: "devex: fix worktree-sync MAIN_BRANCH resolution"
+[pr-captain-land] Switched back to master
+[pr-captain-land] CI check (lint-and-test): PENDING... SUCCESS (attempt 4 of 30, 80s)
+[pr-captain-land] Merging PR #118 via pr-merge --principal-approved
+[pr-captain-land] Merged. Syncing master... fetched + merged origin/master
+[pr-captain-land] Released v1.10 on GitHub
+[pr-captain-land] Dispatched monofolk/jordan/devex: "PR #118 landed — v1.10 released"
+✓ Land complete. Size: M, ~3-10 minutes (CI wait dominates).
+```
+
+### Dry-run to preview
+
+Captain wants to see the PR body before committing:
+
+```
+/pr-captain-land jordan-devex-d12-r3 --dry-run
+```
+
+Expected: walks Steps 1-4 (precondition check + receipt verify + version-bump preview + PR body compose) and stops before mutation. Prints the proposed PR title, body, and version bump target. Exit 0.
+
+### Custom title override
+
+```
+/pr-captain-land jordan-devex-d12-r3 --title "[devex] Critical: fix worktree-sync for all fleet agents"
+```
+
+Uses the override instead of the agent's scope.
+
+### Land without release
+
+Rare — a PR that shouldn't cut a release (e.g., a doc-only amendment to a prior release):
+
+```
+/pr-captain-land jordan-captain-d41-r22-doc-fix --no-release
+```
+
+Steps 1–7 run; Step 8 skips release creation; Step 9 dispatches agent without a release URL.
+
+## Failure-mode examples
+
+### Not in main checkout
+
+Captain accidentally invokes from a worktree:
+
+```
+/pr-captain-land jordan-devex-d12-r3
+```
+
+```
+[pr-captain-land] ERROR: Preflight failed — not in main checkout.
+  Current: /Users/jordan_of/code/monofolk/.claude/worktrees/devex
+  Expected: main checkout (first entry of `git worktree list`)
+  Fix: cd to main checkout and re-run, OR use /pr-submit if you're an agent.
+```
+
+Exit 1. Zero mutation. (Runtime precondition — Layer 4 of the captain-only defense.)
+
+### Agent branch name fails validation
+
+Rare — adversarial branch name or typo:
+
+```
+/pr-captain-land "evil; rm -rf /"
+```
+
+```
+[pr-captain-land] ERROR: Invalid branch name.
+  Provided: "evil; rm -rf /"
+  Required: regex ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$, no '..', no leading '-'
+```
+
+Exit 1. (Branch-name validation from ccf054ad / MAR finding F-SEC-2.)
+
+### Receipt mismatch (most common legit failure)
+
+Captain's coord commits landed on master between agent's `/pr-prep` and captain's `/pr-captain-land`. Agent's receipt hash no longer matches:
+
+```
+[pr-captain-land] Preflight OK
+[pr-captain-land] Switched to jordan-devex-d12-r3
+[pr-captain-land] ERROR: No receipt matches current diff-hash (c1d2e3f).
+  Searched: claude/workstreams/**/qgr/*qgr-pr-prep-*-c1d2e3f.md (0 matches)
+  The agent's receipt was signed against an older origin/master baseline.
+[pr-captain-land] Switching back to master.
+[pr-captain-land] Dispatching agent: "Receipt stale — re-run /pr-prep + /pr-submit."
+```
+
+Exit 1. Captain is back on master, agent is notified, no partial state.
+
+### CI failure
+
+```
+[pr-captain-land] ... (steps 1-6 succeed)
+[pr-captain-land] CI check (lint-and-test): PENDING... FAILURE (attempt 2 of 30, 40s)
+[pr-captain-land] Switching back to master.
+[pr-captain-land] Dispatching agent: "CI failed — fix and re-submit. Version bump commit (abc1234) stays on your branch."
+```
+
+Exit 1. Version-bump commit is on the agent's branch; they can push more fixes on top. On re-submit, `pr-captain-land` detects current version == target and skips re-bump.
+
+### CI timeout
+
+10-minute wait elapsed with no resolution:
+
+```
+[pr-captain-land] CI check (lint-and-test): still PENDING after 30 attempts (10min)
+[pr-captain-land] Switching back to master.
+[pr-captain-land] Timeout — captain investigate manually. PR #118 open at https://github.com/...
+```
+
+Exit 1. Captain uses `gh pr checks 118` + whatever manual resolution.
+
+### Merge fails after green CI
+
+Unusual — likely branch-protection edge:
+
+```
+[pr-captain-land] CI green. Merging via pr-merge --principal-approved.
+[pr-captain-land] ERROR: pr-merge exit 3 (branch protection blocked).
+  Fallback: run /pr-captain-merge 118 --principal-approved manually.
+```
+
+Exit 1. Release is skipped. Captain resolves via the companion skill.
+
+### Release creation fails but merge succeeded
+
+Most common: GitHub release API hiccup:
+
+```
+[pr-captain-land] Merged PR #118 successfully.
+[pr-captain-land] gh-release create v1.10 FAILED: ...
+[pr-captain-land] WARN: merge is the primary outcome (success). Release creation deferred.
+  Captain: run `gh release create v1.10 --target master --notes-file ...` manually.
+[pr-captain-land] Dispatched agent with merge confirmation (no release URL).
+```
+
+Exit 0 because merge is authoritative. (MAR follow-up H13 proposes stricter semantics — track there.)
+
+### Dispatch emission fails at the end
+
+```
+[pr-captain-land] Merged + released successfully.
+[pr-captain-land] WARN: dispatch emission failed (ISCP tool error).
+  Agent will see the PR landed on next /sync, even without the dispatch.
+```
+
+Exit 0. Merge + release are the authoritative record.
+
+## Four-layer defense in action
+
+Each of the four defense layers has caught a different incident in development:
+
+1. **`disable-model-invocation: true`** — prevented an auto-tool-use accidentally firing during a multi-turn coord dialog
+2. **`paths: []`** — prevented the skill from auto-surfacing when captain opened a file under `.claude/worktrees/*/` (which is where this skill definitely should not fire)
+3. **`captain-` name qualifier** — a new agent browsing the skill list asked "wait, is this captain-only?" → answered by the name before even reading SKILL.md
+4. **Runtime precondition** — caught a case where the first three layers were all bypassed (captain copied the script to a worktree sandbox to test) and the script refused to run because `pwd` wasn't the main checkout
+
+Defense in depth works.
+
+## Concurrency note
+
+**Never run two `/pr-captain-land` simultaneously.** Phase 1 pilot enforces this by captain discipline (one captain, one sequential skill). Phase 2 adds a lockfile at `$HOME/.agency/monofolk/pr-captain-land.lock`.
+
+Captain CAN run other non-land work concurrently (dispatch reads, flag triage, reviewer-agent launches). Just not two lands.

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -1,0 +1,158 @@
+# pr-captain-land Protocol
+
+Full step-by-step execution flow for `/pr-captain-land`, with failure modes and recovery paths. This document is the contract; the script at `scripts/pr-captain-land` implements it.
+
+## Preconditions checklist
+
+Before any mutation, the script must verify ALL of these:
+
+| # | Check | Failure action |
+|---|---|---|
+| 1 | `pwd` equals main checkout (first `git worktree list` entry) | exit 1, point at /pr-captain-land help |
+| 2 | Current branch is `master` or `main` | exit 1, ask captain to switch |
+| 3 | `git status --porcelain` empty | exit 1, list dirty files |
+| 4 | `<agent-branch>` exists on origin | exit 1, list suggestion |
+| 5 | Diff-hash of `<agent-branch>` matches a QGR receipt at `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | exit 1, tell agent to re-prep |
+
+Any failure => zero mutation, clean error message.
+
+## The 9 steps
+
+### Step 1 — Switch to agent branch
+
+```
+./claude/tools/git-captain switch-branch <agent-branch>
+```
+
+Current working branch becomes the agent's. Main checkout is now sitting on agent's branch.
+
+**Failure:** switch fails (dirty tree, branch doesn't exist locally). Script exits; captain resolves.
+
+### Step 2 — Verify receipt
+
+Compute current diff-hash against `origin/master`. Find receipt matching that hash.
+
+```
+./claude/tools/diff-hash --base origin/master --json
+# extract hash
+find claude/workstreams -name "*qgr-pr-prep-*-{hash}.md"
+```
+
+**Failure:** no matching receipt. Branch state doesn't match what /pr-submit claimed. Switch back to master, exit 1. Agent must re-prep.
+
+### Step 3 — Bump `monofolk_version`
+
+Read current version from `claude/config/manifest.json`. Bump minor (e.g., 1.8 → 1.9). Write back with `updated_at` refreshed to current UTC timestamp.
+
+Commit via `git-safe-commit` with message:
+```
+chore(manifest): bump monofolk_version {old} → {new} for PR landing (captain)
+```
+
+Push to origin.
+
+**Failure:** push fails (concurrent captain activity, branch protection edge case). Switch back to master, exit 1.
+
+### Step 4 — Create PR
+
+```
+./claude/tools/pr-create --title "{title}" --body "{body}"
+```
+
+Title: `--title` flag value, or `<agent-branch>` as fallback. Body: captain-authored fleet-aware description that wraps the agent's scope with:
+- "Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot)"
+- Branch, receipt path, hash, version bump
+- Release v{new} will follow on merge
+
+**Failure:** pr-create blocks on receipt mismatch (race with a concurrent captain coord commit on master). Re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
+
+### Step 5 — Switch back to master
+
+```
+./claude/tools/git-captain switch-branch master
+```
+
+Captain should sit on master for the wait-and-merge phase. Avoids any accidental commit landing on the PR branch.
+
+### Step 6 — Watch CI
+
+Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Look at the `lint-and-test` check.
+
+| State | Action |
+|---|---|
+| SUCCESS | proceed to Step 7 |
+| FAILURE | exit 1 — agent must fix + push + resubmit |
+| PENDING / IN_PROGRESS | wait 20s, poll again |
+
+Max 30 attempts = 10 minutes. On timeout, exit 1.
+
+**Note on `deploy-preview-backend`**: this check is environmental flake (ordinaryfolk org lookup issue). IGNORED by /pr-captain-land. Only `lint-and-test` is the gate.
+
+### Step 7 — Merge
+
+```
+./claude/tools/pr-merge {pr-num} --principal-approved
+```
+
+Uses admin merge (principal-approved flag gated). True merge commit — never squash, never rebase per framework discipline.
+
+**Failure:** merge conflicts (agent's branch drifted from master during the CI wait). Exit 1; captain resolves.
+
+### Step 8 — Sync master + create release
+
+```
+./claude/tools/git-captain fetch
+./claude/tools/git-captain merge-from-origin
+./claude/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+```
+
+Release notes: captain-authored, references the PR number and agent.
+
+**Failure (release only):** release creation fails but merge succeeded → warn captain, suggest manual `gh release create`. Skill returns success (merge is the primary outcome).
+
+### Step 9 — Dispatch agent
+
+Dispatch type: `master-updated`
+Subject: `PR #{num} landed — v{new} released (pr-captain-land)`
+Body: PR URL, release URL, version bump, Phase 1 pilot feedback request
+
+Agent receives on their next /session-resume.
+
+## Recovery flows
+
+### Version-bump landed but CI failed
+
+The version-bump commit is on agent's branch. Two paths:
+
+- **Agent fixes + pushes** — version bump stays, new fixes layer on top. /pr-captain-land can be re-run after agent re-submits via /pr-submit. Version doesn't bump again (current → same).
+- **Agent wants fresh state** — captain reverts the version-bump commit on agent's branch (separate cleanup).
+
+Recommend the first path; simpler.
+
+### Receipt invalidated mid-flow (Step 4 retry)
+
+Between /pr-submit and /pr-captain-land, a captain coord commit may land on master, changing origin/master and thus the diff-hash. Agent's receipt no longer matches.
+
+Detected at Step 2 or Step 4 (pr-create). Script exits; agent re-runs /pr-prep (re-signs receipt) + /pr-submit.
+
+### CI green but merge fails
+
+Likely branch-protection edge case. Script exits; captain uses `/pr-captain-merge <num> --principal-approved` manually to resolve.
+
+### Dispatch monitor doesn't pick up /pr-submit
+
+Captain manually runs `/pr-captain-land <branch>`. Dispatch integration is auto-convenience, not required for correctness.
+
+## Concurrency
+
+**One /pr-captain-land at a time.** Running two simultaneously would race on the version bump. No tool-level lock today; captain discipline enforces. Phase 2 adds a lockfile.
+
+Captain can run other non-land work (dispatch reads, flag triage, reviewer agent launches) concurrently with /pr-captain-land. Just not two /pr-captain-land.
+
+## Protocol versioning
+
+v1.0 — this document. Phase 1 pilot.
+
+v1.1 (planned): parse full dispatch payload instead of just branch name; agent's scope text becomes the PR body core.
+
+v2.0 (planned): dispatch-monitor auto-invocation (captain doesn't type /pr-captain-land; monitor picks up /pr-submit dispatch and fires /pr-captain-land).

--- a/.claude/skills/pr-captain-land/scripts/README.md
+++ b/.claude/skills/pr-captain-land/scripts/README.md
@@ -1,0 +1,71 @@
+# scripts/
+
+## `pr-captain-land`
+
+Bash script that implements the 9-step land protocol. Invoked by the skill's Flow.
+
+### Entry point
+
+```bash
+bash "$CLAUDE_PROJECT_DIR/.claude/skills/pr-captain-land/scripts/pr-captain-land" <agent-branch> [flags]
+```
+
+### Security hardening (MAR fixes applied `ccf054ad`)
+
+Two security findings from the comprehensive MAR were fixed in-place on this script and must be preserved across any refactor:
+
+1. **Python code injection in manifest version-bump** (F-SEC-1 / CRITICAL-3): the original implementation used Python f-string interpolation with shell-sourced values (`f"""... {NEW_VER} ..."""`), which allowed branch-name-adversarial version bumps to inject Python code. **Fixed** by passing values as environment variables and accessing them via `os.environ`:
+
+   ```bash
+   MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
+     import json, os, sys
+     path = os.environ["MANIFEST"]
+     new_ver = os.environ["NEW_VER"]
+     ...
+   '
+   ```
+
+   Any future refactor MUST preserve the env-var pattern. Do NOT re-introduce f-string interpolation of shell values.
+
+2. **Unvalidated `$AGENT_BRANCH` flowing into git/gh/dispatch** (F-SEC-2): the original implementation accepted branch names verbatim. **Fixed** by a regex gate at the top of the script:
+
+   ```bash
+   if ! [[ "$AGENT_BRANCH" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$ ]]; then
+     echo "ERROR: Invalid branch name" >&2; exit 1
+   fi
+   # Also reject '..' and leading '-'
+   ```
+
+   Any future refactor MUST preserve the validation. Add, don't relax.
+
+### What it does
+
+Implements the 9 steps from the skill's Flow:
+
+1. Preflight — checks main-checkout + branch=master + clean tree + remote-branch exists + branch-name-valid + receipt-found
+2. Switch to agent branch via `git-captain switch-branch`
+3. Verify receipt against current diff-hash
+4. Bump `monofolk_version` (security-hardened per above), commit, push
+5. Create PR via `pr-create`
+6. Switch back to master
+7. Watch CI (poll `gh pr view --json statusCheckRollup` every 20s, max 30 attempts)
+8. Merge via `pr-merge --principal-approved` + `gh-release create v{new}`
+9. Dispatch agent with `master-updated` + PR URL + release URL
+
+### Exit codes
+
+- `0` — land complete (merge succeeded; release + dispatch may have warned)
+- `1` — precondition / state error (preflight, receipt mismatch, CI fail, CI timeout, merge fail)
+- `2` — tool composition error (gh/git-captain/dispatch unavailable)
+
+### Related
+
+- `../SKILL.md` — the skill definition
+- `../reference.md` — full step-by-step protocol + recovery flows
+- `../examples.md` — happy-path + failure-mode examples
+- `ccf054ad` — the commit that applied the two security fixes documented above
+- the-agency#314 — upstream package MAR summary
+
+## Why a script, not inline skill instructions
+
+Nine sequential steps with conditional branching, CI polling loops, and multi-tool composition is beyond reliable inline execution. The script enforces the exact sequence and provides single-entry atomic invocation.

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+#
+# pr-captain-land — Captain lands an agent's prepared branch as a PR + release
+#
+# WHAT: Captain runs this in the main checkout to own the full PR lifecycle
+# for a branch prepared by an agent via /submit-for-pr. Switches to the
+# branch, verifies the QGR receipt, bumps the version, creates the PR with
+# a captain-authored description, watches CI, merges, cuts the release, and
+# dispatches the agent with the outcome.
+#
+# WHY: Addresses the-agency#296 — single serialization point for version
+# bumps + PR creation + release creation. Eliminates version-bump races,
+# QGR hash races, and split responsibility.
+#
+# SCOPE: Phase 1 pilot — sandbox tool in usr/jordan/captain/tools/. Tested
+# by dogfooding on one captain-driven PR before promotion to .claude/skills/.
+#
+# USAGE:
+#   pr-captain-land <agent-branch> [--dry-run] [--title "..."] [--no-release]
+#
+# PRECONDITIONS (tool enforces):
+#   - Running in main checkout on master
+#   - Tree is clean
+#   - <agent-branch> exists on origin
+#   - <agent-branch> has a valid QGR receipt
+#
+# WRITTEN: 2026-04-19 (Phase 1 pilot, the-agency#296)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "pr-captain-land: not in a git repository" >&2
+    exit 1
+}
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+AGENT_BRANCH=""
+DRY_RUN=false
+CUSTOM_TITLE=""
+SKIP_RELEASE=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --dry-run) DRY_RUN=true; shift ;;
+        --title) CUSTOM_TITLE="$2"; shift 2 ;;
+        --no-release) SKIP_RELEASE=true; shift ;;
+        --help|-h)
+            echo "Usage: $0 <agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
+            exit 0
+            ;;
+        -*) echo "pr-captain-land: unknown flag: $1" >&2; exit 2 ;;
+        *) AGENT_BRANCH="$1"; shift ;;
+    esac
+done
+
+if [[ -z "$AGENT_BRANCH" ]]; then
+    echo "pr-captain-land: <agent-branch> is required" >&2
+    exit 2
+fi
+
+# Security: validate branch name (F-SEC-2 from MAR 2026-04-19).
+# $AGENT_BRANCH flows into git/gh commands + dispatch --to routing.
+# Reject anything that could escape quoting or traverse paths.
+# Git ref-name constraints + defense-in-depth for our contexts.
+if ! [[ "$AGENT_BRANCH" =~ ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$ ]]; then
+    echo "pr-captain-land: invalid branch name '$AGENT_BRANCH' — must be [a-zA-Z0-9][a-zA-Z0-9/_.-]*" >&2
+    exit 2
+fi
+if [[ "$AGENT_BRANCH" == *..* ]] || [[ "$AGENT_BRANCH" == -* ]]; then
+    echo "pr-captain-land: branch name '$AGENT_BRANCH' contains forbidden sequence (.. or leading -)" >&2
+    exit 2
+fi
+
+# ── Precondition: in main checkout on master ────────────────────────────────
+
+MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
+    echo "pr-captain-land: must run from main checkout (you're in a worktree)." >&2
+    echo "  Main checkout: $MAIN_CHECKOUT" >&2
+    echo "  Current:       $REPO_ROOT" >&2
+    exit 1
+fi
+
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "main" ]]; then
+    echo "pr-captain-land: captain must be on master (you're on $CURRENT_BRANCH)." >&2
+    exit 1
+fi
+
+# ── Precondition: clean tree ─────────────────────────────────────────────────
+
+DIRTY=$(git status --porcelain 2>/dev/null)
+if [[ -n "$DIRTY" ]]; then
+    echo "pr-captain-land: master tree dirty — commit or stash first." >&2
+    echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
+    exit 1
+fi
+
+# ── Precondition: agent branch exists on origin ─────────────────────────────
+
+bash "$REPO_ROOT/claude/tools/git-captain" fetch >/dev/null 2>&1 || true
+
+if ! git show-ref --verify --quiet "refs/remotes/origin/$AGENT_BRANCH"; then
+    echo "pr-captain-land: branch '$AGENT_BRANCH' not found on origin." >&2
+    exit 1
+fi
+
+# ── Switch to agent branch ───────────────────────────────────────────────────
+
+echo "→ Switching to $AGENT_BRANCH..."
+bash "$REPO_ROOT/claude/tools/git-captain" switch-branch "$AGENT_BRANCH" >/dev/null
+
+# ── Verify QGR receipt ───────────────────────────────────────────────────────
+
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/claude/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+                 python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
+                 echo "")
+DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
+
+RECEIPT=$(find "$REPO_ROOT/claude/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+if [[ -z "$RECEIPT" ]]; then
+    echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
+    echo "  Agent must run /pr-prep to produce a receipt before submitting." >&2
+    # Switch back to master before exit
+    bash "$REPO_ROOT/claude/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    exit 1
+fi
+
+RECEIPT_REL="${RECEIPT#$REPO_ROOT/}"
+echo "→ Receipt: $RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
+
+# ── Bump monofolk_version on the branch ─────────────────────────────────────
+
+MANIFEST="$REPO_ROOT/claude/config/manifest.json"
+# Security: pass values via env, never string-interpolate into python source
+# (F-SEC-1 / CRITICAL-3 from MAR 2026-04-19). Prevents RCE if manifest is
+# ever attacker-controllable.
+CURRENT_VER=$(MANIFEST="$MANIFEST" python3 -c '
+import json, os
+print(json.load(open(os.environ["MANIFEST"]))["monofolk_version"])
+')
+
+# Parse and bump — value via env, not f-string
+NEW_VER=$(CURRENT_VER="$CURRENT_VER" python3 -c '
+import os, sys
+v = os.environ["CURRENT_VER"]
+parts = v.split(".")
+if len(parts) == 2:
+    major, minor = int(parts[0]), int(parts[1])
+    print(f"{major}.{minor+1}")
+elif len(parts) == 1:
+    print(f"{int(parts[0])+1}")
+else:
+    print(v)
+    sys.exit(1)
+')
+
+if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
+    echo "pr-captain-land: could not bump version from $CURRENT_VER" >&2
+    bash "$REPO_ROOT/claude/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    exit 1
+fi
+
+echo "→ Bumping monofolk_version $CURRENT_VER → $NEW_VER"
+
+if [[ "$DRY_RUN" == false ]]; then
+    # Security: env vars, not string interpolation (F-SEC-1)
+    MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
+import json, os
+from datetime import datetime, timezone
+path = os.environ["MANIFEST"]
+m = json.load(open(path))
+m["monofolk_version"] = os.environ["NEW_VER"]
+m["project"]["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+json.dump(m, open(path, "w"), indent=2)
+'
+    bash "$REPO_ROOT/claude/tools/git-safe" add claude/config/manifest.json
+    bash "$REPO_ROOT/claude/tools/git-safe-commit" \
+        "chore(manifest): bump monofolk_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
+        --no-work-item >/dev/null
+
+    bash "$REPO_ROOT/claude/tools/git-push" "$AGENT_BRANCH" >/dev/null
+    echo "→ Version bumped + pushed"
+fi
+
+# ── Create PR ────────────────────────────────────────────────────────────────
+
+PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
+PR_BODY=$(cat <<EOF
+Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot).
+
+Branch prepared by agent via /submit-for-pr. Captain owns the landing lifecycle:
+- Switched to \`$AGENT_BRANCH\`
+- Verified QGR receipt \`$RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`)
+- Bumped \`monofolk_version\` $CURRENT_VER → $NEW_VER
+- Will merge when CI is green
+- Will create release v$NEW_VER
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)
+
+if [[ "$DRY_RUN" == true ]]; then
+    echo "→ [DRY-RUN] Would create PR:"
+    echo "    Title: $PR_TITLE"
+    echo "    Body:  (see stdout)"
+    # Switch back to master
+    bash "$REPO_ROOT/claude/tools/git-captain" switch-branch master >/dev/null
+    echo "pr-captain-land: dry-run complete"
+    exit 0
+fi
+
+echo "→ Creating PR..."
+PR_URL=$(bash "$REPO_ROOT/claude/tools/pr-create" --title "$PR_TITLE" --body "$PR_BODY" 2>&1 | \
+         tail -1 | grep -oE 'https://github.com/[^ ]+' || echo "")
+
+if [[ -z "$PR_URL" ]]; then
+    echo "pr-captain-land: pr-create did not return a URL — check output above" >&2
+    bash "$REPO_ROOT/claude/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    exit 1
+fi
+
+PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+echo "→ PR created: $PR_URL (#$PR_NUM)"
+
+# ── Back to master for merge ────────────────────────────────────────────────
+
+bash "$REPO_ROOT/claude/tools/git-captain" switch-branch master >/dev/null
+echo "→ Back on master"
+
+# ── Wait for CI ──────────────────────────────────────────────────────────────
+
+echo "→ Waiting for CI..."
+ATTEMPTS=0
+MAX_ATTEMPTS=30  # 30 × 20s = 10 minutes
+while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
+    STATE=$(gh pr view "$PR_NUM" --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name=="lint-and-test") | .conclusion' 2>/dev/null || echo "")
+    if [[ "$STATE" == "SUCCESS" ]]; then
+        echo "→ lint-and-test: PASSED"
+        break
+    fi
+    if [[ "$STATE" == "FAILURE" ]]; then
+        echo "pr-captain-land: lint-and-test FAILED on PR #$PR_NUM" >&2
+        echo "  Agent must fix, push, and re-submit via /submit-for-pr." >&2
+        exit 1
+    fi
+    sleep 20
+    ATTEMPTS=$((ATTEMPTS + 1))
+done
+
+if [[ $ATTEMPTS -eq $MAX_ATTEMPTS ]]; then
+    echo "pr-captain-land: CI timeout on PR #$PR_NUM — check manually" >&2
+    exit 1
+fi
+
+# ── Merge ────────────────────────────────────────────────────────────────────
+
+echo "→ Merging PR #$PR_NUM..."
+bash "$REPO_ROOT/claude/tools/pr-merge" "$PR_NUM" --principal-approved >/dev/null 2>&1 || {
+    echo "pr-captain-land: pr-merge failed — check manually" >&2
+    exit 1
+}
+
+# ── Sync master ──────────────────────────────────────────────────────────────
+
+bash "$REPO_ROOT/claude/tools/git-captain" fetch >/dev/null 2>&1
+bash "$REPO_ROOT/claude/tools/git-captain" merge-from-origin >/dev/null 2>&1
+
+# ── Create release ───────────────────────────────────────────────────────────
+
+if [[ "$SKIP_RELEASE" == false ]]; then
+    echo "→ Creating release v$NEW_VER..."
+    bash "$REPO_ROOT/claude/tools/gh-release" create "v$NEW_VER" \
+        --target master \
+        --title "v$NEW_VER — $PR_TITLE" \
+        --notes "Captain-landed via pr-captain-land (the-agency#296 Phase 1 pilot). See PR #$PR_NUM." \
+        >/dev/null 2>&1 || {
+        echo "pr-captain-land: gh-release failed — create manually" >&2
+    }
+fi
+
+# ── Dispatch agent with outcome ─────────────────────────────────────────────
+
+# Agent is encoded in the branch name or retrievable from the branch's commits
+# For Phase 1 pilot: assume branch name hints at agent (e.g., captain-X, devex-Y)
+# Full lookup happens when promoted to .claude/skills/
+
+AGENT_HINT="${AGENT_BRANCH%%-*}"  # naive parse: prefix before first dash
+echo "→ Dispatching $AGENT_HINT agent with merge outcome..."
+
+bash "$REPO_ROOT/claude/tools/dispatch" create \
+    --type master-updated \
+    --to "monofolk/jordan/$AGENT_HINT" \
+    --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \
+    --body "Captain-landed your branch \`$AGENT_BRANCH\` via the-agency#296 Phase 1 pilot flow.
+
+- PR: $PR_URL
+- Release: https://github.com/ordinaryfolk/monofolk/releases/tag/v$NEW_VER
+- Version: $CURRENT_VER → $NEW_VER
+
+Your branch is merged to master. Run /session-resume to pick up on your next cycle.
+
+Phase 1 pilot feedback: did anything feel off about the handoff? Reply dispatch.
+
+-- monofolk/jordan/captain" \
+    >/dev/null 2>&1 || true
+
+# ── Done ─────────────────────────────────────────────────────────────────────
+
+echo ""
+echo "pr-captain-land: complete"
+echo "  PR:      $PR_URL"
+echo "  Release: v$NEW_VER"
+echo "  Merged:  ✓"

--- a/.claude/skills/pr-captain-merge/SKILL.md
+++ b/.claude/skills/pr-captain-merge/SKILL.md
@@ -1,0 +1,168 @@
+---
+name: pr-captain-merge
+description: Captain-only. Merge a PR safely — true merge commit (never squash, never rebase), branch protection respected, --principal-approved gate for --admin override. Prevents the "accidentally squashed via the wide GitHub UI button" failure mode that has burned the fleet.
+agency-skill-version: 2
+when_to_use: Captain on master in main checkout, after PR has passed CI and principal has approved (verbally or via GitHub review). Invoked by captain directly or as a step within /pr-captain-land. NEVER from a worktree. NEVER auto-invoked (disable-model-invocation).
+argument-hint: "<pr-number> [--principal-approved] [--delete-branch] [--dry-run]"
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - claude/REFERENCE-SAFE-TOOLS.md
+  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+---
+
+<!--
+  allowed-tools omitted — inherits Bash(*) from .claude/settings.json.
+  Subcommand-level restriction (e.g. Bash(gh pr merge *)) silently blocked
+  fleet agents in the past (flag #62/#63 / devex dispatch #171).
+  This skill legitimately calls gh + claude/tools/pr-merge + claude/tools/git-*
+  — narrow tool-level restriction would work but would need maintenance as
+  called tools evolve. Inherit Bash(*) is safer.
+-->
+
+# pr-captain-merge
+
+Captain's safe wrapper for merging PRs on GitHub. Always a true merge commit (no squash, no rebase). Respects branch protection by default. `--principal-approved` is the only way to engage `--admin` override.
+
+**Name pattern:** `pr-` prefix groups with the PR skill family (autocomplete `/pr<tab>` shows the full kit), `captain-` qualifier makes captain-only scope visible at a glance.
+
+## Why this exists
+
+Raw `gh pr merge` is too easy to misuse:
+
+- GitHub's UI nudges toward squash (the wide button)
+- The `--squash` flag is one keystroke away from `--merge`
+- `--admin` bypasses branch protection silently
+- Without discipline, the captain shipped 4 squash merges in one day (pre-v2 incident)
+
+`pr-captain-merge` is the gate — skill-level enforcement plus the underlying `claude/tools/pr-merge` tool that does the actual work.
+
+## Required reading
+
+Before running, Read the files in `required_reading:` frontmatter. `GIT-MERGE-NOT-REBASE.md` explains why we never squash or rebase. `SAFE-TOOLS.md` covers the safe-tool family this skill composes.
+
+## Usage
+
+```
+/pr-captain-merge <pr-number>
+/pr-captain-merge <pr-number> --principal-approved
+/pr-captain-merge <pr-number> --delete-branch
+/pr-captain-merge <pr-number> --dry-run
+```
+
+## Preconditions
+
+- Captain is on master in main checkout. Not in a worktree.
+- PR number is known. Captain has verified PR is not in draft.
+- CI has passed (or deploy-preview flake is understood and ignored).
+- Principal has approved — either via GitHub review OR verbally in this conversation.
+- For `--principal-approved`: the principal's authorization is in THIS conversation. Do not infer from prior sessions.
+
+If any precondition is missing, STOP. Ask the principal to resolve, or use the non-approved path and let branch protection block.
+
+## Flow / Steps
+
+### Step 1: Pre-flight
+
+1. Confirm the PR number (ask if missing).
+2. Confirm you're not on the PR's branch — captain merges from master or any non-PR branch.
+3. If you're going to use `--principal-approved`, confirm the principal has authorized in THIS conversation. Don't infer from history.
+
+### Step 2: Invoke the tool
+
+```
+./claude/tools/pr-merge <N>
+```
+
+Or with explicit principal approval (only when they verbally OK'd in-session):
+
+```
+./claude/tools/pr-merge <N> --principal-approved
+```
+
+Tool enforces:
+- `--merge` always (never `--squash`, never `--rebase`)
+- Branch protection respected by default
+- `--admin` only when `--principal-approved` flag is present
+
+### Step 3: Handle the outcome
+
+**On success** (exit 0): report merge URL + next-step recommendation (sync master via `./claude/tools/_sync-main-ref`, or wait for `/pr-captain-post-merge`).
+
+**On branch-protection block** (exit 3): tool prints the gate. Two resolutions:
+- Ask principal to `gh pr review <N> --approve` in GitHub UI, then re-run.
+- If principal authorized in this conversation but not GitHub UI, re-run with `--principal-approved`.
+
+**On merge conflict** (exit 1): resolve locally first:
+```
+gh pr checkout <N>
+./claude/tools/git-safe merge-from-master --remote
+# resolve conflicts
+./claude/tools/git-safe add <files>
+./claude/tools/git-captain merge-continue
+./claude/tools/git-push <branch>
+# then retry
+/pr-captain-merge <N>
+```
+
+### Step 4: Post-merge (handoff or chain)
+
+After successful merge:
+- Sync local master: `./claude/tools/_sync-main-ref`
+- If release PR: run `/pr-captain-post-merge` (or `/pr-captain-post-merge` once refactored) to create GitHub release + fleet notification.
+- Notify affected agents: `/dispatch create --type master-updated --to <agent>`
+- Notify cross-repo collaborators: `/collaborate` if relevant
+
+## Failure modes
+
+- **CI failing:** do NOT merge. Address the failure; restart from `/pr-prep` or captain's diagnosis.
+- **Merge conflicts on agent's branch:** sent back for agent to resolve. Captain doesn't resolve agent's conflicts.
+- **Principal-approved flag without in-conversation authorization:** DO NOT PASS. Ask the principal explicitly; wait for their OK; then pass the flag. Captain attests to something real.
+- **Squash or rebase attempted:** blocked by tool. No way in the skill to request.
+
+## What this does NOT do
+
+- **Does not write commits** — merge happens server-side at GitHub.
+- **Does not delete the local branch** — that's captain's next decision (or `/pr-captain-post-merge`).
+- **Does not auto-tag a release** — explicit `gh release create` afterward (or via `/pr-captain-post-merge`).
+- **Does not push** — merge is server-side; no local push.
+- **Does not squash, does not rebase** — blocked by the underlying tool (`claude/tools/pr-merge`).
+
+## Why never squash, never rebase
+
+Both rewrite history. The-agency framework is built on visible, append-only history:
+
+- Branch commits are individually meaningful (QGRs, fixes, version bumps)
+- Merge commits create a permanent record of integration
+- `git log --graph` shows the actual flow
+- Bisecting works against real commits, not synthetic squash blobs
+
+Cost: heavier `git log` output. Benefit: you can SEE what happened and WHY, which is essential when fleet agents and adopters all have to read the same history.
+
+## Captain-only — four-layer defense
+
+Defense in depth against accidental invocation from the wrong context:
+
+1. **`disable-model-invocation: true`** in frontmatter — Claude cannot auto-invoke. Captain must type the command.
+2. **`paths: []`** (intentionally empty) — no auto-activation from any file path.
+3. **Name contains `captain-`** — any reader sees scope in the skill listing.
+4. **Runtime precondition** — underlying `claude/tools/pr-merge` checks caller context before engaging `--admin`.
+
+## Status
+
+`active` — ships as of agency-skill-version 2 adoption 2026-04-19. Replaces v1 `pr-merge` skill.
+
+## Related
+
+- `/pr-captain-land` — composite skill that calls this as its merge step
+- `/pr-prep` — the QG-before-PR-create (agent-side)
+- `/pr-submit` — agent hands branch to captain for landing
+- `/pr-captain-post-merge` (TBD refactored to `/pr-captain-post-merge`) — release + fleet-notify after merge
+- `claude/tools/pr-merge` — the underlying safe-merge tool
+- `claude/hookify/hookify.block-raw-gh-pr-merge.md` — hookify rule that blocks bare `gh pr merge`
+- `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the discipline rationale
+- the-agency#296 — PR lifecycle ownership (the-agency direction)
+- the-agency#298 — skill refactor recommendation (the methodology)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-captain-merge/assets/README.md
+++ b/.claude/skills/pr-captain-merge/assets/README.md
@@ -1,0 +1,7 @@
+# assets/
+
+Empty by design. This skill has no templates or static assets — the merge message comes from GitHub (the default merge commit template), and the skill itself has no user-facing artifacts beyond log lines.
+
+If the captain-owned merge flow ever grows a release-note template or configurable merge-message block, it would live here.
+
+The v2 bundle-structure requirement says this directory exists even when empty; this README explains why.

--- a/.claude/skills/pr-captain-merge/examples.md
+++ b/.claude/skills/pr-captain-merge/examples.md
@@ -1,0 +1,171 @@
+# pr-captain-merge — examples
+
+## Happy-path examples
+
+### Minimal merge
+
+Captain on master, PR #42 has green CI, principal approved via GitHub review (not just verbal).
+
+```
+/pr-captain-merge 42
+```
+
+Expected output:
+```
+Merging PR #42...
+Merged successfully: https://github.com/org/repo/pull/42
+Next: sync master with `./claude/tools/_sync-main-ref` or run /pr-captain-post-merge
+```
+
+Exit 0. Branch protection respected (no admin bypass needed because GitHub review was present).
+
+### Merge with principal approval (verbal, admin bypass)
+
+Captain on master, PR #42 green, principal said "yes, merge it" in this conversation. No GitHub review.
+
+```
+/pr-captain-merge 42 --principal-approved
+```
+
+Expected output:
+```
+Merging PR #42 (admin bypass, principal-approved)...
+Merged: https://github.com/org/repo/pull/42
+Admin invocation logged.
+```
+
+Exit 0.
+
+### Merge + delete-branch
+
+Captain wants to clean up remote branch after merge.
+
+```
+/pr-captain-merge 42 --delete-branch
+```
+
+Expected: same as minimal, plus remote branch deleted.
+
+### Dry-run preview
+
+Captain wants to confirm what would happen without touching GitHub.
+
+```
+/pr-captain-merge 42 --dry-run
+```
+
+Expected output: "[DRY-RUN] Would merge PR #42 via true merge commit. Principal-approved: no. Branch protection: respected."
+
+Exit 0, no merge performed.
+
+---
+
+## Edge-case examples
+
+### Branch-protection block (no principal approval)
+
+PR #42 has no GitHub review, captain tries to merge without `--principal-approved`.
+
+```
+/pr-captain-merge 42
+```
+
+Expected output:
+```
+BLOCKED: PR #42 cannot merge — branch protection requires 1 approval.
+Resolutions:
+  (a) Ask principal to `gh pr review 42 --approve` in GitHub UI, then retry.
+  (b) If principal authorized in this conversation, retry with --principal-approved.
+```
+
+Exit 3.
+
+### Merge conflict
+
+PR #42 has conflicts with master.
+
+```
+/pr-captain-merge 42
+```
+
+Expected output:
+```
+MERGE CONFLICT: PR #42 cannot merge cleanly.
+Resolve locally:
+  gh pr checkout 42
+  ./claude/tools/git-safe merge-from-master --remote
+  # resolve conflicts
+  ./claude/tools/git-safe add <files>
+  ./claude/tools/git-captain merge-continue
+  ./claude/tools/git-push <branch>
+  # then retry /pr-captain-merge 42
+```
+
+Exit 1.
+
+### Invoked from a worktree (should refuse)
+
+Agent runs `/pr-captain-merge` from their worktree.
+
+Expected: skill's `paths: []` plus `disable-model-invocation: true` means it shouldn't auto-fire. If agent manually invokes, the underlying `claude/tools/pr-merge` checks context and refuses:
+
+```
+REFUSED: pr-merge must be invoked from main checkout on master. You're in a worktree.
+Ask captain to run /pr-captain-merge instead.
+```
+
+Exit 2.
+
+### Squash/rebase attempt (structural impossibility)
+
+No flag exists on the skill or the tool to squash or rebase. If an agent tries `--squash`, the tool rejects:
+
+```
+REFUSED: --squash is not supported. pr-captain-merge always uses true merge commit.
+See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md for rationale.
+```
+
+Exit 2.
+
+---
+
+## Integration examples
+
+### As Step 7 of `/pr-captain-land`
+
+When captain runs the full captain-owned PR lifecycle:
+
+```
+/pr-captain-land <agent-branch>
+```
+
+Internally, Step 7 invokes `pr-captain-merge`:
+```
+→ CI green, merging PR #45...
+→ Merged: https://github.com/org/repo/pull/45
+→ Step 8: creating release v1.10...
+```
+
+The `--principal-approved` flag propagates from `pr-captain-land`'s caller.
+
+### Before `/pr-captain-post-merge`
+
+Captain merges via this skill, then runs `/pr-captain-post-merge` (or the refactored `/pr-captain-post-merge`) to create release + fleet-notify:
+
+```
+/pr-captain-merge 42 --principal-approved
+/pr-captain-post-merge 42
+```
+
+Results: PR merged + v-tag created + fleet dispatched.
+
+### With `/collaborate` for cross-repo
+
+If merged PR affects cross-repo collaborators:
+
+```
+/pr-captain-merge 42 --principal-approved
+/collaborate create the-agency --subject "monofolk PR #42 merged, includes framework port X"
+```
+
+Cross-repo notice follows the merge.

--- a/.claude/skills/pr-captain-merge/reference.md
+++ b/.claude/skills/pr-captain-merge/reference.md
@@ -1,0 +1,52 @@
+# pr-captain-merge — unique protocol
+
+This skill's unique protocol is thin — most of the behavior is in `claude/tools/pr-merge` and documented by the required_reading `GIT-MERGE-NOT-REBASE.md`. What lives here:
+
+## The `--principal-approved` contract
+
+`--principal-approved` is a captain **attestation**, not a user flag. When captain passes `--principal-approved` to `claude/tools/pr-merge`, captain is asserting:
+
+> "The principal has, in THIS conversation, authorized merging PR #N using admin-bypass if branch protection gates are in the way. I am invoking `--admin` under their authority."
+
+**Rules:**
+
+1. **In-conversation means in-conversation.** Not "the principal approved this PR last week." The authorization must be visible to any reviewer reading the transcript.
+2. **Principal's exact words matter less than explicit authorization.** "yes, merge" / "go ahead and merge that" / "ship it with principal approval" — all explicit.
+3. **Ambiguous authorizations do NOT qualify.** "looks good" is not authorization. "I'll review later" is not authorization.
+4. **When in doubt, DO NOT pass `--principal-approved`.** Let branch protection do its job.
+
+## Exit-code semantics (from `claude/tools/pr-merge`)
+
+| Exit | Meaning | Skill response |
+|---|---|---|
+| 0 | Merged successfully | Report URL, recommend next step (`post-merge`, sync master) |
+| 1 | Merge conflict | Send back for agent to resolve; don't loop in captain |
+| 2 | General tool error | Surface stderr; captain investigates |
+| 3 | Branch-protection block | Two paths (see Step 3 in SKILL.md) |
+
+## Composition with `pr-captain-land`
+
+When captain runs `/pr-captain-land`, this skill is invoked as Step 7 of the 9-step land flow. In that composition:
+
+- `--principal-approved` is passed if captain initiated `/pr-captain-land` with the flag (principal authorized the full lifecycle, not just the merge)
+- Exit codes propagate to `/pr-captain-land`'s step handler — Step 8 (release) does not run if this Step 7 fails
+
+See `pr-captain-land/references/land-protocol.md` for the full integration.
+
+## Why the tool is separate from the skill
+
+`claude/tools/pr-merge` is a bash tool invokable outside Claude (during CI, manual captain shell, etc.). The skill wraps it with Claude-context preconditions + principal-approval attestation. Same pattern as other Triangle-enforced operations:
+
+- Tool: does the work
+- Skill: composes the work with context + guardrails
+- Hookify: prevents raw invocation
+
+## Principal-approval logging
+
+`claude/tools/pr-merge` logs every `--admin` invocation with:
+- PR number
+- Captain identity (from `agent-identity`)
+- Timestamp
+- Session reference
+
+Log lives in `~/.agency/<repo>/logs/pr-merge.log`. Audit trail for post-incident review.

--- a/.claude/skills/pr-captain-merge/scripts/README.md
+++ b/.claude/skills/pr-captain-merge/scripts/README.md
@@ -1,0 +1,7 @@
+# scripts/
+
+Empty by design. This skill is pure orchestration — it invokes `claude/tools/pr-merge` directly and handles the agent-side workflow around it. No skill-specific scripts needed.
+
+If future refinement requires a dedicated preflight or post-merge helper (beyond what `claude/tools/pr-merge` handles), it would land here.
+
+The v2 bundle-structure requirement says this directory exists even when empty; this README explains why.

--- a/.claude/skills/pr-captain-post-merge/SKILL.md
+++ b/.claude/skills/pr-captain-post-merge/SKILL.md
@@ -1,0 +1,194 @@
+---
+name: pr-captain-post-merge
+description: Captain-only. After a PR has merged on GitHub, verify the merge, merge origin/master locally, sync all worktrees, create the GitHub release (every PR is a release), and clean up the PR branch. Formerly `/post-merge` — v2 rename to noun-actor-verb.
+agency-skill-version: 2
+when_to_use: Captain on master in main checkout, immediately after a PR has merged on GitHub. Triggered when principal says "merged" / "done" / indicates a PR landed, or as Step 8 of /pr-captain-land. NEVER from a worktree. NEVER auto-invoked.
+argument-hint: "<pr-number>"
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - claude/REFERENCE-WORKTREE-DISCIPLINE.md
+  - claude/REFERENCE-SAFE-TOOLS.md
+---
+
+<!--
+  allowed-tools omitted — inherits Bash(*) from .claude/settings.json.
+  Subcommand-level restriction silently blocks fleet agents (flag #62/#63
+  / devex dispatch #171 / the-agency#298 caveat). This skill touches
+  gh, git-captain, git-safe, gh-release, sync-all (sub-skill), and
+  branch-delete — broad surface that would require maintenance at
+  subcommand level. Inherit Bash(*).
+-->
+
+# pr-captain-post-merge
+
+Captain's post-merge flow. Runs after a PR has landed on GitHub to verify the merge, reconcile master locally, propagate to worktrees, create the GitHub release, and clean up the PR branch.
+
+**Name pattern:** `pr-` prefix groups with the PR skill family (autocomplete `/pr<tab>`), `captain-` qualifier flags captain-only scope, `post-merge` describes the action.
+
+## Why this exists
+
+After a PR merges on GitHub, several things must happen locally and across the fleet:
+
+- Master must be reconciled with origin/master (the merge commit landed upstream)
+- All worktrees must sync so agents pick up the merged work
+- A GitHub release must be created (every PR is a release — CI enforces this via `release-tag-check` workflow)
+- The PR branch should be cleaned up so it doesn't linger
+
+Without this skill, each step is manual and skippable. The `release-tag-check` workflow in particular will turn main CI red if a merge lands without a release tag. This skill ensures every merge has a release.
+
+**Never resets master to origin** — per `REFERENCE-GIT-MERGE-NOT-REBASE.md`, we merge, never reset.
+
+## Required reading
+
+Before proceeding, Read the files listed in `required_reading:` frontmatter. `GIT-MERGE-NOT-REBASE.md` explains the merge discipline that this skill enforces. `WORKTREE-DISCIPLINE.md` covers the fleet propagation step.
+
+## Usage
+
+```
+/pr-captain-post-merge <pr-number>
+```
+
+If `<pr-number>` is omitted, the skill queries `gh pr list --state merged --limit 1` for the most recently merged PR and confirms with the user before proceeding.
+
+## Preconditions
+
+- Captain on master (not main, though either is accepted per `REFERENCE-GIT-MERGE-NOT-REBASE.md` convention resolution).
+- In the main checkout, NOT a worktree.
+- Working tree clean.
+- PR has actually merged on GitHub (`gh pr view <N>` returns state `MERGED`).
+- `claude/config/manifest.json` version was bumped BEFORE the PR was created (via `/pr-prep` or `/release` or `/pr-captain-land`). If not, skill stops and warns — do NOT push directly to main to fix; create a follow-up PR instead.
+
+## Flow / Steps
+
+### Step 1: Safety checks
+
+1. Confirm on master in main checkout.
+2. Confirm clean working tree.
+3. If PR number is omitted, query most recent merged PR and confirm.
+
+### Step 2: Verify PR merged
+
+```
+gh pr view <N> --json state,mergedAt,mergeCommit
+```
+
+Confirm `state` is `MERGED`. If not, stop.
+
+### Step 3: Fetch origin
+
+```
+./claude/tools/git-captain fetch origin
+```
+
+### Step 4: Merge origin/master
+
+Check divergence:
+
+```
+git rev-list --left-right --count origin/master...HEAD
+```
+
+- **If diverged** (both sides > 0 — expected after squash or rebase PR):
+  1. Verify merge-base exists: `git merge-base origin/master HEAD`. If fails, ABORT.
+  2. Tag for recovery: `git tag sync/pre-merge-$(date +%Y%m%d-%H%M%S)`
+  3. Merge: `./claude/tools/git-captain merge-from-origin` (produces merge commit per framework discipline).
+  4. If conflicts: skill halts, reports, asks principal to resolve.
+- **If behind only**: `./claude/tools/git-captain merge-from-origin` fast-forwards cleanly.
+
+**Never `git reset --hard origin/master`.** Per `REFERENCE-GIT-MERGE-NOT-REBASE.md`, we never rewrite history.
+
+### Step 5: Invoke /sync-all
+
+```
+/sync-all
+```
+
+Propagates the merge to every worktree. Worktree-side agents pick up the new content on their next `/session-resume`.
+
+### Step 6: Create GitHub release
+
+**Every PR is a release.** MANDATORY. Mechanically enforced by `release-tag-check` workflow (the-agency equivalent of D41-R20).
+
+1. Parse PR title for release name (e.g., "D39-R1: ..." → version 39.1).
+2. Verify `manifest.json` version matches expectations (bumped before the PR was created).
+3. Create release:
+   ```
+   ./claude/tools/gh-release create v<version> --target master --title "<title>" --notes "<notes>"
+   ```
+4. **Hard-verify** release exists (fail-loud, not optional):
+   ```
+   gh release view v<version>
+   ```
+   If non-zero, the release was NOT created. Do NOT proceed to Step 7. Fix and retry.
+
+If version format doesn't match `D#-R#` (e.g., hotfix PR), use `v<monofolk_version>.pr<N>` as fallback.
+
+**Never push directly to main.** If version is wrong, create a follow-up PR.
+
+### Step 7: Clean up PR branch
+
+If the PR's head branch still exists locally:
+
+```
+./claude/tools/git-captain branch-delete <branch> --force
+```
+
+`--force` required — the local PR branch typically has commits not reachable from main's history (QGR receipts, dispatch artifacts). Safe `-d` would refuse.
+
+If the branch doesn't exist locally (e.g., captain used `pr-merge --delete-branch` already), this step is a no-op.
+
+### Step 8: Report
+
+```
+Post-merge complete:
+  PR:             #<N> (<title>)
+  Version:        <old> → <new>
+  Release:        v<version> created at <url>
+  Master:         synced with origin/master (<sha>)
+  Worktrees:      synced via /sync-all
+  Branch cleanup: <branch> deleted / kept
+```
+
+## Failure modes
+
+- **PR not merged on GitHub:** Step 2 fails. Skill reports state and stops. Captain investigates.
+- **Merge-base missing:** Step 4 aborts. Usually means force-push or squash obliterated shared history. Principal decides recovery.
+- **Merge conflict in Step 4:** Skill halts after `git-captain merge-from-origin` reports conflict. Captain resolves manually, then re-runs from Step 4.
+- **Release creation fails (Step 6):** CRITICAL. Skill refuses to proceed to Step 7. Captain investigates (token? network? gh-release tool error?). Releases MUST land before branch cleanup.
+- **Manifest version not bumped:** Step 6 warns + stops. Create a follow-up PR to bump. Never push directly to main.
+- **Branch cleanup fails:** Step 7 warn + continue (cleanup is nice-to-have; release is the gate).
+
+## What this does NOT do
+
+- **Does not merge the PR itself** — that's `/pr-captain-merge`.
+- **Does not create the PR** — that's `/pr-captain-create` (or agent-side via `/pr-submit` → `/pr-captain-land`).
+- **Does not rewrite history** — no squash, no rebase, no hard reset.
+- **Does not push directly to main** — version mismatches require follow-up PR, not direct push.
+- **Does not run the quality gate** — QG happened during `/pr-prep` pre-PR.
+
+## Captain-only — four-layer defense
+
+1. **`disable-model-invocation: true`** — Claude can't auto-invoke. Captain types it.
+2. **`paths: []`** — no auto-activation from any file path.
+3. **Name contains `captain-`** — visible scope in the skill listing.
+4. **Runtime precondition** — Step 1 refuses if not on master in main checkout.
+
+## Status
+
+`active` (v2, post-refactor from legacy `post-merge` 2026-04-19).
+
+## Related
+
+- `/pr-captain-merge` — the merge itself, runs before this skill
+- `/pr-captain-land` — the full captain-owned PR lifecycle (this skill is Step 8 of that flow)
+- `/sync-all` — the fleet-sync sub-skill this calls in Step 5
+- `/release` (TBD refactored to `/captain-release`) — alternate entry point that runs /pr-captain-merge + this skill in one flow
+- `claude/tools/gh-release` — the release-creation tool
+- `claude/tools/git-captain` — safe captain-side git operations
+- `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- the-agency#296 — PR lifecycle ownership (Phase 1 pilot context)
+- the-agency#315 — V1→V2 migration (this refactor lives under Tier 1)
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-captain-post-merge/assets/README.md
+++ b/.claude/skills/pr-captain-post-merge/assets/README.md
@@ -1,0 +1,7 @@
+# assets/
+
+Empty by design. `pr-captain-post-merge` has no templates or static assets — release notes are captain-authored per-release, not templated.
+
+If a standardized release-notes template ever becomes valuable (e.g., for adopter-facing releases with a fixed schema), it would live here.
+
+The v2 bundle-structure requirement says this directory exists even when empty; this README explains why.

--- a/.claude/skills/pr-captain-post-merge/examples.md
+++ b/.claude/skills/pr-captain-post-merge/examples.md
@@ -1,0 +1,174 @@
+# pr-captain-post-merge — examples
+
+## Happy-path examples
+
+### Normal post-merge after a well-prepared PR
+
+Captain merged PR #110 (pr-captain-merge), now runs:
+
+```
+/pr-captain-post-merge 110
+```
+
+Expected output:
+```
+Post-merge complete:
+  PR:             #110 (feat: /service-add + /ui-add SPEC-PROVIDER scaffolding)
+  Version:        1.7 → 1.8
+  Release:        v1.8 created at https://github.com/org/repo/releases/tag/v1.8
+  Master:         synced with origin/master (e47ce53a)
+  Worktrees:      synced via /sync-all
+  Branch cleanup: devex kept (worktree branch, not a feature branch)
+```
+
+### Post-merge with auto-detected PR
+
+Captain says "the PR merged" without specifying number. Skill queries latest merged PR and confirms:
+
+```
+/pr-captain-post-merge
+```
+
+Expected prompt: "Most recently merged PR is #110 (feat: /service-add...). Proceed? [y/N]"
+
+### Post-merge with release detection for D#-R# pattern
+
+Captain merged PR #193 titled "D41-R5: ...". Release tag auto-derived:
+
+```
+/pr-captain-post-merge 193
+```
+
+Expected: release `v41.5` created (not `v1.N`).
+
+---
+
+## Edge-case examples
+
+### PR not merged yet (Step 2 fails)
+
+```
+/pr-captain-post-merge 111
+```
+
+Expected output:
+```
+STOP: PR #111 state is OPEN, not MERGED.
+  Merge the PR first via /pr-captain-merge 111 [--principal-approved]
+  Then re-run /pr-captain-post-merge 111.
+```
+
+Exit 1.
+
+### Manifest version not bumped (Step 6 warn)
+
+Captain merged PR #112 but version wasn't bumped before PR creation:
+
+```
+/pr-captain-post-merge 112
+```
+
+Expected output:
+```
+STOP: manifest.json shows monofolk_version 1.8. No bump detected for this PR.
+  Version should have been bumped before PR creation (/pr-prep or /release).
+  Do NOT push directly to main to fix.
+  Create a follow-up PR that bumps to 1.9, then re-run /pr-captain-post-merge 112.
+```
+
+Exit 1. No release created.
+
+### Release creation fails mid-flight (Step 6)
+
+`gh-release create` returns non-zero (token expired, network flake):
+
+```
+/pr-captain-post-merge 110
+```
+
+Expected output:
+```
+FAIL: release v1.8 creation failed: <error from gh>.
+  Resolve (token / network / quota) and retry.
+  Do NOT proceed to branch cleanup — main CI will go red until release lands.
+```
+
+Exit 2. Step 7 and 8 skipped.
+
+### Branch-delete fails (Step 7 warn)
+
+Branch doesn't exist locally (captain already deleted remote via `pr-merge --delete-branch`):
+
+```
+/pr-captain-post-merge 110
+```
+
+Step 7 output:
+```
+[pr-captain-post-merge] Step 7: PR branch 'captain-X' not found locally — already cleaned up.
+```
+
+Skill continues to Step 8. Exit 0.
+
+### Invoked from worktree (should refuse)
+
+Agent runs `/pr-captain-post-merge` from their worktree:
+
+Expected: `paths: []` + `disable-model-invocation: true` combined with Step 1 precondition:
+```
+REFUSED: pr-captain-post-merge must run in main checkout on master.
+  You are in: .claude/worktrees/devex
+  Ask captain to run it, or switch to main checkout.
+```
+
+Exit 2.
+
+---
+
+## Integration examples
+
+### As Step 8 of `/pr-captain-land`
+
+When captain runs the full captain-owned PR lifecycle:
+
+```
+/pr-captain-land <agent-branch>
+```
+
+Internally:
+- Step 7 invokes `/pr-captain-merge`
+- Step 8 invokes `/pr-captain-post-merge`
+
+Output from `/pr-captain-land` includes the combined report.
+
+### Chained with `/collaborate` for cross-repo notice
+
+After a PR that affects cross-repo collaborators:
+
+```
+/pr-captain-post-merge 110
+/collaborate create the-agency --subject "monofolk v1.8 shipped — /service-add + /ui-add"
+```
+
+Cross-repo dispatch follows the release.
+
+### After a hotfix PR (non-standard version scheme)
+
+Hotfix PR #197 with no D#-R# in title:
+
+```
+/pr-captain-post-merge 197
+```
+
+Resolution order fallback kicks in → tag `v1.8.pr197` created. Skill reports the naming fallback explicitly so captain can verify.
+
+### Manually after `/release` (legacy flow)
+
+If captain used legacy `/release` flow (which creates the PR but doesn't run post-merge automatically):
+
+```
+/release  # creates + pushes + merges PR
+/pr-captain-post-merge <N>  # landed + release + cleanup
+```
+
+New workflow prefers `/pr-captain-land` which chains everything.

--- a/.claude/skills/pr-captain-post-merge/reference.md
+++ b/.claude/skills/pr-captain-post-merge/reference.md
@@ -1,0 +1,61 @@
+# pr-captain-post-merge — unique protocol
+
+Most of this skill's behavior is covered by `required_reading:` docs (git-merge discipline, worktree discipline, safe tools) and by the underlying tools (`gh-release`, `git-captain`, `/sync-all`). Skill-unique content:
+
+## Release naming protocol
+
+The GitHub release tag is derived from the merged PR's title/branch. Resolution order:
+
+1. **`D#-R#` pattern** in PR title (e.g., `D39-R1: ...`) → tag `v39.1`
+2. **`agency-skill-version`-matched pattern** in PR body → tag per the-agency convention (if applicable)
+3. **`monofolk_version` match** against current `manifest.json` → tag `v<monofolk_version>` (e.g., `v1.8`)
+4. **Hotfix / non-standard** → `v<monofolk_version>.pr<PR-number>` (e.g., `v1.8.pr110`)
+
+The tag is NEVER chosen by captain's judgment after the fact. It's derived mechanically from committed state (manifest + PR title).
+
+## Release notes composition
+
+Release notes body is captain-authored from:
+
+- PR title (one-liner)
+- PR description summary (2-3 sentences max)
+- Key changes listed in PR description
+- Incident lineage if applicable (e.g., "fixes the-agency#296")
+- Link back to the PR
+
+Release notes are NOT the PR description verbatim — they're audience-for-release-readers. Less jargon than PR descriptions; more "what shipped + why it matters."
+
+## The `release-tag-check` contract
+
+GitHub Actions workflow `release-tag-check` runs on every push to master. If a merge commit lands without a matching release tag, CI goes red on main immediately. This skill's Step 6 is the gate that prevents that red state.
+
+**Failure mode:** if Step 6 fails and captain proceeds to Step 7 (branch cleanup), main CI will be red until a release is created manually. The skill's hard-verify in Step 6 is there specifically to prevent that progression.
+
+## Composition with `/pr-captain-land`
+
+When captain runs `/pr-captain-land`, this skill is invoked as Step 8. In that composition:
+
+- The merge (Step 7 of `/pr-captain-land`) has already happened via `/pr-captain-merge`
+- Steps 1-2 of this skill are skipped (parent skill has verified)
+- Steps 3-8 run in sequence
+- Exit code propagates; if Step 6 (release creation) fails, the full land flow fails
+
+See `.claude/skills/pr-captain-land/references/land-protocol.md` for the full integration.
+
+## Recovery flows
+
+### Release created with wrong tag
+
+`gh release delete v<wrong>` + re-run Step 6 with correct version. Only safe if no downstream deployment referenced the bad tag.
+
+### Master already synced before skill runs
+
+Step 4 detects no divergence; merge-from-origin is a no-op. Skill continues to Step 5 normally.
+
+### /sync-all fails
+
+Step 5 fails → skill reports, captain investigates worktree state. Release (Step 6) can still proceed; worktree sync is per-worktree and not release-blocking.
+
+### Branch already deleted
+
+Step 7 no-op. Skill reports "kept / already-gone" and exits clean.

--- a/.claude/skills/pr-captain-post-merge/scripts/README.md
+++ b/.claude/skills/pr-captain-post-merge/scripts/README.md
@@ -1,0 +1,7 @@
+# scripts/
+
+Empty by design. `pr-captain-post-merge` is pure orchestration — it invokes `claude/tools/gh-release`, `claude/tools/git-captain`, `/sync-all` (via Skill tool), and `gh` directly. No skill-specific scripts needed.
+
+If future refinement requires a dedicated release-notes composer or branch-cleanup helper beyond what `claude/tools/gh-release` provides, it would land here.
+
+The v2 bundle-structure requirement says this directory exists even when empty; this README explains why.

--- a/.claude/skills/pr-submit/SKILL.md
+++ b/.claude/skills/pr-submit/SKILL.md
@@ -1,0 +1,167 @@
+---
+name: pr-submit
+description: Agent-side signal to captain that your branch is ready for PR landing. Runs preconditions (clean tree, pushed, matching QGR receipt) then dispatches captain with a structured payload. Captain's /pr-captain-land picks it up. Replaces the distributed "agent creates PR" model with a captain-owned PR lifecycle (the-agency#296).
+agency-skill-version: 2
+when_to_use: Agent in a worktree after /pr-prep succeeds and branch is pushed to origin. Replaces manual /pr-create invocation by agents. NEVER from master or main checkout — that's captain's /pr-captain-land.
+argument-hint: "--scope \"one-line PR summary\" [--priority normal|high]"
+paths:
+  - .claude/worktrees/**
+required_reading:
+  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - claude/REFERENCE-ISCP-PROTOCOL.md
+---
+
+<!--
+  allowed-tools intentionally omitted — inherits Bash(*) from
+  .claude/settings.json. Subcommand-level restriction at the skill level
+  silently blocked fleet agents in the past (flag #62/#63; devex dispatch
+  #171). This skill composes git-safe, dispatch, and diff-hash — tool-level
+  narrow restriction would work but needs maintenance as composed tools
+  evolve. Inherit Bash(*) is safer.
+-->
+
+# pr-submit
+
+Agent-side handoff to captain: "my branch is ready for PR landing." Captain picks up the dispatch and runs `/pr-captain-land` to own the remaining PR lifecycle (version bump, PR creation, CI wait, merge, release, fleet-notify).
+
+## Why this exists
+
+Per the-agency#296: the distributed "agent creates PR, captain merges" model causes four failure modes that the captain-owned lifecycle eliminates:
+
+- **Version-bump races** — two agents bump `monofolk_version` simultaneously against the same `origin/master` baseline; one loses.
+- **QGR hash races** — captain's coord commits land on master between an agent's QG and that agent's PR creation, invalidating the receipt mid-flow.
+- **Split release responsibility** — agent opens PR but captain creates the release; ownership is asymmetric and release steps get skipped.
+- **Inconsistent PR descriptions** — each agent writes their own; no fleet-wide coherence for review or history-mining.
+
+Solution: captain owns the PR lifecycle end-to-end. Agent owns substance + QG. `/pr-submit` is the single handoff point — a structured dispatch with branch, SHA, diff-hash, receipt path, and scope summary.
+
+## Required reading
+
+Before running, Read the files listed in `required_reading:` frontmatter.
+
+- `REFERENCE-CODE-REVIEW-LIFECYCLE.md` — where this skill sits in the end-to-end PR flow.
+- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — the five-hash receipt chain this skill verifies against.
+- `REFERENCE-ISCP-PROTOCOL.md` — the dispatch protocol the handoff uses.
+
+The dispatch payload schema itself is in this skill's `reference.md`.
+
+## Usage
+
+```
+/pr-submit --scope "one-line PR summary"
+/pr-submit --scope "..." --priority high
+```
+
+- `--scope`: **required.** One-line summary of what this PR delivers (becomes part of the dispatch subject + body).
+- `--priority normal|high`: optional. Defaults to `normal`. `high` raises dispatch visibility in captain's queue.
+
+## Preconditions
+
+The script enforces all of these before dispatching; any failure exits non-zero with a clear error and **no** dispatch is sent:
+
+1. Running in an agent worktree (`.claude/worktrees/<name>/`), **not** the main checkout.
+2. Current branch is not `master` / `main` / `HEAD` (not detached).
+3. Tree is clean — `git status --porcelain` empty.
+4. Current branch is pushed to origin and `origin/<branch>` equals local `HEAD`.
+5. A QGR receipt exists at `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` where `{hash}` matches the current `diff-hash` against `origin/master`.
+
+If preconditions 3 or 4 fail, fix them (commit/push via `/git-safe-commit` or `/sync`) and retry. If precondition 5 fails, you need to re-run `/pr-prep` to sign a fresh receipt.
+
+## Flow / Steps
+
+### Step 1: Preflight
+
+`scripts/pr-submit` computes all preconditions. If any fail, exit 1 with a one-line reason. No partial state.
+
+### Step 2: Resolve identity + branch state
+
+1. Resolve agent identity via `./claude/tools/agent-identity` (principal + agent + repo).
+2. Capture `BRANCH` = `git rev-parse --abbrev-ref HEAD`.
+3. Capture `SHA` = `git rev-parse HEAD`.
+4. Verify `git rev-parse "origin/$BRANCH"` equals `SHA`.
+
+### Step 3: Compute diff-hash
+
+```
+./claude/tools/diff-hash --base origin/master --json
+```
+
+Capture the full SHA-256 and the 7-char short form. The 7-char short form is what matches the receipt filename suffix.
+
+### Step 4: Locate receipt
+
+Glob for `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash-short}.md`. Exactly one receipt should match. If zero, exit 1 — agent must re-run `/pr-prep`. If multiple, pick the most recent and warn.
+
+### Step 5: Compose dispatch payload
+
+Follow the schema in `reference.md` (protocol v1.0). Envelope:
+
+```
+to:       monofolk/{principal}/captain
+type:     pr-submit
+priority: normal | high
+subject:  "Ready for PR landing: {branch} — {scope}"
+```
+
+Body is the markdown template in `reference.md` — branch, SHA, diff-hash, receipt path, scope, captain-action list.
+
+### Step 6: Emit dispatch
+
+```
+./claude/tools/dispatch create \
+  --to monofolk/{principal}/captain \
+  --type pr-submit \
+  --subject "<subject>" \
+  --body "<body>"
+```
+
+Capture the dispatch ID. Report to the agent: "Submitted to captain as dispatch `<id>`. Captain will run `/pr-captain-land <branch>`; you'll receive a `master-updated` dispatch when the PR lands."
+
+### Step 7: Stand by
+
+Agent does NOT:
+
+- Create the PR
+- Bump `monofolk_version`
+- Merge
+- Create the release
+
+Agent stands by to respond to review comments via `/pr-respond` if any come. On merge, a `master-updated` dispatch arrives with PR URL + release tag.
+
+## Failure modes
+
+- **Preflight fails** (Step 1): exit 1 with the failing precondition. No mutation, no dispatch. Fix the precondition and retry.
+- **Origin mismatch** (Step 2.4): local HEAD and `origin/<branch>` diverge. Push or pull first (`./claude/tools/git-push <branch>` or `git-safe fetch` + merge).
+- **Receipt missing** (Step 4): no QGR matching current diff-hash. Re-run `/pr-prep` to regenerate.
+- **Dispatch emission fails** (Step 6): ISCP tool error. Script exits 1; agent retries. Dispatch creation is idempotent-safe (duplicate dispatches just clutter the queue — captain can resolve).
+- **Captain never picks up**: a non-failure but a stall. Agent can re-dispatch with `--priority high` or flag the captain directly.
+
+## What this does NOT do
+
+- **Does not create the PR.** That's captain's `/pr-captain-land`. Agent must not run `gh pr create` or `/pr-create` after this.
+- **Does not bump `monofolk_version`.** Captain is the single writer.
+- **Does not merge anything.** Agent has no write access to master.
+- **Does not modify the branch.** The branch stays exactly as `/pr-prep` left it.
+- **Does not wait for captain.** Fire-and-forget dispatch; agent returns to other work.
+
+## Status
+
+`active` (v2, agency-skill-version 2 from birth — this skill is the Phase 1 pilot for the-agency#296 captain-owned PR lifecycle). Ready for fleet-wide dogfood on designex / patient / of-mobile next PRs.
+
+## Related
+
+- `/pr-captain-land` — captain-side companion; consumes this skill's dispatch
+- `/pr-prep` — the QG-before-PR-create that produces the receipt this skill verifies
+- `/pr-respond` — agent-side skill for handling captain review comments (planned)
+- `claude/tools/dispatch` — the ISCP tool this skill wraps for emission
+- `claude/tools/diff-hash` — receipt-matching hash
+- `claude/tools/agent-identity` — principal/agent/repo resolution
+- `reference.md` — dispatch payload schema (protocol v1.0)
+- `examples.md` — happy-path + failure-mode examples
+- the-agency#296 — PR lifecycle ownership design
+- the-agency#298 — skill refactor recommendation
+- the-agency#314 — upstream package MAR summary
+- the-agency#315 — V1→V2 migration master issue
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-submit/assets/README.md
+++ b/.claude/skills/pr-submit/assets/README.md
@@ -1,0 +1,7 @@
+# assets/
+
+Empty by design. `pr-submit` has no static templates or assets — the dispatch body is generated dynamically from runtime state (branch, SHA, hash, receipt path, scope) at emission time.
+
+Bundle structure requires this directory (v2 spec §5); this README explains the intentional emptiness so audit tooling doesn't flag it as drift.
+
+If future extensions need templates (e.g., a captain-side reply template for `pr-submit-rejected`), they land here.

--- a/.claude/skills/pr-submit/examples.md
+++ b/.claude/skills/pr-submit/examples.md
@@ -1,0 +1,161 @@
+# pr-submit — examples
+
+## Happy-path examples
+
+### Agent finishes work, dispatches captain
+
+Agent in `.claude/worktrees/devex`, branch `jordan-devex-d12-r3`, tree clean, pushed, receipt signed from `/pr-prep`:
+
+```
+/pr-submit --scope "devex: fix worktree-sync MAIN_BRANCH resolution — never read HEAD of main checkout"
+```
+
+Expected:
+
+```
+[pr-submit] Preflight OK: worktree=devex, branch=jordan-devex-d12-r3, sha=a3f9b21, pushed=ok
+[pr-submit] Diff hash: 8b4c2e1 (vs origin/master)
+[pr-submit] Receipt: claude/workstreams/devex/qgr/monofolk-jordan-devex-devex-d12r3-qgr-pr-prep-20260419-1430-8b4c2e1.md
+[pr-submit] Dispatched to monofolk/jordan/captain as d-019da47f-8b4c
+→ Captain will run /pr-captain-land jordan-devex-d12-r3
+→ You'll receive a master-updated dispatch when the PR lands.
+```
+
+Size: S. Fast pass, ~2-3 seconds.
+
+### High-priority submission
+
+Agent has a fleet-blocking fix ready:
+
+```
+/pr-submit --scope "devex: fix raw gh pr create block breaking every worktree" --priority high
+```
+
+Dispatch is marked `priority: high` — captain's dispatch monitor surfaces it above normal-priority items.
+
+## Failure-mode examples
+
+### Not in a worktree
+
+Agent accidentally runs from main checkout:
+
+```
+/pr-submit --scope "..."
+```
+
+```
+[pr-submit] ERROR: Preflight failed — not in an agent worktree.
+  Current: /Users/jordan_of/code/monofolk (main checkout)
+  Expected: .claude/worktrees/<name>/
+  Fix: cd into the agent's worktree, or if you're captain, use /pr-captain-land instead.
+```
+
+Exit 1. No dispatch sent.
+
+### Dirty tree
+
+```
+/pr-submit --scope "..."
+```
+
+```
+[pr-submit] ERROR: Preflight failed — tree not clean.
+  Uncommitted: 2 files (src/foo.ts, tests/foo.test.ts)
+  Fix: commit or stash via /git-safe-commit or /session-compact.
+```
+
+Exit 1.
+
+### Unpushed or diverged from origin
+
+```
+[pr-submit] ERROR: Preflight failed — local HEAD and origin/<branch> diverge.
+  local:  a3f9b21
+  origin: e47ce53
+  Fix: run /sync or push via ./claude/tools/git-push <branch>.
+```
+
+Exit 1.
+
+### Receipt missing
+
+```
+[pr-submit] ERROR: Preflight failed — no QGR receipt matches current diff-hash (8b4c2e1).
+  Searched: claude/workstreams/**/qgr/*qgr-pr-prep-*-8b4c2e1.md
+  Fix: run /pr-prep to sign a fresh receipt, then re-try /pr-submit.
+```
+
+Exit 1. The receipt is the proof the QG ran against this exact state; no skipping.
+
+### Multiple receipts match (warning, not failure)
+
+Rare — two `/pr-prep` runs produced matching hashes (e.g., no change between runs):
+
+```
+[pr-submit] WARN: 2 receipts match diff-hash 8b4c2e1. Using most recent:
+  claude/workstreams/devex/qgr/monofolk-jordan-devex-devex-d12r3-qgr-pr-prep-20260419-1430-8b4c2e1.md
+[pr-submit] Dispatched to captain as d-019da47f-8b4c
+```
+
+Proceeds with exit 0. Captain re-verifies during `/pr-captain-land`.
+
+## Dispatch payload example
+
+The dispatch body that lands in captain's inbox (see `reference.md` for full schema):
+
+```markdown
+# Ready for PR landing — devex: fix worktree-sync MAIN_BRANCH resolution
+
+## Branch ready
+
+- **Branch:** `jordan-devex-d12-r3`
+- **Agent:** monofolk/jordan/devex
+- **HEAD:** `a3f9b21f...` (pushed to origin)
+- **Diff base:** `origin/master`
+- **Diff hash:** `8b4c2e1`
+
+## QGR receipt
+
+- **Path:** `claude/workstreams/devex/qgr/monofolk-jordan-devex-devex-d12r3-qgr-pr-prep-20260419-1430-8b4c2e1.md`
+- **Verified:** local receipt file matches current state
+
+## Scope summary
+
+devex: fix worktree-sync MAIN_BRANCH resolution — never read HEAD of main checkout
+
+## Captain action requested
+
+Run /pr-captain-land on branch `jordan-devex-d12-r3`:
+
+1. Switch to `jordan-devex-d12-r3`
+2. Verify receipt against current state
+3. Bump `monofolk_version` in manifest (serialized — single writer)
+4. Create PR with captain-authored fleet-aware description
+5. Watch CI (`lint-and-test` gate)
+6. Merge when green
+7. Create GitHub release v{monofolk_version}
+8. Dispatch back with merge confirmation + release tag
+
+## What I (agent) will NOT do
+
+- Create the PR myself
+- Bump `monofolk_version` myself
+- Merge myself
+- Create the release myself
+
+Captain owns the PR lifecycle. I stand by to /pr-respond if review comments come.
+
+Over.
+
+-- monofolk/jordan/devex
+```
+
+## What to expect next
+
+Captain picks up the dispatch (either via `dispatch-monitor` or manual read), runs `/pr-captain-land <branch>`, and you eventually get back:
+
+- `master-updated` dispatch with PR URL + release tag
+- Any review comments routed via `/pr-respond`
+- If CI fails or receipt mismatches: a `pr-submit-rejected` dispatch telling you to re-prep and re-submit
+
+No additional action required from the agent unless review or rejection comes.

--- a/.claude/skills/pr-submit/reference.md
+++ b/.claude/skills/pr-submit/reference.md
@@ -1,0 +1,101 @@
+# pr-submit Dispatch Payload Protocol
+
+## Purpose
+
+Defines the structured payload `/pr-submit` sends to captain. Captain's `/pr-captain-land` relies on this structure to land the PR correctly. Changes to the payload require coordinated changes on both sides.
+
+## Dispatch envelope
+
+```
+type:       dispatch
+to:         monofolk/{principal}/captain
+priority:   normal | high
+subject:    "Ready for PR landing: {branch} — {scope}"
+in_reply_to: null | <prior-dispatch-id>
+```
+
+## Body structure (markdown)
+
+```markdown
+# Ready for PR landing — {scope}
+
+## Branch ready
+
+- **Branch:** `{branch}`
+- **Agent:** monofolk/{principal}/{agent}
+- **HEAD:** `{sha}` (pushed to origin)
+- **Diff base:** `origin/master`
+- **Diff hash:** `{hash-7-char}`
+
+## QGR receipt
+
+- **Path:** `{receipt-relative-to-repo-root}`
+- **Verified:** local receipt file matches current state
+
+## Scope summary
+
+{one-line summary from --scope flag}
+
+## Captain action requested
+
+Run /pr-captain-land on branch `{branch}`:
+
+1. Switch to `{branch}`
+2. Verify receipt against current state
+3. Bump `monofolk_version` in manifest (serialized — single writer)
+4. Create PR with captain-authored fleet-aware description
+5. Watch CI (`lint-and-test` gate)
+6. Merge when green
+7. Create GitHub release v{monofolk_version}
+8. Dispatch back with merge confirmation + release tag
+
+## What I (agent) will NOT do
+
+- Create the PR myself
+- Bump `monofolk_version` myself
+- Merge myself
+- Create the release myself
+
+Captain owns the PR lifecycle. I stand by to /pr-respond if review comments come.
+
+Over.
+
+-- monofolk/{principal}/{agent}
+```
+
+## Field specifications
+
+| Field | Type | Source | Constraint |
+|---|---|---|---|
+| `branch` | string | `git rev-parse --abbrev-ref HEAD` | Not `master`, not `HEAD` (detached) |
+| `sha` | string (40 char hex) | `git rev-parse HEAD` | Must equal `origin/{branch}` |
+| `diff-hash` | string (7 char hex) | `./claude/tools/diff-hash --base origin/master --json` | First 7 of full SHA-256 |
+| `receipt-path` | string | Glob `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | Must exist, must match hash |
+| `scope` | string | `--scope` flag | Required, non-empty |
+| `priority` | enum | `--priority` flag | `normal` (default) or `high` |
+
+## Captain-side parsing (/pr-captain-land)
+
+Captain's `/pr-captain-land` script:
+
+1. Reads the dispatch by ID or picks up from dispatch monitor
+2. Parses `branch` and `diff-hash` from the body (regex against the structured fields)
+3. Switches to that branch via `git-captain switch-branch`
+4. Recomputes `diff-hash` on the branch and compares to the dispatched hash (must match)
+5. Verifies the receipt file exists at the dispatched path
+6. Proceeds with landing
+
+## Protocol versioning
+
+v1.0 — initial Phase 1 pilot (this document)
+
+Future versions:
+- v1.1: add `substance-summary` field (agent-authored, captain uses as PR body)
+- v1.2: add `preferred-merge-method` (currently always `merge`, may allow rebase for specific branches)
+- v2.0: machine-parseable JSON block alongside markdown body for stricter captain parsing
+
+## Breaking changes
+
+Any change to `branch`, `sha`, `diff-hash`, or `receipt-path` semantics is breaking. Bump major version and coordinate with pr-captain-land update.
+
+Non-breaking additions (new fields captain ignores if not present) can happen without coordination.

--- a/.claude/skills/pr-submit/scripts/README.md
+++ b/.claude/skills/pr-submit/scripts/README.md
@@ -1,0 +1,43 @@
+# scripts/
+
+## `pr-submit`
+
+Bash script that runs the preflight and emits the dispatch. Invoked by the skill's Flow (Steps 1–6 map directly to script sections).
+
+### Entry point
+
+```bash
+bash "$CLAUDE_PROJECT_DIR/.claude/skills/pr-submit/scripts/pr-submit" --scope "..."
+```
+
+The skill's `argument-hint` frontmatter mirrors this CLI.
+
+### What it does
+
+1. Resolves agent identity (`./claude/tools/agent-identity`) — aborts outside an agent worktree
+2. Verifies tree clean, branch pushed, origin matches HEAD
+3. Computes `./claude/tools/diff-hash --base origin/master --json` for the receipt lookup
+4. Globs `claude/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`, picks most recent if multiple
+5. Composes the dispatch body per `../reference.md` schema
+6. Emits via `./claude/tools/dispatch create --to monofolk/{principal}/captain --type pr-submit --subject "..." --body "..."`
+7. Captures and reports the dispatch ID
+
+### Exit codes
+
+- `0` — dispatch sent successfully
+- `1` — preflight failed (not in worktree, dirty tree, unpushed, receipt missing, etc.)
+- `2` — dispatch emission failed (ISCP tool error)
+
+### Related
+
+- `../SKILL.md` — the skill definition the script implements
+- `../reference.md` — dispatch payload schema (protocol v1.0)
+- `../examples.md` — happy-path + failure-mode examples
+
+## Why a script, not inline skill instructions
+
+Multiple preflight checks + hash computation + glob lookup + dispatch emission is too much for reliable inline step-by-step execution under varying agent contexts. The script makes the sequence atomic and testable.
+
+## Skill-tools versioning
+
+The `scripts/` directory pattern is part of the v2 bundle structure (see `claude/REFERENCE-SKILL-AUTHORING.md` §5). Each skill gets its own `scripts/` namespace; no global `claude/tools/` collision.

--- a/.claude/skills/pr-submit/scripts/pr-submit
+++ b/.claude/skills/pr-submit/scripts/pr-submit
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+#
+# submit-for-pr — Agent signals captain that a branch is ready for PR landing
+#
+# WHAT: After /pr-prep succeeds (QG green, receipt signed, branch pushed),
+# the agent runs this to dispatch captain with structured PR-landing context.
+# Captain picks up via dispatch monitor and runs /pr-captain-land on the agent's
+# branch, owning PR creation + version bump + CI watch + merge + release.
+#
+# WHY: Addresses the-agency#296 — distributed PR ownership causes version-bump
+# races, QGR hash races, split responsibility on release creation, and
+# inconsistent PR descriptions. Captain-owned PR lifecycle moves all of that
+# to a single serialization point (captain on master).
+#
+# SCOPE: Phase 1 pilot — sandbox tool in usr/jordan/captain/tools/. Tested
+# by dogfooding on one captain-driven PR before promotion to .claude/skills/.
+#
+# USAGE:
+#   submit-for-pr --scope "one-line summary" [--priority normal|high]
+#
+# PRECONDITIONS (tool enforces):
+#   - Running in an agent worktree (not main checkout)
+#   - Tree is clean
+#   - Branch has been pushed to origin
+#   - A QGR receipt exists matching current branch state
+#
+# OUTPUT:
+#   - Dispatch created to captain with structured payload
+#   - Agent prints "Submitted for PR landing — captain will pick up."
+#
+# WRITTEN: 2026-04-19 (Phase 1 pilot, the-agency#296)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+    echo "submit-for-pr: not in a git repository" >&2
+    exit 1
+}
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+SCOPE=""
+PRIORITY="normal"
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --scope) SCOPE="$2"; shift 2 ;;
+        --priority) PRIORITY="$2"; shift 2 ;;
+        --help|-h)
+            echo "Usage: $0 --scope \"one-line PR summary\" [--priority normal|high]"
+            echo ""
+            echo "Preconditions:"
+            echo "  - In an agent worktree (not main checkout)"
+            echo "  - Clean tree"
+            echo "  - Branch pushed to origin"
+            echo "  - QGR receipt exists for current state"
+            exit 0
+            ;;
+        *) echo "submit-for-pr: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ -z "$SCOPE" ]]; then
+    echo "submit-for-pr: --scope is required (one-line PR summary)" >&2
+    exit 2
+fi
+
+# ── Precondition: not in main checkout ───────────────────────────────────────
+
+MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+if [[ "$REPO_ROOT" == "$MAIN_CHECKOUT" ]]; then
+    echo "submit-for-pr: running in main checkout — this tool is for agent worktrees." >&2
+    echo "  Captain (in main checkout) creates PRs directly via /pr-create." >&2
+    exit 1
+fi
+
+# ── Precondition: clean tree ─────────────────────────────────────────────────
+
+DIRTY=$(git status --porcelain 2>/dev/null)
+if [[ -n "$DIRTY" ]]; then
+    echo "submit-for-pr: working tree dirty — commit or stash first." >&2
+    echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
+    exit 1
+fi
+
+# ── Precondition: branch pushed ──────────────────────────────────────────────
+
+BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+if [[ "$BRANCH" == "HEAD" ]]; then
+    echo "submit-for-pr: detached HEAD — switch to a branch first." >&2
+    exit 1
+fi
+
+LOCAL_SHA=$(git rev-parse HEAD 2>/dev/null)
+REMOTE_SHA=$(git rev-parse "origin/$BRANCH" 2>/dev/null || echo "")
+
+if [[ -z "$REMOTE_SHA" ]]; then
+    echo "submit-for-pr: branch '$BRANCH' not pushed to origin — run git push first." >&2
+    exit 1
+fi
+
+if [[ "$LOCAL_SHA" != "$REMOTE_SHA" ]]; then
+    echo "submit-for-pr: local branch ahead of origin/$BRANCH — push your latest commits first." >&2
+    echo "  local:  $LOCAL_SHA" >&2
+    echo "  remote: $REMOTE_SHA" >&2
+    exit 1
+fi
+
+# ── Precondition: QGR receipt exists ─────────────────────────────────────────
+#
+# Receipt lives at claude/workstreams/{workstream}/qgr/*.md. We try to find
+# one matching the current diff hash against origin/master.
+
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/claude/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+                 python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
+                 echo "")
+DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
+
+if [[ -z "$DIFF_HASH_SHORT" ]]; then
+    echo "submit-for-pr: could not compute diff hash against origin/master." >&2
+    echo "  Tool: $REPO_ROOT/claude/tools/diff-hash" >&2
+    exit 1
+fi
+
+# Look for receipt matching this hash
+RECEIPT=$(find "$REPO_ROOT/claude/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+
+if [[ -z "$RECEIPT" ]]; then
+    echo "submit-for-pr: no QGR receipt found matching current state (hash: $DIFF_HASH_SHORT)." >&2
+    echo "  Run /pr-prep to produce one." >&2
+    exit 1
+fi
+
+RECEIPT_REL="${RECEIPT#$REPO_ROOT/}"
+
+# ── Detect agent identity ────────────────────────────────────────────────────
+
+AGENT=""
+if [[ -f "$REPO_ROOT/.claude/worktrees/$(basename "$REPO_ROOT")/.agency-agent" ]]; then
+    AGENT=$(cat "$REPO_ROOT/.claude/worktrees/$(basename "$REPO_ROOT")/.agency-agent")
+elif command -v "$REPO_ROOT/claude/tools/agent-identity" &>/dev/null; then
+    AGENT=$("$REPO_ROOT/claude/tools/agent-identity" 2>/dev/null || echo "")
+fi
+if [[ -z "$AGENT" ]]; then
+    AGENT=$(basename "$REPO_ROOT")  # fallback to worktree dir name
+fi
+
+PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2
+
+# ── Build dispatch body ──────────────────────────────────────────────────────
+
+DISPATCH_BODY=$(cat <<EOF
+# Ready for PR landing — $SCOPE
+
+## Branch ready
+
+- **Branch:** \`$BRANCH\`
+- **Agent:** monofolk/$PRINCIPAL/$AGENT
+- **HEAD:** \`$LOCAL_SHA\` (pushed to origin)
+- **Diff base:** \`origin/master\`
+- **Diff hash:** \`$DIFF_HASH_SHORT\`
+
+## QGR receipt
+
+- **Path:** \`$RECEIPT_REL\`
+- **Verified:** local receipt file matches current state
+
+## Scope summary
+
+$SCOPE
+
+## Captain action requested
+
+Run /pr-captain-land on branch \`$BRANCH\`:
+
+1. Switch to \`$BRANCH\`
+2. Verify receipt against current state
+3. Bump \`monofolk_version\` in manifest (serialized — single writer)
+4. Create PR with captain-authored fleet-aware description
+5. Watch CI (\`lint-and-test\` gate)
+6. Merge when green
+7. Create GitHub release v{monofolk_version}
+8. Dispatch back with merge confirmation + release tag
+
+## What I (agent) will NOT do
+
+- Create the PR myself
+- Bump \`monofolk_version\` myself
+- Merge myself
+- Create the release myself
+
+Captain owns the PR lifecycle. I stand by to /pr-respond if review comments come.
+
+Over.
+
+-- monofolk/$PRINCIPAL/$AGENT
+EOF
+)
+
+# ── Send dispatch ────────────────────────────────────────────────────────────
+
+"$REPO_ROOT/claude/tools/dispatch" create \
+    --type dispatch \
+    --to "monofolk/$PRINCIPAL/captain" \
+    --subject "Ready for PR landing: $BRANCH — $SCOPE" \
+    --body "$DISPATCH_BODY" \
+    ${PRIORITY:+--priority "$PRIORITY"} >/dev/null
+
+echo "submit-for-pr: submitted"
+echo "  branch:   $BRANCH"
+echo "  receipt:  $RECEIPT_REL"
+echo "  hash:     $DIFF_HASH_SHORT"
+echo "  dispatch: sent to monofolk/$PRINCIPAL/captain (priority: $PRIORITY)"
+echo ""
+echo "Captain will pick up and run /pr-captain-land. Stand by for merge dispatch."

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -1,62 +1,145 @@
 ---
-description: Merge target into current branch and push to origin. The ONLY command that pushes.
+name: sync
+description: Merge a target branch into the current branch and push to origin. The ONLY framework skill that pushes to a remote. Requires explicit confirmation. Never rebases. Default-actor skill (agents and captain both use it; captain for captain-* branches, agents for their worktree branches).
+agency-skill-version: 2
+when_to_use: On any non-master branch (worktree agent branch OR captain-* branch), when ready to push committed work to origin. NEVER from master (use PR flow instead). NEVER for auto-invocation — always requires confirmation.
+argument-hint: "[<target-branch>]"
+paths: []
+disable-model-invocation: true
+required_reading:
+  - claude/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - claude/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
-  Flag #62/#63: allowed-tools removed. Inherits Bash(*) from
-  .claude/settings.json. Restricting to specific subcommand patterns at the
-  skill level silently blocks agents on permission prompts the agent cannot
-  see — see dispatch #171 for the devex incident that surfaced this trap.
+  allowed-tools omitted — inherits Bash(*). Composes git-captain + git-safe
+  + git-push with user confirmation at each step. Subcommand-level restriction
+  unsafe (flag #62/#63).
 -->
 
-# Sync — Push to Origin
+# sync
 
-Merge target into current branch and push to origin. This is the **only** command that pushes to a remote. Requires explicit confirmation. **Never rebases.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+The framework's single authorized push path. Merges a target branch (default `origin/master`) into the current branch and pushes to origin. Every other push attempt is blocked by hookify (raw `git push` refused at the hook layer).
 
-## Arguments
+**Name pattern:** noun-verb (`sync` is both noun and verb by context). No actor qualifier because sync is default-actor — anyone on a non-master branch uses it.
 
-- $ARGUMENTS: Optional target branch (default: `origin/master`).
+## Why this exists
 
-## Steps
+Pushing is a privileged action. Without a single authorized path:
+
+- Agents push broken branches (no QG run)
+- Captain pushes to master accidentally (catastrophic — bypasses PR review)
+- Forced pushes overwrite teammates' work
+
+`sync` enforces: (a) not master, (b) clean tree, (c) single-worktree checkout, (d) confirmation before each destructive step, (e) merge not rebase. The underlying `claude/tools/git-push` tool adds its own layer of safety (blocks main/master, blocks bare `--force`).
+
+## Required reading
+
+Before proceeding, Read the files listed in `required_reading:` frontmatter.
+
+## Usage
+
+```
+/sync                    # merge origin/master into current branch, push
+/sync origin/main        # explicit target
+/sync other-branch       # merge from a non-default target
+```
+
+## Preconditions
+
+- Current branch is NOT master (or main). Running on master aborts.
+- Working tree is clean.
+- Branch is checked out here (not in another worktree).
+
+## Flow / Steps
 
 ### Step 1: Safety checks
 
-1. Get current branch. If on master, **abort**: "Never push directly to master. Use a PR."
+1. Get current branch. If master, **abort**: "Never push directly to master. Use a PR."
 2. Verify clean working tree.
-3. Verify not checked out in another worktree.
+3. Verify this branch is not checked out in another worktree (prevents dual-commit race).
 
 ### Step 2: Fetch
 
-Run `git fetch origin`.
+```
+./claude/tools/git-captain fetch
+```
 
 ### Step 3: Show what will be pushed
 
-Run `git log --oneline origin/{current-branch}..HEAD` (if remote tracking exists) or `git log --oneline {target}..HEAD`.
+```
+git log --oneline origin/<current-branch>..HEAD   # if tracking exists
+git log --oneline <target>..HEAD                  # if no tracking
+```
 
-Show the commits that will be pushed.
+Captain shows commit list; principal verifies scope.
 
 ### Step 4: Confirm
 
-Ask the user:
-> Merge {target} into {branch} and push to origin/{branch}?
+Prompt:
+
+> Merge `<target>` into `<branch>` and push to `origin/<branch>`?
 
 **Do not push without explicit confirmation.**
 
-### Step 5: Merge
+### Step 5: Merge target
 
-Run `git merge {target}`. Handle conflicts (show, ask user to resolve or abort).
+```
+git merge <target>
+```
+
+If conflicts: show conflict files, ask principal to resolve or abort. No auto-resolution.
 
 ### Step 6: Push
 
-Run `./claude/tools/git-push {branch}`.
+```
+./claude/tools/git-push <branch>
+```
 
-**Never raw `git push`.** The tool validates the target (blocks main/master) and is the only authorized push path. Raw git push is blocked by hookify.
+**Never raw `git push`** — blocked by hookify. `git-push` tool validates target (refuses main/master), checks force-with-lease semantics, and is the only authorized push path in the framework.
 
 ### Step 7: Report
 
 ```
 Sync complete:
-  Branch: {branch}
-  Pushed: N commits to origin/{branch}
-  Base: {target}
+  Branch: <branch>
+  Pushed: N commits to origin/<branch>
+  Base:   <target>
 ```
+
+## Failure modes
+
+- **On master**: abort (Step 1). Never push master directly.
+- **Dirty tree**: abort. Commit or stash.
+- **Branch checked out elsewhere**: abort. Only one worktree at a time can sync.
+- **Merge conflict** (Step 5): halt; principal resolves or aborts.
+- **Push rejected** (non-fast-forward, branch protection, etc.): report; principal investigates.
+
+## What this does NOT do
+
+- **Does not push master**: abort on master.
+- **Does not rebase**: uses merge commits only (per `REFERENCE-GIT-MERGE-NOT-REBASE.md`).
+- **Does not force-push bare**: only via `--force-with-lease` and only via `git-push` tool.
+- **Does not create PRs**: that's `/captain-release` (captain) or `/pr-submit` (agent).
+- **Does not run QG**: that's `/pr-prep`. Run QG BEFORE `/sync` if this push is PR-bound.
+
+## disable-model-invocation: true
+
+Pushing is destructive and requires principal confirmation. Model auto-invocation could push in the wrong context. The `disable-model-invocation: true` frontmatter prevents that. Principal/captain types `/sync` explicitly.
+
+## Status
+
+`active` (v2, refactored in-place from legacy `sync` 2026-04-19; name unchanged).
+
+## Related
+
+- `/captain-release` — captain's one-flow release (includes sync internally)
+- `/pr-submit` — agent signals captain; no direct push
+- `/pr-captain-land` — captain's lifecycle for agent-owned branches
+- `/captain-sync-all` — captain's master-sync (never pushes; different scope)
+- `/worktree-sync` — worktree sync (never pushes; local master merge only)
+- `claude/tools/git-push` — underlying authorized push tool
+- `claude/hookify/hookify.block-raw-git-push.md` — blocks raw `git push`
+- `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/sync/assets/README.md
+++ b/.claude/skills/sync/assets/README.md
@@ -1,0 +1,5 @@
+# assets/
+
+Empty by design. `sync` has no templates or static assets — report format is generated inline.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/.claude/skills/sync/examples.md
+++ b/.claude/skills/sync/examples.md
@@ -1,0 +1,157 @@
+# sync — examples
+
+## Happy-path examples
+
+### Agent pushes worktree branch after commits
+
+Agent on `devex` branch with 3 local commits:
+
+```
+/sync
+```
+
+Flow: fetch → show 3 commits to push → "Merge origin/master and push to origin/devex? [y/N]" → merges master → pushes → reports.
+
+### Captain syncs captain-* branch
+
+Captain on `captain-ref-doc-update`:
+
+```
+/sync
+```
+
+Same flow. Captain confirms push; work lands on origin ready for PR.
+
+### Sync with non-default target
+
+Agent wants to integrate another feature branch before pushing:
+
+```
+/sync feature-other
+```
+
+Merges `feature-other` into current branch, then pushes current branch.
+
+---
+
+## Edge-case examples
+
+### On master (abort)
+
+```
+/sync
+```
+
+Expected:
+```
+ABORT: never push directly to master.
+  On master: use a PR flow (/captain-release or /pr-submit).
+```
+
+Exit 1.
+
+### Dirty tree (abort)
+
+```
+/sync
+```
+
+Expected:
+```
+ABORT: working tree dirty. Commit or stash before sync:
+   M apps/foo/src/bar.ts
+  ?? apps/foo/tests/bar.test.ts
+```
+
+Exit 1.
+
+### Branch checked out in another worktree
+
+Agent has `feature-x` checked out in worktree A and also locally. Running `/sync` from local:
+
+```
+/sync
+```
+
+Expected:
+```
+ABORT: branch 'feature-x' is checked out in another worktree at:
+  .claude/worktrees/feature-x
+Sync from there instead, or switch to a different local branch.
+```
+
+Exit 1.
+
+### Merge conflict during Step 5
+
+```
+/sync
+```
+
+Expected:
+```
+Step 5: merge origin/master conflicted:
+  CONFLICT (content): apps/foo/src/shared.ts
+  
+Resolve manually:
+  git status
+  # edit conflicted files
+  git-safe add apps/foo/src/shared.ts
+  git-captain merge-continue
+  # re-run /sync
+```
+
+Exit 1. Working tree left mid-merge for resolution.
+
+### Push rejected (branch protection)
+
+```
+/sync
+```
+
+Expected:
+```
+Step 6: push to origin/devex rejected.
+  git-push tool reports: branch protection — must be reviewed.
+  Resolve:
+    - Create a PR via /captain-release or /pr-submit
+    - Or ask principal to review branch
+```
+
+Exit 1.
+
+---
+
+## Integration examples
+
+### Standalone push (no PR yet)
+
+Agent staged some commits, wants origin copy but not yet ready to PR:
+
+```
+# ... work + /git-safe-commit ...
+/sync
+# later, when ready:
+/pr-submit --scope "<one-liner>"
+```
+
+### Part of captain-release
+
+```
+/captain-release "..."  # internally calls git-push (equivalent to /sync's push step)
+```
+
+No separate `/sync` call needed; captain-release composes it.
+
+### Force-with-lease after amend
+
+Agent amended their last commit and wants to update the remote:
+
+```
+# ... amend + force-with-lease ...
+/sync
+```
+
+Flow: fetch → show amended commit → confirm → `git-push --force-with-lease`.
+
+`git-push` tool detects the force-with-lease need automatically when local history is rewritten. Hookify blocks bare `--force`; `--force-with-lease` is permitted.

--- a/.claude/skills/sync/reference.md
+++ b/.claude/skills/sync/reference.md
@@ -1,0 +1,51 @@
+# sync — unique protocol
+
+## Target branch semantics
+
+- **Default (`origin/master`)**: most common usage. Before pushing, pull in the latest master state so the push contains all prior master content + this branch's unique commits.
+- **Explicit (`<target>`)**: rare. Useful when syncing between feature branches or when target is a different upstream ref.
+
+Resolution:
+
+```
+TARGET="${1:-origin/master}"
+```
+
+## Why merge before push?
+
+Convention: every push to origin should include all master content up to the tip that was current when you started the branch. This is `git merge origin/master` — integrate upstream before sharing yours.
+
+Alternative (rebase-before-push) is BANNED by framework per `REFERENCE-GIT-MERGE-NOT-REBASE.md`. Merge commits preserve the branch's real history; rebase creates synthetic commits that break bisect and blur authorship.
+
+## The `git-push` tool as the authorized path
+
+`claude/tools/git-push` is the only permitted push invocation. It:
+
+- Blocks pushes to `main` / `master` branches (hard refusal)
+- Requires `--force-with-lease` for any force push (blocks bare `--force`)
+- Logs every push to `~/.agency/<repo>/logs/push.log`
+- Returns distinct exit codes for different failure modes (branch protection, rejected, network)
+
+Hookify rules `block-raw-tools.sh` ensures bare `git push` is blocked at the shell level. This skill + the tool together enforce the single-push-path discipline.
+
+## Composition with `/captain-release`
+
+`/captain-release` internally invokes `/sync` semantics in Step 4 (push step). The combined flow is:
+
+1. QG → 2. commit → 3. confirm push → 4. `git-push` → 5. PR create → 6. version bump → 7. push version bump
+
+The inner push steps (4 and 7) both use the underlying `claude/tools/git-push`. `/sync` provides a standalone invocation of the same primitive for cases where captain has already committed separately and just needs to push.
+
+## Force-with-lease vs force
+
+- **`--force-with-lease`**: refuses push if remote has changed since last fetch. Safe for overwriting YOUR own prior pushed commits after rebase / amend. (But we don't rebase here.)
+- **`--force` (bare)**: overwrites remote regardless. Can destroy teammates' work. **Banned.**
+
+`git-push` tool defaults to `--force-with-lease` when a force push is requested. Bare `--force` requires explicit principal-approved override (not implemented; deliberately absent).
+
+## When NOT to use `/sync`
+
+- **On master**: use a PR (agent-side: `/pr-submit`; captain: `/captain-release`).
+- **For a release**: use `/captain-release` (includes sync + PR + version bump).
+- **For fleet-wide master sync**: use `/captain-sync-all` (local-only; never pushes).
+- **To sync a single worktree with master**: use `/worktree-sync` (merges master locally; never pushes).

--- a/.claude/skills/sync/scripts/README.md
+++ b/.claude/skills/sync/scripts/README.md
@@ -1,0 +1,5 @@
+# scripts/
+
+Empty by design. `sync` composes `git-captain fetch` + `git merge` + `claude/tools/git-push`. No skill-specific scripts needed.
+
+Bundle structure requires this directory; this README explains the intentional emptiness.

--- a/claude/REFERENCE-ESTIMATION.md
+++ b/claude/REFERENCE-ESTIMATION.md
@@ -1,0 +1,107 @@
+# Estimation Discipline — size and complexity, not time
+
+Humans can't reliably estimate time. Agents can't either. When agents attempt to estimate time, they pick up the worst habits of humans. This reference documents the-agency's discipline: **never estimate time; always estimate size and complexity.**
+
+## Rule
+
+When describing the scope of future work — in agency-issues, plans, PVRs, A&Ds, commit messages, dispatches, or transcripts — use:
+
+- **Size:** `S` / `M` / `L` / `XL`
+- **Complexity:** `Easy` / `Moderate` / `Challenging`
+
+Do NOT use: minutes, hours, days, weeks, months, "by end of week," "next sprint," "~2 days," "4-6 weeks."
+
+## Why
+
+1. **Both humans and agents are terrible at time estimates.** Effort follows a fat-tailed distribution. Best-case is rare; median is usually 2-3× best-case; worst-case can be 10×+.
+2. **Time estimates become commitments.** "I think this is 2 days" gets remembered as "they said 2 days." When the real work takes 5 days, trust erodes.
+3. **Calendar time is the wrong axis anyway.** The-agency's "we ship today" discipline means work lands when it's ready, not when the calendar said. Scope changes, priorities shift, unknowns surface.
+4. **Size + complexity captures what actually matters:** is the work chunky or small? Is the unknown-unknown factor high or low?
+5. **Agents have no idea how long something takes in human clock-time.** We don't have clocks. We have work units.
+
+## What to say instead
+
+### When scoping a single piece of work
+
+| Situation | BAD (time) | GOOD (size + complexity) |
+|---|---|---|
+| Refactor a single skill | "30-60 minutes" | "Size: S. Complexity: Easy if Tier 2/4; Challenging if Tier 3." |
+| Build a new tool | "~3 days" | "Size: M. Complexity: Moderate — depends on scope decisions." |
+| Fleet-wide migration | "4-6 weeks" | "Size: XL. Complexity: Challenging — coordination-heavy, but each step is S-M." |
+
+### When scoping a multi-phase effort
+
+Use **phases and gates**, not calendar periods. Example:
+
+**BAD:**
+> Phase 1 (week 1): do X.
+> Phase 2 (week 2): do Y.
+> Phase 3 (week 3+): do Z.
+
+**GOOD:**
+> Phase 1 — Foundation. Size: M. Complexity: Moderate. Gate: methodology doc + registry landed.
+> Phase 2 — Tier 1 refactors. Size: L. Complexity: Challenging. Gate: all Tier 1 skills pass skill-audit.
+> Phase 3 — Fleet adoption. Size: L. Complexity: Moderate. Gate: every adopter fleet pulled the framework update and reports clean.
+
+Each phase is complete when its gate is satisfied. No calendar time attached. We ship as each gate is reached.
+
+### When the principal or stakeholder asks "when?"
+
+**BAD:** "probably by Friday" / "two weeks from now" / "end of the month."
+
+**GOOD:** describe the gate + size + complexity.
+
+> "This is Size M, Complexity Moderate. Gate: QG passes + upstream PR merged. I'll work it continuously; expect the gate to be reached after the blocker on X clears."
+
+If a calendar milestone genuinely matters (e.g., external demo date), handle that as a fixed date the work must LAND before — the work size/complexity is independent of that date.
+
+### When reporting progress
+
+**BAD:** "50% done" / "at the 3-week mark" / "behind schedule."
+
+**GOOD:** describe phase-gate state.
+
+> "Phase 1 gate cleared (methodology doc + registry landed). Phase 2 in progress; 2 of 7 Tier 1 skills refactored. Phase 2 gate is all 7 passing skill-audit."
+
+## Definitions
+
+### Size
+
+- **S** — single artifact, single commit, single PR. One skill refactor in a familiar tier. One reference doc update. One dispatch.
+- **M** — multi-artifact, multi-commit, possibly coupled with other work. A new tool + its skill. A full case-study skill bundle. A protocol extraction from a body-heavy skill.
+- **L** — multi-PR / multi-phase, spanning several artifacts. A methodology rollout. A fleet coordination effort. A refactor of a skill family (Tier 1 destructive + all their dependencies).
+- **XL** — framework-scale change. The whole V1→V2 migration. A new agent type across the fleet. A replacement of a core primitive.
+
+### Complexity
+
+- **Easy** — known solution space, known tools, known outcome. Template-style work.
+- **Moderate** — known solution space, some unknowns in execution (tooling edge cases, adopter coordination, refactor depth).
+- **Challenging** — unknown solution space, high unknown-unknown factor, design work required. New methodology discovery, novel integrations, cross-system work.
+
+**Size and complexity are independent.** An XL task can be Easy (fleet-wide boilerplate sweep with scripting) or Challenging (methodology design + adoption). An S task can be Challenging (tiny but subtle correctness issue).
+
+## Examples applied to this session's work
+
+- **REFERENCE-SKILL-AUTHORING.md** — Size: L. Complexity: Challenging. Gate: adopted methodology documented + referenced from case-study skills.
+- **pr-captain-merge refactor** — Size: M. Complexity: Moderate.
+- **Filing the-agency#314, #315, #316** — Size: M each. Complexity: Moderate.
+- **V1 → V2 migration (full sweep, #315)** — Size: XL. Complexity: Challenging (coordination + design per tier).
+- **Operations audit gap-fills (#316)** — Size: XL overall, with 6 HIGH-priority gaps each S-M. Complexity: Moderate per-gap; Challenging as a coordinated effort.
+
+## For agents
+
+If you catch yourself writing "week," "day," "hour," "sprint," "by end of X" in a scoping context, STOP. Replace with size + complexity + gate. If you can't articulate the gate, the work isn't well-scoped yet — go fix THAT before estimating.
+
+If a human explicitly asks "when?", answer in gate terms. If they persist, say honestly: "I don't estimate time — I estimate size and complexity. The gate for this work is X, and I'll work it continuously until X is satisfied."
+
+## For humans
+
+This discipline applies to humans too. When a human says "I think that'll take 2 days" during the-agency work, the captain (or whoever is transcribing) converts to size/complexity on the way into the artifact. The human's gut-feel is noted, but the durable record uses size/complexity.
+
+## Upstream
+
+This reference doc is part of the-agency framework. Adopters inherit the discipline via normal framework sync. If you're porting to another repo or installing the-agency fresh, this doc ships with it.
+
+---
+
+*Captured 2026-04-19 after Principal Jordan caught the captain repeatedly using time estimates in agency-issues (#296, #315, #316). Upstreamed to the-agency same day. Amend via PR with commit message explaining the refinement.*

--- a/claude/REFERENCE-SKILL-AUTHORING.md
+++ b/claude/REFERENCE-SKILL-AUTHORING.md
@@ -1,0 +1,315 @@
+# Skill Authoring — the-agency v2 methodology
+
+How we build skills in the-agency framework. Covers the v2 spec (`agency-skill-version: 2`), bundle structure, frontmatter, naming, dependencies, and the full workflow for creating a new skill or upgrading an existing v1 skill.
+
+**Status:** v2 methodology spec. Active adoption. First case studies landed 2026-04-19 (pr-submit, pr-captain-land, iteration-complete, phase-complete). Upstreamed to the-agency via relevant PRs.
+
+## Required reading (before authoring any skill)
+
+- `claude/REFERENCE-WHAT-IS-CLAUDE-CODE.md` — grounding on Claude Code's primitives (agent, tools, CLAUDE.md, skills, hooks). If you don't know the difference between a skill and a slash command, read this first.
+- [Anthropic — The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+- [Claude Code — Skills documentation](https://code.claude.com/docs/en/skills)
+- [skills-cli on PyPI](https://pypi.org/project/skills-cli/) (first-party CLI we adopt)
+- [skill-creator skill at github.com/anthropics/skills](https://github.com/anthropics/skills/tree/main/skills/skill-creator) (first-party interactive design skill)
+
+## Why this spec exists
+
+Before v2, the-agency's skills had:
+
+- Minimal frontmatter (often just `description`)
+- No consistent bundle structure — most skills were bare `SKILL.md` files, no `scripts/` / `references/` / `examples/`
+- No declared dependency graph between skills and framework reference docs
+- No registry
+- No discipline on `allowed-tools` (flag #62/#63 — subcommand-level patterns silently blocked fleet agents)
+- No naming discipline (some `noun-verb`, some verb-first, some with actor prefixes, some without)
+
+Result: skills were fragmented, hard to review, and hard for adopters to understand at a glance.
+
+v2 makes skills **cohesive, self-describing, declaratively-specified units**. Every v2 skill is a full bundle with complete frontmatter, explicit dependencies, and a registry entry. Reading one v2 skill tells you everything the skill does, depends on, and costs.
+
+## Version scheme
+
+```yaml
+agency-skill-version: 2
+```
+
+- **`1`** (legacy) — the-agency skills prior to 2026-04-19. Minimal structure. Still functional; tagged v1 in the registry so we know which skills haven't been upgraded.
+- **`2`** (current) — this spec. Full bundle + full frontmatter + registered.
+- Future versions bump the integer when the spec changes in breaking ways. Minor revisions to the spec (e.g., adding an optional field) do NOT bump; they extend v2.
+
+The field is declared in SKILL.md frontmatter. Every v2 skill MUST have it.
+
+## What v2 requires (the spec)
+
+### 1. Full bundle structure — always
+
+```
+my-skill/
+├── SKILL.md           # overview, frontmatter, instructions — ALWAYS present
+├── reference.md       # skill-unique protocol/spec — ALWAYS present (may be short)
+├── examples.md        # happy-path + edge + integration examples — ALWAYS present
+├── scripts/           # executable code — ALWAYS present (may be empty)
+└── assets/            # templates, static files — ALWAYS present (may be empty)
+```
+
+All five MUST be present. If any is empty, include a short note explaining why. Example for a no-op `scripts/`:
+
+```
+# scripts/README.md
+# This skill is pure orchestration — invokes /quality-gate via the Skill tool.
+# No custom scripts needed. Directory preserved for bundle-structure consistency.
+```
+
+**Rationale:** predictable layout for readers; empty sections force the author to explicitly think "have I really checked I don't need this?"; diff-audit friendly over time.
+
+### 2. Frontmatter — all fields required
+
+```yaml
+---
+name: skill-name
+description: What it does + front-loaded key use case. First 1,536 chars used by Claude's matcher.
+agency-skill-version: 2
+when_to_use: Explicit trigger phrases + anti-trigger phrases. "NEVER from X" statements as needed.
+argument-hint: "<arg1> <arg2> [--flag value]"
+paths:                               # Auto-scoping. Empty list for captain-on-master-only skills.
+  - .claude/worktrees/**
+disable-model-invocation: false      # true for destructive captain-only skills
+allowed-tools: ...                   # See §3 below. Called out explicitly.
+required_reading:                    # Framework reference docs this skill needs.
+  - claude/REFERENCE-QUALITY-GATE.md
+  - claude/REFERENCE-WORKTREE-DISCIPLINE.md
+---
+```
+
+No optional frontmatter fields in v2. Every field MUST be present. If a field doesn't apply, include it with an explicit null/empty + comment explaining why.
+
+### 3. `allowed-tools` — tool-level only, never subcommand-level
+
+**Critical discipline.** From flag #62/#63 and devex dispatch #171:
+
+- **Subcommand-level restriction silently blocks fleet agents.** Example of what NOT to do: `allowed-tools: Bash(git status *)`. The permission prompt fires for something Claude's matcher cannot see or surface; the agent hangs with no visible error. This burned fleet agents.
+- **Tool-level restriction is safe.** Example: `allowed-tools: Bash(claude/tools/git-safe:*), Bash(claude/tools/dispatch:*)`.
+- **When in doubt, inherit `Bash(*)` from `.claude/settings.json`** by omitting `allowed-tools` from the skill frontmatter. Include an inline comment explaining why — like iteration-complete + phase-complete do.
+
+**Path convention:** agency tools live at `claude/tools/` (future: `agency/tools/` when the rename lands). `.claude/tools/` is NOT the right path — that would be Claude Code's own space.
+
+### 4. `required_reading` pattern (Option C until @path lands)
+
+Claude Code does NOT support `@path/to/file.md` imports in SKILL.md today (only in CLAUDE.md). See the-agency#306 for the feature request.
+
+Interim workaround: `required_reading:` frontmatter field lists framework reference docs the skill depends on. SKILL.md body has an early "Required reading" step that tells the agent to Read those files before proceeding.
+
+```yaml
+required_reading:
+  - claude/REFERENCE-QUALITY-GATE.md
+  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+```
+
+```markdown
+## Required reading
+
+Before proceeding, Read the files listed in `required_reading:` frontmatter. These contain protocol details this skill relies on.
+```
+
+When Claude Code adds `@path` support, migrating from `required_reading:` to inline `@path` directives is mechanical; skill content doesn't change.
+
+### 5. Body structure — 9 standard sections
+
+Every v2 SKILL.md body has these sections, in this order. Empty sections get explicit "N/A because …" content.
+
+1. **Why this exists** — the pain addressed
+2. **Usage** — invocation syntax
+3. **Required reading** — directs agent to Read the `required_reading:` frontmatter files
+4. **Preconditions** — what must be true before running (or "None — …")
+5. **Flow / Steps** — numbered step-by-step (or "Single step — …")
+6. **Failure modes** — per-step what can go wrong + recovery (or "No destructive operations; failures are benign")
+7. **What this does NOT do** — explicit non-goals, companion skills (or "N/A")
+8. **Status** — `active | pilot | deprecated | experimental | retired`
+9. **Related** — companion skills, reference docs, upstream issues
+
+All 9 headings are REQUIRED. "Required reading" is the v2-added section that directs the agent to Read the `required_reading:` frontmatter entries before acting.
+
+### 6. Naming — noun-verb, with noun-actor-verb for scoped skills
+
+**Rules:**
+
+- **Primary form: `noun-verb`.** Verbs include imperative actions (`-create`, `-land`, `-merge`) and state-transition verbs (`-complete` = "complete this X"; `-review`; `-prepare`).
+- **When scoped to a specific actor, use `noun-actor-verb`.** Example: `pr-captain-land` (pr = noun, captain = actor, land = verb).
+- **Default actor (agent / anyone) gets no qualifier.** Only non-default actors (captain, or future specialized roles) need explicit names.
+
+Examples:
+- `pr-submit` — agent submits their branch for captain landing. Default actor; no qualifier.
+- `pr-captain-land` — captain lands an agent's branch. Captain-only; qualifier.
+- `iteration-complete` — any agent completes an iteration. Default actor; no qualifier.
+- `captain-review` — captain reviews. Could be `pr-captain-review` in v2 if it's specifically PR review.
+
+**Grouping effect:** `noun-` prefix groups related skills in autocomplete. `/pr<tab>` shows the full PR toolkit.
+
+### 7. Registry row
+
+Every v2 skill has a row in `claude/REFERENCE-SKILLS-INDEX.md`. Schema:
+
+| Column | Contents |
+|---|---|
+| Name | skill name (matches directory + `name:` frontmatter) |
+| Description | one-line summary (first sentence of `description:`) |
+| Agency-Skill-Version | `1` or `2` |
+| Scope | `agent` / `captain` / `both` |
+| Status | `active` / `pilot` / `deprecated` / `experimental` / `retired` |
+| Required Reading | comma-separated reference-doc basenames |
+
+Row is maintained by the author (via the `skill-create` workflow — automated where possible). Drift between row and reality is caught by `skill-audit` (see §Tools).
+
+## Bundle file roles
+
+### `SKILL.md` — the contract
+
+- Frontmatter as §2
+- Body as §5 (9 sections)
+- Front-loads what an agent needs to decide: what this does, when to use it, what it needs to run
+
+### `reference.md` — skill-unique protocol
+
+- **Holds content unique to this skill** — not duplicated from `claude/REFERENCE-*.md`
+- Examples: `pr-submit/reference/dispatch-payload.md` spec (structure of the dispatch message), `pr-captain-land/reference/land-protocol.md` (9-step flow detail)
+- If the skill has NO unique protocol (pure orchestration or trivial), `reference.md` exists but is short: "This skill has no unique protocol. See `required_reading:` for all behavior specifications."
+
+### `examples.md` — how invocation looks
+
+Three categories always present:
+
+- **Happy-path examples** — typical invocations with expected output
+- **Edge-case examples** — preconditions failing, what error looks like
+- **Integration examples** — how this skill fits with others (composability)
+
+Examples are both human-readable AND signal for Claude's matcher. Good examples reduce false-positive invocations.
+
+### `scripts/` — executable code specific to this skill
+
+- **Rule of thumb:** if called by more than one skill, the code lives in `claude/tools/`. If called by one skill only, it lives in that skill's `scripts/`.
+- Scripts invoke shared tools directly (e.g., `claude/tools/git-safe`) — don't wrap them.
+- If no skill-specific scripts are needed, directory is empty with a short `README.md` explaining why.
+
+### `assets/` — templates, static files
+
+- Where skill-specific templates, sample configs, or binary assets live
+- If unused, empty dir with a `README.md` noting why
+
+## Dependencies
+
+### Required framework dependencies
+
+- **`uv`** — Python package manager. Pre-installed or installed via `curl -LsSf https://astral.sh/uv/install.sh | sh`.
+- **`skills-cli`** — Anthropic's first-party CLI. Installed via `uv tool install skills-cli`. Provides `skills validate`, `skills create`, `skills list`, etc.
+
+**Install mechanism:** framework-level SessionStart hook checks for presence and installs missing deps. Tracked as the-agency#307. Until that lands, adopters install manually (one-time).
+
+### Why adopt Anthropic's tooling?
+
+- `skills-cli validate` already does structural validation (YAML frontmatter, naming conventions) — Anthropic-maintained, tracks spec changes
+- `skills create` produces scaffolds matching current spec
+- `/skill-creator` skill handles interactive design + eval
+
+Our `skill-create` and `skill-audit` layer AGENCY-SPECIFIC concerns (registry drift, agency-v2 compliance, required_reading path validity) on top. Don't re-implement Anthropic's checks.
+
+## Tools (available in the-agency framework)
+
+| Tool | Role | Source |
+|---|---|---|
+| `skills validate <dir>` | Structural validation (YAML frontmatter, naming) | Anthropic `skills-cli` |
+| `skills create <name>` | Scaffold skill bundle per current spec | Anthropic `skills-cli` |
+| `/skill-creator` | Interactive 4-mode design: Create / Eval / Improve / Benchmark | Anthropic skill |
+| `skill-create` (ours) | Wraps `skills create` + adds agency-v2 post-processing (registry row, agency-skill-version field, required_reading template) | the-agency |
+| `skill-audit` (ours) | Agency-layer checks: registry drift, agency-v2 compliance, required_reading path validity, naming conformance | the-agency |
+
+## Workflow — creating a new v2 skill
+
+1. **Design phase** — clarify what the skill does, when it fires, who invokes it, what tools it needs. Optionally run `/skill-creator` for interactive design.
+2. **Scaffold** — run `skill-create <name> --description "..." [--actor captain|agent]`. Creates `.claude/skills/<name>/` with full bundle structure and v2 frontmatter template.
+3. **Author `SKILL.md`** — fill frontmatter fully; write body with all 9 sections.
+4. **Author `reference.md`** — skill-unique protocol or stub if none.
+5. **Author `examples.md`** — three example categories.
+6. **Author scripts** (if any) — in `scripts/`.
+7. **Register** — add row to `claude/REFERENCE-SKILLS-INDEX.md`.
+8. **Verify** — run `skill-audit <name>`. Must pass before commit.
+9. **Dogfood** — invoke the skill for the case it's designed for; iterate.
+10. **Commit + PR** — via `/git-safe-commit` + `/pr-submit` (if using new PR lifecycle) or `/pr-prep` + `/pr-create`.
+11. **Upstream** — after merge, run `/upstream-port` to port to the-agency if framework-level.
+
+## Workflow — upgrading a v1 skill to v2
+
+1. **Identify the skill** — v1 skills have minimal frontmatter, often just `description`.
+2. **Audit current state** — read SKILL.md. Note current arguments pattern (`$ARGUMENTS` is v1; `argument-hint:` is v2).
+3. **Add the 4 missing frontmatter fields** — `name`, `agency-skill-version: 2`, `when_to_use`, `argument-hint`, `paths`, `required_reading`, `allowed-tools` (with discipline per §3).
+4. **Create the missing bundle files** — `reference.md`, `examples.md`, `scripts/` (may be empty with note).
+5. **Restructure body into 9 sections** — add any missing sections with explicit "N/A because …" content.
+6. **Register** — add row to `REFERENCE-SKILLS-INDEX.md` with version `2`.
+7. **Verify** — run `skill-audit`. Must pass.
+8. **Commit** — single commit per skill refactor, clear message referencing the v2 upgrade.
+9. **Upstream** — port via `/upstream-port`.
+
+## Case studies
+
+### Case study #1 — new skills (clean build under v2)
+
+**`pr-submit` + `pr-captain-land`** — Phase 1 pilot for the-agency#296 (captain-owned PR lifecycle).
+
+- Built clean under the v2 spec
+- Full bundle structure
+- Showcases `paths:` scoping (agent worktree-only vs captain main-checkout-only)
+- Showcases `disable-model-invocation: true` on the destructive captain-only skill
+- Showcases noun-actor-verb naming (`pr-captain-land`)
+- Committed via `030123b3` → `86c34e2e` → `df222b29`
+
+### Case study #2 — retrofit on protocol-heavy production skills
+
+**`iteration-complete` + `phase-complete`** — retrofit from v1.
+
+- Existing production skills upgraded without behavior change
+- Frontmatter expanded to meet v2
+- Body retained (protocol IS the skill for these)
+- Allowed-tools deliberately inherited `Bash(*)` with inline rationale comment (flag #62/#63)
+- Committed via `e14961c4`
+- Surfaced the `allowed-tools` caveat that refined the methodology
+
+### Case study #3 — Tier 1 destructive retrofit (in progress)
+
+**`pr-merge` → `pr-captain-merge`** — first Tier 1 destructive skill retrofit using v2.
+
+- Expected to validate: naming pattern, full bundle on destructive skill, `disable-model-invocation: true`, narrow tool-level `allowed-tools`
+- Will drive final refinements to `skill-create` and `skill-audit` design
+
+## Required reading for skill authors
+
+Every skill author, before writing their first v2 skill:
+
+- This document (`REFERENCE-SKILL-AUTHORING.md`)
+- `claude/REFERENCE-WHAT-IS-CLAUDE-CODE.md`
+- Anthropic's [skill-building guide PDF](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+- Claude Code's [skills docs](https://code.claude.com/docs/en/skills)
+
+Every skill author should Read the `required_reading:` frontmatter files of any skill they're refactoring — those are the skill's declared dependencies.
+
+## Upstream relationships
+
+- **the-agency#298** — Skills review + refactor recommendation. This methodology is the answer to the recommendation.
+- **the-agency#296** — PR lifecycle ownership (Phase 1 pilot, drove pr-submit + pr-captain-land)
+- **the-agency#306** — Claude Code `@path` imports in SKILL.md (feature request for the future replacement of `required_reading:`)
+- **the-agency#307** — SessionStart dependency-install mechanism (required for `uv` + `skills-cli` bootstrap)
+- **the-agency#308** — REFERENCE-WHAT-IS-CLAUDE-CODE.md ported
+
+## Adoption
+
+- **Framework (the-agency):** adopts this spec. All new skills v2. Retrofit plan for v1 skills tracked in `REFERENCE-SKILLS-INDEX.md`.
+- **Adopters (monofolk et al.):** pull framework updates; refactor their own skills to v2 opportunistically. `skill-audit` catches drift.
+
+## Out of scope (for v2)
+
+- Skills that span multiple agencies (cross-repo) — handled by `collaborate` skill family, not by v2 spec directly.
+- Skills that require runtime evaluation harnesses (integration tests, eval suites) — use `/skill-creator`'s Eval mode; agency-specific eval layering is v3 work.
+- Automated registry backfill for v1 skills — manual or batch-scripted for the initial bulk import.
+
+---
+
+*Living document. Amend via PR against this file with a commit message referencing what changed and why.*
+*Last updated: 2026-04-19 (monofolk initial; ported upstream same day).*

--- a/claude/REFERENCE-SKILL-AUTHORING.md
+++ b/claude/REFERENCE-SKILL-AUTHORING.md
@@ -133,21 +133,34 @@ The `skill-audit` tool enforces both presence and order; out-of-order sections f
 
 **Retroactive note (MAR 2026-04-19):** earlier drafts of this spec had Usage at position 2 and Required reading at position 3. The case-study skills all adopted the opposite order independently for pedagogical reasons (deps before syntax), and `skill-audit`'s REQUIRED_SECTIONS array matches the case-study order. The spec now matches the audit + case-study reality.
 
-### 6. Naming — noun-verb, with noun-actor-verb for scoped skills
+### 6. Naming — noun-verb, with actor qualifier for scoped skills
 
-**Rules:**
+**Three valid forms (in preference order):**
 
-- **Primary form: `noun-verb`.** Verbs include imperative actions (`-create`, `-land`, `-merge`) and state-transition verbs (`-complete` = "complete this X"; `-review`; `-prepare`).
-- **When scoped to a specific actor, use `noun-actor-verb`.** Example: `pr-captain-land` (pr = noun, captain = actor, land = verb).
-- **Default actor (agent / anyone) gets no qualifier.** Only non-default actors (captain, or future specialized roles) need explicit names.
+1. **`noun-verb`** — the default. Verbs include imperative actions (`-create`, `-land`, `-merge`) and state-transition verbs (`-complete` = "complete this X"; `-review`; `-prepare`).
+2. **`noun-actor-verb`** — use when the skill is scoped to a specific actor AND has a clear noun. Example: `pr-captain-land` (pr = noun, captain = actor, land = verb).
+3. **`actor-verb`** — use when the skill is scoped to a specific actor BUT has no clear noun (i.e., the verb itself stands for the full action). Examples: `captain-release`, `captain-review`, `captain-sync-all`, `captain-log`.
+
+**Which form to use:**
+
+- Default actor (agent / anyone) never needs an actor qualifier → use form 1 (`noun-verb`)
+- Captain-scoped skill with a clear noun → use form 2 (`noun-captain-verb`, e.g. `pr-captain-land`)
+- Captain-scoped skill where noun ≡ verb or is awkward to separate → use form 3 (`captain-verb`, e.g. `captain-release`)
 
 Examples:
-- `pr-submit` — agent submits their branch for captain landing. Default actor; no qualifier.
-- `pr-captain-land` — captain lands an agent's branch. Captain-only; qualifier.
-- `iteration-complete` — any agent completes an iteration. Default actor; no qualifier.
-- `captain-review` — captain reviews. Could be `pr-captain-review` in v2 if it's specifically PR review.
+- `pr-submit` — form 1. Agent submits their branch. Default actor; no qualifier.
+- `pr-captain-land` — form 2. Captain lands a PR. Noun = pr, actor = captain, verb = land.
+- `pr-captain-merge` — form 2. Captain merges a PR. Same structure.
+- `captain-release` — form 3. Captain does a release. "release" is both noun and verb; inserting a separate noun (like `pr-captain-release`) is awkward when the release is the PR-landing step, not a PR noun itself.
+- `captain-sync-all` — form 3. Captain syncs the fleet. No single noun naturally precedes.
+- `captain-log` — form 3. Captain logs an entry. "log" is the verb-on-the-noun.
+- `iteration-complete` — form 1. Any agent completes an iteration. Default actor.
 
-**Grouping effect:** `noun-` prefix groups related skills in autocomplete. `/pr<tab>` shows the full PR toolkit.
+**When in doubt, prefer form 2 over form 3.** If a noun exists and isn't awkward, surface it. Form 3 is legitimate but only when inserting a noun would force an artificial hyphenation.
+
+**Grouping effect:** `noun-` prefix groups related skills in autocomplete. `/pr<tab>` shows the full PR toolkit. `captain-` prefix also groups, but captain-only operations — see `captain-<tab>` for the captain's toolkit.
+
+**Audit enforcement:** `skill-audit` does NOT enforce naming form — naming is an authoring guideline, not a correctness invariant. It DOES enforce that skills named with a `captain-` prefix or `-captain-` infix have the captain-only four-layer defense (`paths: []` + `disable-model-invocation: true`).
 
 ### 7. Registry row
 

--- a/claude/REFERENCE-SKILL-AUTHORING.md
+++ b/claude/REFERENCE-SKILL-AUTHORING.md
@@ -118,8 +118,8 @@ When Claude Code adds `@path` support, migrating from `required_reading:` to inl
 Every v2 SKILL.md body has these sections, in this order. Empty sections get explicit "N/A because …" content.
 
 1. **Why this exists** — the pain addressed
-2. **Usage** — invocation syntax
-3. **Required reading** — directs agent to Read the `required_reading:` frontmatter files
+2. **Required reading** — directs agent to Read the `required_reading:` frontmatter files **before** invocation syntax (agent learns dependencies before learning how to call)
+3. **Usage** — invocation syntax
 4. **Preconditions** — what must be true before running (or "None — …")
 5. **Flow / Steps** — numbered step-by-step (or "Single step — …")
 6. **Failure modes** — per-step what can go wrong + recovery (or "No destructive operations; failures are benign")
@@ -127,7 +127,11 @@ Every v2 SKILL.md body has these sections, in this order. Empty sections get exp
 8. **Status** — `active | pilot | deprecated | experimental | retired`
 9. **Related** — companion skills, reference docs, upstream issues
 
-All 9 headings are REQUIRED. "Required reading" is the v2-added section that directs the agent to Read the `required_reading:` frontmatter entries before acting.
+All 9 headings are REQUIRED, in this order. "Required reading" is the v2-added section that directs the agent to Read the `required_reading:` frontmatter entries before acting. Putting it at position 2 (before Usage) ensures the agent loads dependencies into context before reading invocation syntax.
+
+The `skill-audit` tool enforces both presence and order; out-of-order sections fail the audit as noncompliant.
+
+**Retroactive note (MAR 2026-04-19):** earlier drafts of this spec had Usage at position 2 and Required reading at position 3. The case-study skills all adopted the opposite order independently for pedagogical reasons (deps before syntax), and `skill-audit`'s REQUIRED_SECTIONS array matches the case-study order. The spec now matches the audit + case-study reality.
 
 ### 6. Naming — noun-verb, with noun-actor-verb for scoped skills
 

--- a/claude/REFERENCE-SKILLS-INDEX.md
+++ b/claude/REFERENCE-SKILLS-INDEX.md
@@ -1,0 +1,167 @@
+# Skills Index — the-agency framework registry
+
+Authoritative registry of skills in this the-agency install. Captures which skills exist, which `agency-skill-version` they conform to (v1 legacy vs v2), their scope, status, and key framework reference dependencies.
+
+**Kept in sync with reality via `skill-audit` (captain tool).** Drift between this document and the on-disk state of `.claude/skills/*/SKILL.md` is an error — audit reports it, author fixes it.
+
+**This is the definition source:** row here is what the framework considers the skill's canonical state. SKILL.md frontmatter ultimately provides the values, but the registry is the curated + audited view.
+
+## Reading this document
+
+- **Agency-Skill-Version** — `1` (legacy, pre-2026-04-19) or `2` (current methodology per `REFERENCE-SKILL-AUTHORING.md`).
+- **Scope** — `agent` (worktree-side), `captain` (main-checkout/master), `both` (invoked from either), `subagent` (only invoked by another skill via Agent/Skill delegation).
+- **Status** — `active` (shipped, in use), `pilot` (new, dogfooding), `experimental` (unstable), `deprecated` (use-but-will-retire), `retired` (do-not-use).
+- **Required Reading** — basenames of `claude/REFERENCE-*.md` the skill depends on (empty if none).
+
+Framework-level skills discovered by Claude Code live at `.claude/skills/<name>/`. Plugin-supplied skills (e.g., `hookify:*`, `feature-dev:*`) aren't tracked here unless adopted into the-agency framework.
+
+## Version overview
+
+| Version | Count | Meaning |
+|---|---|---|
+| `2` | 9 | Full v2 methodology — shipped as case studies 2026-04-19 |
+| `1` | ~54 | Legacy skills awaiting v2 upgrade |
+
+**Retrofit progress:** `9 / 63 ≈ 14.3%` at v2. Target: all framework-level active skills at v2 before end of the-agency#298 rollout.
+
+## Skills table
+
+Organized alphabetically by name.
+
+| Name | Description | Agency-Skill-Version | Scope | Status | Required Reading |
+|---|---|---|---|---|---|
+| agency-health | Fleet health check across workstream / agent / worktree dimensions | 1 | both | active | |
+| agency-issue | File, view, comment, close issues against the-agency framework on GitHub | 1 | both | active | FEEDBACK-FORMAT |
+| captain-log | Append to / read captain's narrative log | 1 | captain | active | |
+| captain-review | Review all draft PRs, generate dispatch reports for worktree agents | 1 | captain | active | CODE-REVIEW-LIFECYCLE |
+| changelog-watch | Monitor Claude Code changelog for new releases + features | 1 | both | active | |
+| code-review | Code-review current branch vs origin/master using 7 parallel review agents | 1 | both | active | QUALITY-GATE, CODE-REVIEW-LIFECYCLE |
+| collaborate | Cross-repo dispatch lifecycle (check / read / resolve / reply / push) | 1 | captain | active | ISCP-PROTOCOL |
+| coord-commit | Commit coordination artifacts (handoffs, dispatches, seeds, config) without QG | 1 | both | active | HANDOFF-SPEC, ISCP-PROTOCOL |
+| crawl-sites | Crawl and extract content from configured sites via provider engine | 1 | both | active | |
+| define | Drive toward complete PVR using 1B1 protocol with completeness checklist | 1 | agent | active | DEVELOPMENT-METHODOLOGY |
+| deploy | Deploy project via configured platform provider | 1 | both | active | |
+| design | Drive toward complete A&D using 1B1 protocol with completeness checklist | 1 | agent | active | DEVELOPMENT-METHODOLOGY |
+| diff-summary | Classify git diffs as formatting-only vs substantive | 1 | both | active | |
+| dispatch | Manage dispatches — list, read, fetch, reply, create, resolve | 1 | both | active | ISCP-PROTOCOL |
+| dispatch-read | Read a dispatch and mark it read — works from any branch or worktree | 1 | both | active | ISCP-PROTOCOL |
+| flag | Quick-capture observations to queue for later follow-up or 1B1 | 1 | both | active | ISCP-PROTOCOL |
+| flag-triage | Structured flag review — categorize, approve, dispose (3-bucket triage) | 1 | both | active | ISCP-PROTOCOL |
+| git-safe-commit | QG-aware commit wrapper — never raw `git commit` | 1 | both | active | SAFE-TOOLS, QUALITY-GATE |
+| handoff | Write session handoff using handoff tool — archive, write, verify | 1 | both | active | HANDOFF-SPEC |
+| iteration-complete | Run QG after completing an iteration — review, fix, test, report, auto-commit | 2 | agent | active | QUALITY-GATE, RECEIPT-INFRASTRUCTURE |
+| monitor-ci | Monitor GitHub Actions CI status via background streaming | 1 | both | active | |
+| monitor-dispatches | Event-driven dispatch monitoring via Monitor tool | 1 | both | active | ISCP-PROTOCOL |
+| phase-complete | Run full QG after completing a phase — review, fix, test, report, commit | 2 | agent | active | QUALITY-GATE, RECEIPT-INFRASTRUCTURE |
+| plan-complete | Complete a plan — final deep QG, finalize artifacts, produce reference doc | 1 | agent | active | QUALITY-GATE, DEVELOPMENT-METHODOLOGY |
+| pr-captain-post-merge | Captain-only. Post-PR-merge flow — verify merge, sync master, /sync-all, cut release, cleanup branch | 2 | captain | active | GIT-MERGE-NOT-REBASE, WORKTREE-DISCIPLINE, SAFE-TOOLS |
+| pr-captain-land | Captain lands agent's prepared branch — PR + CI + merge + release + notify | 2 | captain | pilot | QUALITY-GATE, WORKTREE-DISCIPLINE |
+| pr-captain-merge | Captain-only. Merge PR safely — true merge commit (never squash/rebase), --principal-approved gate | 2 | captain | active | GIT-MERGE-NOT-REBASE, SAFE-TOOLS, CODE-REVIEW-LIFECYCLE |
+| pr-prep | Run QG before creating PR — review, fix, test, report, produce QGR receipt | 1 | agent | active | QUALITY-GATE, CODE-REVIEW-LIFECYCLE |
+| pr-respond | Fetch PR review comments, compose threaded replies, resolve threads | 1 | agent | active | CODE-REVIEW-LIFECYCLE |
+| pr-submit | Agent signals captain that branch is ready for PR landing (Phase 1 pilot) | 2 | agent | pilot | WORKTREE-DISCIPLINE |
+| pre-phase-review | Review PVR, A&D, Plan before starting a new phase | 1 | agent | active | DEVELOPMENT-METHODOLOGY |
+| preview | Preview project via configured infrastructure provider | 1 | both | active | |
+| principal-create | Onboard a new principal — scaffold sandbox, register agent, write CLAUDE-PRINCIPAL.md, mutate agency.yaml | 1 | captain | active | AGENT-ADDRESSING, CONTRIBUTION-MODEL |
+| quality-gate | Run the QG — parallel agent review, fix cycle, test, report (composable) | 1 | both | active | QUALITY-GATE, RECEIPT-INFRASTRUCTURE |
+| rebase | DEPRECATED — use `git merge <target>` or `/sync` instead | 1 | both | deprecated | GIT-MERGE-NOT-REBASE |
+| captain-release | Captain-only. Quality-check, commit, push, create PR, cut release in one flow | 2 | captain | active | QUALITY-GATE, CODE-REVIEW-LIFECYCLE, GIT-MERGE-NOT-REBASE |
+| review-pr | Review a PR and post comments after approval (does NOT make code changes) | 1 | agent | active | CODE-REVIEW-LIFECYCLE |
+| run-in | Run command in target directory without touching parent shell CWD | 1 | both | active | SAFE-TOOLS |
+| sandbox-activate | Activate a sandbox item by symlinking to Claude Code discovery location | 1 | both | active | |
+| sandbox-adopt | Graduate sandbox experiment to shared team-wide tooling | 1 | both | active | |
+| sandbox-create | Create new experimental command, hook, rule, tool, or script in sandbox | 1 | both | active | |
+| sandbox-deactivate | Remove sandbox symlink to deactivate experimental item | 1 | both | active | |
+| sandbox-init | Set up a new engineer's sandbox workspace under usr/ | 1 | both | active | |
+| sandbox-list | Show all sandbox items across engineers with activation status | 1 | both | active | |
+| sandbox-status | Show all active sandbox symlinks and their health | 1 | both | active | |
+| sandbox-try | Try another engineer's sandbox experiment by symlinking locally | 1 | both | active | |
+| secret | Secret management — set, get, list, delete, rotate, scan via provider | 1 | both | active | |
+| service-add | Add a backend service (NestJS) to existing workstream via SPEC-PROVIDER starter pack | 1 | agent | active | |
+| session-compact | Mid-session context refresh — commit, write handoff, then compact | 1 | both | active | HANDOFF-SPEC |
+| session-end | End session cleanly — commit, write handoff, report readiness | 1 | both | active | HANDOFF-SPEC |
+| session-list | List past Claude Code sessions with metadata | 1 | both | active | |
+| session-read | Read a past session and produce a structured summary | 1 | both | active | |
+| session-resume | Full worktree session startup — sync, handoff, dispatches, report | 1 | both | active | HANDOFF-SPEC, ISCP-PROTOCOL |
+| sync | Merge target into current branch + push to origin (the ONLY command that pushes) | 2 | both | active | GIT-MERGE-NOT-REBASE, SAFE-TOOLS |
+| captain-sync-all | Captain-only. Fetch, merge origin into master, merge worktree work, sync all worktrees. NEVER pushes. | 2 | captain | active | GIT-MERGE-NOT-REBASE, WORKTREE-DISCIPLINE, SAFE-TOOLS |
+| transcript | Real-time conversation capture — records dialogue + decisions as they happen | 1 | both | active | |
+| ui-add | Add frontend app (Next.js) to existing workstream via SPEC-PROVIDER starter pack | 1 | agent | active | |
+| upstream-port | Port files from source repo to the-agency — auto path mapping, PR creation | 1 | captain | active | |
+| workstream-create | Create new workstream with scaffolded artifacts, agent registrations, optional worktree | 1 | captain | active | REPO-STRUCTURE |
+| worktree-create | Create new git worktree with dedicated branch + bootstrapped dev env | 1 | both | active | WORKTREE-DISCIPLINE |
+| worktree-delete | Remove a git worktree and optionally delete its branch | 1 | captain | active | WORKTREE-DISCIPLINE |
+| worktree-list | List all git worktrees with status info (branch, clean/dirty, deps) | 1 | both | active | WORKTREE-DISCIPLINE |
+| worktree-sync | Sync worktree with master — merge, copy settings, run sandbox-sync | 1 | agent | active | WORKTREE-DISCIPLINE |
+
+## Retrofit priorities
+
+### Tier 1 — destructive / captain-only
+
+These are the highest-priority refactors. Their behavior is destructive or captain-scoped, so the v2 discipline (disable-model-invocation, narrow allowed-tools, explicit captain-only scope) matters most.
+
+- [x] `pr-merge` → **`pr-captain-merge`** (Case study #3 — **LANDED 2026-04-19**)
+- [ ] `pr-create` → **`pr-captain-create`**
+- [x] `post-merge` → **`pr-captain-post-merge`** (Case study #4 — **LANDED 2026-04-19**)
+- [ ] `release` → **`captain-release`** (unclear if PR-specific or broader)
+- [ ] `sync-all` → **`captain-sync-all`**
+- [ ] `sync` → keep as-is (push-authorized discipline is in the skill body; name already conveys)
+- [ ] `workstream-create` → captain-scope review
+- [ ] `worktree-delete` → captain-scope review
+
+### Tier 2 — path-scoped agent skills
+
+Add `paths:` scoping to worktree-only skills.
+
+- [ ] `session-resume` (worktree-only)
+- [ ] `handoff` (worktree-authored)
+- [ ] `coord-commit` (worktree-authored)
+- [ ] `flag` (both but more commonly agent)
+- [ ] `dispatch-read` (both)
+- [ ] `pr-prep` (agent)
+- [ ] `pr-respond` (agent)
+- [ ] `pre-phase-review` (agent)
+- [ ] `plan-complete` (agent)
+
+### Tier 3 — protocol-heavy skills
+
+Benefit most from full `reference.md` extraction.
+
+- [ ] `quality-gate` (5-hash receipt protocol — huge extraction opportunity)
+- [ ] `dispatch` (ISCP protocol)
+- [ ] `collaborate` (cross-repo protocol)
+- [ ] `captain-review` (review flow)
+- [ ] `code-review` (7-reviewer protocol)
+
+### Tier 4 — rest
+
+Low-priority v2 upgrades. Frontmatter additions, body restructuring, registry row sync.
+
+- All remaining v1 skills from the table above.
+
+## Plugin-supplied skills (not tracked here)
+
+These are installed via Claude Code plugins, not authored by the-agency. We do not track them in this registry but list for awareness:
+
+- `hookify:*` (5 skills) — the hookify plugin
+- `feature-dev:*` (1 skill) — feature-dev plugin
+- Webflow skills (15 skills) — Webflow Claude.ai integration
+- Miscellaneous (update-config, simplify, fewer-permission-prompts, loop, schedule, claude-api, init, review, security-review, etc.) — Claude Code native or generic plugins
+
+If we ever absorb one of these into the-agency framework, it gets a row.
+
+## How to maintain this document
+
+**When creating a new skill:** `skill-create` tool adds the row automatically (once built). Until then, add manually.
+
+**When refactoring a skill v1 → v2:** update the `Agency-Skill-Version` column from `1` to `2`. Update `Required Reading` if frontmatter changed. Note in `Status` if pilot/experimental/active shifted.
+
+**When deprecating a skill:** set `Status` to `deprecated`. Retain row; do not delete. Add a note in the skill's `SKILL.md` pointing to the replacement.
+
+**When retiring a skill:** set `Status` to `retired`. Keep row for historical reference.
+
+**Automated verification:** `skill-audit` scans `.claude/skills/*/SKILL.md`, compares against this registry, reports drift. Run before commit if you touched any skill frontmatter.
+
+---
+
+*Initial bootstrap: 2026-04-19 (monofolk). Upstreamed to the-agency same day. Kept current as skills evolve.*

--- a/claude/REFERENCE-WHAT-IS-CLAUDE-CODE.md
+++ b/claude/REFERENCE-WHAT-IS-CLAUDE-CODE.md
@@ -1,0 +1,179 @@
+# What Is Claude Code — reference for agents and humans
+
+A grounding reference on Claude Code's architecture: what it is, what the primitives are, and how they compose. Load before reasoning about skills, CLAUDE.md, hooks, subagents, or tools. Particularly important for agents authoring or reviewing skill methodology (see `REFERENCE-SKILL-AUTHORING.md`).
+
+**Source consolidation:** compiled 2026-04-19 from Anthropic platform docs (platform.claude.com, code.claude.com, resources.anthropic.com), GitHub public repos (anthropics/claude-code, anthropics/skills), and community first-party writeups. Per-claim citations in the original research thread in `claude/workstreams/captain/transcripts/design-transcript-20260419.md`.
+
+## Core platform components
+
+### Claude Code (top-level agent)
+
+The main agent that sits between the user and their project. Reads code, plans edits, runs commands, orchestrates subagents. It's the "brain" that decides what tools to call, what subagents to spawn, and how to structure multi-step coding tasks. It is the thing YOU ARE (if you are a Claude Code agent reading this).
+
+### IDE / terminal UI
+
+The interface (VS Code, JetBrains, CLI, web, etc.) where the user types prompts and sees plan/code diffs. Ships user messages to the agent and renders results. Decision logic lives in the agent layer, not in the UI.
+
+### Tools (bash, read, edit/write, test, etc.)
+
+The concrete "hands" of the agent. Shell execution, file reading/writing, code search, git, and custom tools exposed via the Model Context Protocol (MCP). The agent uses these to observe, change, and validate the project.
+
+## Project-level configuration files
+
+### CLAUDE.md
+
+A markdown file in the project root that defines:
+
+- Coding standards, architecture, and design decisions.
+- Preferred libraries, frameworks, and file-layout patterns.
+- Review checklists, guardrails, "what not to do."
+
+**Scope:** Repo-wide, persistent.
+**Focus:**
+- **WHY** the project exists and **WHAT** it is (domain, business purpose, big picture).
+- **WHAT** the main pieces are (architecture, directories, services, data flows).
+- **HOW at a policy / convention level** — code style, patterns and anti-patterns, workflows, guardrails.
+
+**Role:** Shapes **how Claude thinks** about the project and what "good work" looks like. Auto-loaded at the start of each session; becomes part of the agent's system prompt for that repo.
+
+**Supports `@path/to/file.md` imports** — content is expanded inline at launch. (SKILL.md does NOT support this today; see `the-agency#306` for feature request.)
+
+**Summary:** *"The project's WHY + WHAT + high-level HOW, baked into the agent's identity for that repo."*
+
+### AGENTS.md (optional)
+
+An open standard agent-instructions file any agent can read. If `CLAUDE.md` is absent, Claude Code falls back to `AGENTS.md` as baseline project guide. Lets a project maintain Claude-specific rules (`CLAUDE.md`) while still sharing a common agent-instructions schema with other tools.
+
+## Agent, subagents, and delegation
+
+### Agent (lead / main agent)
+
+The primary Claude Code instance:
+- Maintains session-wide context and memory.
+- Plans the overall workflow (e.g., "modify X, add Y, run tests").
+
+### Subagents
+
+Lightweight, specialized Claude instances with:
+- Their own system prompts and scopes (e.g., security-only, testing-only, refactor-only).
+- Separate context windows to avoid polluting the main conversation.
+
+The main agent can delegate tasks to subagents and merge or summarize results back into the top-level plan. Use cases: security audits, test-generation, refactors you want to keep conceptually isolated. In the-agency framework, subagents are formalized as `reviewer-code`, `reviewer-security`, `reviewer-design`, `reviewer-test`, `reviewer-scorer` — invoked by the quality-gate skill.
+
+## Commands, skills, and automation
+
+### Slash commands (e.g., `/review-pr`, `/deploy-staging`)
+
+Shortcuts typed in the chat to invoke predefined workflows. Often tied to combinations of tools and hooks (run lint, run tests, deploy, post to Slack).
+
+### Skills
+
+A unified extensibility model that packages:
+- Logic for when and how to react to user messages.
+- Associated tools and MCP servers.
+- Auto-invocation conditions (e.g., skills that fire when files in a certain directory change, via `paths:` frontmatter).
+
+Skills are discovered and composed automatically when users ask a related question. They're how Claude "knows" which tools and patterns to pull in.
+
+**Skill bundle structure** (per Anthropic skill-building guide):
+```
+my-skill/
+├── SKILL.md           # required — overview + navigation + frontmatter
+├── reference.md       # detailed protocol — loaded when needed
+├── examples.md        # usage examples — loaded when needed
+├── scripts/           # executable code — invoked, not loaded
+└── assets/            # templates, static files
+```
+
+**Scope:** Per-task or per-workflow.
+**Focus:** Concrete **HOW-to-execute** sequences — run this tool in this order with this agent type, under these preconditions, producing this output.
+**Role:** Shapes **how Claude acts** to carry out tasks, often using the policies/context from `CLAUDE.md` as inputs.
+
+### Hooks
+
+Pre- or post-action scripts that run around tool invocations, edits, or session events:
+- Auto-format after every edit (`PostToolUse:Edit`)
+- Run linter or tests before committing (`PreToolUse:Bash`)
+- Check ISCP dispatches on session start (`SessionStart`)
+- Archive handoff before compact (`PreCompact`)
+
+Hooks weave project conventions into the agent's behavior without rewriting prompts. Hook types include `SessionStart`, `PreToolUse`, `PostToolUse`, `PreCompact`, and others.
+
+## How everything fits together
+
+### Startup
+
+- User opens a project; Claude Code session starts.
+- Claude reads `CLAUDE.md` (or `AGENTS.md`) into agent context, establishing project rules and structure.
+- `SessionStart` hooks fire (e.g., ISCP dispatch check, worktree sync, collaboration check).
+
+### Planning
+
+- User describes a task ("add a new endpoint").
+- Main agent plans the work, selects relevant tools, may spawn subagents for specialized concerns.
+
+### Execution
+
+- Agent executes tools (reads files, edits code, runs shell commands) and composes results.
+- Skills and hooks fire automatically or via slash commands to enforce linting, formatting, CI-style checks.
+
+### Feedback loop
+
+- Changes shown in IDE/terminal; user reviews, approves, or requests refinements.
+- Agent updates internal memory; over time learns common patterns beyond what's in `CLAUDE.md`.
+
+## Architecture layers (conceptual)
+
+| Layer | What lives there |
+|---|---|
+| **User** | User in IDE/terminal, sending prompts and commands |
+| **Agent** | Main agent + subagents planning and delegating |
+| **Tool** | bash, read/write, MCP tools, CI/CD integrations |
+| **Config** | `CLAUDE.md` / `AGENTS.md` as auto-loaded context; skills + hooks as reusable automation |
+
+## Mental model — CLAUDE.md vs commands/skills
+
+| | CLAUDE.md | Commands / Skills |
+|---|---|---|
+| **Scope** | Repo-wide, persistent | Per-task, per-workflow |
+| **Focus** | WHY + WHAT + guideline-level HOW | Concrete HOW-to-execute |
+| **Role** | Shapes how Claude **thinks** about the project | Shapes how Claude **acts** to carry out a task |
+| **Lifetime** | Loaded at session start, part of system prompt | Loaded on invocation, used for the task |
+
+`CLAUDE.md` tells the agent the repo's identity and conventions. Skills tell the agent how to execute specific procedures. Skills often reference or assume the conventions from `CLAUDE.md` as inputs.
+
+## How the-agency framework layers on top
+
+The-agency (and AIADLC methodology) extends Claude Code's primitives with framework-level conventions:
+
+- **Principals + agents + captains** — formalized roles on top of Claude Code's agent primitive. Principal is the human; captain is the coordinator agent; worktree agents are specialized by workstream.
+- **Skills as the interface** — every capability is a skill; agents use `/` autocomplete to discover.
+- **Hookify** — behavioral enforcement rules that block unsafe actions (raw `git commit`, force-push, compound bash).
+- **ISCP** — Inter-Session Communication Protocol (dispatches + flags) on top of file-based + SQLite-DB-based messaging.
+- **Reference docs** — `claude/REFERENCE-*.md` as framework-level knowledge the agent pulls on demand.
+- **Worktrees** — multi-agent per-workstream isolation, all sharing one `.git/`.
+- **Quality gate** — subagent-based parallel review before commits cross boundaries.
+
+See `claude/CLAUDE-THEAGENCY.md` for the-agency's own bootloader.
+
+## For agents reading this: what to do with it
+
+1. **On any skill authoring / review work**, treat this as required reading. `REFERENCE-SKILL-AUTHORING.md` references this doc.
+2. **When proposing new skills, commands, or hooks**, map your proposal to one of the layers above. If it doesn't fit cleanly, question whether the primitive is right.
+3. **When adopters ask "what does Claude Code do"**, point them here before the-agency-specific docs — this is the foundation.
+4. **When you're confused about CLAUDE.md vs skills vs hooks**, re-read the mental-model table. Most confusion is in that axis.
+
+## References
+
+- [Claude Code overview](https://code.claude.com/docs/en/overview)
+- [Platforms / IDEs](https://code.claude.com/docs/en/platforms)
+- [Skills documentation](https://code.claude.com/docs/en/skills)
+- [Memory / CLAUDE.md docs](https://code.claude.com/docs/en/memory.md)
+- [Best Practices](https://code.claude.com/docs/en/best-practices)
+- [The Complete Guide to Building Skills for Claude (PDF)](https://resources.anthropic.com/hubfs/The-Complete-Guide-to-Building-Skill-for-Claude.pdf)
+- [Skill-creator (first-party)](https://github.com/anthropics/skills/tree/main/skills/skill-creator)
+- [skills-cli on PyPI](https://pypi.org/project/skills-cli/)
+
+---
+
+*Captured during monofolk design session 2026-04-19. Upstreamed to the-agency. Keep current as Claude Code docs evolve.*

--- a/claude/tools/lint-embedded-python
+++ b/claude/tools/lint-embedded-python
@@ -1,0 +1,179 @@
+#!/bin/bash
+#
+# lint-embedded-python — Syntax-check Python heredocs embedded in bash scripts
+#
+# WHAT: Scans bash scripts for `python3 <<'PYEOF' ... PYEOF` and
+# `python3 -c '... '` blocks, extracts the Python source, and validates
+# it via `python3 -c "import ast; ast.parse(src)"`. Catches typos inside
+# embedded Python at commit time instead of at runtime.
+#
+# WHY: Finding #10 (T4 / the-agency#320 retro-MAR 2026-04-19) — ~100 lines
+# of Python embedded in bash tools (skill-audit, skill-create, skill-upgrade,
+# pr-captain-land) had no syntax-check at commit time. A typo inside a
+# heredoc was only surfaced at runtime, potentially in production.
+#
+# USAGE:
+#   lint-embedded-python [file1.sh file2.sh ...]
+#   lint-embedded-python --help
+#
+# With no args, lints a curated list of known-to-contain-Python tools.
+# With args, lints exactly those files.
+#
+# Designed to be hooked into pre-commit or CI.
+#
+# EXIT CODES:
+#   0 — all embedded Python parses cleanly
+#   1 — one or more syntax errors found
+#   2 — tool / invocation error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+
+if [[ "${1:-}" = "--help" || "${1:-}" = "-h" ]]; then
+  cat <<'EOF'
+Usage: lint-embedded-python [file1.sh file2.sh ...]
+
+Scans bash scripts for embedded Python (heredocs and `python3 -c` blocks)
+and syntax-checks them via `python3 -m py_compile` / ast.parse.
+
+With no args, lints a curated default list of known-containing tools:
+  - claude/tools/skill-audit
+  - claude/tools/skill-create
+  - claude/tools/skill-upgrade
+  - .claude/skills/pr-captain-land/scripts/pr-captain-land
+
+With args, lints exactly those files.
+
+Exit codes:
+  0 — all clean
+  1 — syntax error(s) found
+  2 — tool / invocation error
+
+Install to pre-commit via:
+  bash claude/tools/lint-embedded-python
+EOF
+  exit 0
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "lint-embedded-python: python3 not available; cannot validate" >&2
+  exit 2
+fi
+
+# Determine files to check
+declare -a FILES
+if [[ $# -gt 0 ]]; then
+  FILES=("$@")
+else
+  # Default list — known-containing tools
+  FILES=(
+    "$REPO_ROOT/claude/tools/skill-audit"
+    "$REPO_ROOT/claude/tools/skill-create"
+    "$REPO_ROOT/claude/tools/skill-upgrade"
+    "$REPO_ROOT/.claude/skills/pr-captain-land/scripts/pr-captain-land"
+  )
+fi
+
+TOTAL_BLOCKS=0
+TOTAL_ERRORS=0
+FAILED_FILES=()
+
+# For each file, extract embedded python via python3 itself (safer than
+# grep-and-split shell acrobatics — we already depend on python3, lean
+# into it).
+for FILE in "${FILES[@]}"; do
+  if [[ ! -f "$FILE" ]]; then
+    echo "lint-embedded-python: skipping missing file: $FILE" >&2
+    continue
+  fi
+
+  # Export path for the python extractor; it reads and finds Python blocks
+  result=$(FILE="$FILE" python3 <<'PYEOF'
+import os, sys, re, ast
+
+path = os.environ["FILE"]
+with open(path, "r", encoding="utf-8", errors="replace") as f:
+    src = f.read()
+
+blocks = []
+
+# Pattern 1: heredocs — <<'PYEOF' ... PYEOF (single-quoted delimiter means
+# no shell expansion; we need a matching terminator on its own line).
+# Support common delimiters: PYEOF, EOF, PYTHON, PY.
+heredoc_pat = re.compile(
+    r"<<[-]?[\t ]*[\'\"]?(PYEOF|PY|PYTHON|EOF)[\'\"]?\s*\n(.*?)\n[\t ]*\1\b",
+    re.DOTALL,
+)
+for m in heredoc_pat.finditer(src):
+    delim, body = m.group(1), m.group(2)
+    # Only treat as python if the body contains obvious python signals
+    if re.search(r"^(import |from |def |class |print\(|sys\.exit)", body, re.M):
+        blocks.append(("heredoc/"+delim, m.start(2), body))
+
+# Pattern 2: python3 -c '...' with single-quoted body.
+# Find `python3 -c '` and match to next `'` that is not escaped.
+# Bash single-quoted strings cannot contain escaped quotes — so the first `'`
+# always terminates. Works reliably here.
+inline_pat = re.compile(
+    r"python3\s+-c\s+\'(.*?)\'",
+    re.DOTALL,
+)
+for m in inline_pat.finditer(src):
+    body = m.group(1)
+    if re.search(r"(import |print\()", body):
+        blocks.append(("python3 -c", m.start(1), body))
+
+errors = []
+for kind, offset, body in blocks:
+    try:
+        ast.parse(body)
+    except SyntaxError as e:
+        # Convert offset to line number in the source file for reporting
+        line_before = src.count("\n", 0, offset) + 1
+        errors.append({
+            "kind": kind,
+            "file_line": line_before + (e.lineno or 1) - 1,
+            "file_line_block_start": line_before,
+            "msg": str(e.msg),
+            "block_line": e.lineno,
+            "offset": e.offset,
+        })
+
+print(f"{len(blocks)}|{len(errors)}")
+for e in errors:
+    print(f"  ERROR: {e['kind']} starting at line {e['file_line_block_start']}: "
+          f"{e['msg']} (block line {e['block_line']}, col {e['offset']})")
+PYEOF
+)
+  blocks_count=$(echo "$result" | head -n1 | cut -d'|' -f1)
+  errors_count=$(echo "$result" | head -n1 | cut -d'|' -f2)
+  TOTAL_BLOCKS=$((TOTAL_BLOCKS + blocks_count))
+  TOTAL_ERRORS=$((TOTAL_ERRORS + errors_count))
+
+  if [[ "$errors_count" -gt 0 ]]; then
+    echo "✗ $FILE — $errors_count error(s) in $blocks_count block(s)" >&2
+    echo "$result" | tail -n +2 >&2
+    FAILED_FILES+=("$FILE")
+  else
+    echo "✓ $FILE — $blocks_count embedded python block(s) clean"
+  fi
+done
+
+echo ""
+echo "── Summary ──"
+echo "  Files scanned:  ${#FILES[@]}"
+echo "  Python blocks:  $TOTAL_BLOCKS"
+echo "  Syntax errors:  $TOTAL_ERRORS"
+
+if [[ $TOTAL_ERRORS -gt 0 ]]; then
+  echo ""
+  echo "Failed files:"
+  for f in "${FAILED_FILES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi
+
+exit 0

--- a/claude/tools/skill-audit
+++ b/claude/tools/skill-audit
@@ -29,12 +29,22 @@
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
 SKILLS_DIR="$REPO_ROOT/.claude/skills"
 REGISTRY="$REPO_ROOT/claude/REFERENCE-SKILLS-INDEX.md"
+
+# the-agency#320 item 3: structured telemetry
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+  # shellcheck source=./lib/_log-helper
+  source "$SCRIPT_DIR/lib/_log-helper"
+else
+  # No-op shims if helper missing — keep tool functional without telemetry
+  log_start() { echo ""; }
+  log_end()   { :; }
+fi
 
 # Required body-structure section headings per REFERENCE-SKILL-AUTHORING.md §5
 REQUIRED_SECTIONS=(
@@ -112,12 +122,91 @@ fi
 
 # Extract a YAML frontmatter field value from a SKILL.md file.
 # Handles: scalar values, YAML lists (returns all list items, one per line).
-# Anchors field match to end-of-field (colon followed by space or EOL).
+#
+# the-agency#320 item 2: YAML-aware parsing (PyYAML / yq) preferred over awk.
+# Fallback: awk (safe when skill content is well-formed; hardened by Anthropic
+# `skills validate` which runs as outer gate when skills-cli is installed).
+#
+# Strategy: try python3+yaml first (ubiquitous on macOS + most Linuxes),
+# then yq, then awk. If first parser succeeds, we get real YAML semantics:
+# block scalars, flow-style nested mappings, duplicate-key handling (YAML
+# takes last; awk took first — consistent YAML behavior matters for audit).
 _get_frontmatter() {
   local file="$1" field="$2"
   if [[ ! -f "$file" ]]; then
     echo ""; return
   fi
+
+  # Try python3+yaml (preferred — pure YAML semantics)
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    FILE="$file" FIELD="$field" python3 -c '
+import os, sys, yaml
+path = os.environ["FILE"]
+field = os.environ["FIELD"]
+with open(path, "r", encoding="utf-8") as f:
+    txt = f.read()
+# Extract frontmatter between leading "---" and next "---"
+if not txt.startswith("---"):
+    sys.exit(0)
+end = txt.find("\n---", 3)
+if end < 0:
+    sys.exit(0)
+fm_src = txt[3:end].lstrip("\n")
+try:
+    fm = yaml.safe_load(fm_src) or {}
+except yaml.YAMLError:
+    sys.exit(0)
+if not isinstance(fm, dict) or field not in fm:
+    # Not declared — emit nothing so caller treats as missing
+    sys.exit(0)
+val = fm[field]
+if val is None:
+    # Declared but null — emit sentinel so caller distinguishes from missing
+    print("~")
+elif isinstance(val, list):
+    if len(val) == 0:
+        # Declared empty list — emit sentinel "[]" for parity with awk behavior
+        # (so audit sees "field declared" even when list is empty)
+        print("[]")
+    else:
+        for item in val:
+            print(item)
+elif isinstance(val, bool):
+    # YAML true/false as lowercase (awk emitted verbatim)
+    print("true" if val else "false")
+elif isinstance(val, (dict,)):
+    # Flow-style nested mapping — emit as YAML one-liner
+    print(yaml.safe_dump(val, default_flow_style=True).rstrip())
+else:
+    # Scalar (string/int/float). Empty string is declared-but-empty —
+    # emit sentinel "~" so shell caller sees non-empty.
+    if val == "":
+        print("~")
+    else:
+        print(val)
+' 2>/dev/null && return
+  fi
+
+  # Try yq (yq v4+)
+  if command -v yq >/dev/null 2>&1; then
+    # Extract frontmatter, then eval field. `yq` on plain YAML file only.
+    local tmp_fm
+    tmp_fm=$(mktemp)
+    awk '/^---$/ { if (++i == 1) next; else exit } i==1' "$file" > "$tmp_fm"
+    local out
+    if out=$(yq eval ".${field}" "$tmp_fm" 2>/dev/null); then
+      rm -f "$tmp_fm"
+      if [[ "$out" == "null" ]]; then
+        return
+      fi
+      # yq emits list items as "- item"; strip to match python3 output
+      echo "$out" | sed -E 's/^- //'
+      return
+    fi
+    rm -f "$tmp_fm"
+  fi
+
+  # Fallback: awk (v1 behavior — may disagree with real YAML on edge cases)
   awk -v field="$field" '
     BEGIN { in_fm=0; in_list=0 }
     /^---$/ { if (in_fm==0) { in_fm=1; next } else { exit } }
@@ -313,6 +402,9 @@ _audit_skill() {
 
 # ── Audit loop ───────────────────────────────────────────────────────────────
 
+# the-agency#320 item 3: structured run telemetry
+RUN_ID=$(log_start "skill-audit" "$@" 2>/dev/null || echo "")
+
 if [[ -n "$TARGET" ]]; then
   _audit_skill "$TARGET"
 else
@@ -372,9 +464,18 @@ fi
 
 # ── Exit code ────────────────────────────────────────────────────────────────
 
+_final_exit() {
+  local code="$1"
+  local summary="audited=$AUDIT_COUNT clean=$CLEAN_COUNT drift=$DRIFT_COUNT noncompliant=$NONCOMPLIANT_COUNT fixed=$FIXED_COUNT"
+  if [[ -n "$RUN_ID" ]]; then
+    log_end "$RUN_ID" "success" "$code" "0" "$summary" 2>/dev/null || :
+  fi
+  exit "$code"
+}
+
 if [[ "$NONCOMPLIANT_COUNT" -gt 0 ]]; then
-  exit 2
+  _final_exit 2
 elif [[ "$DRIFT_COUNT" -gt 0 ]]; then
-  exit 1
+  _final_exit 1
 fi
-exit 0
+_final_exit 0

--- a/claude/tools/skill-audit
+++ b/claude/tools/skill-audit
@@ -494,23 +494,62 @@ fi
 # ── Report ───────────────────────────────────────────────────────────────────
 
 if [[ "$JSON" = true ]]; then
-  printf '{\n'
-  printf '  "audited": %d,\n' "$AUDIT_COUNT"
-  printf '  "clean": %d,\n' "$CLEAN_COUNT"
-  printf '  "drift": %d,\n' "$DRIFT_COUNT"
-  printf '  "noncompliant": %d,\n' "$NONCOMPLIANT_COUNT"
-  printf '  "fixed": %d,\n' "$FIXED_COUNT"
-  printf '  "issues": ['
-  first=true
-  if [[ ${#ISSUES[@]} -gt 0 ]]; then
-    for issue in "${ISSUES[@]}"; do
-      if [[ "$first" = true ]]; then first=false; else printf ','; fi
-      escaped=$(printf '%s' "$issue" | sed 's/"/\\"/g')
-      printf '\n    "%s"' "$escaped"
-    done
+  # Finding #12 (T10 / retro-MAR 2026-04-19): emit JSON via python's json.dumps
+  # instead of hand-rolled printf. Prior implementation only escaped `"` via
+  # `sed 's/"/\\"/g'`, which broke on backslashes, control chars, multibyte
+  # characters, and newlines — producing invalid JSON when an issue string
+  # contained any of these (e.g., file paths on Windows, kebab names with
+  # unicode escapes, etc.). Proper JSON emitter ensures downstream consumers
+  # (`jq`, python `json.load`, any schema validator) parse successfully.
+  #
+  # Pass counts + issues via env vars (the ccf054ad-style env-var pattern,
+  # never f-string interpolation — the issue strings are agent-controlled
+  # data and must not flow through code interpolation).
+  if command -v python3 >/dev/null 2>&1; then
+    # Serialize issues array through a NUL-delimited stream to preserve any
+    # embedded chars safely (newlines, quotes, backslashes).
+    # Build the NUL stream once, pass via fd via process substitution.
+    _issues_nul=$(printf '%s\0' "${ISSUES[@]+"${ISSUES[@]}"}")
+    AUDITED="$AUDIT_COUNT" CLEAN="$CLEAN_COUNT" DRIFT="$DRIFT_COUNT" \
+    NONCOMPLIANT="$NONCOMPLIANT_COUNT" FIXED="$FIXED_COUNT" \
+    ISSUES_NUL="$_issues_nul" \
+    python3 -c '
+import os, sys, json
+issues_raw = os.environ.get("ISSUES_NUL", "")
+# NUL-delimited; filter empty trailing split
+issues = [s for s in issues_raw.split("\x00") if s]
+out = {
+    "audited": int(os.environ["AUDITED"]),
+    "clean": int(os.environ["CLEAN"]),
+    "drift": int(os.environ["DRIFT"]),
+    "noncompliant": int(os.environ["NONCOMPLIANT"]),
+    "fixed": int(os.environ["FIXED"]),
+    "issues": issues,
+}
+print(json.dumps(out, indent=2, ensure_ascii=False))
+'
+  else
+    # Fallback: legacy printf path for systems without python3 (rare; we
+    # require python3 for the frontmatter parser anyway, so this is safety
+    # net only). Known limitations documented in retro-MAR T10.
+    printf '{\n'
+    printf '  "audited": %d,\n' "$AUDIT_COUNT"
+    printf '  "clean": %d,\n' "$CLEAN_COUNT"
+    printf '  "drift": %d,\n' "$DRIFT_COUNT"
+    printf '  "noncompliant": %d,\n' "$NONCOMPLIANT_COUNT"
+    printf '  "fixed": %d,\n' "$FIXED_COUNT"
+    printf '  "issues": ['
+    first=true
+    if [[ ${#ISSUES[@]} -gt 0 ]]; then
+      for issue in "${ISSUES[@]}"; do
+        if [[ "$first" = true ]]; then first=false; else printf ','; fi
+        escaped=$(printf '%s' "$issue" | sed 's/"/\\"/g')
+        printf '\n    "%s"' "$escaped"
+      done
+    fi
+    printf '\n  ]\n'
+    printf '}\n'
   fi
-  printf '\n  ]\n'
-  printf '}\n'
 else
   # Always print fixes when --fix used, even in --quiet mode
   local_print=false

--- a/claude/tools/skill-audit
+++ b/claude/tools/skill-audit
@@ -327,8 +327,23 @@ _audit_skill() {
   for f in "${required_fields[@]}"; do
     local val
     val=$(_get_frontmatter "$skill_file" "$f")
+    # Finding #4 (code-9 / retro-MAR): reject sentinels "~" (declared null /
+    # declared empty string) and "[]" (declared empty list) for fields where
+    # empty is not meaningful content. Exception: `paths` can legitimately be
+    # `[]` for captain-only skills (four-layer defense — see D8).
     if [[ -z "$val" ]]; then
       ISSUES+=("$skill_name (v2): missing frontmatter field '$f'")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    elif [[ "$val" = "~" ]]; then
+      # Declared but null or empty-string — not acceptable for required content fields
+      ISSUES+=("$skill_name (v2): frontmatter field '$f' is empty/null (declared but no value)")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    elif [[ "$val" = "[]" && "$f" != "paths" ]]; then
+      # Empty list is only valid for `paths` (captain-only four-layer defense).
+      # All other list fields (required_reading) must have at least one entry.
+      ISSUES+=("$skill_name (v2): frontmatter field '$f' is an empty list (must have at least one entry)")
       NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
       issues_for_skill=$((issues_for_skill + 1))
     fi
@@ -341,6 +356,37 @@ _audit_skill() {
     ISSUES+=("$skill_name (v2): frontmatter name='$declared_name' doesn't match directory")
     NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
     issues_for_skill=$((issues_for_skill + 1))
+  fi
+
+  # 3b. Captain-only cross-field consistency (finding #9 / D8 from retro-MAR).
+  # Three distinct scoping patterns on v2 skills:
+  #
+  #   (a) Agent-scoped:       paths: .claude/worktrees/**, no DMI
+  #   (b) Default-actor safe: paths: [], DMI: true, no captain- prefix
+  #                           (e.g., `sync` — high-risk default-actor that
+  #                           needs explicit confirmation)
+  #   (c) Captain-only:       paths: [], DMI: true, captain- in name
+  #
+  # The rule we enforce: IF name contains `captain-`, THEN paths MUST be [] AND
+  # DMI MUST be true. Converse does NOT hold (sync is (b), not captain-only).
+  local dmi paths_val
+  dmi=$(_get_frontmatter "$skill_file" "disable-model-invocation")
+  paths_val=$(_get_frontmatter "$skill_file" "paths")
+  local has_dmi_true=false has_empty_paths=false has_captain_name=false
+  [[ "$dmi" = "true" || "$dmi" = "True" ]] && has_dmi_true=true
+  [[ "$paths_val" = "[]" ]] && has_empty_paths=true
+  [[ "$skill_name" =~ ^captain-|-captain- ]] && has_captain_name=true
+
+  if [[ "$has_captain_name" = true ]]; then
+    local missing_layers=""
+    [[ "$has_dmi_true" = false ]] && missing_layers="${missing_layers}disable-model-invocation:true, "
+    [[ "$has_empty_paths" = false ]] && missing_layers="${missing_layers}paths:[], "
+    missing_layers="${missing_layers%, }"
+    if [[ -n "$missing_layers" ]]; then
+      ISSUES+=("$skill_name (v2): captain-named skill missing defense layers: $missing_layers")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    fi
   fi
 
   # 4. required_reading paths resolve to real files
@@ -359,10 +405,12 @@ _audit_skill() {
     done <<< "$rr"
   fi
 
-  # 5. Body section headings (9 required per v2 spec)
+  # 5. Body section headings (9 required per v2 spec, IN ORDER)
   # Use anchored regex (-E + ^) to avoid matching H3 (### Foo) as H2 (## Foo).
   # Fix for H5 from MAR 2026-04-19 — grep -F substring match was too lenient.
+  # ORDER enforcement added per finding #7 (D1+D2 dedup) from retro-MAR.
   if [[ -f "$skill_file" ]]; then
+    # Presence check (existing behavior)
     for section in "${REQUIRED_SECTIONS[@]}"; do
       # Escape regex metacharacters in section name for safe grep -E.
       # Required sections use '##', '/', and spaces — / and space are literal in ERE.
@@ -377,6 +425,35 @@ _audit_skill() {
         fi
       fi
     done
+
+    # Order check — extract all H2 headings with line numbers, filter to
+    # required ones (accepting loose-match variants), assert sequence
+    # matches REQUIRED_SECTIONS order. Only runs if all required sections
+    # were present (order check on a file with missing sections is noisy).
+    local actual_order=""
+    actual_order=$(grep -En "^## " "$skill_file" 2>/dev/null | while IFS=: read -r ln heading; do
+      # Normalize: strip trailing "— notes" style suffixes for comparison
+      local base="${heading%% — *}"
+      for required in "${REQUIRED_SECTIONS[@]}"; do
+        if [[ "$base" == "$required" || "$heading" == "$required" ]]; then
+          echo "$required"
+          break
+        fi
+      done
+    done)
+
+    # Build expected sequence from REQUIRED_SECTIONS (array order)
+    local expected_seq=""
+    for s in "${REQUIRED_SECTIONS[@]}"; do
+      expected_seq="${expected_seq}${s}"$'\n'
+    done
+    expected_seq="${expected_seq%$'\n'}"
+
+    if [[ -n "$actual_order" && "$actual_order" != "$expected_seq" ]]; then
+      ISSUES+=("$skill_name (v2): body sections out of order (expected: Why → Required reading → Usage → Preconditions → Flow → Failure modes → NOT do → Status → Related)")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    fi
   fi
 
   # 6. Registry row

--- a/claude/tools/skill-audit
+++ b/claude/tools/skill-audit
@@ -1,0 +1,380 @@
+#!/bin/bash
+#
+# skill-audit — Audit framework skills for agency-skill-version 2 compliance
+#                + registry consistency
+#
+# WHAT: For each skill under .claude/skills/, checks:
+#   (a) structural validity (calls `skills validate` if skills-cli present)
+#   (b) agency-v2 compliance (required frontmatter fields, bundle files,
+#       body section headings)
+#   (c) required_reading paths resolve to real files
+#   (d) registry consistency — row in REFERENCE-SKILLS-INDEX.md exists and
+#       matches directory name
+#
+# WHY: the-agency#298 + #315 — automated audit of the v2 methodology rollout.
+# Manual drift detection doesn't scale past 60 skills.
+#
+# USAGE:
+#   skill-audit                    # audit all skills
+#   skill-audit <skill-name>       # audit one
+#   skill-audit --json             # machine-readable output
+#   skill-audit --fix              # auto-fix drift where safe
+#   skill-audit --quiet            # only print on issues
+#
+# EXIT CODES:
+#   0 — clean
+#   1 — drift (registry vs filesystem mismatch)
+#   2 — v2 non-compliance
+#   3 — tool error
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+SKILLS_DIR="$REPO_ROOT/.claude/skills"
+REGISTRY="$REPO_ROOT/claude/REFERENCE-SKILLS-INDEX.md"
+
+# Required body-structure section headings per REFERENCE-SKILL-AUTHORING.md §5
+REQUIRED_SECTIONS=(
+  "## Why this exists"
+  "## Required reading"
+  "## Usage"
+  "## Preconditions"
+  "## Flow / Steps"
+  "## Failure modes"
+  "## What this does NOT do"
+  "## Status"
+  "## Related"
+)
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+TARGET=""
+JSON=false
+FIX=false
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --json) JSON=true; shift ;;
+    --fix) FIX=true; shift ;;
+    --quiet|-q) QUIET=true; shift ;;
+    --version) echo "skill-audit $TOOL_VERSION"; exit 0 ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: skill-audit [<skill-name>] [--json] [--fix] [--quiet]
+
+Audit framework skills for agency-skill-version 2 compliance + registry
+consistency. Checks structure, v2 frontmatter, bundle completeness,
+required_reading paths, body sections, and registry drift.
+
+Exit codes:
+  0 — clean
+  1 — drift (registry <-> filesystem mismatch)
+  2 — v2 non-compliance
+  3 — tool error
+
+See claude/REFERENCE-SKILL-AUTHORING.md for the v2 spec.
+EOF
+      exit 0
+      ;;
+    -*) echo "skill-audit: unknown flag: $1" >&2; exit 2 ;;
+    *) TARGET="$1"; shift ;;
+  esac
+done
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+
+if [[ ! -d "$SKILLS_DIR" ]]; then
+  echo "skill-audit: skills directory not found at $SKILLS_DIR" >&2
+  exit 3
+fi
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "skill-audit: registry not found at $REGISTRY" >&2
+  exit 3
+fi
+
+# If TARGET specified, validate it exists as a directory
+if [[ -n "$TARGET" && ! -d "$SKILLS_DIR/$TARGET" ]]; then
+  echo "skill-audit: skill '$TARGET' not found at $SKILLS_DIR/$TARGET" >&2
+  exit 3
+fi
+
+SKILLS_VALIDATE_AVAILABLE=false
+if command -v skills &>/dev/null; then
+  SKILLS_VALIDATE_AVAILABLE=true
+fi
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Extract a YAML frontmatter field value from a SKILL.md file.
+# Handles: scalar values, YAML lists (returns all list items, one per line).
+# Anchors field match to end-of-field (colon followed by space or EOL).
+_get_frontmatter() {
+  local file="$1" field="$2"
+  if [[ ! -f "$file" ]]; then
+    echo ""; return
+  fi
+  awk -v field="$field" '
+    BEGIN { in_fm=0; in_list=0 }
+    /^---$/ { if (in_fm==0) { in_fm=1; next } else { exit } }
+    in_fm==1 {
+      # Match "field:" followed by space or end-of-line (not field_other:)
+      if ($0 ~ "^"field":([ \t]|$)") {
+        sub("^"field":[ \t]*", "", $0)
+        if ($0 == "") { in_list=1 } else { print $0; exit }
+      } else if (in_list==1) {
+        # List continuation: indented lines; stop on any top-level key
+        if ($0 ~ /^[ \t]/) {
+          print $0
+        } else {
+          in_list=0
+        }
+      }
+    }
+  ' "$file"
+}
+
+_get_version() {
+  _get_frontmatter "$1" "agency-skill-version" | tr -d ' '
+}
+
+# ── Audit state ──────────────────────────────────────────────────────────────
+
+AUDIT_COUNT=0
+CLEAN_COUNT=0
+DRIFT_COUNT=0
+NONCOMPLIANT_COUNT=0
+FIXED_COUNT=0
+
+ISSUES=()
+
+# ── Audit a single skill ─────────────────────────────────────────────────────
+
+_audit_skill() {
+  local skill_name="$1"
+  local skill_dir="$SKILLS_DIR/$skill_name"
+  local skill_file="$skill_dir/SKILL.md"
+  local version
+  local issues_for_skill=0
+
+  AUDIT_COUNT=$((AUDIT_COUNT + 1))
+
+  if [[ ! -f "$skill_file" ]]; then
+    ISSUES+=("$skill_name: missing SKILL.md")
+    NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+    return
+  fi
+
+  version=$(_get_version "$skill_file")
+
+  # v1 skills: only registry check applies
+  if [[ "$version" != "2" ]]; then
+    if ! grep -qF "| $skill_name " "$REGISTRY" 2>/dev/null; then
+      ISSUES+=("$skill_name (v${version:-1}): not in registry")
+      DRIFT_COUNT=$((DRIFT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    fi
+    if [[ $issues_for_skill -eq 0 ]]; then
+      CLEAN_COUNT=$((CLEAN_COUNT + 1))
+    fi
+    return
+  fi
+
+  # === v2 compliance ===
+
+  # 1. Bundle completeness (5 required paths)
+  local required_paths=(
+    "$skill_dir/SKILL.md"
+    "$skill_dir/reference.md"
+    "$skill_dir/examples.md"
+    "$skill_dir/scripts"
+    "$skill_dir/assets"
+  )
+  for p in "${required_paths[@]}"; do
+    if [[ ! -e "$p" ]]; then
+      local rel="${p#"$skill_dir/"}"
+      ISSUES+=("$skill_name (v2): missing $rel")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+      if [[ "$FIX" = true ]]; then
+        case "$rel" in
+          reference.md)
+            printf "# %s — unique protocol\n\nTODO: fill or note empty\n" "$skill_name" > "$p"
+            FIXED_COUNT=$((FIXED_COUNT + 1))
+            ;;
+          examples.md)
+            printf "# %s — examples\n\n## Happy-path\n\n## Edge-case\n\n## Integration\n" "$skill_name" > "$p"
+            FIXED_COUNT=$((FIXED_COUNT + 1))
+            ;;
+          scripts)
+            mkdir -p "$p"
+            printf "# scripts/\n\nTODO: describe or note empty\n" > "$p/README.md"
+            FIXED_COUNT=$((FIXED_COUNT + 1))
+            ;;
+          assets)
+            mkdir -p "$p"
+            printf "# assets/\n\nTODO: describe or note empty\n" > "$p/README.md"
+            FIXED_COUNT=$((FIXED_COUNT + 1))
+            ;;
+        esac
+      fi
+    fi
+  done
+
+  # 2. Required frontmatter fields
+  local required_fields=(
+    "name"
+    "description"
+    "agency-skill-version"
+    "when_to_use"
+    "argument-hint"
+    "paths"
+    "required_reading"
+  )
+  for f in "${required_fields[@]}"; do
+    local val
+    val=$(_get_frontmatter "$skill_file" "$f")
+    if [[ -z "$val" ]]; then
+      ISSUES+=("$skill_name (v2): missing frontmatter field '$f'")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    fi
+  done
+
+  # 3. Name matches dir
+  local declared_name
+  declared_name=$(_get_frontmatter "$skill_file" "name" | tr -d ' ')
+  if [[ "$declared_name" != "$skill_name" && -n "$declared_name" ]]; then
+    ISSUES+=("$skill_name (v2): frontmatter name='$declared_name' doesn't match directory")
+    NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+    issues_for_skill=$((issues_for_skill + 1))
+  fi
+
+  # 4. required_reading paths resolve to real files
+  local rr
+  rr=$(_get_frontmatter "$skill_file" "required_reading")
+  if [[ -n "$rr" ]]; then
+    while IFS= read -r rr_line; do
+      local rr_path
+      rr_path=$(echo "$rr_line" | sed 's/^[ \t]*-[ \t]*//')
+      [[ -z "$rr_path" || "$rr_path" =~ ^# ]] && continue
+      if [[ ! -f "$REPO_ROOT/$rr_path" ]]; then
+        ISSUES+=("$skill_name (v2): required_reading path not found: $rr_path")
+        NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+        issues_for_skill=$((issues_for_skill + 1))
+      fi
+    done <<< "$rr"
+  fi
+
+  # 5. Body section headings (9 required per v2 spec)
+  # Use anchored regex (-E + ^) to avoid matching H3 (### Foo) as H2 (## Foo).
+  # Fix for H5 from MAR 2026-04-19 — grep -F substring match was too lenient.
+  if [[ -f "$skill_file" ]]; then
+    for section in "${REQUIRED_SECTIONS[@]}"; do
+      # Escape regex metacharacters in section name for safe grep -E.
+      # Required sections use '##', '/', and spaces — / and space are literal in ERE.
+      local pattern="^${section//\//\\/}\$"
+      if ! grep -qE "$pattern" "$skill_file" 2>/dev/null; then
+        # Also accept the heading with trailing content (e.g., "## Usage — notes")
+        local pattern_loose="^${section//\//\\/}( |\$)"
+        if ! grep -qE "$pattern_loose" "$skill_file" 2>/dev/null; then
+          ISSUES+=("$skill_name (v2): missing body section '$section'")
+          NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+          issues_for_skill=$((issues_for_skill + 1))
+        fi
+      fi
+    done
+  fi
+
+  # 6. Registry row
+  if ! grep -qF "| $skill_name " "$REGISTRY" 2>/dev/null; then
+    ISSUES+=("$skill_name (v2): not in registry (claude/REFERENCE-SKILLS-INDEX.md)")
+    DRIFT_COUNT=$((DRIFT_COUNT + 1))
+    issues_for_skill=$((issues_for_skill + 1))
+  fi
+
+  # 7. Anthropic skills validate
+  if [[ "$SKILLS_VALIDATE_AVAILABLE" = true ]]; then
+    if ! skills validate "$skill_dir" &>/dev/null; then
+      ISSUES+=("$skill_name (v2): skills validate reports structural issue")
+      NONCOMPLIANT_COUNT=$((NONCOMPLIANT_COUNT + 1))
+      issues_for_skill=$((issues_for_skill + 1))
+    fi
+  fi
+
+  if [[ $issues_for_skill -eq 0 ]]; then
+    CLEAN_COUNT=$((CLEAN_COUNT + 1))
+  fi
+}
+
+# ── Audit loop ───────────────────────────────────────────────────────────────
+
+if [[ -n "$TARGET" ]]; then
+  _audit_skill "$TARGET"
+else
+  for d in "$SKILLS_DIR"/*/; do
+    [[ -d "$d" ]] || continue
+    _audit_skill "$(basename "$d")"
+  done
+fi
+
+# ── Report ───────────────────────────────────────────────────────────────────
+
+if [[ "$JSON" = true ]]; then
+  printf '{\n'
+  printf '  "audited": %d,\n' "$AUDIT_COUNT"
+  printf '  "clean": %d,\n' "$CLEAN_COUNT"
+  printf '  "drift": %d,\n' "$DRIFT_COUNT"
+  printf '  "noncompliant": %d,\n' "$NONCOMPLIANT_COUNT"
+  printf '  "fixed": %d,\n' "$FIXED_COUNT"
+  printf '  "issues": ['
+  first=true
+  if [[ ${#ISSUES[@]} -gt 0 ]]; then
+    for issue in "${ISSUES[@]}"; do
+      if [[ "$first" = true ]]; then first=false; else printf ','; fi
+      escaped=$(printf '%s' "$issue" | sed 's/"/\\"/g')
+      printf '\n    "%s"' "$escaped"
+    done
+  fi
+  printf '\n  ]\n'
+  printf '}\n'
+else
+  # Always print fixes when --fix used, even in --quiet mode
+  local_print=false
+  if [[ "$QUIET" = false ]] || [[ ${#ISSUES[@]} -gt 0 ]] || [[ "$FIX" = true && "$FIXED_COUNT" -gt 0 ]]; then
+    local_print=true
+  fi
+
+  if [[ "$local_print" = true ]]; then
+    echo ""
+    echo "Skill Audit — $AUDIT_COUNT skills audited"
+    echo "-----------------------------------------"
+    echo "  [ok]   Clean:         $CLEAN_COUNT"
+    echo "  [warn] Drift:         $DRIFT_COUNT"
+    echo "  [fail] Non-compliant: $NONCOMPLIANT_COUNT"
+    if [[ "$FIX" = true ]]; then
+      echo "  [fix]  Auto-fixed:    $FIXED_COUNT"
+    fi
+    echo ""
+    if [[ ${#ISSUES[@]} -gt 0 ]]; then
+      echo "Issues:"
+      for issue in "${ISSUES[@]}"; do
+        echo "  - $issue"
+      done
+      echo ""
+    fi
+  fi
+fi
+
+# ── Exit code ────────────────────────────────────────────────────────────────
+
+if [[ "$NONCOMPLIANT_COUNT" -gt 0 ]]; then
+  exit 2
+elif [[ "$DRIFT_COUNT" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/claude/tools/skill-create
+++ b/claude/tools/skill-create
@@ -213,6 +213,10 @@ if [[ "$UPGRADE_MODE" = true ]]; then
   echo "[skill-create --upgrade] Retrofitting $NAME to v2 compliance..."
 
   # Read existing frontmatter fields (best-effort via python3+yaml)
+  # Finding #2 (code-2 / the-agency#320 retro-MAR): emit str(val) unconditionally.
+  # Prior implementation `print(val if isinstance(val, str) else "")` returned
+  # empty for non-string scalars, so an `agency-skill-version: 2` (int) value
+  # read as "" and the EXISTING_VERSION v2-detect below always missed.
   _existing() {
     local field="$1"
     if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
@@ -232,7 +236,11 @@ except yaml.YAMLError:
 val = fm.get(os.environ["FIELD"])
 if val is None:
     sys.exit(0)
-print(val if isinstance(val, str) else "")
+# Emit as string for shell consumption; YAML ints + floats stringify cleanly.
+# Lists/dicts collapse to repr — callers of _existing today only ask for
+# scalar fields, so this is adequate. If a future caller wants list support,
+# use the python3+yaml path in skill-audit._get_frontmatter instead.
+print(val if not isinstance(val, (list, dict)) else "")
 ' 2>/dev/null
     fi
   }
@@ -269,6 +277,12 @@ print(val if isinstance(val, str) else "")
   # Preserves existing name/description/body content. Only adds TODO placeholders
   # for v2-required fields that don't exist.
   if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    # Finding #1 (code-1 / the-agency#320 retro-MAR): under `set -e`, python's
+    # non-zero exit killed the script BEFORE `UPGRADE_FM_EXIT=$?` ran, making
+    # the intended 3-way branching (0 ok / 4 hard fail / other warn+continue)
+    # dead code. Wrap with set +e so the exit-code inspection actually runs,
+    # then re-enable set -e afterwards.
+    set +e
     FILE="$SKILL_FILE" NAME="$NAME" python3 <<'PYEOF'
 import os, sys, yaml
 path = os.environ["FILE"]
@@ -334,6 +348,7 @@ with open(path, "w", encoding="utf-8") as f:
 print("[skill-create --upgrade] frontmatter updated (added missing v2 fields)")
 PYEOF
     UPGRADE_FM_EXIT=$?
+    set -e
     if [[ $UPGRADE_FM_EXIT -ne 0 && $UPGRADE_FM_EXIT -ne 4 ]]; then
       echo "[skill-create --upgrade] frontmatter update errored (exit $UPGRADE_FM_EXIT), continuing" >&2
     elif [[ $UPGRADE_FM_EXIT -eq 4 ]]; then

--- a/claude/tools/skill-create
+++ b/claude/tools/skill-create
@@ -154,11 +154,18 @@ fi
 
 # Cleanup trap — handles BOTH partial scaffold AND mktemp tmp file (H14 from MAR).
 # Single trap, composes both concerns so one doesn't overwrite the other.
+# CRITICAL: the scaffold-removal arm is create-mode ONLY. In upgrade mode
+# the skill already exists with real content — deleting it on any exit path
+# would destroy work. Upgrade mode flags $UPGRADE_MODE=true to gate the arm.
 SUCCESS_MARK=false
 TMP_REG=""
 _cleanup_all() {
     if [[ -n "$TMP_REG" ]] && [[ -f "$TMP_REG" ]]; then
         rm -f "$TMP_REG"
+    fi
+    # NEVER delete in upgrade mode — the skill pre-exists, deletion is destructive.
+    if [[ "$UPGRADE_MODE" = true ]]; then
+        return
     fi
     if [[ "$SUCCESS_MARK" != "true" ]] && [[ -d "$SKILLS_DIR/$NAME" ]]; then
         rm -rf "$SKILLS_DIR/$NAME"

--- a/claude/tools/skill-create
+++ b/claude/tools/skill-create
@@ -23,42 +23,65 @@
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
 SKILLS_DIR="$REPO_ROOT/.claude/skills"
 REGISTRY="$REPO_ROOT/claude/REFERENCE-SKILLS-INDEX.md"
+LOCK_FILE="$REPO_ROOT/.claude/skill-create.lock"
+
+# the-agency#320 item 3: structured telemetry
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+  # shellcheck source=./lib/_log-helper
+  source "$SCRIPT_DIR/lib/_log-helper"
+else
+  log_start() { echo ""; }
+  log_end()   { :; }
+fi
 
 # ── Args ─────────────────────────────────────────────────────────────────────
 
 NAME=""
 DESCRIPTION=""
 ACTOR="agent"
+UPGRADE_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --description) DESCRIPTION="$2"; shift 2 ;;
     --actor) ACTOR="$2"; shift 2 ;;
+    --upgrade) UPGRADE_MODE=true; shift ;;
     --version) echo "skill-create $TOOL_VERSION"; exit 0 ;;
     --help|-h)
       cat <<'EOF'
-Usage: skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
+Usage:
+  skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
+  skill-create --upgrade <name>
 
-Scaffolds an agency-skill-version 2 compliant skill bundle per
-claude/REFERENCE-SKILL-AUTHORING.md.
+Modes:
+  create (default)    — scaffold new v2-compliant skill bundle
+  --upgrade           — retrofit existing v1 skill to v2 (the-agency#320 item 1)
 
-Arguments:
+Create-mode arguments:
   <name>              Skill name (noun-verb or noun-actor-verb). Kebab-case.
   --description       One-line description. Must NOT contain newlines or
                       pipe characters (YAML/markdown-table safe).
   --actor             agent (default) | captain | both | subagent.
 
+Upgrade-mode arguments:
+  --upgrade <name>    Existing v1 skill name under .claude/skills/<name>.
+                      Scaffolds missing bundle files (reference.md, examples.md,
+                      scripts/README, assets/README), adds v2 required frontmatter
+                      fields with TODO placeholders (does NOT overwrite existing
+                      name/description/body content), bumps registry row to v2.
+
 Exit codes:
   0 — success
   1 — precondition failure
   2 — arg parse / input validation error
-  3 — skill already exists
+  3 — skill already exists (create) / skill doesn't exist (upgrade)
+  4 — upgrade would overwrite content (safety abort)
 EOF
       exit 0
       ;;
@@ -71,45 +94,62 @@ if [[ -z "$NAME" ]]; then
   echo "skill-create: <name> is required" >&2; exit 2
 fi
 
-if [[ -z "$DESCRIPTION" ]]; then
-  echo "skill-create: --description is required" >&2; exit 2
-fi
-
-case "$ACTOR" in
-  agent|captain|both|subagent) ;;
-  *) echo "skill-create: --actor must be agent, captain, both, or subagent" >&2; exit 2 ;;
-esac
-
 # Kebab-case validation for NAME (path-traversal + YAML-safety guard)
 if ! [[ "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
   echo "skill-create: name must be lowercase kebab-case (letters, numbers, hyphens)" >&2; exit 2
 fi
 
-# Description validation — must be single-line, no pipes
-# Prevents YAML frontmatter corruption (F1) and markdown-table injection (F2)
-if [[ "$DESCRIPTION" == *$'\n'* ]]; then
-  echo "skill-create: --description must be single-line (no newlines)" >&2; exit 2
-fi
-if [[ "$DESCRIPTION" == *"|"* ]]; then
-  echo "skill-create: --description must not contain '|' (breaks registry markdown table)" >&2; exit 2
-fi
+# Description is only required in create mode
+if [[ "$UPGRADE_MODE" = false ]]; then
+  if [[ -z "$DESCRIPTION" ]]; then
+    echo "skill-create: --description is required (create mode)" >&2; exit 2
+  fi
 
-# Sanitize quotes + backslashes for YAML safety — emit as YAML double-quoted scalar
-DESC_YAML=$(printf '%s' "$DESCRIPTION" | sed 's/\\/\\\\/g; s/"/\\"/g')
+  case "$ACTOR" in
+    agent|captain|both|subagent) ;;
+    *) echo "skill-create: --actor must be agent, captain, both, or subagent" >&2; exit 2 ;;
+  esac
+
+  # Description validation — must be single-line, no pipes
+  # Prevents YAML frontmatter corruption (F1) and markdown-table injection (F2)
+  if [[ "$DESCRIPTION" == *$'\n'* ]]; then
+    echo "skill-create: --description must be single-line (no newlines)" >&2; exit 2
+  fi
+  if [[ "$DESCRIPTION" == *"|"* ]]; then
+    echo "skill-create: --description must not contain '|' (breaks registry markdown table)" >&2; exit 2
+  fi
+
+  # Sanitize quotes + backslashes for YAML safety — emit as YAML double-quoted scalar
+  DESC_YAML=$(printf '%s' "$DESCRIPTION" | sed 's/\\/\\\\/g; s/"/\\"/g')
+fi
 
 # ── Preconditions ────────────────────────────────────────────────────────────
 
-if ! command -v skills &>/dev/null; then
-  echo "skill-create: skills-cli not found. Install with: uv tool install skills-cli" >&2
-  echo "  (see the-agency#307 — SessionStart dependency-install mechanism)" >&2
-  exit 1
-fi
-
 mkdir -p "$SKILLS_DIR"
 
-if [[ -d "$SKILLS_DIR/$NAME" ]]; then
-  echo "skill-create: skill '$NAME' already exists at $SKILLS_DIR/$NAME" >&2
-  exit 3
+# skills-cli is only needed in create mode (upgrade never calls `skills create`)
+if [[ "$UPGRADE_MODE" = false ]]; then
+  if ! command -v skills &>/dev/null; then
+    echo "skill-create: skills-cli not found. Install with: uv tool install skills-cli" >&2
+    echo "  (see the-agency#307 — SessionStart dependency-install mechanism)" >&2
+    exit 1
+  fi
+
+  if [[ -d "$SKILLS_DIR/$NAME" ]]; then
+    echo "skill-create: skill '$NAME' already exists at $SKILLS_DIR/$NAME" >&2
+    echo "  Hint: use --upgrade <name> to retrofit an existing v1 skill to v2." >&2
+    exit 3
+  fi
+else
+  # Upgrade mode: skill must EXIST
+  if [[ ! -d "$SKILLS_DIR/$NAME" ]]; then
+    echo "skill-create --upgrade: skill '$NAME' not found at $SKILLS_DIR/$NAME" >&2
+    exit 3
+  fi
+  if [[ ! -f "$SKILLS_DIR/$NAME/SKILL.md" ]]; then
+    echo "skill-create --upgrade: SKILL.md missing at $SKILLS_DIR/$NAME/SKILL.md" >&2
+    exit 3
+  fi
 fi
 
 # Cleanup trap — handles BOTH partial scaffold AND mktemp tmp file (H14 from MAR).
@@ -131,6 +171,208 @@ if [[ ! -f "$REGISTRY" ]]; then
   echo "skill-create: registry not found at $REGISTRY" >&2
   echo "  Expected claude/REFERENCE-SKILLS-INDEX.md to exist. Run bootstrap first." >&2
   exit 1
+fi
+
+# the-agency#320 item 3: structured run telemetry
+RUN_ID=$(log_start "skill-create" "$@" 2>/dev/null || echo "")
+
+# the-agency#320 item 4: serialize registry writes (concurrent-append safety)
+# Open fd 9 for the lockfile. `flock -x 9` acquires exclusive lock; releases
+# on script exit (fd closed). Safe across multiple skill-create invocations.
+# Works on macOS (util-linux flock or brew-installed flock) and Linux.
+_registry_lock() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE" || return 1
+    flock -x -w 30 9 || {
+      echo "skill-create: could not acquire registry lock after 30s" >&2
+      return 1
+    }
+  fi
+  # If no flock available, fall through without locking (single-writer assumption).
+  return 0
+}
+
+_registry_unlock() {
+  if command -v flock >/dev/null 2>&1; then
+    flock -u 9 2>/dev/null || :
+    exec 9>&- 2>/dev/null || :
+  fi
+}
+
+# ── Upgrade mode (the-agency#320 item 1) ────────────────────────────────────
+
+if [[ "$UPGRADE_MODE" = true ]]; then
+  SKILL_FILE="$SKILLS_DIR/$NAME/SKILL.md"
+  echo "[skill-create --upgrade] Retrofitting $NAME to v2 compliance..."
+
+  # Read existing frontmatter fields (best-effort via python3+yaml)
+  _existing() {
+    local field="$1"
+    if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+      FILE="$SKILL_FILE" FIELD="$field" python3 -c '
+import os, sys, yaml
+with open(os.environ["FILE"], "r", encoding="utf-8") as f:
+    txt = f.read()
+if not txt.startswith("---"):
+    sys.exit(0)
+end = txt.find("\n---", 3)
+if end < 0:
+    sys.exit(0)
+try:
+    fm = yaml.safe_load(txt[3:end].lstrip("\n")) or {}
+except yaml.YAMLError:
+    sys.exit(0)
+val = fm.get(os.environ["FIELD"])
+if val is None:
+    sys.exit(0)
+print(val if isinstance(val, str) else "")
+' 2>/dev/null
+    fi
+  }
+
+  EXISTING_VERSION=$(_existing "agency-skill-version")
+  if [[ "$EXISTING_VERSION" = "2" ]]; then
+    echo "[skill-create --upgrade] $NAME is already agency-skill-version 2. No frontmatter changes needed."
+  fi
+
+  # Create missing bundle files (safe — only writes if absent)
+  mkdir -p "$SKILLS_DIR/$NAME/scripts" "$SKILLS_DIR/$NAME/assets"
+
+  if [[ ! -f "$SKILLS_DIR/$NAME/reference.md" ]]; then
+    printf "# %s — unique protocol\n\nTODO: fill with protocol unique to this skill, or note: \"This skill has no unique protocol. See required_reading in SKILL.md for all behavior specifications.\"\n" "$NAME" > "$SKILLS_DIR/$NAME/reference.md"
+    echo "[skill-create --upgrade] created reference.md"
+  fi
+
+  if [[ ! -f "$SKILLS_DIR/$NAME/examples.md" ]]; then
+    printf "# %s — examples\n\n## Happy-path examples\n\nTODO: typical invocations with expected output\n\n## Edge-case examples\n\nTODO: preconditions failing, what error looks like\n\n## Integration examples\n\nTODO: how this skill fits with other skills; composability\n" "$NAME" > "$SKILLS_DIR/$NAME/examples.md"
+    echo "[skill-create --upgrade] created examples.md"
+  fi
+
+  if [[ ! -f "$SKILLS_DIR/$NAME/scripts/README.md" ]]; then
+    printf "# scripts/\n\nTODO: describe what scripts live here and why. If empty by design, explain: \"Empty by design. This skill is pure orchestration — no skill-specific scripts needed.\"\n" > "$SKILLS_DIR/$NAME/scripts/README.md"
+    echo "[skill-create --upgrade] created scripts/README.md"
+  fi
+
+  if [[ ! -f "$SKILLS_DIR/$NAME/assets/README.md" ]]; then
+    printf "# assets/\n\nTODO: describe templates/static files here. If empty by design, explain: \"Empty by design. This skill has no user-facing templates or static assets.\"\n" > "$SKILLS_DIR/$NAME/assets/README.md"
+    echo "[skill-create --upgrade] created assets/README.md"
+  fi
+
+  # Add v2 frontmatter fields if missing (use python3+yaml for safety).
+  # Preserves existing name/description/body content. Only adds TODO placeholders
+  # for v2-required fields that don't exist.
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    FILE="$SKILL_FILE" NAME="$NAME" python3 <<'PYEOF'
+import os, sys, yaml
+path = os.environ["FILE"]
+skill_name = os.environ["NAME"]
+with open(path, "r", encoding="utf-8") as f:
+    txt = f.read()
+if not txt.startswith("---"):
+    print("skill-create --upgrade: SKILL.md missing frontmatter — cannot safely add v2 fields", file=sys.stderr)
+    sys.exit(4)
+end = txt.find("\n---", 3)
+if end < 0:
+    print("skill-create --upgrade: SKILL.md frontmatter not terminated", file=sys.stderr)
+    sys.exit(4)
+fm_src = txt[3:end].lstrip("\n")
+rest = txt[end+4:]  # after "\n---"
+try:
+    fm = yaml.safe_load(fm_src) or {}
+except yaml.YAMLError as e:
+    print(f"skill-create --upgrade: SKILL.md frontmatter parse error: {e}", file=sys.stderr)
+    sys.exit(4)
+if not isinstance(fm, dict):
+    print("skill-create --upgrade: SKILL.md frontmatter not a mapping", file=sys.stderr)
+    sys.exit(4)
+
+changed = False
+# Add missing v2 fields with TODO placeholders
+if "agency-skill-version" not in fm:
+    fm["agency-skill-version"] = 2; changed = True
+if "when_to_use" not in fm:
+    fm["when_to_use"] = "TODO: explicit trigger phrases + anti-trigger phrases"; changed = True
+if "argument-hint" not in fm:
+    fm["argument-hint"] = "TODO: <arg1> [--flag value]"; changed = True
+if "paths" not in fm:
+    fm["paths"] = ["TODO: .claude/worktrees/** (agent) or [] (captain/subagent)"]; changed = True
+if "required_reading" not in fm:
+    fm["required_reading"] = ["claude/REFERENCE-SKILL-AUTHORING.md"]; changed = True
+
+if not changed:
+    sys.exit(0)
+
+# Re-emit frontmatter preserving key order
+out = "---\n"
+# Preserve order-of-importance: name, description, version, trigger, args, paths, disable, required_reading, rest
+order = [
+    "name", "description", "agency-skill-version", "when_to_use",
+    "argument-hint", "paths", "disable-model-invocation", "required_reading",
+]
+seen = set()
+for k in order:
+    if k in fm:
+        out += yaml.safe_dump({k: fm[k]}, default_flow_style=False, sort_keys=False)
+        seen.add(k)
+# Remaining keys in original order
+for k, v in fm.items():
+    if k not in seen:
+        out += yaml.safe_dump({k: v}, default_flow_style=False, sort_keys=False)
+        seen.add(k)
+out += "---\n"
+out += rest if rest.startswith("\n") else "\n" + rest
+
+with open(path, "w", encoding="utf-8") as f:
+    f.write(out)
+print("[skill-create --upgrade] frontmatter updated (added missing v2 fields)")
+PYEOF
+    UPGRADE_FM_EXIT=$?
+    if [[ $UPGRADE_FM_EXIT -ne 0 && $UPGRADE_FM_EXIT -ne 4 ]]; then
+      echo "[skill-create --upgrade] frontmatter update errored (exit $UPGRADE_FM_EXIT), continuing" >&2
+    elif [[ $UPGRADE_FM_EXIT -eq 4 ]]; then
+      exit 4
+    fi
+  else
+    echo "[skill-create --upgrade] python3+yaml not available; frontmatter fields NOT added automatically" >&2
+    echo "  Manual step: add agency-skill-version: 2, when_to_use, argument-hint, paths, required_reading" >&2
+  fi
+
+  # Update registry row — bump version to 2 if row exists, append if missing
+  _registry_lock || exit 1
+  if grep -qE "^\| $NAME " "$REGISTRY" 2>/dev/null; then
+    # Replace the version column in the existing row (assuming 3rd column)
+    tmp=$(mktemp)
+    awk -v skill="$NAME" 'BEGIN{FS=OFS="|"} {
+      if ($2 ~ "^ "skill" $") { $4 = " 2 " }
+      print
+    }' "$REGISTRY" > "$tmp" && mv "$tmp" "$REGISTRY"
+    echo "[skill-create --upgrade] Registry row version bumped to 2."
+  else
+    echo "[skill-create --upgrade] Registry row for '$NAME' not found; run skill-audit to surface drift." >&2
+  fi
+  _registry_unlock
+
+  # Run audit to report remaining gaps
+  if [[ -x "$SCRIPT_DIR/skill-audit" ]]; then
+    echo ""
+    echo "[skill-create --upgrade] Running skill-audit for $NAME..."
+    "$SCRIPT_DIR/skill-audit" "$NAME" || true
+  fi
+
+  echo ""
+  echo "[ok] skill '$NAME' upgraded to v2 scaffolding."
+  echo ""
+  echo "Author checklist:"
+  echo "  [ ] Review SKILL.md frontmatter — replace TODO placeholders with real content"
+  echo "  [ ] Ensure body has the 9 required sections (see REFERENCE-SKILL-AUTHORING.md §5)"
+  echo "  [ ] Fill reference.md / examples.md / scripts+assets/README.md as appropriate"
+  echo "  [ ] Run skill-audit to confirm 0 non-compliance"
+  echo "  [ ] Commit via /git-safe-commit"
+
+  if [[ -n "$RUN_ID" ]]; then
+    log_end "$RUN_ID" "success" "0" "0" "upgraded $NAME" 2>/dev/null || :
+  fi
+  exit 0
 fi
 
 # ── Determine scoping based on actor ─────────────────────────────────────────
@@ -301,6 +543,9 @@ NEW_ROW="| $NAME | $SUMMARY | 2 | $REGISTRY_SCOPE | pilot | SKILL-AUTHORING |"
 TMP_REG=$(mktemp)
 # Note: TMP_REG cleanup is handled by the composed _cleanup_all trap set above.
 
+# the-agency#320 item 4: serialize registry writes
+_registry_lock || exit 1
+
 INSERTED=false
 while IFS= read -r line; do
   if [[ "$INSERTED" = false && "$line" == "## Retrofit priorities" ]]; then
@@ -321,6 +566,8 @@ else
   TMP_REG=""
   echo "[skill-create] Registry row appended at EOF (anchor section heading missing — review placement)."
 fi
+
+_registry_unlock
 
 # Mark full success — _cleanup_all trap will skip the partial-scaffold removal.
 SUCCESS_MARK=true
@@ -360,5 +607,9 @@ Next steps (author checklist):
   [ ] If pilot, dogfood once before promoting Status to 'active'.
 
 EOF
+
+if [[ -n "$RUN_ID" ]]; then
+  log_end "$RUN_ID" "success" "0" "0" "created $NAME actor=$ACTOR" 2>/dev/null || :
+fi
 
 exit 0

--- a/claude/tools/skill-create
+++ b/claude/tools/skill-create
@@ -45,43 +45,54 @@ fi
 NAME=""
 DESCRIPTION=""
 ACTOR="agent"
-UPGRADE_MODE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --description) DESCRIPTION="$2"; shift 2 ;;
     --actor) ACTOR="$2"; shift 2 ;;
-    --upgrade) UPGRADE_MODE=true; shift ;;
+    --upgrade)
+      # the-agency#320 finding D5 (retro-MAR 2026-04-19): --upgrade was split
+      # into a separate tool `skill-upgrade` per subcommand convention.
+      # Deprecated: redirect to `skill-upgrade` and warn.
+      echo "skill-create: --upgrade flag is DEPRECATED — use \`skill-upgrade <name>\` instead." >&2
+      echo "  Redirecting to skill-upgrade (this compatibility shim will be removed in v2.0)..." >&2
+      shift
+      # Remaining positional arg (if any) becomes the upgrade target
+      if [[ $# -eq 0 ]]; then
+        echo "skill-create --upgrade: <name> is required" >&2
+        exit 2
+      fi
+      UPGRADE_TARGET="$1"; shift
+      exec "$SCRIPT_DIR/skill-upgrade" "$UPGRADE_TARGET" "$@"
+      ;;
     --version) echo "skill-create $TOOL_VERSION"; exit 0 ;;
     --help|-h)
       cat <<'EOF'
-Usage:
-  skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
-  skill-create --upgrade <name>
+Usage: skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
 
-Modes:
-  create (default)    — scaffold new v2-compliant skill bundle
-  --upgrade           — retrofit existing v1 skill to v2 (the-agency#320 item 1)
+Scaffolds a new v2-compliant skill bundle:
+  - .claude/skills/<name>/SKILL.md (with v2 frontmatter + 9-section body template)
+  - .claude/skills/<name>/reference.md (unique-protocol stub)
+  - .claude/skills/<name>/examples.md (happy-path + edge-case + integration stubs)
+  - .claude/skills/<name>/scripts/README.md
+  - .claude/skills/<name>/assets/README.md
+  - Registry row appended to claude/REFERENCE-SKILLS-INDEX.md (serialized via flock)
 
-Create-mode arguments:
+Arguments:
   <name>              Skill name (noun-verb or noun-actor-verb). Kebab-case.
   --description       One-line description. Must NOT contain newlines or
                       pipe characters (YAML/markdown-table safe).
   --actor             agent (default) | captain | both | subagent.
 
-Upgrade-mode arguments:
-  --upgrade <name>    Existing v1 skill name under .claude/skills/<name>.
-                      Scaffolds missing bundle files (reference.md, examples.md,
-                      scripts/README, assets/README), adds v2 required frontmatter
-                      fields with TODO placeholders (does NOT overwrite existing
-                      name/description/body content), bumps registry row to v2.
+To retrofit an existing v1 skill to v2, use `skill-upgrade <name>`.
 
 Exit codes:
   0 — success
   1 — precondition failure
   2 — arg parse / input validation error
-  3 — skill already exists (create) / skill doesn't exist (upgrade)
-  4 — upgrade would overwrite content (safety abort)
+  3 — skill already exists
+
+See claude/REFERENCE-SKILL-AUTHORING.md for the v2 spec.
 EOF
       exit 0
       ;;
@@ -99,73 +110,52 @@ if ! [[ "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
   echo "skill-create: name must be lowercase kebab-case (letters, numbers, hyphens)" >&2; exit 2
 fi
 
-# Description is only required in create mode
-if [[ "$UPGRADE_MODE" = false ]]; then
-  if [[ -z "$DESCRIPTION" ]]; then
-    echo "skill-create: --description is required (create mode)" >&2; exit 2
-  fi
-
-  case "$ACTOR" in
-    agent|captain|both|subagent) ;;
-    *) echo "skill-create: --actor must be agent, captain, both, or subagent" >&2; exit 2 ;;
-  esac
-
-  # Description validation — must be single-line, no pipes
-  # Prevents YAML frontmatter corruption (F1) and markdown-table injection (F2)
-  if [[ "$DESCRIPTION" == *$'\n'* ]]; then
-    echo "skill-create: --description must be single-line (no newlines)" >&2; exit 2
-  fi
-  if [[ "$DESCRIPTION" == *"|"* ]]; then
-    echo "skill-create: --description must not contain '|' (breaks registry markdown table)" >&2; exit 2
-  fi
-
-  # Sanitize quotes + backslashes for YAML safety — emit as YAML double-quoted scalar
-  DESC_YAML=$(printf '%s' "$DESCRIPTION" | sed 's/\\/\\\\/g; s/"/\\"/g')
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "skill-create: --description is required" >&2; exit 2
 fi
+
+case "$ACTOR" in
+  agent|captain|both|subagent) ;;
+  *) echo "skill-create: --actor must be agent, captain, both, or subagent" >&2; exit 2 ;;
+esac
+
+# Description validation — must be single-line, no pipes
+# Prevents YAML frontmatter corruption (F1) and markdown-table injection (F2)
+if [[ "$DESCRIPTION" == *$'\n'* ]]; then
+  echo "skill-create: --description must be single-line (no newlines)" >&2; exit 2
+fi
+if [[ "$DESCRIPTION" == *"|"* ]]; then
+  echo "skill-create: --description must not contain '|' (breaks registry markdown table)" >&2; exit 2
+fi
+
+# Sanitize quotes + backslashes for YAML safety — emit as YAML double-quoted scalar
+DESC_YAML=$(printf '%s' "$DESCRIPTION" | sed 's/\\/\\\\/g; s/"/\\"/g')
 
 # ── Preconditions ────────────────────────────────────────────────────────────
 
 mkdir -p "$SKILLS_DIR"
 
-# skills-cli is only needed in create mode (upgrade never calls `skills create`)
-if [[ "$UPGRADE_MODE" = false ]]; then
-  if ! command -v skills &>/dev/null; then
-    echo "skill-create: skills-cli not found. Install with: uv tool install skills-cli" >&2
-    echo "  (see the-agency#307 — SessionStart dependency-install mechanism)" >&2
-    exit 1
-  fi
+if ! command -v skills &>/dev/null; then
+  echo "skill-create: skills-cli not found. Install with: uv tool install skills-cli" >&2
+  echo "  (see the-agency#307 — SessionStart dependency-install mechanism)" >&2
+  exit 1
+fi
 
-  if [[ -d "$SKILLS_DIR/$NAME" ]]; then
-    echo "skill-create: skill '$NAME' already exists at $SKILLS_DIR/$NAME" >&2
-    echo "  Hint: use --upgrade <name> to retrofit an existing v1 skill to v2." >&2
-    exit 3
-  fi
-else
-  # Upgrade mode: skill must EXIST
-  if [[ ! -d "$SKILLS_DIR/$NAME" ]]; then
-    echo "skill-create --upgrade: skill '$NAME' not found at $SKILLS_DIR/$NAME" >&2
-    exit 3
-  fi
-  if [[ ! -f "$SKILLS_DIR/$NAME/SKILL.md" ]]; then
-    echo "skill-create --upgrade: SKILL.md missing at $SKILLS_DIR/$NAME/SKILL.md" >&2
-    exit 3
-  fi
+if [[ -d "$SKILLS_DIR/$NAME" ]]; then
+  echo "skill-create: skill '$NAME' already exists at $SKILLS_DIR/$NAME" >&2
+  echo "  Hint: use \`skill-upgrade $NAME\` to retrofit an existing v1 skill to v2." >&2
+  exit 3
 fi
 
 # Cleanup trap — handles BOTH partial scaffold AND mktemp tmp file (H14 from MAR).
 # Single trap, composes both concerns so one doesn't overwrite the other.
-# CRITICAL: the scaffold-removal arm is create-mode ONLY. In upgrade mode
-# the skill already exists with real content — deleting it on any exit path
-# would destroy work. Upgrade mode flags $UPGRADE_MODE=true to gate the arm.
+# Create-mode only. Upgrade-mode lives in the separate `skill-upgrade` tool
+# (split per the-agency#320 D5 / retro-MAR 2026-04-19).
 SUCCESS_MARK=false
 TMP_REG=""
 _cleanup_all() {
     if [[ -n "$TMP_REG" ]] && [[ -f "$TMP_REG" ]]; then
         rm -f "$TMP_REG"
-    fi
-    # NEVER delete in upgrade mode — the skill pre-exists, deletion is destructive.
-    if [[ "$UPGRADE_MODE" = true ]]; then
-        return
     fi
     if [[ "$SUCCESS_MARK" != "true" ]] && [[ -d "$SKILLS_DIR/$NAME" ]]; then
         rm -rf "$SKILLS_DIR/$NAME"
@@ -205,197 +195,6 @@ _registry_unlock() {
     exec 9>&- 2>/dev/null || :
   fi
 }
-
-# ── Upgrade mode (the-agency#320 item 1) ────────────────────────────────────
-
-if [[ "$UPGRADE_MODE" = true ]]; then
-  SKILL_FILE="$SKILLS_DIR/$NAME/SKILL.md"
-  echo "[skill-create --upgrade] Retrofitting $NAME to v2 compliance..."
-
-  # Read existing frontmatter fields (best-effort via python3+yaml)
-  # Finding #2 (code-2 / the-agency#320 retro-MAR): emit str(val) unconditionally.
-  # Prior implementation `print(val if isinstance(val, str) else "")` returned
-  # empty for non-string scalars, so an `agency-skill-version: 2` (int) value
-  # read as "" and the EXISTING_VERSION v2-detect below always missed.
-  _existing() {
-    local field="$1"
-    if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
-      FILE="$SKILL_FILE" FIELD="$field" python3 -c '
-import os, sys, yaml
-with open(os.environ["FILE"], "r", encoding="utf-8") as f:
-    txt = f.read()
-if not txt.startswith("---"):
-    sys.exit(0)
-end = txt.find("\n---", 3)
-if end < 0:
-    sys.exit(0)
-try:
-    fm = yaml.safe_load(txt[3:end].lstrip("\n")) or {}
-except yaml.YAMLError:
-    sys.exit(0)
-val = fm.get(os.environ["FIELD"])
-if val is None:
-    sys.exit(0)
-# Emit as string for shell consumption; YAML ints + floats stringify cleanly.
-# Lists/dicts collapse to repr — callers of _existing today only ask for
-# scalar fields, so this is adequate. If a future caller wants list support,
-# use the python3+yaml path in skill-audit._get_frontmatter instead.
-print(val if not isinstance(val, (list, dict)) else "")
-' 2>/dev/null
-    fi
-  }
-
-  EXISTING_VERSION=$(_existing "agency-skill-version")
-  if [[ "$EXISTING_VERSION" = "2" ]]; then
-    echo "[skill-create --upgrade] $NAME is already agency-skill-version 2. No frontmatter changes needed."
-  fi
-
-  # Create missing bundle files (safe — only writes if absent)
-  mkdir -p "$SKILLS_DIR/$NAME/scripts" "$SKILLS_DIR/$NAME/assets"
-
-  if [[ ! -f "$SKILLS_DIR/$NAME/reference.md" ]]; then
-    printf "# %s — unique protocol\n\nTODO: fill with protocol unique to this skill, or note: \"This skill has no unique protocol. See required_reading in SKILL.md for all behavior specifications.\"\n" "$NAME" > "$SKILLS_DIR/$NAME/reference.md"
-    echo "[skill-create --upgrade] created reference.md"
-  fi
-
-  if [[ ! -f "$SKILLS_DIR/$NAME/examples.md" ]]; then
-    printf "# %s — examples\n\n## Happy-path examples\n\nTODO: typical invocations with expected output\n\n## Edge-case examples\n\nTODO: preconditions failing, what error looks like\n\n## Integration examples\n\nTODO: how this skill fits with other skills; composability\n" "$NAME" > "$SKILLS_DIR/$NAME/examples.md"
-    echo "[skill-create --upgrade] created examples.md"
-  fi
-
-  if [[ ! -f "$SKILLS_DIR/$NAME/scripts/README.md" ]]; then
-    printf "# scripts/\n\nTODO: describe what scripts live here and why. If empty by design, explain: \"Empty by design. This skill is pure orchestration — no skill-specific scripts needed.\"\n" > "$SKILLS_DIR/$NAME/scripts/README.md"
-    echo "[skill-create --upgrade] created scripts/README.md"
-  fi
-
-  if [[ ! -f "$SKILLS_DIR/$NAME/assets/README.md" ]]; then
-    printf "# assets/\n\nTODO: describe templates/static files here. If empty by design, explain: \"Empty by design. This skill has no user-facing templates or static assets.\"\n" > "$SKILLS_DIR/$NAME/assets/README.md"
-    echo "[skill-create --upgrade] created assets/README.md"
-  fi
-
-  # Add v2 frontmatter fields if missing (use python3+yaml for safety).
-  # Preserves existing name/description/body content. Only adds TODO placeholders
-  # for v2-required fields that don't exist.
-  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
-    # Finding #1 (code-1 / the-agency#320 retro-MAR): under `set -e`, python's
-    # non-zero exit killed the script BEFORE `UPGRADE_FM_EXIT=$?` ran, making
-    # the intended 3-way branching (0 ok / 4 hard fail / other warn+continue)
-    # dead code. Wrap with set +e so the exit-code inspection actually runs,
-    # then re-enable set -e afterwards.
-    set +e
-    FILE="$SKILL_FILE" NAME="$NAME" python3 <<'PYEOF'
-import os, sys, yaml
-path = os.environ["FILE"]
-skill_name = os.environ["NAME"]
-with open(path, "r", encoding="utf-8") as f:
-    txt = f.read()
-if not txt.startswith("---"):
-    print("skill-create --upgrade: SKILL.md missing frontmatter — cannot safely add v2 fields", file=sys.stderr)
-    sys.exit(4)
-end = txt.find("\n---", 3)
-if end < 0:
-    print("skill-create --upgrade: SKILL.md frontmatter not terminated", file=sys.stderr)
-    sys.exit(4)
-fm_src = txt[3:end].lstrip("\n")
-rest = txt[end+4:]  # after "\n---"
-try:
-    fm = yaml.safe_load(fm_src) or {}
-except yaml.YAMLError as e:
-    print(f"skill-create --upgrade: SKILL.md frontmatter parse error: {e}", file=sys.stderr)
-    sys.exit(4)
-if not isinstance(fm, dict):
-    print("skill-create --upgrade: SKILL.md frontmatter not a mapping", file=sys.stderr)
-    sys.exit(4)
-
-changed = False
-# Add missing v2 fields with TODO placeholders
-if "agency-skill-version" not in fm:
-    fm["agency-skill-version"] = 2; changed = True
-if "when_to_use" not in fm:
-    fm["when_to_use"] = "TODO: explicit trigger phrases + anti-trigger phrases"; changed = True
-if "argument-hint" not in fm:
-    fm["argument-hint"] = "TODO: <arg1> [--flag value]"; changed = True
-if "paths" not in fm:
-    fm["paths"] = ["TODO: .claude/worktrees/** (agent) or [] (captain/subagent)"]; changed = True
-if "required_reading" not in fm:
-    fm["required_reading"] = ["claude/REFERENCE-SKILL-AUTHORING.md"]; changed = True
-
-if not changed:
-    sys.exit(0)
-
-# Re-emit frontmatter preserving key order
-out = "---\n"
-# Preserve order-of-importance: name, description, version, trigger, args, paths, disable, required_reading, rest
-order = [
-    "name", "description", "agency-skill-version", "when_to_use",
-    "argument-hint", "paths", "disable-model-invocation", "required_reading",
-]
-seen = set()
-for k in order:
-    if k in fm:
-        out += yaml.safe_dump({k: fm[k]}, default_flow_style=False, sort_keys=False)
-        seen.add(k)
-# Remaining keys in original order
-for k, v in fm.items():
-    if k not in seen:
-        out += yaml.safe_dump({k: v}, default_flow_style=False, sort_keys=False)
-        seen.add(k)
-out += "---\n"
-out += rest if rest.startswith("\n") else "\n" + rest
-
-with open(path, "w", encoding="utf-8") as f:
-    f.write(out)
-print("[skill-create --upgrade] frontmatter updated (added missing v2 fields)")
-PYEOF
-    UPGRADE_FM_EXIT=$?
-    set -e
-    if [[ $UPGRADE_FM_EXIT -ne 0 && $UPGRADE_FM_EXIT -ne 4 ]]; then
-      echo "[skill-create --upgrade] frontmatter update errored (exit $UPGRADE_FM_EXIT), continuing" >&2
-    elif [[ $UPGRADE_FM_EXIT -eq 4 ]]; then
-      exit 4
-    fi
-  else
-    echo "[skill-create --upgrade] python3+yaml not available; frontmatter fields NOT added automatically" >&2
-    echo "  Manual step: add agency-skill-version: 2, when_to_use, argument-hint, paths, required_reading" >&2
-  fi
-
-  # Update registry row — bump version to 2 if row exists, append if missing
-  _registry_lock || exit 1
-  if grep -qE "^\| $NAME " "$REGISTRY" 2>/dev/null; then
-    # Replace the version column in the existing row (assuming 3rd column)
-    tmp=$(mktemp)
-    awk -v skill="$NAME" 'BEGIN{FS=OFS="|"} {
-      if ($2 ~ "^ "skill" $") { $4 = " 2 " }
-      print
-    }' "$REGISTRY" > "$tmp" && mv "$tmp" "$REGISTRY"
-    echo "[skill-create --upgrade] Registry row version bumped to 2."
-  else
-    echo "[skill-create --upgrade] Registry row for '$NAME' not found; run skill-audit to surface drift." >&2
-  fi
-  _registry_unlock
-
-  # Run audit to report remaining gaps
-  if [[ -x "$SCRIPT_DIR/skill-audit" ]]; then
-    echo ""
-    echo "[skill-create --upgrade] Running skill-audit for $NAME..."
-    "$SCRIPT_DIR/skill-audit" "$NAME" || true
-  fi
-
-  echo ""
-  echo "[ok] skill '$NAME' upgraded to v2 scaffolding."
-  echo ""
-  echo "Author checklist:"
-  echo "  [ ] Review SKILL.md frontmatter — replace TODO placeholders with real content"
-  echo "  [ ] Ensure body has the 9 required sections (see REFERENCE-SKILL-AUTHORING.md §5)"
-  echo "  [ ] Fill reference.md / examples.md / scripts+assets/README.md as appropriate"
-  echo "  [ ] Run skill-audit to confirm 0 non-compliance"
-  echo "  [ ] Commit via /git-safe-commit"
-
-  if [[ -n "$RUN_ID" ]]; then
-    log_end "$RUN_ID" "success" "0" "0" "upgraded $NAME" 2>/dev/null || :
-  fi
-  exit 0
-fi
 
 # ── Determine scoping based on actor ─────────────────────────────────────────
 

--- a/claude/tools/skill-create
+++ b/claude/tools/skill-create
@@ -1,0 +1,364 @@
+#!/bin/bash
+#
+# skill-create — Scaffold an agency-skill-version 2 compliant skill bundle
+#
+# WHAT: Wraps Anthropic's `skills create` (from skills-cli) and layers
+# agency-v2 requirements: full bundle (SKILL.md + reference.md + examples.md
+# + scripts/ + assets/), all-fields frontmatter template, registry-row
+# append to claude/REFERENCE-SKILLS-INDEX.md.
+#
+# WHY: authors create skills ad-hoc today. Frontmatter incomplete; bundle
+# fragments; registry drifts. This tool enforces the v2 spec from scaffold.
+#
+# Part of the-agency#298 + #314 + #315 + #316 methodology work.
+#
+# USAGE:
+#   skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
+#
+# EXIT CODES:
+#   0 — scaffold created, registry row appended
+#   1 — precondition failed or skills-cli error
+#   2 — arg parse error / input validation failure
+#   3 — skill already exists
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+SKILLS_DIR="$REPO_ROOT/.claude/skills"
+REGISTRY="$REPO_ROOT/claude/REFERENCE-SKILLS-INDEX.md"
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+NAME=""
+DESCRIPTION=""
+ACTOR="agent"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --description) DESCRIPTION="$2"; shift 2 ;;
+    --actor) ACTOR="$2"; shift 2 ;;
+    --version) echo "skill-create $TOOL_VERSION"; exit 0 ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: skill-create <name> --description "what it does" [--actor captain|agent|both|subagent]
+
+Scaffolds an agency-skill-version 2 compliant skill bundle per
+claude/REFERENCE-SKILL-AUTHORING.md.
+
+Arguments:
+  <name>              Skill name (noun-verb or noun-actor-verb). Kebab-case.
+  --description       One-line description. Must NOT contain newlines or
+                      pipe characters (YAML/markdown-table safe).
+  --actor             agent (default) | captain | both | subagent.
+
+Exit codes:
+  0 — success
+  1 — precondition failure
+  2 — arg parse / input validation error
+  3 — skill already exists
+EOF
+      exit 0
+      ;;
+    -*) echo "skill-create: unknown flag: $1" >&2; exit 2 ;;
+    *) NAME="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "skill-create: <name> is required" >&2; exit 2
+fi
+
+if [[ -z "$DESCRIPTION" ]]; then
+  echo "skill-create: --description is required" >&2; exit 2
+fi
+
+case "$ACTOR" in
+  agent|captain|both|subagent) ;;
+  *) echo "skill-create: --actor must be agent, captain, both, or subagent" >&2; exit 2 ;;
+esac
+
+# Kebab-case validation for NAME (path-traversal + YAML-safety guard)
+if ! [[ "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  echo "skill-create: name must be lowercase kebab-case (letters, numbers, hyphens)" >&2; exit 2
+fi
+
+# Description validation — must be single-line, no pipes
+# Prevents YAML frontmatter corruption (F1) and markdown-table injection (F2)
+if [[ "$DESCRIPTION" == *$'\n'* ]]; then
+  echo "skill-create: --description must be single-line (no newlines)" >&2; exit 2
+fi
+if [[ "$DESCRIPTION" == *"|"* ]]; then
+  echo "skill-create: --description must not contain '|' (breaks registry markdown table)" >&2; exit 2
+fi
+
+# Sanitize quotes + backslashes for YAML safety — emit as YAML double-quoted scalar
+DESC_YAML=$(printf '%s' "$DESCRIPTION" | sed 's/\\/\\\\/g; s/"/\\"/g')
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+
+if ! command -v skills &>/dev/null; then
+  echo "skill-create: skills-cli not found. Install with: uv tool install skills-cli" >&2
+  echo "  (see the-agency#307 — SessionStart dependency-install mechanism)" >&2
+  exit 1
+fi
+
+mkdir -p "$SKILLS_DIR"
+
+if [[ -d "$SKILLS_DIR/$NAME" ]]; then
+  echo "skill-create: skill '$NAME' already exists at $SKILLS_DIR/$NAME" >&2
+  exit 3
+fi
+
+# Cleanup trap — handles BOTH partial scaffold AND mktemp tmp file (H14 from MAR).
+# Single trap, composes both concerns so one doesn't overwrite the other.
+SUCCESS_MARK=false
+TMP_REG=""
+_cleanup_all() {
+    if [[ -n "$TMP_REG" ]] && [[ -f "$TMP_REG" ]]; then
+        rm -f "$TMP_REG"
+    fi
+    if [[ "$SUCCESS_MARK" != "true" ]] && [[ -d "$SKILLS_DIR/$NAME" ]]; then
+        rm -rf "$SKILLS_DIR/$NAME"
+        echo "skill-create: aborted; removed partial scaffold at $SKILLS_DIR/$NAME" >&2
+    fi
+}
+trap _cleanup_all EXIT
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "skill-create: registry not found at $REGISTRY" >&2
+  echo "  Expected claude/REFERENCE-SKILLS-INDEX.md to exist. Run bootstrap first." >&2
+  exit 1
+fi
+
+# ── Determine scoping based on actor ─────────────────────────────────────────
+
+PATHS_LINE=""
+DISABLE_MODEL_INVOCATION="false"
+case "$ACTOR" in
+  agent)
+    PATHS_LINE='  - .claude/worktrees/**'
+    ;;
+  captain)
+    PATHS_LINE='  []'
+    DISABLE_MODEL_INVOCATION="true"
+    ;;
+  both|subagent)
+    PATHS_LINE='  []'
+    ;;
+esac
+
+# ── Invoke Anthropic skills create (subshell to protect caller cwd) ──────────
+
+echo "[skill-create] Invoking skills create for base scaffold..."
+(
+  cd "$SKILLS_DIR" || exit 1
+  skills create "$NAME" >/dev/null 2>&1 || true
+) || true
+
+# Ensure bundle structure exists (idempotent)
+mkdir -p "$SKILLS_DIR/$NAME/scripts" "$SKILLS_DIR/$NAME/assets"
+
+# ── Overwrite SKILL.md with agency-v2 template ──────────────────────────────
+
+cat > "$SKILLS_DIR/$NAME/SKILL.md" <<EOF
+---
+name: $NAME
+description: "$DESC_YAML"
+agency-skill-version: 2
+when_to_use: "TODO: explicit trigger phrases + anti-trigger phrases. NEVER-from-X statements as needed."
+argument-hint: "TODO: <arg1> <arg2> [--flag value]"
+paths:
+$PATHS_LINE
+disable-model-invocation: $DISABLE_MODEL_INVOCATION
+required_reading:
+  - claude/REFERENCE-SKILL-AUTHORING.md
+  # TODO: add framework reference docs this skill depends on, e.g.:
+  # - claude/REFERENCE-QUALITY-GATE.md
+---
+
+<!--
+  allowed-tools omitted — inherits Bash(*) from .claude/settings.json.
+  Subcommand-level restriction silently blocks fleet agents (flag #62/#63
+  / devex dispatch #171 / the-agency#298 caveat). If narrowing is
+  warranted here, use TOOL-level only (e.g., Bash(claude/tools/git-safe:*)).
+-->
+
+# $NAME
+
+TODO: One-line overview expanding the description. What this skill does.
+
+## Why this exists
+
+TODO: the pain addressed. Why reach for this over some alternative.
+
+## Required reading
+
+Before proceeding, Read the files listed in \`required_reading:\` frontmatter. They contain protocol details this skill relies on.
+
+## Usage
+
+\`\`\`
+/$NAME TODO: arg pattern
+\`\`\`
+
+## Preconditions
+
+TODO: what must be true before running, or "None — …"
+
+## Flow / Steps
+
+TODO: numbered step-by-step, or "Single step — …"
+
+## Failure modes
+
+TODO: per-step what can go wrong + recovery, or "No destructive operations; failures are benign"
+
+## What this does NOT do
+
+TODO: explicit non-goals, companion skills, or "N/A — scope is unambiguous"
+
+## Status
+
+pilot
+
+## Related
+
+TODO: companion skills, reference docs, upstream issues
+EOF
+
+# ── Create reference.md stub ─────────────────────────────────────────────────
+
+cat > "$SKILLS_DIR/$NAME/reference.md" <<EOF
+# $NAME — unique protocol
+
+TODO: protocol detail UNIQUE to this skill. Do not duplicate content from
+claude/REFERENCE-*.md — those are declared in SKILL.md required_reading.
+
+If this skill has no unique protocol, keep this note minimal:
+"This skill has no unique protocol. See required_reading in SKILL.md for
+all behavior specifications."
+EOF
+
+# ── Create examples.md stub ──────────────────────────────────────────────────
+
+cat > "$SKILLS_DIR/$NAME/examples.md" <<EOF
+# $NAME — examples
+
+## Happy-path examples
+
+TODO: typical invocations with expected output
+
+## Edge-case examples
+
+TODO: preconditions failing, what error looks like
+
+## Integration examples
+
+TODO: how this skill fits with other skills; composability
+EOF
+
+# ── Create scripts/README.md ─────────────────────────────────────────────────
+
+cat > "$SKILLS_DIR/$NAME/scripts/README.md" <<EOF
+# scripts/
+
+TODO: describe what scripts live here and why. If empty by design,
+explain: "Empty by design. This skill is pure orchestration — no
+skill-specific scripts needed."
+
+The v2 bundle-structure requirement says this directory exists even
+when empty; this README explains why.
+EOF
+
+# ── Create assets/README.md ──────────────────────────────────────────────────
+
+cat > "$SKILLS_DIR/$NAME/assets/README.md" <<EOF
+# assets/
+
+TODO: describe templates/static files here. If empty by design,
+explain: "Empty by design. This skill has no user-facing templates
+or static assets."
+
+The v2 bundle-structure requirement says this directory exists even
+when empty; this README explains why.
+EOF
+
+# ── Append registry row (atomic via mktemp + mv, with cleanup trap) ─────────
+
+# One-line summary — first sentence, but handle version-numbers like "v2.0"
+# by taking the first period-then-space or period-at-end split.
+# Fall back to the whole description if no natural sentence boundary exists.
+SUMMARY=$(printf '%s' "$DESCRIPTION" | awk 'BEGIN{FS="\\. "} {print $1}' | head -c 100)
+# Escape any remaining markdown-table meta (defense in depth; pipes already rejected)
+SUMMARY="${SUMMARY//|/\\|}"
+
+REGISTRY_SCOPE="$ACTOR"
+NEW_ROW="| $NAME | $SUMMARY | 2 | $REGISTRY_SCOPE | pilot | SKILL-AUTHORING |"
+
+TMP_REG=$(mktemp)
+# Note: TMP_REG cleanup is handled by the composed _cleanup_all trap set above.
+
+INSERTED=false
+while IFS= read -r line; do
+  if [[ "$INSERTED" = false && "$line" == "## Retrofit priorities" ]]; then
+    printf '%s\n' "$NEW_ROW" >> "$TMP_REG"
+    printf '\n' >> "$TMP_REG"
+    INSERTED=true
+  fi
+  printf '%s\n' "$line" >> "$TMP_REG"
+done < "$REGISTRY"
+
+if [[ "$INSERTED" = true ]]; then
+  mv "$TMP_REG" "$REGISTRY"
+  TMP_REG=""    # mv consumed the tmp file; tell the trap not to re-rm it
+  echo "[skill-create] Registry row appended."
+else
+  printf '\n%s\n' "$NEW_ROW" >> "$REGISTRY"
+  rm -f "$TMP_REG"
+  TMP_REG=""
+  echo "[skill-create] Registry row appended at EOF (anchor section heading missing — review placement)."
+fi
+
+# Mark full success — _cleanup_all trap will skip the partial-scaffold removal.
+SUCCESS_MARK=true
+
+# ── Author checklist ─────────────────────────────────────────────────────────
+
+cat <<EOF
+
+[ok] skill '$NAME' scaffolded at .claude/skills/$NAME/
+
+Next steps (author checklist):
+
+  [ ] Edit .claude/skills/$NAME/SKILL.md
+      - Fill description if the one you passed needs refinement
+      - Fill when_to_use with explicit trigger/anti-trigger phrases
+      - Fill argument-hint with real arg pattern
+      - Add required_reading entries for framework docs this skill needs
+      - Fill all 9 body sections. Use "N/A because ..." for genuinely empty.
+
+  [ ] Edit .claude/skills/$NAME/reference.md
+      - Protocol detail unique to this skill, or keep note minimal
+
+  [ ] Edit .claude/skills/$NAME/examples.md
+      - Happy-path / Edge-case / Integration examples
+
+  [ ] Decide if scripts/ needs real content. If not, update the README.
+
+  [ ] Decide if assets/ needs real content. If not, update the README.
+
+  [ ] Run skill-audit to verify v2 compliance + registry correctness:
+        claude/tools/skill-audit $NAME
+
+  [ ] Commit via /git-safe-commit.
+
+  [ ] If framework-level, upstream-port to the-agency after merge.
+
+  [ ] If pilot, dogfood once before promoting Status to 'active'.
+
+EOF
+
+exit 0

--- a/claude/tools/skill-upgrade
+++ b/claude/tools/skill-upgrade
@@ -1,0 +1,317 @@
+#!/bin/bash
+#
+# skill-upgrade — Retrofit a v1 skill to v2 compliance
+#
+# WHAT: For an existing v1 skill under .claude/skills/<name>/:
+#   (a) Scaffold missing bundle files (reference.md, examples.md,
+#       scripts/README.md, assets/README.md) with TODO placeholders
+#   (b) Add missing v2 frontmatter fields (agency-skill-version: 2,
+#       when_to_use, argument-hint, paths, required_reading) with TODO
+#       placeholders — preserves existing name, description, body
+#   (c) Bump registry row version from 1 to 2
+#   (d) Run skill-audit to surface remaining gaps
+#
+# Split from skill-create per the-agency#320 finding D5 (retro-MAR 2026-04-19):
+# `skill-create --upgrade <name>` broke the subcommand convention used by
+# dispatch / git-captain / git-safe / receipt-sign (verb-first single
+# purpose), overloaded skill-create with two unrelated responsibilities, and
+# made the CLI ambiguous between create-mode and upgrade-mode args. Two
+# tools = two purposes, matches framework convention.
+#
+# Backwards compat: `skill-create --upgrade <name>` still works but emits
+# a deprecation warning and dispatches to this tool.
+#
+# USAGE:
+#   skill-upgrade <name>
+#
+# EXIT CODES:
+#   0 — success (skill scaffolded, frontmatter updated, registry bumped)
+#   1 — precondition failed (python+yaml unavailable, repo not initialized)
+#   2 — arg parse error
+#   3 — skill doesn't exist / SKILL.md missing
+#   4 — SKILL.md frontmatter malformed (cannot safely add v2 fields)
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="${CLAUDE_PROJECT_DIR:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
+SKILLS_DIR="$REPO_ROOT/.claude/skills"
+REGISTRY="$REPO_ROOT/claude/REFERENCE-SKILLS-INDEX.md"
+LOCK_FILE="$REPO_ROOT/.claude/skill-create.lock"  # shared lock with skill-create
+
+# Telemetry (graceful no-op if helper absent)
+if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
+  # shellcheck source=./lib/_log-helper
+  source "$SCRIPT_DIR/lib/_log-helper"
+else
+  log_start() { echo ""; }
+  log_end()   { :; }
+fi
+
+# ── Args ─────────────────────────────────────────────────────────────────────
+
+NAME=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version) echo "skill-upgrade $TOOL_VERSION"; exit 0 ;;
+    --help|-h)
+      cat <<'EOF'
+Usage: skill-upgrade <name>
+
+Retrofit an existing v1 skill to v2 compliance:
+  - Scaffolds missing bundle files with TODO placeholders
+  - Adds missing v2 frontmatter fields with TODO placeholders
+  - Preserves existing name, description, body content
+  - Bumps registry row version to 2
+  - Runs skill-audit to surface remaining gaps
+
+Author still must fill real content per the TODOs.
+
+Exit codes:
+  0 — success
+  1 — precondition failure
+  2 — arg parse error
+  3 — skill doesn't exist / SKILL.md missing
+  4 — frontmatter malformed
+
+See claude/REFERENCE-SKILL-AUTHORING.md for the v2 spec.
+EOF
+      exit 0
+      ;;
+    -*) echo "skill-upgrade: unknown flag: $1" >&2; exit 2 ;;
+    *) NAME="$1"; shift ;;
+  esac
+done
+
+if [[ -z "$NAME" ]]; then
+  echo "skill-upgrade: <name> is required" >&2; exit 2
+fi
+
+# Kebab-case validation for NAME (path-traversal + YAML-safety guard)
+if ! [[ "$NAME" =~ ^[a-z][a-z0-9-]*$ ]]; then
+  echo "skill-upgrade: name must be lowercase kebab-case (letters, numbers, hyphens)" >&2; exit 2
+fi
+
+# ── Preconditions ────────────────────────────────────────────────────────────
+
+if [[ ! -d "$SKILLS_DIR/$NAME" ]]; then
+  echo "skill-upgrade: skill '$NAME' not found at $SKILLS_DIR/$NAME" >&2
+  exit 3
+fi
+
+SKILL_FILE="$SKILLS_DIR/$NAME/SKILL.md"
+if [[ ! -f "$SKILL_FILE" ]]; then
+  echo "skill-upgrade: SKILL.md missing at $SKILL_FILE" >&2
+  exit 3
+fi
+
+if [[ ! -f "$REGISTRY" ]]; then
+  echo "skill-upgrade: registry not found at $REGISTRY" >&2
+  echo "  Expected claude/REFERENCE-SKILLS-INDEX.md to exist. Run bootstrap first." >&2
+  exit 1
+fi
+
+# ── flock serialization (shared with skill-create) ──────────────────────────
+
+_registry_lock() {
+  if command -v flock >/dev/null 2>&1; then
+    exec 9>"$LOCK_FILE" || return 1
+    flock -x -w 30 9 || {
+      echo "skill-upgrade: could not acquire registry lock after 30s" >&2
+      return 1
+    }
+  fi
+  return 0
+}
+
+_registry_unlock() {
+  if command -v flock >/dev/null 2>&1; then
+    flock -u 9 2>/dev/null || :
+    exec 9>&- 2>/dev/null || :
+  fi
+}
+
+# ── Execute ──────────────────────────────────────────────────────────────────
+
+RUN_ID=$(log_start "skill-upgrade" "$@" 2>/dev/null || echo "")
+
+echo "[skill-upgrade] Retrofitting $NAME to v2 compliance..."
+
+# Read existing frontmatter fields (best-effort via python3+yaml).
+# Finding #2 (code-2 / retro-MAR): emit all non-list/dict scalars verbatim so
+# int values (like `agency-skill-version: 2`) stringify correctly.
+_existing() {
+  local field="$1"
+  if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+    FILE="$SKILL_FILE" FIELD="$field" python3 -c '
+import os, sys, yaml
+with open(os.environ["FILE"], "r", encoding="utf-8") as f:
+    txt = f.read()
+if not txt.startswith("---"):
+    sys.exit(0)
+end = txt.find("\n---", 3)
+if end < 0:
+    sys.exit(0)
+try:
+    fm = yaml.safe_load(txt[3:end].lstrip("\n")) or {}
+except yaml.YAMLError:
+    sys.exit(0)
+val = fm.get(os.environ["FIELD"])
+if val is None:
+    sys.exit(0)
+print(val if not isinstance(val, (list, dict)) else "")
+' 2>/dev/null
+  fi
+}
+
+EXISTING_VERSION=$(_existing "agency-skill-version")
+if [[ "$EXISTING_VERSION" = "2" ]]; then
+  echo "[skill-upgrade] $NAME is already agency-skill-version 2. No frontmatter changes needed."
+fi
+
+# Create missing bundle files (safe — only writes if absent)
+mkdir -p "$SKILLS_DIR/$NAME/scripts" "$SKILLS_DIR/$NAME/assets"
+
+if [[ ! -f "$SKILLS_DIR/$NAME/reference.md" ]]; then
+  printf "# %s — unique protocol\n\nTODO: fill with protocol unique to this skill, or note: \"This skill has no unique protocol. See required_reading in SKILL.md for all behavior specifications.\"\n" "$NAME" > "$SKILLS_DIR/$NAME/reference.md"
+  echo "[skill-upgrade] created reference.md"
+fi
+
+if [[ ! -f "$SKILLS_DIR/$NAME/examples.md" ]]; then
+  printf "# %s — examples\n\n## Happy-path examples\n\nTODO: typical invocations with expected output\n\n## Edge-case examples\n\nTODO: preconditions failing, what error looks like\n\n## Integration examples\n\nTODO: how this skill fits with other skills; composability\n" "$NAME" > "$SKILLS_DIR/$NAME/examples.md"
+  echo "[skill-upgrade] created examples.md"
+fi
+
+if [[ ! -f "$SKILLS_DIR/$NAME/scripts/README.md" ]]; then
+  printf "# scripts/\n\nTODO: describe what scripts live here and why. If empty by design, explain: \"Empty by design. This skill is pure orchestration — no skill-specific scripts needed.\"\n" > "$SKILLS_DIR/$NAME/scripts/README.md"
+  echo "[skill-upgrade] created scripts/README.md"
+fi
+
+if [[ ! -f "$SKILLS_DIR/$NAME/assets/README.md" ]]; then
+  printf "# assets/\n\nTODO: describe templates/static files here. If empty by design, explain: \"Empty by design. This skill has no user-facing templates or static assets.\"\n" > "$SKILLS_DIR/$NAME/assets/README.md"
+  echo "[skill-upgrade] created assets/README.md"
+fi
+
+# Add v2 frontmatter fields if missing (via python3+yaml for safety).
+# Preserves existing name/description/body content.
+if command -v python3 >/dev/null 2>&1 && python3 -c "import yaml" >/dev/null 2>&1; then
+  # Finding #1 (code-1 / retro-MAR): wrap with set +e so UPGRADE_FM_EXIT
+  # capture actually runs after python non-zero exit, restoring the
+  # intended 3-way branching (0 ok / 4 hard fail / other warn+continue).
+  set +e
+  FILE="$SKILL_FILE" NAME="$NAME" python3 <<'PYEOF'
+import os, sys, yaml
+path = os.environ["FILE"]
+skill_name = os.environ["NAME"]
+with open(path, "r", encoding="utf-8") as f:
+    txt = f.read()
+if not txt.startswith("---"):
+    print("skill-upgrade: SKILL.md missing frontmatter — cannot safely add v2 fields", file=sys.stderr)
+    sys.exit(4)
+end = txt.find("\n---", 3)
+if end < 0:
+    print("skill-upgrade: SKILL.md frontmatter not terminated", file=sys.stderr)
+    sys.exit(4)
+fm_src = txt[3:end].lstrip("\n")
+rest = txt[end+4:]  # after "\n---"
+try:
+    fm = yaml.safe_load(fm_src) or {}
+except yaml.YAMLError as e:
+    print(f"skill-upgrade: SKILL.md frontmatter parse error: {e}", file=sys.stderr)
+    sys.exit(4)
+if not isinstance(fm, dict):
+    print("skill-upgrade: SKILL.md frontmatter not a mapping", file=sys.stderr)
+    sys.exit(4)
+
+changed = False
+# Add missing v2 fields with TODO placeholders
+if "agency-skill-version" not in fm:
+    fm["agency-skill-version"] = 2; changed = True
+if "when_to_use" not in fm:
+    fm["when_to_use"] = "TODO: explicit trigger phrases + anti-trigger phrases"; changed = True
+if "argument-hint" not in fm:
+    fm["argument-hint"] = "TODO: <arg1> [--flag value]"; changed = True
+if "paths" not in fm:
+    fm["paths"] = ["TODO: .claude/worktrees/** (agent) or [] (captain/subagent)"]; changed = True
+if "required_reading" not in fm:
+    fm["required_reading"] = ["claude/REFERENCE-SKILL-AUTHORING.md"]; changed = True
+
+if not changed:
+    sys.exit(0)
+
+# Re-emit frontmatter preserving key order
+out = "---\n"
+order = [
+    "name", "description", "agency-skill-version", "when_to_use",
+    "argument-hint", "paths", "disable-model-invocation", "required_reading",
+]
+seen = set()
+for k in order:
+    if k in fm:
+        out += yaml.safe_dump({k: fm[k]}, default_flow_style=False, sort_keys=False)
+        seen.add(k)
+for k, v in fm.items():
+    if k not in seen:
+        out += yaml.safe_dump({k: v}, default_flow_style=False, sort_keys=False)
+        seen.add(k)
+out += "---\n"
+out += rest if rest.startswith("\n") else "\n" + rest
+
+with open(path, "w", encoding="utf-8") as f:
+    f.write(out)
+print("[skill-upgrade] frontmatter updated (added missing v2 fields)")
+PYEOF
+  UPGRADE_FM_EXIT=$?
+  set -e
+  if [[ $UPGRADE_FM_EXIT -ne 0 && $UPGRADE_FM_EXIT -ne 4 ]]; then
+    echo "[skill-upgrade] frontmatter update errored (exit $UPGRADE_FM_EXIT), continuing" >&2
+  elif [[ $UPGRADE_FM_EXIT -eq 4 ]]; then
+    if [[ -n "$RUN_ID" ]]; then
+      log_end "$RUN_ID" "failed" "4" "0" "upgrade failed — frontmatter malformed" 2>/dev/null || :
+    fi
+    exit 4
+  fi
+else
+  echo "[skill-upgrade] python3+yaml not available; frontmatter fields NOT added automatically" >&2
+  echo "  Manual step: add agency-skill-version: 2, when_to_use, argument-hint, paths, required_reading" >&2
+fi
+
+# Update registry row — bump version to 2 if row exists, warn if missing
+_registry_lock || exit 1
+if grep -qE "^\| $NAME \|" "$REGISTRY" 2>/dev/null; then
+  # Use anchored grep at column boundary for the version bump awk pattern too
+  tmp=$(mktemp)
+  awk -v skill="$NAME" 'BEGIN{FS=OFS="|"} {
+    if ($2 ~ "^ "skill" $") { $4 = " 2 " }
+    print
+  }' "$REGISTRY" > "$tmp" && mv "$tmp" "$REGISTRY"
+  echo "[skill-upgrade] Registry row version bumped to 2."
+else
+  echo "[skill-upgrade] Registry row for '$NAME' not found; run skill-audit to surface drift." >&2
+fi
+_registry_unlock
+
+# Run audit to report remaining gaps
+if [[ -x "$SCRIPT_DIR/skill-audit" ]]; then
+  echo ""
+  echo "[skill-upgrade] Running skill-audit for $NAME..."
+  "$SCRIPT_DIR/skill-audit" "$NAME" || true
+fi
+
+echo ""
+echo "[ok] skill '$NAME' upgraded to v2 scaffolding."
+echo ""
+echo "Author checklist:"
+echo "  [ ] Review SKILL.md frontmatter — replace TODO placeholders with real content"
+echo "  [ ] Ensure body has the 9 required sections (see REFERENCE-SKILL-AUTHORING.md §5)"
+echo "  [ ] Fill reference.md / examples.md / scripts+assets/README.md as appropriate"
+echo "  [ ] Run skill-audit to confirm 0 non-compliance"
+echo "  [ ] Commit via /git-safe-commit"
+
+if [[ -n "$RUN_ID" ]]; then
+  log_end "$RUN_ID" "success" "0" "0" "upgraded $NAME" 2>/dev/null || :
+fi
+exit 0

--- a/claude/tools/tests/test-skill-create.sh
+++ b/claude/tools/tests/test-skill-create.sh
@@ -17,6 +17,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TOOLS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 TOOL="$TOOLS_DIR/skill-create"
+UPGRADE_TOOL="$TOOLS_DIR/skill-upgrade"
 
 PASS=0
 FAIL=0
@@ -186,7 +187,7 @@ repo=$(setup_repo)
 make_v1_skill "$repo" "test-skill-1"
 # Marker file proves the directory survived
 echo "MARKER" > "$repo/.claude/skills/test-skill-1/MARKER"
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-1 >/dev/null 2>&1 || true
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" test-skill-1 >/dev/null 2>&1 || true
 assert_file_exists "t1.1 SKILL.md survives --upgrade" "$repo/.claude/skills/test-skill-1/SKILL.md"
 assert_file_exists "t1.2 MARKER file survives --upgrade" "$repo/.claude/skills/test-skill-1/MARKER"
 cleanup
@@ -201,7 +202,7 @@ echo ""
 echo "Test 2: --upgrade scaffolds missing bundle files"
 repo=$(setup_repo)
 make_v1_skill "$repo" "test-skill-2"
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-2 >/dev/null 2>&1 || true
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" test-skill-2 >/dev/null 2>&1 || true
 assert_file_exists "t2.1 reference.md created" "$repo/.claude/skills/test-skill-2/reference.md"
 assert_file_exists "t2.2 examples.md created" "$repo/.claude/skills/test-skill-2/examples.md"
 assert_file_exists "t2.3 scripts/README.md created" "$repo/.claude/skills/test-skill-2/scripts/README.md"
@@ -217,7 +218,7 @@ echo ""
 echo "Test 3: --upgrade adds missing v2 frontmatter fields"
 repo=$(setup_repo)
 make_v1_skill "$repo" "test-skill-3"
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-3 >/dev/null 2>&1 || true
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" test-skill-3 >/dev/null 2>&1 || true
 fm=$(cat "$repo/.claude/skills/test-skill-3/SKILL.md")
 assert_contains "t3.1 name preserved" "name: test-skill-3" "$fm"
 assert_contains "t3.2 description preserved" "A v1 skill for testing" "$fm"
@@ -238,7 +239,7 @@ echo "Test 4: --upgrade on v2 skill is idempotent (detects existing v2)"
 repo=$(setup_repo)
 make_v2_skill "$repo" "test-skill-4"
 before_sha=$(shasum "$repo/.claude/skills/test-skill-4/SKILL.md" | awk '{print $1}')
-out=$(CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-4 2>&1 || true)
+out=$(CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" test-skill-4 2>&1 || true)
 after_sha=$(shasum "$repo/.claude/skills/test-skill-4/SKILL.md" | awk '{print $1}')
 assert_contains "t4.1 announces no frontmatter changes needed" "already agency-skill-version 2" "$out"
 # Must detect v2 and NOT touch the file (pre-fix: _existing returned "" for int, silent re-write)
@@ -254,7 +255,7 @@ echo ""
 echo "Test 5: --upgrade on missing skill exits 3"
 repo=$(setup_repo)
 set +e
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade nonexistent-skill >/dev/null 2>&1
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" nonexistent-skill >/dev/null 2>&1
 ec=$?
 set -e
 assert_exit_code "t5.1 exit code 3 on missing skill" "3" "$ec"
@@ -269,7 +270,7 @@ echo "Test 6: --upgrade on skill with no SKILL.md exits 3"
 repo=$(setup_repo)
 mkdir -p "$repo/.claude/skills/empty-skill"
 set +e
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade empty-skill >/dev/null 2>&1
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" empty-skill >/dev/null 2>&1
 ec=$?
 set -e
 assert_exit_code "t6.1 exit code 3 on missing SKILL.md" "3" "$ec"
@@ -293,7 +294,7 @@ just a body, no frontmatter
 EOF
 printf '| broken-skill | no frontmatter | 1 | agent | active | SKILL-AUTHORING |\n' >> "$repo/claude/REFERENCE-SKILLS-INDEX.md"
 set +e
-CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade broken-skill >/dev/null 2>&1
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" broken-skill >/dev/null 2>&1
 ec=$?
 set -e
 # Pre-fix: set -e kills the script before UPGRADE_FM_EXIT=$? captures, so exit
@@ -345,6 +346,50 @@ set -e
 assert_exit_code "t9.1 newline in description rejected" "2" "$ec_nl"
 assert_exit_code "t9.2 pipe in description rejected" "2" "$ec_pipe"
 cleanup
+
+# ============================================================================
+# Test 10: skill-create --upgrade now redirects to skill-upgrade
+# (backwards-compat shim with deprecation warning).
+# Maps to the-agency#320 D5 finding — mode-flag → subcommand split.
+# ============================================================================
+
+echo ""
+echo "Test 10: skill-create --upgrade redirects to skill-upgrade with deprecation warning"
+repo=$(setup_repo)
+make_v1_skill "$repo" "redirect-test"
+out=$(CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade redirect-test 2>&1 || true)
+assert_contains "t10.1 deprecation warning shown" "DEPRECATED" "$out"
+assert_contains "t10.2 redirect happens" "Redirecting to skill-upgrade" "$out"
+assert_file_exists "t10.3 upgrade still worked via redirect" "$repo/.claude/skills/redirect-test/reference.md"
+cleanup
+
+# ============================================================================
+# Test 11: skill-upgrade rejects bad names (same validation as skill-create).
+# ============================================================================
+
+echo ""
+echo "Test 11: skill-upgrade rejects invalid names"
+repo=$(setup_repo)
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" "../etc/passwd" >/dev/null 2>&1
+ec_traversal=$?
+CLAUDE_PROJECT_DIR="$repo" "$UPGRADE_TOOL" "UPPER" >/dev/null 2>&1
+ec_upper=$?
+set -e
+assert_exit_code "t11.1 traversal rejected" "2" "$ec_traversal"
+assert_exit_code "t11.2 uppercase rejected" "2" "$ec_upper"
+cleanup
+
+# ============================================================================
+# Test 12: skill-upgrade --help shows independent help (not skill-create's).
+# ============================================================================
+
+echo ""
+echo "Test 12: skill-upgrade has its own --help and --version"
+out=$("$UPGRADE_TOOL" --help 2>&1)
+assert_contains "t12.1 help mentions v1→v2 retrofit" "v1 skill to v2" "$out"
+ver=$("$UPGRADE_TOOL" --version 2>&1)
+assert_contains "t12.2 version reported" "skill-upgrade" "$ver"
 
 # --- Report ---
 echo ""

--- a/claude/tools/tests/test-skill-create.sh
+++ b/claude/tools/tests/test-skill-create.sh
@@ -1,0 +1,357 @@
+#!/bin/bash
+#
+# test-skill-create.sh — Tests for claude/tools/skill-create (v2-compliant
+# skill bundle scaffolder + v1→v2 upgrade retrofitter).
+#
+# Purpose: pin regressions for bugs identified in the retroactive MAR run
+# at the-agency#314/#315/#320 cluster (commits c69ea338..HEAD on monofolk
+# master). Each test maps to a specific scorer-ranked finding.
+#
+# Run: bash claude/tools/tests/test-skill-create.sh
+#
+# Uses tempdirs to isolate from the real repo. Creates minimal skill and
+# registry fixtures; exercises --upgrade and create paths.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOOLS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+TOOL="$TOOLS_DIR/skill-create"
+
+PASS=0
+FAIL=0
+ERRORS=""
+TMPBASE=""
+
+# --- Test harness ---
+assert_eq() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected: ${expected}\n    actual:   ${actual}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_contains() {
+    local test_name="$1" expected="$2" actual="$3"
+    if echo "$actual" | grep -qF "$expected"; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected to contain: ${expected}\n    actual: ${actual}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_file_exists() {
+    local test_name="$1" path="$2"
+    if [ -f "$path" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected file to exist: ${path}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_path_exists() {
+    local test_name="$1" path="$2"
+    if [ -e "$path" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected path to exist: ${path}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+assert_exit_code() {
+    local test_name="$1" expected="$2" actual="$3"
+    if [ "$expected" = "$actual" ]; then
+        PASS=$((PASS + 1))
+        printf "  ✓ %s\n" "$test_name"
+    else
+        FAIL=$((FAIL + 1))
+        ERRORS="${ERRORS}\n  FAIL: ${test_name}\n    expected exit code: ${expected}\n    actual: ${actual}"
+        printf "  ✗ %s\n" "$test_name"
+    fi
+}
+
+# --- Fixtures ---
+setup_repo() {
+    TMPBASE=$(mktemp -d)
+    local repo="$TMPBASE/repo"
+    mkdir -p "$repo/.claude/skills" "$repo/claude" "$repo/.git"
+    # Minimal registry fixture with the anchor heading the tool expects
+    cat > "$repo/claude/REFERENCE-SKILLS-INDEX.md" <<'EOF'
+# REFERENCE-SKILLS-INDEX
+
+Registry of skills.
+
+| Name | Description | V | Scope | Status | Required Reading |
+|------|-------------|---|-------|--------|------------------|
+
+## Retrofit priorities
+
+EOF
+    # Spoof a .git so git rev-parse works
+    (cd "$repo" && git init -q 2>/dev/null)
+    echo "$repo"
+}
+
+make_v1_skill() {
+    local repo="$1" name="$2"
+    local sk_dir="$repo/.claude/skills/$name"
+    mkdir -p "$sk_dir"
+    cat > "$sk_dir/SKILL.md" <<EOF
+---
+name: $name
+description: A v1 skill for testing
+---
+
+# $name
+
+Some body content.
+EOF
+    # Add a matching registry row
+    # Use printf so we don't run into echo's backslash handling
+    printf '| %s | A v1 skill for testing | 1 | agent | active | SKILL-AUTHORING |\n' "$name" >> "$repo/claude/REFERENCE-SKILLS-INDEX.md"
+}
+
+make_v2_skill() {
+    local repo="$1" name="$2"
+    local sk_dir="$repo/.claude/skills/$name"
+    mkdir -p "$sk_dir/scripts" "$sk_dir/assets"
+    cat > "$sk_dir/SKILL.md" <<EOF
+---
+name: $name
+description: A v2 skill for testing
+agency-skill-version: 2
+when_to_use: during testing
+argument-hint: "<arg>"
+paths:
+  - .claude/worktrees/**
+required_reading:
+  - claude/REFERENCE-SKILL-AUTHORING.md
+---
+
+# $name
+
+## Why this exists
+## Required reading
+## Usage
+## Preconditions
+## Flow / Steps
+## Failure modes
+## What this does NOT do
+## Status
+## Related
+EOF
+    printf "TODO\n" > "$sk_dir/reference.md"
+    printf "TODO\n" > "$sk_dir/examples.md"
+    printf "TODO\n" > "$sk_dir/scripts/README.md"
+    printf "TODO\n" > "$sk_dir/assets/README.md"
+    printf '| %s | A v2 skill for testing | 2 | agent | active | SKILL-AUTHORING |\n' "$name" >> "$repo/claude/REFERENCE-SKILLS-INDEX.md"
+}
+
+cleanup() {
+    if [ -n "$TMPBASE" ] && [ -d "$TMPBASE" ]; then
+        rm -rf "$TMPBASE"
+    fi
+}
+trap cleanup EXIT
+
+# --- Tests ---
+
+echo ""
+echo "Running skill-create tests..."
+echo ""
+
+# ============================================================================
+# Test 1: EXIT trap does NOT delete existing skill on --upgrade (regression
+# guard for the bug discovered during this session — _cleanup_all was
+# rm -rf'ing the skill dir when SUCCESS_MARK was not set on the upgrade path).
+# Maps to scorer finding #5 (T1+code-1 dedup).
+# ============================================================================
+
+echo "Test 1: --upgrade preserves existing skill dir across exit"
+repo=$(setup_repo)
+make_v1_skill "$repo" "test-skill-1"
+# Marker file proves the directory survived
+echo "MARKER" > "$repo/.claude/skills/test-skill-1/MARKER"
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-1 >/dev/null 2>&1 || true
+assert_file_exists "t1.1 SKILL.md survives --upgrade" "$repo/.claude/skills/test-skill-1/SKILL.md"
+assert_file_exists "t1.2 MARKER file survives --upgrade" "$repo/.claude/skills/test-skill-1/MARKER"
+cleanup
+
+# ============================================================================
+# Test 2: --upgrade creates the 4 missing bundle files (reference.md,
+# examples.md, scripts/README.md, assets/README.md).
+# Maps to normal happy-path validation of --upgrade.
+# ============================================================================
+
+echo ""
+echo "Test 2: --upgrade scaffolds missing bundle files"
+repo=$(setup_repo)
+make_v1_skill "$repo" "test-skill-2"
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-2 >/dev/null 2>&1 || true
+assert_file_exists "t2.1 reference.md created" "$repo/.claude/skills/test-skill-2/reference.md"
+assert_file_exists "t2.2 examples.md created" "$repo/.claude/skills/test-skill-2/examples.md"
+assert_file_exists "t2.3 scripts/README.md created" "$repo/.claude/skills/test-skill-2/scripts/README.md"
+assert_file_exists "t2.4 assets/README.md created" "$repo/.claude/skills/test-skill-2/assets/README.md"
+cleanup
+
+# ============================================================================
+# Test 3: --upgrade adds v2 frontmatter fields with TODO placeholders
+# preserving existing name + description.
+# ============================================================================
+
+echo ""
+echo "Test 3: --upgrade adds missing v2 frontmatter fields"
+repo=$(setup_repo)
+make_v1_skill "$repo" "test-skill-3"
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-3 >/dev/null 2>&1 || true
+fm=$(cat "$repo/.claude/skills/test-skill-3/SKILL.md")
+assert_contains "t3.1 name preserved" "name: test-skill-3" "$fm"
+assert_contains "t3.2 description preserved" "A v1 skill for testing" "$fm"
+assert_contains "t3.3 agency-skill-version: 2 added" "agency-skill-version: 2" "$fm"
+assert_contains "t3.4 when_to_use added (TODO placeholder ok)" "when_to_use:" "$fm"
+assert_contains "t3.5 required_reading added" "required_reading:" "$fm"
+cleanup
+
+# ============================================================================
+# Test 4: --upgrade is idempotent on already-v2 skill (finding T5 / #24).
+# Re-running --upgrade must not change a v2 SKILL.md byte-content beyond
+# benign whitespace. Key gate: the EXISTING_VERSION check must detect v2
+# (finding #2 / code-2 — _existing must not return empty for int scalar).
+# ============================================================================
+
+echo ""
+echo "Test 4: --upgrade on v2 skill is idempotent (detects existing v2)"
+repo=$(setup_repo)
+make_v2_skill "$repo" "test-skill-4"
+before_sha=$(shasum "$repo/.claude/skills/test-skill-4/SKILL.md" | awk '{print $1}')
+out=$(CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade test-skill-4 2>&1 || true)
+after_sha=$(shasum "$repo/.claude/skills/test-skill-4/SKILL.md" | awk '{print $1}')
+assert_contains "t4.1 announces no frontmatter changes needed" "already agency-skill-version 2" "$out"
+# Must detect v2 and NOT touch the file (pre-fix: _existing returned "" for int, silent re-write)
+assert_eq "t4.2 SKILL.md byte-identical after --upgrade on v2" "$before_sha" "$after_sha"
+cleanup
+
+# ============================================================================
+# Test 5: --upgrade on missing skill exits 3 (not 0 or some other code).
+# Finding T6 / #30 — exit-code matrix.
+# ============================================================================
+
+echo ""
+echo "Test 5: --upgrade on missing skill exits 3"
+repo=$(setup_repo)
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade nonexistent-skill >/dev/null 2>&1
+ec=$?
+set -e
+assert_exit_code "t5.1 exit code 3 on missing skill" "3" "$ec"
+cleanup
+
+# ============================================================================
+# Test 6: --upgrade on skill with dir but no SKILL.md exits 3.
+# ============================================================================
+
+echo ""
+echo "Test 6: --upgrade on skill with no SKILL.md exits 3"
+repo=$(setup_repo)
+mkdir -p "$repo/.claude/skills/empty-skill"
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade empty-skill >/dev/null 2>&1
+ec=$?
+set -e
+assert_exit_code "t6.1 exit code 3 on missing SKILL.md" "3" "$ec"
+# And critically: the empty dir still exists (not rm -rf'd by trap — same
+# guard as test 1 but with an even more aggressive reproduction).
+assert_path_exists "t6.2 empty skill dir preserved across exit" "$repo/.claude/skills/empty-skill"
+cleanup
+
+# ============================================================================
+# Test 7: --upgrade on SKILL.md with broken frontmatter exits 4 (not 0, not
+# silent pass). Finding #1 / code-1 — set -e + UPGRADE_FM_EXIT capture.
+# ============================================================================
+
+echo ""
+echo "Test 7: --upgrade on broken frontmatter exits 4"
+repo=$(setup_repo)
+mkdir -p "$repo/.claude/skills/broken-skill"
+# No leading "---" → python exits 4
+cat > "$repo/.claude/skills/broken-skill/SKILL.md" <<EOF
+just a body, no frontmatter
+EOF
+printf '| broken-skill | no frontmatter | 1 | agent | active | SKILL-AUTHORING |\n' >> "$repo/claude/REFERENCE-SKILLS-INDEX.md"
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" --upgrade broken-skill >/dev/null 2>&1
+ec=$?
+set -e
+# Pre-fix: set -e kills the script before UPGRADE_FM_EXIT=$? captures, so exit
+# code would be whatever python emitted (but script terminates early; real
+# exit code is 4 from set -e semantics — verify).
+assert_exit_code "t7.1 exit code 4 on broken frontmatter" "4" "$ec"
+cleanup
+
+# ============================================================================
+# Test 8: create mode — kebab-case name validation rejects bad names.
+# Finding T3 / #17 — NAME regex rejection.
+# ============================================================================
+
+echo ""
+echo "Test 8: create mode rejects bad skill names"
+
+repo=$(setup_repo)
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "../etc/passwd" --description "x" >/dev/null 2>&1
+ec_traversal=$?
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "BadName" --description "x" >/dev/null 2>&1
+ec_upper=$?
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "9leading" --description "x" >/dev/null 2>&1
+ec_digit=$?
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "a/b" --description "x" >/dev/null 2>&1
+ec_slash=$?
+set -e
+assert_exit_code "t8.1 path traversal rejected" "2" "$ec_traversal"
+assert_exit_code "t8.2 uppercase rejected" "2" "$ec_upper"
+assert_exit_code "t8.3 leading digit rejected" "2" "$ec_digit"
+assert_exit_code "t8.4 slash rejected" "2" "$ec_slash"
+cleanup
+
+# ============================================================================
+# Test 9: create mode rejects descriptions with newlines or pipe chars.
+# Finding T2 / #16 — description validation.
+# ============================================================================
+
+echo ""
+echo "Test 9: create mode rejects unsafe descriptions"
+repo=$(setup_repo)
+set +e
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "valid-name-1" --description "multi
+line" >/dev/null 2>&1
+ec_nl=$?
+CLAUDE_PROJECT_DIR="$repo" "$TOOL" "valid-name-2" --description "has | pipe" >/dev/null 2>&1
+ec_pipe=$?
+set -e
+assert_exit_code "t9.1 newline in description rejected" "2" "$ec_nl"
+assert_exit_code "t9.2 pipe in description rejected" "2" "$ec_pipe"
+cleanup
+
+# --- Report ---
+echo ""
+echo "────────────────────────────────────────────────"
+echo "Results: $PASS passed, $FAIL failed"
+if [ "$FAIL" -gt 0 ]; then
+    echo -e "$ERRORS"
+    exit 1
+fi
+exit 0

--- a/claude/workstreams/captain/qgr/the-agency-jordan-captain-captain-v2-package-retro-qg-qgr-pr-prep-20260419-1705-429ae81.md
+++ b/claude/workstreams/captain/qgr/the-agency-jordan-captain-captain-v2-package-retro-qg-qgr-pr-prep-20260419-1705-429ae81.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: captain
+project: v2-package-retro-qg
+diff_base: c69ea338^
+hash_a: 429ae81
+hash_b: 93bee15
+hash_c: 06fd69c
+hash_d: 06fd69c
+hash_d_source: "principal-directive — 'Follow the process' + retrospective attestation of prior commits"
+hash_e: 429ae81
+date: 2026-04-19T17:05
+---
+
+# Receipt: pr-prep — v2-package-retro-qg
+
+## Chain of Trust
+- A (original): 429ae81
+- B (findings): 93bee15
+- C (triage): 06fd69c
+- D (principal): 06fd69c — principal-directive — 'Follow the process' + retrospective attestation of prior commits
+- E (final): 429ae81
+
+## Review Summary
+Retro-QG over commits c69ea338..HEAD on monofolk master — BLOCKER-1/2 + #320 follow-ups + EXIT-trap fix. 4 reviewers + scorer identified 62 findings, scorer filtered to 30 (>=50 threshold). Fixed: code-1 (set -e kills exit capture), code-2 (non-string scalar returned empty), code-9 (sentinel acceptance in audit), D1+D2 (body section order — spec amended + audit enforces order), D8 (captain-only cross-field). Added 23 regression tests in test-skill-create.sh. Fleet skill-audit: 63/63 clean. 4 items deferred to follow-up (broader tool redesign, pre-commit hooks, JSON emitter migration, naming convention).

--- a/claude/workstreams/captain/qgr/the-agency-jordan-captain-captain-v2-package-retro-qg-r2-qgr-pr-prep-20260419-1839-55ab450.md
+++ b/claude/workstreams/captain/qgr/the-agency-jordan-captain-captain-v2-package-retro-qg-r2-qgr-pr-prep-20260419-1839-55ab450.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: captain
+project: v2-package-retro-qg-r2
+diff_base: 73a24449
+hash_a: 55ab450
+hash_b: c6fd6ab
+hash_c: 32e0a27
+hash_d: 32e0a27
+hash_d_source: "principal-directive — 'No broken windows. Fix.' (no deferrals)"
+hash_e: 55ab450
+date: 2026-04-19T18:39
+---
+
+# Receipt: pr-prep — v2-package-retro-qg-r2
+
+## Chain of Trust
+- A (original): 55ab450
+- B (findings): c6fd6ab
+- C (triage): 32e0a27
+- D (principal): 32e0a27 — principal-directive — 'No broken windows. Fix.' (no deferrals)
+- E (final): 55ab450
+
+## Review Summary
+Round 2 QGR addressing all 4 items deferred in QGR 429ae81. FIXES: (1) skill-create --upgrade split into skill-upgrade tool (subcommand convention) with deprecated redirect; (2) lint-embedded-python new tool + pre-commit hook (syntax-check python3 heredocs and -c blocks); (3) skill-audit --json migrated from hand-rolled printf to python json.dumps (NUL-delimited issue stream); (4) REFERENCE-SKILL-AUTHORING.md §6 expanded to three naming forms (noun-verb, noun-actor-verb, actor-verb). VERIFICATION: 30/30 tests green (added t10-t12 for redirect + skill-upgrade), 63/63 audit clean, 7/7 embedded python blocks syntax-clean, JSON valid via json.load. No deferrals this round.


### PR DESCRIPTION
## Overview

Consolidated v2 skill methodology as one coherent landing. **This PR is the deliverable tracked in the-agency#314.** It supersedes the individual upstream ports #294-323 (which will be closed on merge, referencing this PR).

## What's in the package

### 📘 4 reference docs

| File | Purpose |
|---|---|
| `claude/REFERENCE-SKILL-AUTHORING.md` | authoritative v2 spec (bundle + 9-section body + naming + allowed-tools + four-layer captain-only defense) |
| `claude/REFERENCE-SKILLS-INDEX.md` | registry schema + tier-based retrofit order |
| `claude/REFERENCE-WHAT-IS-CLAUDE-CODE.md` | grounding on Claude Code platform primitives (skills / settings / hooks / subagents / MCP / plugins) |
| `claude/REFERENCE-ESTIMATION.md` | Size × Complexity framework replacing calendar-time estimates |

### 🔧 2 framework tools

| Tool | What it does |
|---|---|
| `claude/tools/skill-create` | scaffolds v2-compliant skill bundles, wraps Anthropic's `skills-cli create`, appends to registry with composed EXIT trap for atomic failure |
| `claude/tools/skill-audit` | audits skill surface for v2 compliance + registry drift; anchored body-section regex; `--json` / `--fix` / `--quiet` modes; exit codes 0/1/2/3 |

### 🎯 9 v2 case-study skills

**Agent-scoped** (`paths: .claude/worktrees/**`):
- `pr-submit` — agent-side handoff to captain for PR landing
- `iteration-complete` — iteration QG + auto-commit + dispatch captain
- `phase-complete` — phase QG + Sprint Review + dispatch captain
- `sync` — sync branch with master via merge

**Captain-only** (four-layer defense: `disable-model-invocation: true` + `paths: []` + `captain-` name + runtime precondition):
- `pr-captain-merge` — safe merge primitive (never squash, never rebase)
- `pr-captain-land` — 9-step PR landing (switch → verify → bump version → create PR → watch CI → merge → release → dispatch)
- `pr-captain-post-merge` — post-merge release + fleet-notify flow
- `captain-release` — release PR creation
- `captain-sync-all` — fleet-wide sync across all worktrees

## Methodology highlights

### Bundle structure (enforced by `skill-audit`)

```
.claude/skills/<name>/
├── SKILL.md        — 9-section body, agency-skill-version: 2, required_reading list
├── reference.md    — protocol / schema / deep dive
├── examples.md     — happy-path + failure-mode examples
├── scripts/        — bash/python helpers (with README.md)
└── assets/         — templates (with README.md; empty-by-design is valid)
```

### 9 required body sections

Why this exists / Required reading / Usage / Preconditions / Flow / Failure modes / What this does NOT do / Status / Related.

### Naming grammar

`<noun>-<verb>` by default; `<noun>-<actor>-<verb>` when actor scope matters. Agent is the default actor (no qualifier). Captain is always explicit — prefix (`captain-release`, `captain-sync-all`) or infix (`pr-captain-land`, `pr-captain-merge`, `pr-captain-post-merge`).

### `allowed-tools` discipline

Tool-level only, never subcommand-level. Subcommand patterns silently blocked fleet agents ([flag #62](...)/[#63](...); devex dispatch #171). Inherit `Bash(*)` from `.claude/settings.json`.

### `required_reading:` (Option C)

Interim workaround for Claude Code not yet supporting `@path` imports in SKILL.md — tracked as the-agency#306. Skills declare dependencies; the runtime / agent reads them before executing the skill body.

## Security hardening (from MAR)

`pr-captain-land/scripts/pr-captain-land` includes two MAR-driven fixes (monofolk commit `ccf054ad`):

1. **No f-string interpolation of shell values** — manifest version-bump uses `MANIFEST=\"\$MANIFEST\" NEW_VER=\"\$NEW_VER\" python3 -c '... os.environ[...]...'`. Blocks Python code injection via adversarial branch names. **Must be preserved across refactors.**
2. **Branch-name validation** — regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*\$`, no `..`, no leading `-`. Rejects at entry before any `git`/`gh`/`dispatch` composition.

## Pre-merge verification

From monofolk master, all skills individually pass `skill-audit`:

```
Skill Audit — 63 skills audited
-----------------------------------------
  [ok]   Clean:         63
  [warn] Drift:         0
  [fail] Non-compliant: 0
```

## Blockers cleared

Both BLOCKER-1 (pr-submit + pr-captain-land v2 retrofit) and BLOCKER-2 (iteration-complete + phase-complete body retrofit) from the #314 comprehensive MAR are resolved in this package.

## Supersedes

This PR supersedes (and will close on merge) the following individual port PRs that were opened during the iterative sprint but are now redundant:

- #294 — D45-R3 worktree-sync helper (already merged upstream via v45.1? check)
- #295, #300, #301, #302, #303, #304, #305 — earlier tool/skill ports
- #308, #309, #310, #311, #312, #313 — earlier v2 reference doc + skill ports
- #317, #318, #319, #321, #322, #323 — later ports (now subsumed by this PR)

## Refs

- the-agency#314 — "Review, rework, and integrate monofolk's v2 skill methodology" — **this PR is the delivery**
- the-agency#315 — V1→V2 migration master issue (remaining ~52 skills tracked there)
- the-agency#296 — PR lifecycle ownership (pr-submit + pr-captain-land are the Phase 1 pilot)
- the-agency#298 — skill refactor recommendation
- the-agency#306 — `@path` import request (unblocks Option C → Option A transition)
- the-agency#320 — skill-tools follow-ups (non-blocking improvements batched separately)

## Test plan

- [ ] Review the authoritative spec at `claude/REFERENCE-SKILL-AUTHORING.md`
- [ ] Inspect `skill-audit` against the 9 v2 skills in this PR — should be 0 non-compliance, 0 drift
- [ ] Verify security hardening in `pr-captain-land/scripts/pr-captain-land` (env-var pattern + branch regex)
- [ ] Walk one captain-only skill SKILL.md to confirm four-layer defense is consistent
- [ ] Walk one agent-scoped skill SKILL.md to confirm the `paths:` scoping works as designed
- [ ] Confirm `skill-create` scaffold produces an immediately-audit-clean bundle

🤖 Generated with [Claude Code](https://claude.com/claude-code)