### PR TITLE
docs + legal: stay-current README framing + joint copyright + trademark footer (v46.21)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the MIT License above. Use of these marks — in product names, service
+names, branding, or any identifying capacity — requires prior written
+permission from the trademark holders.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ the-agency/
 
 ## Versioning
 
-`agency_version` in `agency/config/manifest.json` follows `{day}.{release}` (e.g. `46.20` = Day 46 Release 20). Released via daily cron (or ad-hoc via `agency/tools/release-cut`). Tags: `v{day}.{release}` + `agency-v{major}` symbolic.
+`agency_version` in `agency/config/manifest.json` follows `{day}.{release}` (e.g. `46.21` = Day 46 Release 21). Released via daily cron (or ad-hoc via `agency/tools/release-cut`). Tags: `v{day}.{release}` + `agency-v{major}` symbolic.
 
 ## For Contributors
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,9 @@ curl -sL https://raw.githubusercontent.com/the-agency-ai/the-agency/main/agency/
   | bash -s -- --principal your-name --project your-project-name
 ```
 
-Pin to a specific release (recommended for reproducible installs):
-
-```bash
-curl -sL https://raw.githubusercontent.com/the-agency-ai/the-agency/main/agency/tools/agency-bootstrap.sh \
-  | bash -s -- --principal your-name --project your-project-name --from-github v46.20
-```
-
 **Do NOT copy-paste angle brackets** — use literal names. The bootstrap refuses `<your-name>` style placeholders on purpose so you don't accidentally install an agent called `<your-name>`.
+
+You *can* pin to a specific release by appending `--from-github v46.20` (or any release tag) to the command above. But TheAgency is iterating fast right now — **we suggest staying current with `main`**.
 
 After install you have a working `agency` CLI at `./agency/tools/agency`, a captain agent registered under `usr/your-name/captain/`, and Claude Code integration wired up in `.claude/`.
 
@@ -65,23 +60,22 @@ Everything under `agency/` is framework build-product — `agency init` copies i
 
 ## Staying Up to Date — `agency update`
 
-Once TheAgency is installed in your repo, pull framework updates directly from GitHub — no clone or git-remote management required.
+Once TheAgency is installed in your repo, pull framework updates directly from GitHub — no clone or git-remote management required. **We're iterating fast right now — staying current with `main` is the suggested path.**
 
 ```bash
 # Preview what would change (no writes):
 ./agency/tools/agency update --from-github --dry-run
 
-# Apply latest main:
+# Apply latest main (recommended):
 ./agency/tools/agency update --from-github
