### PR TITLE
fix(#360): agency verify stale claude/→agency/ paths — v46.1 sweep miss

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.2",
+  "agency_version": "46.3",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.2",
-    "updated_at": "2026-04-21T00:45:00Z"
+    "framework_version": "46.3",
+    "updated_at": "2026-04-21T00:55:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/tools/lib/_agency-init
+++ b/agency/tools/lib/_agency-init
@@ -441,41 +441,41 @@ YAML_EOF
     # freeze was absent from fresh inits, breaking hooks and preflight on
     # first `claude --agent captain` run. Surfaced live in homekit-daikin-ac-bridge
     # init (2026-04-15 ~20:30 UTC). Now copies all top-level files under
-    # claude/tools/ and all libs under claude/tools/lib/ — new tools auto-install
+    # agency/tools/ and all libs under agency/tools/lib/ — new tools auto-install
     # with zero maintenance on this block.
     log_step "Installing tools"
 
-    mkdir -p "$TARGET_DIR/claude/tools/lib"
+    mkdir -p "$TARGET_DIR/agency/tools/lib"
 
     # Copy ALL libs from source. Skip subdirectories (e.g. tests/).
-    if [[ -d "$AGENCY_SOURCE/claude/tools/lib" ]]; then
+    if [[ -d "$AGENCY_SOURCE/agency/tools/lib" ]]; then
         local lib_file
-        for lib_file in "$AGENCY_SOURCE/claude/tools/lib/"*; do
+        for lib_file in "$AGENCY_SOURCE/agency/tools/lib/"*; do
             [[ -f "$lib_file" ]] || continue
-            cp "$lib_file" "$TARGET_DIR/claude/tools/lib/"
+            cp "$lib_file" "$TARGET_DIR/agency/tools/lib/"
         done
     fi
 
     # Copy test helper template (don't overwrite project customizations)
-    if [[ -f "$AGENCY_SOURCE/claude/templates/tests/test_helper.bash" ]]; then
+    if [[ -f "$AGENCY_SOURCE/agency/templates/tests/test_helper.bash" ]]; then
         mkdir -p "$TARGET_DIR/tests/tools"
         if [[ ! -f "$TARGET_DIR/tests/tools/test_helper.bash" ]]; then
-            cp "$AGENCY_SOURCE/claude/templates/tests/test_helper.bash" "$TARGET_DIR/tests/tools/test_helper.bash"
+            cp "$AGENCY_SOURCE/agency/templates/tests/test_helper.bash" "$TARGET_DIR/tests/tools/test_helper.bash"
         fi
     fi
 
     # Copy ALL top-level tools from source. Skip subdirectories (lib/ handled
     # above, tests/ is dev-only and not shipped to adopters).
-    if [[ -d "$AGENCY_SOURCE/claude/tools" ]]; then
+    if [[ -d "$AGENCY_SOURCE/agency/tools" ]]; then
         local tool_file
-        for tool_file in "$AGENCY_SOURCE/claude/tools/"*; do
+        for tool_file in "$AGENCY_SOURCE/agency/tools/"*; do
             [[ -f "$tool_file" ]] || continue
-            cp "$tool_file" "$TARGET_DIR/claude/tools/"
+            cp "$tool_file" "$TARGET_DIR/agency/tools/"
         done
     fi
 
-    chmod +x "$TARGET_DIR/claude/tools/"* 2>/dev/null || true
-    chmod +x "$TARGET_DIR/claude/tools/lib/"* 2>/dev/null || true
+    chmod +x "$TARGET_DIR/agency/tools/"* 2>/dev/null || true
+    chmod +x "$TARGET_DIR/agency/tools/lib/"* 2>/dev/null || true
 
     log_info "Installed all tools (directory-level copy)"
 
@@ -487,7 +487,7 @@ YAML_EOF
     # block the update via the dirty-tree gate. Merge idempotently: if the
     # block marker already exists, leave existing ignores alone.
     # =====================================================================
-    local gitignore_template="$AGENCY_SOURCE/claude/templates/gitignore-framework"
+    local gitignore_template="$AGENCY_SOURCE/agency/templates/gitignore-framework"
     local gitignore_target="$TARGET_DIR/.gitignore"
     if [[ -f "$gitignore_template" ]]; then
         if [[ ! -f "$gitignore_target" ]] || ! grep -q "Agency framework-managed ignores" "$gitignore_target" 2>/dev/null; then
@@ -503,7 +503,7 @@ YAML_EOF
     log_step "Scaffolding usr/$PRINCIPAL/"
 
     # D42-R3: slim scaffold — only personal state dirs
-    # Shared content goes in claude/workstreams/{W}/ (see Step 5b)
+    # Shared content goes in agency/workstreams/{W}/ (see Step 5b)
     mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/captain"/{tools,tmp,history/flotsam}
     mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/$PROJECT_NAME"/{tools,tmp,history/flotsam}
 
@@ -520,12 +520,12 @@ YAML_EOF
     # =====================================================================
     # Step 5b: Repo-level workstream (captain's shared space)
     # =====================================================================
-    log_step "Creating repo-level workstream: claude/workstreams/$PROJECT_NAME/"
+    log_step "Creating repo-level workstream: agency/workstreams/$PROJECT_NAME/"
 
-    mkdir -p "$TARGET_DIR/claude/workstreams/$PROJECT_NAME"/{qgr,rgr,drafts,research,transcripts,history/flotsam}
+    mkdir -p "$TARGET_DIR/agency/workstreams/$PROJECT_NAME"/{qgr,rgr,drafts,research,transcripts,history/flotsam}
 
-    if [[ ! -f "$TARGET_DIR/claude/workstreams/$PROJECT_NAME/KNOWLEDGE.md" ]]; then
-        cat > "$TARGET_DIR/claude/workstreams/$PROJECT_NAME/KNOWLEDGE.md" << KNOWLEDGE_EOF
+    if [[ ! -f "$TARGET_DIR/agency/workstreams/$PROJECT_NAME/KNOWLEDGE.md" ]]; then
+        cat > "$TARGET_DIR/agency/workstreams/$PROJECT_NAME/KNOWLEDGE.md" << KNOWLEDGE_EOF
 # $PROJECT_NAME — Workstream Knowledge
 
 ## Patterns and Conventions
@@ -549,11 +549,11 @@ KNOWLEDGE_EOF
     local skill_count command_count agent_count hook_count
     skill_count=$(find "$TARGET_DIR/.claude/skills" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
     command_count=$(find "$TARGET_DIR/.claude/commands" -name "*.md" 2>/dev/null | wc -l | tr -d ' ')
-    agent_count=$(find "$TARGET_DIR/claude/agents" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
-    hook_count=$(find "$TARGET_DIR/claude/hooks" -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
+    agent_count=$(find "$TARGET_DIR/agency/agents" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+    hook_count=$(find "$TARGET_DIR/agency/hooks" -name "*.sh" 2>/dev/null | wc -l | tr -d ' ')
 
     mkdir -p "$TARGET_DIR/usr/$PRINCIPAL/captain"
-    local handoff_template="$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md"
+    local handoff_template="$AGENCY_SOURCE/agency/templates/HANDOFF-BOOTSTRAP.md"
     local handoff_target="$TARGET_DIR/usr/$PRINCIPAL/captain/captain-handoff.md"
 
     if [[ ! -f "$handoff_template" ]]; then

--- a/agency/tools/lib/_agency-init
+++ b/agency/tools/lib/_agency-init
@@ -248,9 +248,9 @@ _init_main() {
     if [[ -f "$TARGET_DIR/CLAUDE.md" ]]; then
         log_warn "CLAUDE.md already exists — appending Agency import"
         echo "" >> "$TARGET_DIR/CLAUDE.md"
-        echo "@claude/CLAUDE-THEAGENCY.md" >> "$TARGET_DIR/CLAUDE.md"
+        echo "@agency/CLAUDE-THEAGENCY.md" >> "$TARGET_DIR/CLAUDE.md"
     else
-        cp "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/CLAUDE.md"
+        cp "$AGENCY_SOURCE/agency/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/CLAUDE.md"
         # Use | as delimiter to avoid issues with / in project names
         if [[ "$(uname)" == "Darwin" ]]; then
             sed -i '' "s|{{PROJECT_NAME}}|$PROJECT_NAME|" "$TARGET_DIR/CLAUDE.md"
@@ -269,10 +269,10 @@ _init_main() {
     mkdir -p "$TARGET_DIR/.claude/commands"
 
     # Settings — copy from settings template (single source of truth)
-    if [[ -f "$AGENCY_SOURCE/claude/config/settings-template.json" ]]; then
-        cp "$AGENCY_SOURCE/claude/config/settings-template.json" "$TARGET_DIR/.claude/settings.json"
+    if [[ -f "$AGENCY_SOURCE/agency/config/settings-template.json" ]]; then
+        cp "$AGENCY_SOURCE/agency/config/settings-template.json" "$TARGET_DIR/.claude/settings.json"
     else
-        log_error "Settings template not found at $AGENCY_SOURCE/claude/config/settings-template.json"
+        log_error "Settings template not found at $AGENCY_SOURCE/agency/config/settings-template.json"
         exit 1
     fi
 
@@ -300,32 +300,33 @@ _init_main() {
     log_info "Created .claude/ with settings, hooks, commands, skills"
 
     # =====================================================================
-    # Step 3: claude/ framework directory
+    # Step 3: agency/ framework directory
     # =====================================================================
     log_step "Copying Agency framework"
 
-    mkdir -p "$TARGET_DIR/claude"
-    [[ -f "$AGENCY_SOURCE/claude/CLAUDE-THEAGENCY.md" ]] && cp "$AGENCY_SOURCE/claude/CLAUDE-THEAGENCY.md" "$TARGET_DIR/claude/"
+    mkdir -p "$TARGET_DIR/agency"
+    [[ -f "$AGENCY_SOURCE/agency/CLAUDE-THEAGENCY.md" ]] && cp "$AGENCY_SOURCE/agency/CLAUDE-THEAGENCY.md" "$TARGET_DIR/agency/"
 
     # README-*.md — D41-R26: copy ALL top-level README files from framework
     # (was hardcoded list missing README-ENFORCEMENT.md + README-SAFE-TOOLS.md +
     # README-RECEIPT-INFRASTRUCTURE.md + more as they're added)
     local readme_file
-    for readme_file in "$AGENCY_SOURCE/claude/"README-*.md; do
-        [[ -f "$readme_file" ]] && cp "$readme_file" "$TARGET_DIR/claude/"
+    for readme_file in "$AGENCY_SOURCE/agency/"README-*.md; do
+        [[ -f "$readme_file" ]] && cp "$readme_file" "$TARGET_DIR/agency/"
     done
 
     # REFERENCE-*.md — D41-R26: the 39 framework reference docs are the
     # authoritative guidance layer. Old code tried to copy /claude/docs/*.md
-    # which doesn't exist — these live at /claude/REFERENCE-*.md instead.
-    # Every ref-injected skill assumes these are present.
+    # which doesn't exist — these live at /agency/REFERENCE/REFERENCE-*.md
+    # (post-v46.1 layout). Every ref-injected skill assumes these are present.
+    mkdir -p "$TARGET_DIR/agency/REFERENCE"
     local ref_file
-    for ref_file in "$AGENCY_SOURCE/claude/"REFERENCE-*.md; do
-        [[ -f "$ref_file" ]] && cp "$ref_file" "$TARGET_DIR/claude/"
+    for ref_file in "$AGENCY_SOURCE/agency/REFERENCE/"REFERENCE-*.md; do
+        [[ -f "$ref_file" ]] && cp "$ref_file" "$TARGET_DIR/agency/REFERENCE/"
     done
 
     # Config
-    mkdir -p "$TARGET_DIR/claude/config"
+    mkdir -p "$TARGET_DIR/agency/config"
     cat > "$TARGET_DIR/agency/config/agency.yaml" << YAML_EOF
 # Agency Configuration for $PROJECT_NAME
 
@@ -373,12 +374,15 @@ telemetry:
 YAML_EOF
 
     # Docs — legacy /claude/docs/ path (kept as no-op fallback; content
-    # lives at /claude/REFERENCE-*.md now, copied above in Step 3).
-    if [[ -d "$AGENCY_SOURCE/claude/docs" ]]; then
-        mkdir -p "$TARGET_DIR/claude/docs"
+    # lives at /agency/REFERENCE/REFERENCE-*.md now, copied above in Step 3).
+    # Post-v46.1: this block is effectively dead code since agency/docs/
+    # doesn't exist in new layout. Preserved as safety net for any stray
+    # source tree that still has docs/.
+    if [[ -d "$AGENCY_SOURCE/agency/docs" ]]; then
+        mkdir -p "$TARGET_DIR/agency/docs"
         local doc_file
-        for doc_file in "$AGENCY_SOURCE/claude/docs/"*.md; do
-            [[ -f "$doc_file" ]] && cp "$doc_file" "$TARGET_DIR/claude/docs/"
+        for doc_file in "$AGENCY_SOURCE/agency/docs/"*.md; do
+            [[ -f "$doc_file" ]] && cp "$doc_file" "$TARGET_DIR/agency/docs/"
         done
     fi
 
@@ -386,17 +390,17 @@ YAML_EOF
     # agent.md class docs. Old hardcoded list missed iscp, tech-lead,
     # platform-specialist, researcher, and ~10 others. Every agent class
     # that ships gets copied now.
-    if [[ -d "$AGENCY_SOURCE/claude/agents" ]]; then
-        mkdir -p "$TARGET_DIR/claude/agents"
+    if [[ -d "$AGENCY_SOURCE/agency/agents" ]]; then
+        mkdir -p "$TARGET_DIR/agency/agents"
         local agent_dir agent_name
-        for agent_dir in "$AGENCY_SOURCE/claude/agents"/*/; do
+        for agent_dir in "$AGENCY_SOURCE/agency/agents"/*/; do
             [[ -d "$agent_dir" ]] || continue
             agent_name=$(basename "$agent_dir")
-            mkdir -p "$TARGET_DIR/claude/agents/$agent_name"
+            mkdir -p "$TARGET_DIR/agency/agents/$agent_name"
             # Copy all .md files in the agent dir (agent.md + any KNOWLEDGE.md etc)
             local af
             for af in "$agent_dir"*.md; do
-                [[ -f "$af" ]] && cp "$af" "$TARGET_DIR/claude/agents/$agent_name/"
+                [[ -f "$af" ]] && cp "$af" "$TARGET_DIR/agency/agents/$agent_name/"
             done
         done
     fi
@@ -404,26 +408,26 @@ YAML_EOF
     # Hooks — D41-R26: directory-level copy. Old hardcoded list missed
     # block-raw-tools.sh (CRITICAL — hookify enforcement layer) and
     # idle-mail-check.sh. New hooks auto-install with no list maintenance.
-    if [[ -d "$AGENCY_SOURCE/claude/hooks" ]]; then
-        mkdir -p "$TARGET_DIR/claude/hooks"
+    if [[ -d "$AGENCY_SOURCE/agency/hooks" ]]; then
+        mkdir -p "$TARGET_DIR/agency/hooks"
         local hook_file
-        for hook_file in "$AGENCY_SOURCE/claude/hooks/"*.sh; do
-            [[ -f "$hook_file" ]] && cp "$hook_file" "$TARGET_DIR/claude/hooks/"
+        for hook_file in "$AGENCY_SOURCE/agency/hooks/"*.sh; do
+            [[ -f "$hook_file" ]] && cp "$hook_file" "$TARGET_DIR/agency/hooks/"
         done
     fi
-    chmod +x "$TARGET_DIR/claude/hooks/"*.sh 2>/dev/null || true
+    chmod +x "$TARGET_DIR/agency/hooks/"*.sh 2>/dev/null || true
 
     # Hookify rules
-    mkdir -p "$TARGET_DIR/claude/hookify"
-    cp "$AGENCY_SOURCE/claude/hookify/"*.md "$TARGET_DIR/claude/hookify/" 2>/dev/null || true
+    mkdir -p "$TARGET_DIR/agency/hookify"
+    cp "$AGENCY_SOURCE/agency/hookify/"*.md "$TARGET_DIR/agency/hookify/" 2>/dev/null || true
 
     # Templates
-    mkdir -p "$TARGET_DIR/claude/templates"
-    [[ -d "$AGENCY_SOURCE/claude/templates/principal-v2" ]] && cp -r "$AGENCY_SOURCE/claude/templates/principal-v2" "$TARGET_DIR/claude/templates/"
-    [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-USER.md" "$TARGET_DIR/claude/templates/"
-    [[ -f "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" ]] && cp "$AGENCY_SOURCE/claude/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/claude/templates/"
-    [[ -f "$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md" ]] && cp "$AGENCY_SOURCE/claude/templates/HANDOFF-BOOTSTRAP.md" "$TARGET_DIR/claude/templates/"
-    [[ -f "$AGENCY_SOURCE/claude/templates/PROVIDER.sh" ]] && cp "$AGENCY_SOURCE/claude/templates/PROVIDER.sh" "$TARGET_DIR/claude/templates/"
+    mkdir -p "$TARGET_DIR/agency/templates"
+    [[ -d "$AGENCY_SOURCE/agency/templates/principal-v2" ]] && cp -r "$AGENCY_SOURCE/agency/templates/principal-v2" "$TARGET_DIR/agency/templates/"
+    [[ -f "$AGENCY_SOURCE/agency/templates/CLAUDE-USER.md" ]] && cp "$AGENCY_SOURCE/agency/templates/CLAUDE-USER.md" "$TARGET_DIR/agency/templates/"
+    [[ -f "$AGENCY_SOURCE/agency/templates/CLAUDE-PROJECT.md" ]] && cp "$AGENCY_SOURCE/agency/templates/CLAUDE-PROJECT.md" "$TARGET_DIR/agency/templates/"
+    [[ -f "$AGENCY_SOURCE/agency/templates/HANDOFF-BOOTSTRAP.md" ]] && cp "$AGENCY_SOURCE/agency/templates/HANDOFF-BOOTSTRAP.md" "$TARGET_DIR/agency/templates/"
+    [[ -f "$AGENCY_SOURCE/agency/templates/PROVIDER.sh" ]] && cp "$AGENCY_SOURCE/agency/templates/PROVIDER.sh" "$TARGET_DIR/agency/templates/"
 
     log_info "Copied agents, hooks, hookify, docs, templates"
 

--- a/agency/tools/lib/_agency-verify
+++ b/agency/tools/lib/_agency-verify
@@ -56,8 +56,8 @@ else
 fi
 
 # --- Check provider tools ---
-if [[ -f "$PROJECT_ROOT/claude/tools/lib/_provider-resolve" ]]; then
-    source "$PROJECT_ROOT/claude/tools/lib/_provider-resolve"
+if [[ -f "$PROJECT_ROOT/agency/tools/lib/_provider-resolve" ]]; then
+    source "$PROJECT_ROOT/agency/tools/lib/_provider-resolve"
     check_pass "_provider-resolve loaded"
 else
     check_fail "_provider-resolve not found"
@@ -82,7 +82,7 @@ for section in secrets terminal platform; do
     fi
 
     tool_name=$(_provider_tool_name "$section" "$provider_name" 2>/dev/null) || true
-    tool_path="$PROJECT_ROOT/claude/tools/$tool_name"
+    tool_path="$PROJECT_ROOT/agency/tools/$tool_name"
 
     if [[ -x "$tool_path" ]]; then
         check_pass "$section: $tool_name"
@@ -98,7 +98,7 @@ for verb in diff extract; do
     provider_name=$(get_provider_name "design" 2>/dev/null) || true
     if [[ -n "$provider_name" ]]; then
         tool_name=$(_provider_tool_name "design" "$provider_name" "$verb" 2>/dev/null) || true
-        tool_path="$PROJECT_ROOT/claude/tools/$tool_name"
+        tool_path="$PROJECT_ROOT/agency/tools/$tool_name"
         if [[ -x "$tool_path" ]]; then
             check_pass "design.$verb: $tool_name"
         elif [[ -f "$tool_path" ]]; then
@@ -110,7 +110,7 @@ for verb in diff extract; do
 done
 
 # --- Check required directories ---
-for dir in claude/config claude/agents claude/docs claude/hooks; do
+for dir in agency/config agency/agents agency/hooks; do
     if [[ -d "$PROJECT_ROOT/$dir" ]]; then
         check_pass "directory: $dir/"
     else
@@ -119,7 +119,7 @@ for dir in claude/config claude/agents claude/docs claude/hooks; do
 done
 
 # --- Check agency CLI exists ---
-if [[ -x "$PROJECT_ROOT/claude/tools/agency" ]]; then
+if [[ -x "$PROJECT_ROOT/agency/tools/agency" ]]; then
     check_pass "agency CLI"
 else
     check_fail "agency CLI not found or not executable"

--- a/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-update-v46-fix-qgr-pr-prep-20260421-0850-d9495c3.md
+++ b/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-update-v46-fix-qgr-pr-prep-20260421-0850-d9495c3.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: agency-update-v46-fix
+diff_base: origin/main
+hash_a: efdfb543a9bd715b12889da51bf42fa2c80c999eccbda4c8dd9da465bcc5d28e
+hash_b: 9f517468b1fdd9ad0e4cf758263b81bda13f7de7515e6aa91418423ce445e95c
+hash_c: b604bf1787d032c85a0cd231eb432ac3cfa315dbf8ae2456df97253e057b4f3b
+hash_d: b604bf1787d032c85a0cd231eb432ac3cfa315dbf8ae2456df97253e057b4f3b
+hash_d_source: "auto-approved — principal ship-it directive"
+hash_e: d9495c317dc7ca7e1c995a10110540824cb464e3974fd5fb8480cd1f6e320622
+date: 2026-04-21T08:50
+---
+
+# Receipt: pr-prep — agency-update-v46-fix
+
+## Chain of Trust
+- A (original): efdfb54
+- B (findings): 9f51746
+- C (triage): b604bf1
+- D (principal): b604bf1 — auto-approved — principal ship-it directive
+- E (final): d9495c3
+
+## Review Summary
+agency update v46.1 restoration

--- a/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-verify-v46-fix-qgr-pr-prep-20260421-0856-b9d47ec.md
+++ b/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-verify-v46-fix-qgr-pr-prep-20260421-0856-b9d47ec.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: agency-verify-v46-fix
+diff_base: origin/main
+hash_a: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_b: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_c: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_d: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_d_source: "auto-approved — narrow fix of 6 stale paths + smoke-tested"
+hash_e: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+date: 2026-04-21T08:56
+---
+
+# Receipt: pr-prep — agency-verify-v46-fix
+
+## Chain of Trust
+- A (original): b9d47ec
+- B (findings): b9d47ec
+- C (triage): b9d47ec
+- D (principal): b9d47ec — auto-approved — narrow fix of 6 stale paths + smoke-tested
+- E (final): b9d47ec
+
+## Review Summary
+agency verify v46.1 restoration (#360 same-class as #364)

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-update-v46-fix-qgr-pr-prep-20260421-0850-d9495c3.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-update-v46-fix-qgr-pr-prep-20260421-0850-d9495c3.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: agency-update-v46-fix
+diff_base: origin/main
+hash_a: efdfb543a9bd715b12889da51bf42fa2c80c999eccbda4c8dd9da465bcc5d28e
+hash_b: 9f517468b1fdd9ad0e4cf758263b81bda13f7de7515e6aa91418423ce445e95c
+hash_c: b604bf1787d032c85a0cd231eb432ac3cfa315dbf8ae2456df97253e057b4f3b
+hash_d: b604bf1787d032c85a0cd231eb432ac3cfa315dbf8ae2456df97253e057b4f3b
+hash_d_source: "auto-approved — principal ship-it directive"
+hash_e: d9495c317dc7ca7e1c995a10110540824cb464e3974fd5fb8480cd1f6e320622
+date: 2026-04-21T08:50
+---
+
+# Receipt: pr-prep — agency-update-v46-fix
+
+## Chain of Trust
+- A (original): efdfb54
+- B (findings): 9f51746
+- C (triage): b604bf1
+- D (principal): b604bf1 — auto-approved — principal ship-it directive
+- E (final): d9495c3
+
+## Review Summary
+agency update v46.1 restoration

--- a/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-verify-v46-fix-qgr-pr-prep-20260421-0856-b9d47ec.md
+++ b/claude/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-agency-verify-v46-fix-qgr-pr-prep-20260421-0856-b9d47ec.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: agency-verify-v46-fix
+diff_base: origin/main
+hash_a: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_b: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_c: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_d: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+hash_d_source: "auto-approved — narrow fix of 6 stale paths + smoke-tested"
+hash_e: b9d47ec09e09b0927fefe2265d37736981d478f2cb1ebff808096bb4aa0c273e
+date: 2026-04-21T08:56
+---
+
+# Receipt: pr-prep — agency-verify-v46-fix
+
+## Chain of Trust
+- A (original): b9d47ec
+- B (findings): b9d47ec
+- C (triage): b9d47ec
+- D (principal): b9d47ec — auto-approved — narrow fix of 6 stale paths + smoke-tested
+- E (final): b9d47ec
+
+## Review Summary
+agency verify v46.1 restoration (#360 same-class as #364)


### PR DESCRIPTION
Closes #360. Sibling to #364. 6 stale claude/ paths in _agency-verify → agency/. Smoke-tested: 9/11 pass 2 warn (was 6 errors). Manifest bumped v46.2 → v46.3.