### PR TITLE
fix(v46.1): agency init ~50 claude/→agency/ path sweep — installer restored

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.4",
+  "agency_version": "46.5",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.4",
-    "updated_at": "2026-04-21T01:12:00Z"
+    "framework_version": "46.5",
+    "updated_at": "2026-04-21T01:15:00Z"
   },
   "source": {
     "type": "local",


### PR DESCRIPTION
Matches #364/#360 same class: agency init was silently broken on v46.1. Every `agency init` call would have read from nonexistent `$AGENCY_SOURCE/claude/*` paths and written to wrong adopter layout (`$TARGET_DIR/claude/*` instead of agency/).

## Scope

126 lines changed in `agency/tools/lib/_agency-init` — ~50 stale path references swept claude/→agency/:
- CLAUDE.md imports + template paths
- settings-template.json config path
- Step 3 framework-dir creation (config, agents, hooks, hookify, templates, tools, libs, workstreams)
- README-*.md and REFERENCE-*.md copies (REFERENCE moved into agency/REFERENCE/ subdir)
- agency.yaml config dir
- test_helper.bash template
- Tools + libs + hooks + hookify
- gitignore-framework template
- Step 5b repo-level workstream creation
- Dynamic agent_count / hook_count find paths
- Bootstrap handoff template
- Final git add + commit body

## Preserved

All 16 `.claude/` (harness dir) refs unchanged. Historical comments referencing pre-v46.1 layout kept as context.

## Smoke test

`agency init` against mktemp target: all 8 steps completed, output tree contains `agency/{agents,REFERENCE,config,hooks,hookify,templates,tools,workstreams}` with 331 files in adopter's initial commit. Source reads confirmed from agency/ paths.

## Followups (filed in report for captain)

- `agency/templates/CLAUDE-PROJECT.md` has `claude/README-GETTINGSTARTED.md` ref (separate fix, different file)
- Legacy `agency/docs` fallback block (L377-383) swept for consistency but effectively dead code — cleanup candidate
- `tests/tools/agency-init.bats` is empty — write coverage in follow-up

Sibling to #360 + #364 + #367. Manifest bumped 46.4 → 46.5.