-
-# Pin to a specific release tag:
-./agency/tools/agency update --from-github v46.20
 
 # Aggressive cleanup — remove orphaned framework files (prompts for confirmation):
 ./agency/tools/agency update --from-github --prune
 ```
 
 `agency update` is **additive by default** — it adds new files and updates existing framework files, but leaves your `usr/`, workstreams, and any registered `protected_paths` alone. Use `--prune` when you want to clean up files that have been retired upstream.
+
+Need to pin to a specific release? `./agency/tools/agency update --from-github v46.20` (or any release tag). Useful if you hit a regression and need to hold — but we're iterating fast, so staying on `main` is the suggested default.
 
 ## This Repo Structure
 

--- a/agency/LICENSE.md
+++ b/agency/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the MIT License above. Use of these marks — in product names, service
+names, branding, or any identifying capacity — requires prior written
+permission from the trademark holders.

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.20",
+  "agency_version": "46.21",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.20",
+    "framework_version": "46.21",
     "updated_at": "2026-04-22T09:45:00Z"
   },
   "source": {

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-v46.21-docs-legal-qgr-pr-prep-20260422-1214-21ba2f5.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-v46.21-docs-legal-qgr-pr-prep-20260422-1214-21ba2f5.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: v46.21-docs-legal
+diff_base: origin/main
+hash_a: 05c48e0781d529cc0e443e924397275db8c1a188e992b7f5337ac247dbcabefb
+hash_b: b4061fa94671cdb1433334e6de1b6b69d016e6da7d9b8eb4227dfdf6372a6da8
+hash_c: 809542482e2ea7879d5e7f803a6eae1b327d3b2c941aa60000ac952b866b9088
+hash_d: 809542482e2ea7879d5e7f803a6eae1b327d3b2c941aa60000ac952b866b9088
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 21ba2f537a4a51fec01632e54fc63c4706014eae77b080a7e5324911abbd697d
+date: 2026-04-22T12:14
+---
+
+# Receipt: pr-prep — v46.21-docs-legal
+
+## Chain of Trust
+- A (original): 05c48e0
+- B (findings): b4061fa
+- C (triage): 8095424
+- D (principal): 8095424 — auto-approved — no principal 1B1
+- E (final): 21ba2f5
+
+## Review Summary
+v46.21: README stay-current framing + joint copyright/trademark footer across 8 LICENSE files; QG caught 2 HIGH src/ drift + 1 MED versioning example, all fixed

--- a/agency/workstreams/mdpal/LICENSE
+++ b/agency/workstreams/mdpal/LICENSE
@@ -1,6 +1,6 @@
 Reference Source License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to:
@@ -28,3 +28,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the Reference Source License above. Use of these marks — in product
+names, service names, branding, or any identifying capacity — requires prior
+written permission from the trademark holders.

--- a/agency/workstreams/mock-and-mark/LICENSE
+++ b/agency/workstreams/mock-and-mark/LICENSE
@@ -1,6 +1,6 @@
 Reference Source License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to:
@@ -28,3 +28,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the Reference Source License above. Use of these marks — in product
+names, service names, branding, or any identifying capacity — requires prior
+written permission from the trademark holders.

--- a/src/agency/LICENSE.md
+++ b/src/agency/LICENSE.md
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -19,3 +19,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the MIT License above. Use of these marks — in product names, service
+names, branding, or any identifying capacity — requires prior written
+permission from the trademark holders.

--- a/src/agency/config/manifest.json
+++ b/src/agency/config/manifest.json
@@ -1,10 +1,10 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.20",
+  "agency_version": "46.21",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.20",
+    "framework_version": "46.21",
     "updated_at": "2026-04-22T09:45:00Z"
   },
   "source": {

--- a/src/agency/workstreams/mdpal/LICENSE
+++ b/src/agency/workstreams/mdpal/LICENSE
@@ -1,6 +1,6 @@
 Reference Source License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to:
@@ -28,3 +28,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the Reference Source License above. Use of these marks — in product
+names, service names, branding, or any identifying capacity — requires prior
+written permission from the trademark holders.

--- a/src/agency/workstreams/mock-and-mark/LICENSE
+++ b/src/agency/workstreams/mock-and-mark/LICENSE
@@ -1,6 +1,6 @@
 Reference Source License
 
-Copyright (c) 2026 TheAgencyGroup & Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to:
@@ -28,3 +28,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the Reference Source License above. Use of these marks — in product
+names, service names, branding, or any identifying capacity — requires prior
+written permission from the trademark holders.

--- a/src/apps/mdslidepal-web/LICENSE
+++ b/src/apps/mdslidepal-web/LICENSE
@@ -1,6 +1,6 @@
 Reference Source License (RSL)
 
-Copyright (c) 2026 Jordan Dea-Mattson
+Copyright (c) 2026 Jordan Dea-Mattson and TheAgencyGroup
 
 Permission is hereby granted to any person obtaining a copy of this software
 and associated documentation files (the "Software"), to use, copy, and modify
@@ -23,3 +23,19 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+---
+
+TRADEMARK NOTICE
+
+The following are trademarks of Jordan Dea-Mattson and TheAgencyGroup:
+
+  Core:     The Agency, TheAgency, TheAgencyGroup
+  Core:     Valueflow
+  Apps:     MDPal, mdpal, MockAndMark, mockandmark
+  Mascots:  Attack Kittens, Attack Kitties
+
+All rights reserved. No license to use any of the above trademarks is granted
+under the Reference Source License above. Use of these marks — in product
+names, service names, branding, or any identifying capacity — requires prior
+written permission from the trademark holders.


### PR DESCRIPTION
## Summary

Two changes bundled:

### 1. README — pivot pin-vs-main framing (principal direction)

Right now TheAgency is iterating fast. "Pin for reproducibility" is the wrong default — adopters should stay current with `main` and get fixes/improvements as they land. Pinning remains an option for regression-hold scenarios but is no longer the suggested pattern.

- Quick Start: removed "Pin to a specific release (recommended for reproducible installs)" framing. Pin now shown as one-line note after the angle-bracket caveat.
- Staying Up to Date: lead paragraph now says "we're iterating fast — staying current on `main` is the suggested path." Pin removed from code block; added as trailing paragraph for the regression-hold case.
- Versioning section: example bumped `46.5` (stale) → `46.21` (this PR).

### 2. 8 LICENSE files — joint copyright + trademark footer (issue #413)

- **Copyright reorder** to "Jordan Dea-Mattson and TheAgencyGroup" (Jordan first, "and" not "&") per principal 1B1 spec. Rolling year convention (2026 → "2026-YYYY").
- **TRADEMARK NOTICE footer** added, reserving 10 marks:
  - Core: The Agency, TheAgency, TheAgencyGroup, Valueflow
  - Apps: MDPal, mdpal, MockAndMark, mockandmark
  - Mascots: Attack Kittens, Attack Kitties
  - Explicit: "no license to use any of the above trademarks is granted under [MIT/RSL] above."

Files touched (8, not 6 — see QG section):
- `LICENSE` (root, MIT)
- `agency/LICENSE.md` + `src/agency/LICENSE.md` (MIT build + source)
- `agency/workstreams/mdpal/LICENSE` + `src/agency/workstreams/mdpal/LICENSE` (RSL build + source)
- `agency/workstreams/mock-and-mark/LICENSE` + `src/agency/workstreams/mock-and-mark/LICENSE` (RSL build + source)
- `src/apps/mdslidepal-web/LICENSE` (RSL variant — was solo Jordan, now joint)

## QG — caught 2 HIGH drift

First pass missed the `src/agency/workstreams/*/LICENSE` pair (Glob pattern didn't recurse deep enough). Reviewer-design caught both — drift vs agency/ build product would have been reverted on next `src/tools/build`. Fixed in commit `1bc4bd63`. QGR receipt `21ba2f5`.

## Manifest

46.20 → 46.21. Every PR is a release.

## Follow-up issues to file post-merge

- `src/apps/mdslidepal-web/LICENSE` RSL body divergence vs workstream RSL files (pre-existing)
- BATS test asserting LICENSE inventory + copyright format (directly motivated by this PR's near-miss)
- Dual-manifest drift guard (pre-existing)

## Test plan

- [x] commit-precheck green
- [x] All 8 LICENSE files verified consistent (copyright ordering + trademark footer)
- [x] Manifests byte-identical outside version fields
- [x] README command syntaxes still match `agency --help`
- [ ] auto-release cuts v46.21 on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)