### PR TITLE
feat(agency-captain-release-notes): new tool + skill for captain-to-captain coord

### DIFF
--- a/.claude/skills/agency-captain-release-notes/SKILL.md
+++ b/.claude/skills/agency-captain-release-notes/SKILL.md
@@ -1,0 +1,144 @@
+---
+name: agency-captain-release-notes
+description: Captain-only. Generate a release-notes skeleton for the current captain to announce a window of PRs + releases to other captains/principals on the same repo. Auto-populates the mechanical parts (PR table, version window, frontmatter, filename); captain fills qualitative sections (TL;DR, shared changes, behavioral changes, flags, in-flight, coordination asks). Every PR is a release, and every window of releases deserves a note when multiple captains share a repo.
+agency-skill-version: 2
+when_to_use: Captain has landed a burst of PRs on master and wants to broadcast what shipped to other captains/principals working the same repo. Typical cadence — once per session-burst, or daily. Also useful before session-end as a recap artifact.
+argument-hint: "[--start-version vX.Y] [--end-version vX.Y] [--to <addr>] [--audience <string>] [--workstream <name>] [--dry-run] [--stdout]"
+paths: []
+required_reading:
+  - agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+---
+
+# agency-captain-release-notes
+
+Captain-only skill. Generates a release-notes skeleton addressed to other captains or principals on the same repo. Mechanical parts (PR table, version window, frontmatter, output path) are tool-generated; qualitative parts (narrative, shared changes, flags, in-flight) are captain-filled.
+
+**Name pattern:** `agency-` (framework-level skill, upstreamed from the-agency), `captain-` (captain-only scope), `release-notes` (noun).
+
+## Why this exists
+
+When multiple captains (or captain + principal) work the same repo, "here's what I shipped since the last sync" is knowledge stored in `git log` + release tags + private handoffs. Cross-captain visibility requires manually walking `gh release list`, `gh pr list`, correlating by date, assembling a markdown file. Time-consuming, error-prone, drifts.
+
+Captured 2026-04-23 when a captain wrote a release-notes file for cross-captain coord and it took ~15 minutes + a second round when the window expanded. Principal then asked: *"this should be a tool."* So it is.
+
+The tool handles enumeration. The captain handles synthesis. Clean split.
+
+## Required reading
+
+Before running, Read the files listed in `required_reading:` frontmatter.
+
+## Usage
+
+```
+/agency-captain-release-notes                                 # auto-detect everything
+/agency-captain-release-notes --start-version v3.2            # explicit start
+/agency-captain-release-notes --start-version v3.2 --end-version v3.31
+/agency-captain-release-notes --to monofolk/peter/captain     # narrow addressee
+/agency-captain-release-notes --audience "any captain working on monofolk"
+/agency-captain-release-notes --dry-run                       # preview without writing
+/agency-captain-release-notes --stdout                        # print to stdout
+```
+
+### Arguments
+
+- `--start-version <vX.Y>` — first release tag NOT already covered by a prior release-notes file. Auto-detected from most recent prior file's `end_version` if omitted.
+- `--end-version <vX.Y>` — most recent release to include. Auto-detected as the latest tag on master if omitted.
+- `--start-date <ISO>` / `--end-date <ISO>` — alternative to version-based windowing (UTC timestamps).
+- `--to <address>` — specific addressee. Default: broadcast (no specific `to:`, audience-only frontmatter).
+- `--audience <string>` — human-readable audience description. Default: `"any captain or principal working on <project>"`.
+- `--workstream <name>` — workstream directory name under `agency/workstreams/`. Default: project name from `agency/config/agency.yaml`.
+- `--captain <name>` — captain name for filename + frontmatter. Default: resolved from `agency-identity` (`{principal}-{agent}`).
+- `--output <path>` — explicit output file path.
+- `--stdout` — print to stdout instead of writing.
+- `--dry-run` — show what would be written.
+
+## Preconditions
+
+1. `gh` CLI installed (tool queries GitHub for PRs + releases).
+2. Captain is on master or any branch (tool does not care — it queries `gh` not the local branch state).
+3. Repo has at least one release tag (for auto-detection). Not required if `--end-version` passed explicitly.
+
+## Flow / Steps
+
+### Step 1: Generate skeleton
+
+```bash
+./agency/tools/agency-captain-release-notes [...args]
+```
+
+Tool writes to `agency/workstreams/<workstream>/release-notes/release-notes-<YYYYMMDD>-<captain>-<vStart>-<vEnd>.md`.
+
+Skeleton has:
+- YAML frontmatter (from / audience / to / window / prs_landed_count / generated_by)
+- Header block (from / audience / window)
+- TL;DR placeholder
+- **PRs landed table** — auto-populated from `gh pr list`
+- Cross-repo / shared-package changes placeholder
+- Master behavioral changes placeholder
+- Open items / flags placeholder
+- In-flight (not yet PR'd) placeholder
+- Coordination requests placeholder
+- Signoff
+
+### Step 2: Fill qualitative sections
+
+The captain edits the file in place. Each placeholder section has an HTML-comment guidance block telling the captain what belongs there.
+
+Focus areas:
+- **TL;DR** — one paragraph executive summary of what shipped this window
+- **Cross-repo / shared-package changes** — new or changed shared paths (packages/, tools/, config/) that other captains' agents consume downstream
+- **Master behavioral changes** — things downstream branches pick up on next merge (process conventions, receipt patterns, infrastructure)
+- **Open items / flags** — filed framework flags + known issues + workarounds
+- **In-flight** — what's accumulating in captain's branches so others don't duplicate
+- **Coordination requests** — questions / asks for other captains
+
+### Step 3: Commit
+
+Commit via `/coord-commit` (release notes are a pure coord artifact — no QG gate). Or `/git-safe-commit --no-work-item` directly.
+
+### Step 4: Optional dispatch
+
+If the note is narrowly addressed (`--to <addr>`), dispatch a pointer to the addressee so their monitor flags it:
+
+```bash
+./agency/tools/dispatch create --to <addr> --type coord --subject "Release notes published: <vStart>-<vEnd>" --body "<file path>"
+```
+
+For broadcast audiences, skip — the file on master is discoverable.
+
+## Failure modes
+
+- **No releases exist**: tool errors on `--end-version` auto-detection. Pass `--end-version` explicitly.
+- **No prior release-notes file**: `--start-version` auto-detection falls back to `v0.0`. Captain should pass `--start-version` explicitly to anchor the window.
+- **`gh` not installed / not authenticated**: tool dies. Install + `gh auth login` first.
+- **`gh pr list` returns empty**: the window's PRs may all be closed (not merged) or the date-bound filter may be off. Check `--start-date` / `--end-date`.
+
+## What this does NOT do
+
+- **Does not commit.** Tool writes a file; captain commits via `/coord-commit`.
+- **Does not push.** Release notes typically land as coord artifacts on master, not via PR.
+- **Does not dispatch.** Optional Step 4 is captain's call.
+- **Does not fill qualitative sections.** Tool only handles the mechanical parts. Synthesis is the captain's job.
+- **Does not enforce filename convention.** Default convention is `release-notes-{YYYYMMDD}-{captain}-{vStart}-{vEnd}.md`; `--output` overrides.
+
+## Captain-only — three-layer defense
+
+1. `paths: []` — no file-path auto-activation.
+2. Name contains `captain-` — scope visible in skill listing.
+3. Tool runs as the invoking agent regardless, but the skill's audience context + auto-captain-detection via `agent-identity` means non-captain use is semantically awkward (output would carry the wrong captain name). Non-captain use isn't structurally blocked — the convention is softly enforced.
+
+## Status
+
+`active` (v1.0.0, shipped 2026-04-23 as an upstream from monofolk v3.3-v3.31 release-notes convention-capture).
+
+## Related
+
+- `/coord-commit` — how captain commits the filled release notes
+- `/git-safe-commit` — underlying commit tool
+- `/dispatch` — optional Step 4 addressee pointer
+- `agency/tools/agency-captain-release-notes` — the tool this skill wraps
+- `REFERENCE-AGENT-ADDRESSING.md` — addressee format for `--to`
+- the-agency adopter issue tracking upstream integration — TBD
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/agency/tools/agency-captain-release-notes
+++ b/agency/tools/agency-captain-release-notes
@@ -223,28 +223,14 @@ if [[ -z "$START_VERSION" ]]; then
 fi
 START_VERSION="${START_VERSION:-v0.0}"
 
-# --- Gather release list in window (only tags that exist) ---
-# Fetches release tag names + publishedAt, filters to the window.
-RELEASES_JSON=$(gh release list --limit 100 --json tagName,publishedAt 2>/dev/null || echo "[]")
-
 # --- Gather PRs merged in window ---
 # We derive date bounds from release publishedAt if versions were supplied
 # without explicit dates. If --start-date / --end-date were given, those win.
 
 if [[ -z "$START_DATE" ]]; then
     # Map START_VERSION to its publishedAt (date AFTER which to pull PRs)
-    START_DATE=$(echo "$RELEASES_JSON" | awk -v v="$START_VERSION" '
-        /"tagName":/ {
-            # capture name
-            match($0, /"tagName":"[^"]+"/)
-            name = substr($0, RSTART+11, RLENGTH-12)
-        }
-        /"publishedAt":/ {
-            match($0, /"publishedAt":"[^"]+"/)
-            at = substr($0, RSTART+15, RLENGTH-16)
-            if (name == v) { print at; exit }
-        }
-    ')
+    START_DATE=$(gh release list --limit 200 --json tagName,publishedAt \
+        --jq ".[] | select(.tagName == \"$START_VERSION\") | .publishedAt" 2>/dev/null || true)
     # Fallback: empty → 30 days ago
     if [[ -z "$START_DATE" ]]; then
         if date -u -v-30d +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
@@ -256,17 +242,8 @@ if [[ -z "$START_DATE" ]]; then
 fi
 
 if [[ -z "$END_DATE" ]]; then
-    END_DATE=$(echo "$RELEASES_JSON" | awk -v v="$END_VERSION" '
-        /"tagName":/ {
-            match($0, /"tagName":"[^"]+"/)
-            name = substr($0, RSTART+11, RLENGTH-12)
-        }
-        /"publishedAt":/ {
-            match($0, /"publishedAt":"[^"]+"/)
-            at = substr($0, RSTART+15, RLENGTH-16)
-            if (name == v) { print at; exit }
-        }
-    ')
+    END_DATE=$(gh release list --limit 200 --json tagName,publishedAt \
+        --jq ".[] | select(.tagName == \"$END_VERSION\") | .publishedAt" 2>/dev/null || true)
     END_DATE="${END_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
 fi
 
@@ -274,10 +251,11 @@ info "Window: $START_VERSION ($START_DATE) → $END_VERSION ($END_DATE)"
 info "Project: $PROJECT_NAME | Workstream: $WORKSTREAM | Captain: $CAPTAIN_NAME"
 
 # --- Enumerate merged PRs in window ---
-# Use gh's server-side filter if possible; fall back to client-side filter.
+# We don't filter on --base explicitly — repo default branch varies (main vs
+# master) and merged-into-other-branches PRs are rare enough that the date
+# window is the useful gate. Users can filter downstream if needed.
 PRS_JSON=$(gh pr list \
     --state merged \
-    --base master \
     --limit 200 \
     --json number,title,mergedAt,author \
     --jq "[.[] | select(.mergedAt >= \"$START_DATE\" and .mergedAt <= \"$END_DATE\")] | sort_by(.mergedAt)" \

--- a/agency/tools/agency-captain-release-notes
+++ b/agency/tools/agency-captain-release-notes
@@ -1,0 +1,424 @@
+#!/bin/bash
+#
+# agency-captain-release-notes — Generate a captain-to-captain release notes
+# skeleton covering a window of PRs landed on master.
+#
+# What Problem: When multiple captains (or captain + principal) work on the same
+# monofolk-style repo, there's no standing convention for "here's what I shipped
+# since the last sync" — the knowledge lives in git log + release tags + private
+# handoffs. Cross-agent visibility into what landed (and what's in-flight)
+# requires manually walking `gh release list`, `gh pr list`, correlating by date,
+# assembling a markdown file with PR table + qualitative context. This is
+# repetitive, error-prone, and tends to drift.
+#
+# Captured 2026-04-23 when principal asked captain to write a release-notes file
+# for cross-captain coord: "this is a way to tell [other captain] what we have
+# done." Manual authoring took ~15 minutes. Second round ("extend for all of
+# yesterday") required re-walking the window. Principal then asked for a tool +
+# skill so this becomes a single command.
+#
+# How & Why: Mechanical parts (PR enumeration, release window, filename,
+# frontmatter) are tool-generated. Qualitative parts (TL;DR, shared-package
+# changes, behavioral changes, open flags, in-flight) are placeholder sections
+# the captain fills in after the skeleton lands. Keeps the captain's synthesis
+# time focused on what only they can write — the narrative + coordination asks.
+#
+# Scope v1: GENERATE the skeleton to a file (or stdout). Does not commit. Does
+# not dispatch. Does not push. The captain reviews, fills qualitative sections,
+# commits via /coord-commit, pushes via standard PR flow (or leaves as coord
+# artifact on master if that's the convention).
+#
+# Window detection order:
+#   1. Explicit --start-version / --end-version (highest priority)
+#   2. --start-date / --end-date (UTC timestamps)
+#   3. Auto-detect: start = end-version of most recent prior release-notes file
+#      in the release-notes/ directory; end = latest tag on master
+#
+# Output path convention:
+#   agency/workstreams/{workstream}/release-notes/release-notes-{YYYYMMDD}-{captain-name}-{vStart}-{vEnd}.md
+#
+# Audience convention:
+#   Default audience is "any captain or principal working on {project}".
+#   --to <addr> narrows to a specific agent (e.g. monofolk/peter/captain).
+#
+# Written: 2026-04-23 — convention-capture from monofolk v3.3-v3.31 release
+# notes burst.
+
+set -euo pipefail
+
+TOOL_VERSION="1.0.0"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+    PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
+elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    :
+else
+    PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+fi
+
+# --- Colors ---
+if [[ -f "$SCRIPT_DIR/lib/_colors" ]]; then
+    source "$SCRIPT_DIR/lib/_colors"
+else
+    RED=$'\033[0;31m' GREEN=$'\033[0;32m' YELLOW=$'\033[1;33m' BLUE=$'\033[0;34m' NC=$'\033[0m'
+fi
+
+die() { echo "${RED}[ERROR]${NC} $1" >&2; exit 1; }
+info() { echo "${BLUE}[INFO]${NC} $1" >&2; }
+
+# --- Args ---
+START_VERSION=""
+END_VERSION=""
+START_DATE=""
+END_DATE=""
+TO_ADDR=""
+AUDIENCE=""
+WORKSTREAM=""
+OUTPUT_FILE=""
+STDOUT_MODE=false
+DRY_RUN=false
+CAPTAIN_NAME=""
+PROJECT_NAME=""
+
+usage() {
+    cat <<'USAGE'
+agency-captain-release-notes — Generate captain-to-captain release notes skeleton
+
+Usage:
+  agency-captain-release-notes [options]
+
+Options:
+  --start-version <vX.Y>   Starting release tag (exclusive — the last one
+                           already covered by a prior release notes file).
+                           Auto-detected from most recent prior file if omitted.
+  --end-version <vX.Y>     Ending release tag (inclusive — the most recent
+                           release you want covered). Auto-detected from latest
+                           tag on master if omitted.
+  --start-date <ISO>       Alternative to --start-version. UTC timestamp
+                           (YYYY-MM-DDTHH:MMZ).
+  --end-date <ISO>         Alternative to --end-version.
+  --to <address>           Specific addressee (e.g. "monofolk/peter/captain").
+                           Default: broadcast (audience-only frontmatter).
+  --audience <string>      Human-readable audience description. Default:
+                           "any captain or principal working on <project>".
+  --workstream <name>      Workstream directory under agency/workstreams/.
+                           Default: project name from agency/config/agency.yaml.
+  --captain <name>         Captain name for filename + frontmatter (e.g.
+                           "jordan-captain"). Default: resolved from
+                           agency/tools/agent-identity.
+  --output <path>          Explicit output file path. Default:
+                           agency/workstreams/<workstream>/release-notes/
+                           release-notes-<YYYYMMDD>-<captain>-<vStart>-<vEnd>.md
+  --stdout                 Print to stdout instead of writing a file.
+  --dry-run                Show what would be written without writing.
+  --help, -h               Show this help.
+  --version                Show tool version.
+
+Examples:
+  # Simplest invocation — auto-detect everything
+  agency-captain-release-notes
+
+  # Specify window explicitly
+  agency-captain-release-notes --start-version v3.2 --end-version v3.31
+
+  # Address to a specific captain (narrows audience)
+  agency-captain-release-notes --to monofolk/peter/captain
+
+  # Preview without writing
+  agency-captain-release-notes --dry-run
+
+  # Print to stdout (for piping / review)
+  agency-captain-release-notes --stdout
+USAGE
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --start-version)  START_VERSION="$2"; shift 2;;
+        --end-version)    END_VERSION="$2"; shift 2;;
+        --start-date)     START_DATE="$2"; shift 2;;
+        --end-date)       END_DATE="$2"; shift 2;;
+        --to)             TO_ADDR="$2"; shift 2;;
+        --audience)       AUDIENCE="$2"; shift 2;;
+        --workstream)     WORKSTREAM="$2"; shift 2;;
+        --captain)        CAPTAIN_NAME="$2"; shift 2;;
+        --output)         OUTPUT_FILE="$2"; shift 2;;
+        --stdout)         STDOUT_MODE=true; shift;;
+        --dry-run)        DRY_RUN=true; shift;;
+        --help|-h)        usage;;
+        --version)        echo "agency-captain-release-notes $TOOL_VERSION"; exit 0;;
+        *)                die "Unknown argument: $1 (see --help)";;
+    esac
+done
+
+# --- Preflight: require gh CLI ---
+command -v gh >/dev/null 2>&1 || die "gh CLI not found. Install via https://cli.github.com/"
+
+# --- Auto-detect: project name (from agency.yaml) ---
+AGENCY_YAML="$PROJECT_ROOT/agency/config/agency.yaml"
+if [[ -f "$AGENCY_YAML" ]]; then
+    # Very narrow yaml parse: look for "  name:" under "project:" block.
+    # Avoid requiring a yaml library (stdlib-only / zero-pip policy).
+    PROJECT_NAME=$(awk '
+        /^project:/ { in_project=1; next }
+        /^[a-zA-Z]/ && !/^project:/ { in_project=0 }
+        in_project && /^  name:/ { gsub(/.*name: *"?/, ""); gsub(/".*$/, ""); gsub(/[ \t]+$/, ""); print; exit }
+    ' "$AGENCY_YAML")
+fi
+PROJECT_NAME="${PROJECT_NAME:-unknown-project}"
+
+# --- Default workstream = project name ---
+WORKSTREAM="${WORKSTREAM:-$PROJECT_NAME}"
+
+# --- Auto-detect: captain name (from agent-identity) ---
+if [[ -z "$CAPTAIN_NAME" ]]; then
+    if [[ -x "$PROJECT_ROOT/agency/tools/agent-identity" ]]; then
+        # Agent-identity returns fully-qualified address like
+        # "monofolk/jordan/captain" — we want "jordan-captain".
+        AGENT_ADDR=$("$PROJECT_ROOT/agency/tools/agent-identity" --agent-address 2>/dev/null || true)
+        if [[ -n "$AGENT_ADDR" ]]; then
+            # Split by /: <repo>/<principal>/<agent>  → principal-agent
+            IFS='/' read -r _ principal agent <<< "$AGENT_ADDR"
+            if [[ -n "$principal" && -n "$agent" ]]; then
+                CAPTAIN_NAME="${principal}-${agent}"
+            fi
+        fi
+    fi
+fi
+CAPTAIN_NAME="${CAPTAIN_NAME:-unknown-captain}"
+
+# --- Default audience ---
+AUDIENCE="${AUDIENCE:-any captain or principal working on $PROJECT_NAME}"
+
+# --- Window detection ---
+DATE_TODAY="$(date -u +%Y%m%d)"
+
+# end-version: if not given, use the latest release tag on the current repo
+if [[ -z "$END_VERSION" ]]; then
+    END_VERSION=$(gh release list --limit 1 --json tagName --jq '.[0].tagName // ""' 2>/dev/null || true)
+    [[ -z "$END_VERSION" ]] && die "--end-version not given and could not auto-detect (gh release list returned nothing)"
+fi
+
+# start-version: if not given, look in release-notes/ for the most recent file
+# and pull its `end_version` frontmatter value
+RELEASE_NOTES_DIR="$PROJECT_ROOT/agency/workstreams/$WORKSTREAM/release-notes"
+if [[ -z "$START_VERSION" ]]; then
+    if [[ -d "$RELEASE_NOTES_DIR" ]]; then
+        PREV_FILE=$(ls -t "$RELEASE_NOTES_DIR"/*.md 2>/dev/null | head -1 || true)
+        if [[ -n "$PREV_FILE" ]]; then
+            # Grab the prior end_version (naive awk parse of frontmatter).
+            PREV_END=$(awk '
+                /^---/ && !fm { fm=1; next }
+                /^---/ && fm { exit }
+                fm && /^  *end_version:/ { sub(/.*end_version:[ \t]*/, ""); print; exit }
+                fm && /^  *end:/ { sub(/.*end:[ \t]*/, ""); print; exit }
+            ' "$PREV_FILE")
+            if [[ -n "$PREV_END" ]]; then
+                START_VERSION="$PREV_END"
+            fi
+        fi
+    fi
+fi
+START_VERSION="${START_VERSION:-v0.0}"
+
+# --- Gather release list in window (only tags that exist) ---
+# Fetches release tag names + publishedAt, filters to the window.
+RELEASES_JSON=$(gh release list --limit 100 --json tagName,publishedAt 2>/dev/null || echo "[]")
+
+# --- Gather PRs merged in window ---
+# We derive date bounds from release publishedAt if versions were supplied
+# without explicit dates. If --start-date / --end-date were given, those win.
+
+if [[ -z "$START_DATE" ]]; then
+    # Map START_VERSION to its publishedAt (date AFTER which to pull PRs)
+    START_DATE=$(echo "$RELEASES_JSON" | awk -v v="$START_VERSION" '
+        /"tagName":/ {
+            # capture name
+            match($0, /"tagName":"[^"]+"/)
+            name = substr($0, RSTART+11, RLENGTH-12)
+        }
+        /"publishedAt":/ {
+            match($0, /"publishedAt":"[^"]+"/)
+            at = substr($0, RSTART+15, RLENGTH-16)
+            if (name == v) { print at; exit }
+        }
+    ')
+    # Fallback: empty → 30 days ago
+    if [[ -z "$START_DATE" ]]; then
+        if date -u -v-30d +%Y-%m-%dT%H:%M:%SZ >/dev/null 2>&1; then
+            START_DATE=$(date -u -v-30d +%Y-%m-%dT%H:%M:%SZ)
+        else
+            START_DATE=$(date -u -d "30 days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "1970-01-01T00:00:00Z")
+        fi
+    fi
+fi
+
+if [[ -z "$END_DATE" ]]; then
+    END_DATE=$(echo "$RELEASES_JSON" | awk -v v="$END_VERSION" '
+        /"tagName":/ {
+            match($0, /"tagName":"[^"]+"/)
+            name = substr($0, RSTART+11, RLENGTH-12)
+        }
+        /"publishedAt":/ {
+            match($0, /"publishedAt":"[^"]+"/)
+            at = substr($0, RSTART+15, RLENGTH-16)
+            if (name == v) { print at; exit }
+        }
+    ')
+    END_DATE="${END_DATE:-$(date -u +%Y-%m-%dT%H:%M:%SZ)}"
+fi
+
+info "Window: $START_VERSION ($START_DATE) → $END_VERSION ($END_DATE)"
+info "Project: $PROJECT_NAME | Workstream: $WORKSTREAM | Captain: $CAPTAIN_NAME"
+
+# --- Enumerate merged PRs in window ---
+# Use gh's server-side filter if possible; fall back to client-side filter.
+PRS_JSON=$(gh pr list \
+    --state merged \
+    --base master \
+    --limit 200 \
+    --json number,title,mergedAt,author \
+    --jq "[.[] | select(.mergedAt >= \"$START_DATE\" and .mergedAt <= \"$END_DATE\")] | sort_by(.mergedAt)" \
+    2>/dev/null || echo "[]")
+
+PR_COUNT=$(echo "$PRS_JSON" | jq 'length' 2>/dev/null || echo "0")
+info "Found $PR_COUNT PRs in window"
+
+# --- Render PRs table ---
+render_pr_table() {
+    echo "| PR  | Merged (UTC)         | Author         | Title                                                  |"
+    echo "| --- | -------------------- | -------------- | ------------------------------------------------------ |"
+    echo "$PRS_JSON" | jq -r '.[] | "| #\(.number) | \(.mergedAt) | \(.author.login) | \(.title) |"'
+}
+
+# --- Render frontmatter ---
+render_frontmatter() {
+    echo "---"
+    echo "type: release-notes"
+    echo "from: ${PROJECT_NAME}/$(echo "$CAPTAIN_NAME" | tr '-' '/' | sed 's|/captain$|/captain|')"
+    if [[ -n "$TO_ADDR" ]]; then
+        echo "to: $TO_ADDR"
+    fi
+    echo "audience: $AUDIENCE"
+    echo "date: $(date -u +%Y-%m-%d)"
+    echo "window:"
+    echo "  start_version: $START_VERSION"
+    echo "  end_version: $END_VERSION"
+    echo "  wall_clock_start: $START_DATE"
+    echo "  wall_clock_end: $END_DATE"
+    echo "prs_landed_count: $PR_COUNT"
+    echo "generated_by: agency-captain-release-notes v$TOOL_VERSION"
+    echo "---"
+}
+
+# --- Render skeleton body ---
+render_body() {
+    cat <<BODY
+
+# Release Notes — $PROJECT_NAME $START_VERSION through $END_VERSION
+
+**From:** $CAPTAIN_NAME ($PROJECT_NAME/$(echo "$CAPTAIN_NAME" | tr '-' '/'))
+**Audience:** $AUDIENCE
+BODY
+    if [[ -n "$TO_ADDR" ]]; then
+        echo "**Addressed to:** $TO_ADDR"
+    fi
+    cat <<BODY
+**Window:** $START_DATE through $END_DATE ($PR_COUNT PRs)
+
+---
+
+## TL;DR
+
+<!-- Fill in: one-paragraph executive summary of what shipped this window. -->
+
+---
+
+## PRs landed
+
+$(render_pr_table)
+
+---
+
+## Cross-repo / shared-package changes
+
+<!-- Fill in: new or changed shared paths (packages/*, tools/*, config/*)
+     that other captains' agents may consume downstream. If any of their
+     branches pull these, a merge-from-master will pick them up. -->
+
+---
+
+## Master behavioral changes
+
+<!-- Fill in: things downstream branches need to pick up on next merge.
+     - Process changes (conventions, receipt patterns)
+     - Infrastructure (monitors, CI, build)
+     - Tool / skill landings that affect how agents work -->
+
+---
+
+## Open items / flags
+
+<!-- Fill in: anything another captain touching these surfaces should know.
+     - Framework flags filed during this window
+     - Known issues + workarounds
+     - Upstream issues filed (the-agency# / adapter#) -->
+
+---
+
+## In-flight (not yet PR'd)
+
+<!-- Fill in: things accumulating in worktrees as of publish time — so
+     other captains/principals can avoid duplication or collision.
+     Organize by workstream. -->
+
+---
+
+## Coordination requests
+
+<!-- Fill in: any asks / questions for other captains. Keep it to things
+     that would genuinely benefit from their input. -->
+
+---
+
+— $CAPTAIN_NAME
+_generated by \`agency-captain-release-notes\` v${TOOL_VERSION}_
+
+BODY
+}
+
+# --- Determine output path ---
+if [[ "$STDOUT_MODE" == "true" || -n "${OUTPUT_FILE:+x}" ]]; then
+    :  # stdout / explicit output
+else
+    OUTPUT_FILE="$RELEASE_NOTES_DIR/release-notes-${DATE_TODAY}-${CAPTAIN_NAME}-${START_VERSION}-${END_VERSION}.md"
+fi
+
+# --- Dry run: just report ---
+if [[ "$DRY_RUN" == "true" ]]; then
+    info "DRY RUN — would write to: ${OUTPUT_FILE:-<stdout>}"
+    info "  frontmatter fields: from/audience/to/window/prs_landed_count"
+    info "  PR rows: $PR_COUNT"
+    exit 0
+fi
+
+# --- Write output ---
+if [[ "$STDOUT_MODE" == "true" ]]; then
+    render_frontmatter
+    render_body
+else
+    mkdir -p "$(dirname "$OUTPUT_FILE")"
+    {
+        render_frontmatter
+        render_body
+    } > "$OUTPUT_FILE"
+
+    echo "${GREEN}✓${NC} Release notes skeleton written: $OUTPUT_FILE"
+    echo ""
+    echo "Next steps:"
+    echo "  1. Fill qualitative sections (TL;DR, shared-package changes, flags, in-flight, coordination)."
+    echo "  2. Commit via /coord-commit (coord artifact — no QG gate)."
+    echo "  3. (Optional) Dispatch a pointer to specific agents if narrow addressing is needed."
+fi

--- a/agency/workstreams/agency/release-notes/release-notes-20260423-jordan-captain-v46.13-v46.22.md
+++ b/agency/workstreams/agency/release-notes/release-notes-20260423-jordan-captain-v46.13-v46.22.md
@@ -1,0 +1,130 @@
+---
+type: release-notes
+from: the-agency/jordan/captain
+audience: any adopter or captain of the-agency framework
+date: 2026-04-23
+window:
+  start_version: v46.13
+  end_version: v46.22
+  wall_clock_start: 2026-04-21T11:02:29Z
+  wall_clock_end: 2026-04-22T06:13:37Z
+prs_landed_count: 9
+generated_by: agency-captain-release-notes v1.0.0
+---
+
+# Release Notes — the-agency v46.13 through v46.22
+
+**From:** jordan-captain (the-agency/jordan/captain)
+**Audience:** any adopter or captain of the-agency framework
+**Window:** 2026-04-21T11:02:29Z through 2026-04-22T06:13:37Z (9 PRs)
+
+---
+
+## TL;DR
+
+Nine PRs landed on the-agency main between 2026-04-21 and 2026-04-22, advancing the framework from **v46.13 → v46.22**. Headline themes: **V5 plan rollout begins** (src/ split, Python build tool, plan captured to repo), **release-automation hardening** (C#372 A+B+C+D stack fixes), **great-rename-migrate fleet tool** (unblocks adopters pulling new monofolk-style rename into their forks), **README + legal framing** (Quick Start, Stay-Current rationale, joint copyright, trademark footer), plus **housekeeping QG** on PR #362 follow-up.
+
+New upstream tool + skill landing this note: **`agency-captain-release-notes`** (this file's generator) — see #426 on branch `feat/agency-captain-release-notes`.
+
+---
+
+## PRs landed
+
+| PR  | Merged (UTC)         | Author         | Title                                                  |
+| --- | -------------------- | -------------- | ------------------------------------------------------ |
+| #406 | 2026-04-21T12:45:31Z | jordandm | fix(c372): release-automation gap — A+B+C+D 4-fix stack → v46.14 |
+| #410 | 2026-04-21T14:31:57Z | jordandm | fix(bucket-g1): great-rename-migrate tool — fleet unblock v46.15 |
+| #397 | 2026-04-21T14:45:53Z | jordan-of | fix(housekeeping): QG findings on PR #362 follow-up — cp-safe C-1/S-2, skill-audit C-3, captain-* DMI body sweep S-4, test coverage T-1 |
+| #411 | 2026-04-21T14:59:48Z | jordandm | fix(v5-phase-3): prune cruft + restore agency-whoami stub + audit report — v46.17 |
+| #416 | 2026-04-22T01:34:19Z | jordandm | fix(housekeeping): cross-repo migration + iteration archive delete + msg-ref sweep — v46.18 |
+| #418 | 2026-04-22T02:15:29Z | jordandm | fix(v5): Phase 4a src/ split + Phase 5a Python build tool + 18 BATS + diff-hash fix — v46.19 |
+| #421 | 2026-04-22T03:45:49Z | jordandm | docs: README Quick Start + What you Get + agency update + This Repo Structure (v46.20) |
+| #422 | 2026-04-22T04:18:03Z | jordandm | docs + legal: stay-current README framing + joint copyright + trademark footer (v46.21) |
+| #423 | 2026-04-22T06:13:28Z | jordandm | docs: capture V5 plan into repo (agency/workstreams/agency/) + manifest 46.22 |
+
+---
+
+## Cross-repo / shared-package changes
+
+### V5 Phase 4a — `src/` split (#418)
+
+The framework internals moved under `src/` — a staged structural move toward the V5 layout. Adopters pulling via `agency update` will see:
+- Tests relocated under `src/tests/tools/`
+- Internal modules relocated under `src/lib/` (from `agency/tools/lib/`)
+- `diff-hash` + other tools updated to respect the new paths
+- 18 new BATS tests cover the transition
+
+### V5 Phase 5a — Python build tool (#418)
+
+New Python-based build surface introduced, starting the shift off pure-bash for framework-internal composition work. Adopters: no action until Phase 5b binds user-facing commands to it.
+
+### `great-rename-migrate` tool (#410)
+
+New bucket-g1 tool at `agency/tools/great-rename-migrate` — unblocks adopters who want to pull a `claude/` → `agency/` rename convention into their forks without manually walking every hookify symlink + REFERENCE path. Fleet-wide unblock for the Great Rename convention adoption.
+
+### Release automation (C#372 A+B+C+D stack — #406)
+
+Four-fix stack addressing the release-automation gap that blocked previous v46.13 retry:
+- Fix A: post-merge-state detector
+- Fix B: captain-release refuses when prior release is in pending-post-merge
+- Fix C: captain-release-post-merge always cuts the release after merge
+- Fix D: coverage tests hold the invariants
+
+Adopters running `/captain-release` will now see a precondition check ("prior release is pending post-merge — run `/pr-captain-post-merge <PR>` first"). This is intentional — a safety gate you can't skip.
+
+### Housekeeping QG follow-up (#397)
+
+PR #362's QG findings absorbed:
+- **cp-safe C-1/S-2**: additional path-traversal + symlink-escape guards
+- **skill-audit C-3**: widened to catch skills missing `captain-` prefix on captain-only operations
+- **captain-* DMI body sweep S-4**: removed `disable-model-invocation: true` from captain skills (see `REFERENCE-SKILL-CONVENTIONS.md` §1 — DMI blocked captain from invoking captain-scoped skills in their own session)
+- **test coverage T-1**: filled gaps
+
+### README + legal framing (#421, #422)
+
+- Quick Start section with curl-bash one-liner + minimal-setup + first-session walkthrough
+- "What you get" feature bullets
+- Stay-Current rationale for pulling `main` vs pinning a tag
+- Joint copyright with community contributor attribution
+- Trademark footer
+
+---
+
+## Master behavioral changes
+
+- **V5 plan** captured to repo (#423) at `agency/workstreams/agency/` — adopters can now see the full V5 roadmap (src/ split complete, Python build tool started, reamining phases enumerated). Useful context for captains deciding when to pull mid-rollout vs wait.
+- **DMI removed from all captain skills** (#397 S-4): `disable-model-invocation: true` no longer appears in captain skill frontmatter. If your captain skill had it copied from a pre-v46.15 template, update on next skill edit. Behavior unchanged for end-users.
+- **Captain-release precondition tightened** (#406 Fix B): `/captain-release` refuses if the prior release is in pending-post-merge state. Expected next action is `/pr-captain-post-merge <pending-pr>` first.
+- **Release notes convention introduced** — in-flight on `feat/agency-captain-release-notes` (#426), not yet merged. Adopters: once merged, any captain can run `/agency-captain-release-notes` to broadcast what landed.
+
+---
+
+## Open items / flags
+
+- **#425 open:** `agency-bootstrap.sh` has no first-class `--initial-push` escape hatch for fresh repos. Adopters bootstrapping a brand-new private repo hit the git-captain "Push to main is blocked" block. Workaround: `AGENCY_ALLOW_RAW=1 git push -u origin main` once. Suggested fix: dedicated `git-captain initial-push` subcommand that only succeeds when `origin/main` does not yet exist. Filed from monofolk captain during `ordinaryfolk/of-legacy` bootstrap on 2026-04-23.
+- **#426 open (this upstream):** `agency-captain-release-notes` tool + skill — awaits review + merge.
+- **V5 Phase 5b+ pending**: Python build tool bound to user-facing commands. Status in `agency/workstreams/agency/` plan.
+- **Great Rename fleet roll:** `great-rename-migrate` (#410) is available; adopters ready to adopt the convention can run it. Not forced.
+
+---
+
+## In-flight (not yet PR'd)
+
+- **`agency-captain-release-notes`** on `feat/agency-captain-release-notes` (#426) — this tool + skill. 8/8 bats tests pass.
+- **V5 Phase 5b+** — Python build tool bound to user-facing commands. Plan captured at `agency/workstreams/agency/`.
+
+Other work not visible from this captain's window — other captains' work on their own branches may be accumulating separately.
+
+---
+
+## Coordination requests
+
+1. **Review + merge #426** (`agency-captain-release-notes`) — first real-world use (monofolk v3.3-v3.31, 28-PR window) validated the shape. Feedback welcome on default audience copy, frontmatter fields, placeholder sections.
+2. **Review + merge #425 (once someone picks it up)** — `git-captain initial-push` would make fresh-repo bootstrap adopter-friendly.
+3. If other captains are already writing release notes in their forks (monofolk or otherwise), please share the shape you've converged on — this is a new convention and input helps us calibrate before hardening.
+
+---
+
+— jordan-captain
+_generated by `agency-captain-release-notes` v1.0.0_
+

--- a/src/tests/tools/agency-captain-release-notes.bats
+++ b/src/tests/tools/agency-captain-release-notes.bats
@@ -1,0 +1,210 @@
+#!/usr/bin/env bats
+#
+# Tests for agency/tools/agency-captain-release-notes
+#
+# Covers --version, --help, argument parsing, and basic skeleton generation
+# (frontmatter + PR table rendering) using a stubbed `gh` CLI.
+#
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    test_isolation_setup
+
+    TOOL="${REPO_ROOT}/agency/tools/agency-captain-release-notes"
+
+    # Mock project
+    export TEST_REPO="${BATS_TEST_TMPDIR}/mock-repo"
+    mkdir -p "$TEST_REPO"
+    cd "$TEST_REPO"
+    git init --quiet --initial-branch=main 2>/dev/null || git init --quiet
+    git config user.email "test@example.com"
+    git config user.name "Test User"
+
+    mkdir -p agency/tools agency/config agency/workstreams/mockproj/release-notes
+
+    # minimal agency.yaml the tool parses
+    cat > agency/config/agency.yaml <<YAML
+project:
+  name: "mockproj"
+  timezone: "UTC"
+YAML
+
+    # initial commit
+    echo "x" > README.md
+    git add -A
+    git commit -m "initial" --quiet
+    git update-ref refs/remotes/origin/main HEAD
+
+    cp "$TOOL" agency/tools/agency-captain-release-notes
+    chmod +x agency/tools/agency-captain-release-notes
+
+    # Stub gh on PATH so the tool can run offline.
+    STUB_DIR="${BATS_TEST_TMPDIR}/stubs"
+    mkdir -p "$STUB_DIR"
+    cat > "$STUB_DIR/gh" <<'STUB'
+#!/usr/bin/env bash
+# Minimal gh stub — covers only the subcommands the tool calls.
+case "$1 $2" in
+    "release list")
+        # Return one release tag so --end-version auto-detect works
+        echo '[{"tagName":"v1.0","publishedAt":"2026-04-20T00:00:00Z"}]'
+        ;;
+    "pr list")
+        # Return an empty array; window tests stub richer fixtures.
+        echo '[]'
+        ;;
+    *)
+        echo '{}'
+        ;;
+esac
+STUB
+    chmod +x "$STUB_DIR/gh"
+    export PATH="$STUB_DIR:$PATH"
+}
+
+teardown() {
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Version + help
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: --version shows tool version" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes --version
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"agency-captain-release-notes"* ]]
+    [[ "$output" == *"1.0.0"* ]]
+}
+
+@test "agency-captain-release-notes: --help shows usage" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Generate captain-to-captain release notes skeleton"* ]]
+    [[ "$output" == *"--start-version"* ]]
+    [[ "$output" == *"--audience"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Arg parsing
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: rejects unknown arg" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes --bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown argument"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dry run with explicit window
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: --dry-run reports without writing" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes \
+        --start-version v0.9 \
+        --end-version v1.0 \
+        --captain "test-captain" \
+        --workstream "mockproj" \
+        --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"DRY RUN"* ]]
+
+    # No file should have been written
+    run bash -c "ls agency/workstreams/mockproj/release-notes/*.md 2>/dev/null | wc -l | tr -d ' '"
+    [ "$output" == "0" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Stdout mode prints frontmatter + sections
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: --stdout emits frontmatter + placeholders" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes \
+        --start-version v0.9 \
+        --end-version v1.0 \
+        --captain "test-captain" \
+        --workstream "mockproj" \
+        --stdout
+    [ "$status" -eq 0 ]
+    # Frontmatter
+    [[ "$output" == *"type: release-notes"* ]]
+    [[ "$output" == *"audience: any captain or principal working on mockproj"* ]]
+    [[ "$output" == *"generated_by: agency-captain-release-notes"* ]]
+    # Body sections
+    [[ "$output" == *"## TL;DR"* ]]
+    [[ "$output" == *"## PRs landed"* ]]
+    [[ "$output" == *"## Cross-repo / shared-package changes"* ]]
+    [[ "$output" == *"## Open items / flags"* ]]
+    [[ "$output" == *"## In-flight (not yet PR'd)"* ]]
+    [[ "$output" == *"## Coordination requests"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# File output with default path
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: writes to default path" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes \
+        --start-version v0.9 \
+        --end-version v1.0 \
+        --captain "test-captain" \
+        --workstream "mockproj"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Release notes skeleton written"* ]]
+
+    # File should exist under default path
+    DATE_TODAY=$(date -u +%Y%m%d)
+    EXPECTED_FILE="agency/workstreams/mockproj/release-notes/release-notes-${DATE_TODAY}-test-captain-v0.9-v1.0.md"
+    [ -f "$EXPECTED_FILE" ]
+
+    # And should carry the frontmatter
+    run grep -q "^type: release-notes$" "$EXPECTED_FILE"
+    [ "$status" -eq 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Explicit --to adds frontmatter entry
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: --to populates frontmatter" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes \
+        --start-version v0.9 \
+        --end-version v1.0 \
+        --captain "test-captain" \
+        --workstream "mockproj" \
+        --to "mockproj/alice/captain" \
+        --stdout
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"to: mockproj/alice/captain"* ]]
+    # Addressed to line in body too
+    [[ "$output" == *"Addressed to:"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Custom --audience passes through
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-captain-release-notes: --audience overrides default" {
+    cd "$TEST_REPO"
+    run ./agency/tools/agency-captain-release-notes \
+        --start-version v0.9 \
+        --end-version v1.0 \
+        --captain "test-captain" \
+        --workstream "mockproj" \
+        --audience "the fleet" \
+        --stdout
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"audience: the fleet"* ]]
+}


### PR DESCRIPTION
## Summary

Captures a convention proven in monofolk v3.3-v3.31 (28-PR burst, 24+ hour window): when multiple captains (or captain + principal) work the same repo, cross-captain visibility into what shipped + what's in-flight is manually expensive. This tool + skill reduces it to one command.

## What's new

**`agency/tools/agency-captain-release-notes`** (v1.0.0, zero-pip)

- Auto-populates mechanical parts: PR table (via `gh pr list`), version window, frontmatter, filename
- Captain fills qualitative sections: TL;DR, shared-package changes, master behavioral changes, open flags, in-flight, coordination requests
- Default audience: broadcast (`"any captain or principal working on <project>"`)
- `--to <addr>` narrows to a specific addressee (e.g. `monofolk/peter/captain`)
- Window auto-detected from prior release-notes file's `end_version` frontmatter + latest `gh release list` tag
- Output path convention: `agency/workstreams/<workstream>/release-notes/release-notes-<YYYYMMDD>-<captain>-<vStart>-<vEnd>.md`

**`.claude/skills/agency-captain-release-notes/SKILL.md`**

- Captain-only (name contains `captain-`, `paths: []`)
- Wraps the tool with full workflow: generate → fill → commit via `/coord-commit` → optional dispatch
- Cross-references `REFERENCE-AGENT-ADDRESSING.md` and `REFERENCE-SAFE-TOOLS.md`

**`src/tests/tools/agency-captain-release-notes.bats`**

- 8 tests covering `--version`, `--help`, arg parsing, `--dry-run`, `--stdout`, default output path, `--to`, `--audience`
- Uses stubbed `gh` for offline testing
- All passing

## Why it matters

Principal observation (2026-04-23): after 28 PRs landed in a single window, the manual synthesis of "here's what I shipped" took ~15 minutes + a second round when the window expanded. The knowledge lives in `git log` + release tags + private handoffs; aggregating it is repetitive and drifts. The tool handles enumeration; the captain handles synthesis. Clean split.

## Test plan

- [x] `--version` outputs `agency-captain-release-notes 1.0.0`
- [x] `--help` shows usage with all flags
- [x] Unknown arg rejected
- [x] `--dry-run` reports without writing
- [x] `--stdout` emits frontmatter + all placeholder sections
- [x] Default path write works (`release-notes-<date>-<captain>-<vStart>-<vEnd>.md`)
- [x] `--to <addr>` populates frontmatter + body
- [x] `--audience <string>` overrides default

## Convention capture

The first real-world use (monofolk v3.3-v3.31 release notes, 2026-04-23) validated the shape before this PR landed upstream. Adopters can follow the same pattern by running `/agency-captain-release-notes` after each delivery burst.

🤖 Generated with [Claude Code](https://claude.com/claude-code)