### PR TITLE
fix: package.json workspaces tighten to src/apps/mdslidepal-web only

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.7",
+  "agency_version": "46.8",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.7",
-    "updated_at": "2026-04-21T01:45:00Z"
+    "framework_version": "46.8",
+    "updated_at": "2026-04-21T01:55:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-157-dr-format-qgr-pr-prep-20260421-0949-e2f526f.md
+++ b/agency/workstreams/the-agency/qgr/the-agency-jordan-captain-the-agency-157-dr-format-qgr-pr-prep-20260421-0949-e2f526f.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: the-agency
+project: 157-dr-format
+diff_base: origin/main
+hash_a: e2f526f668309194968e295acc3972ceb223c90d0b001bdac99f96b7f05f47a9
+hash_b: e2f526f668309194968e295acc3972ceb223c90d0b001bdac99f96b7f05f47a9
+hash_c: e2f526f668309194968e295acc3972ceb223c90d0b001bdac99f96b7f05f47a9
+hash_d: e2f526f668309194968e295acc3972ceb223c90d0b001bdac99f96b7f05f47a9
+hash_d_source: "auto-approved — trivial format fix"
+hash_e: e2f526f668309194968e295acc3972ceb223c90d0b001bdac99f96b7f05f47a9
+date: 2026-04-21T09:49
+---
+
+# Receipt: pr-prep — 157-dr-format
+
+## Chain of Trust
+- A (original): e2f526f
+- B (findings): e2f526f
+- C (triage): e2f526f
+- D (principal): e2f526f — auto-approved — trivial format fix
+- E (final): e2f526f
+
+## Review Summary
+#157 agency update D/R display

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "url": "https://github.com/the-agency-ai/the-agency/issues"
   },
   "workspaces": [
-    "src/apps/*",
-    "src/apps/*/services/*"
+    "src/apps/mdslidepal-web"
   ],
   "scripts": {
     "test": "pnpm -r --if-present test",


### PR DESCRIPTION
Principal flagged: initial root package.json declared src/apps/* + src/apps/*/services/* as pnpm workspaces, but only one app (mdslidepal-web) is actually a node/TS package. Others are Swift (mdpal/mdpal-app/mdslidepal-mac), design docs (mock-and-mark), or bash ports (monofolk-ports).

Tightened to just `src/apps/mdslidepal-web`. Honest scope. Can expand when more node apps land.