### PR TITLE
fix(worktree-sync): don't pop stale stashes — phantom-merge state

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.22",
+  "agency_version": "46.23",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.22",
-    "updated_at": "2026-04-22T09:45:00Z"
+    "framework_version": "46.23",
+    "updated_at": "2026-05-08T06:30:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/tools/worktree-sync
+++ b/agency/tools/worktree-sync
@@ -151,8 +151,22 @@ DIRTY=$(git status --porcelain 2>/dev/null)
 
 if [[ -n "$DIRTY" ]]; then
     if [[ "$AUTO_MODE" == true ]]; then
-        git stash --quiet 2>/dev/null
-        STASHED=true
+        # CRITICAL: only set STASHED=true if `git stash` actually pushed a stash.
+        # `git stash` (without -u) returns non-zero when only UNTRACKED files exist
+        # (DIRTY catches untracked files via "??" lines). If we set STASHED=true
+        # unconditionally, the later `git stash pop` will pop a STALE stash from
+        # prior sessions — leaving the working tree in a phantom-merge state with
+        # AUTO_MERGE/MERGE_RR/conflict markers but no MERGE_HEAD. This bug
+        # corrupted multiple worktrees in adopter repos on 2026-05-08.
+        # We capture the stash ref at push time so the later pop is unambiguous.
+        STASH_BEFORE=$(git stash list --pretty=format:"%H" 2>/dev/null | head -1 || true)
+        if git stash --quiet 2>/dev/null; then
+            STASH_AFTER=$(git stash list --pretty=format:"%H" 2>/dev/null | head -1 || true)
+            if [[ -n "$STASH_AFTER" && "$STASH_AFTER" != "$STASH_BEFORE" ]]; then
+                STASHED=true
+                STASH_REF="$STASH_AFTER"
+            fi
+        fi
     else
         DIRTY_COUNT=$(echo "$DIRTY" | grep -c . || echo 0)
         echo "worktree-sync: working tree is dirty — commit or stash first" >&2
@@ -198,11 +212,17 @@ else
             echo "  WARNING: git merge --abort failed — repo may not be fully restored." >&2
         fi
 
-        # Unstash if we stashed (disable trap since we're handling it)
+        # Unstash if we stashed (disable trap since we're handling it).
+        # Use the specific stash ref captured at push time to avoid popping
+        # a stale stash that drifted to top via concurrent activity.
         STASH_MSG="no stash taken"
         if [[ "$STASHED" == true ]]; then
             STASHED=false
-            if git stash pop --quiet 2>/dev/null; then
+            if [[ -n "${STASH_REF:-}" ]] && git stash apply "$STASH_REF" --quiet 2>/dev/null; then
+                git stash drop "$STASH_REF" --quiet 2>/dev/null || true
+                STASH_MSG="stashed work restored (ref $STASH_REF)"
+            elif git stash pop --quiet 2>/dev/null; then
+                # Fallback for older invocations that didn't capture STASH_REF
                 STASH_MSG="stashed work restored via git stash pop"
             else
                 STASH_MSG="stash pop failed — your stashed work is still in git stash (run 'git stash list')"
@@ -264,10 +284,20 @@ if [[ "$MERGED" == true ]]; then
 fi
 
 # --- Unstash if we stashed ---
+# Use the specific STASH_REF captured at push time to guarantee we don't pop
+# a stale stash. Without this, a fall-through `git stash pop` would pop
+# whatever's at stash@{0} — including stashes from prior sessions that may
+# conflict with current main content (the 2026-05-08 phantom-merge bug).
 UNSTASH_CONFLICT=false
 if [[ "$STASHED" == true ]]; then
     STASHED=false  # Disable trap — we're handling it
-    if ! git stash pop --quiet 2>/dev/null; then
+    if [[ -n "${STASH_REF:-}" ]]; then
+        if git stash apply "$STASH_REF" --quiet 2>/dev/null; then
+            git stash drop "$STASH_REF" --quiet 2>/dev/null || true
+        else
+            UNSTASH_CONFLICT=true
+        fi
+    elif ! git stash pop --quiet 2>/dev/null; then
         UNSTASH_CONFLICT=true
     fi
 fi


### PR DESCRIPTION
## Summary

CRITICAL framework hotfix. `worktree-sync --auto` was setting `STASHED=true` unconditionally on dirty tree, then later `git stash pop` popped whatever was at top of the stash stack — including stashes from prior sessions, possibly days or weeks old. This caused phantom-merge state (AUTO_MERGE/MERGE_RR + unmerged stages + working-tree conflict markers, **no MERGE_HEAD**) on multiple worktrees in monofolk on 2026-05-08, blocking `/session-resume` across the fleet.

## Root cause

Two bugs combine in `agency/tools/worktree-sync`:

1. `git stash` (without `--include-untracked`) skips untracked files. If `DIRTY` only contained untracked entries (`??` lines), `git stash` exits non-zero ("No local changes to save") and pushes nothing. `2>/dev/null` swallowed the error. `STASHED=true` set regardless.
2. Later, `git stash pop` pops whatever is at top of the stash stack — could be a stale stash from a prior session.

Result: every cold `worktree-sync --auto` on a tree with only-untracked changes pops the oldest stash on the stack, applying its content as "resolved merge content" against the current main HEAD. If the content doesn't match cleanly (e.g. the stash content was superseded by an intervening PR), git writes conflict markers + leaves AUTO_MERGE behind without recording MERGE_HEAD (because it's a stash pop, not a merge). Worktree is now stuck. `git merge --abort` refuses (no MERGE_HEAD).

## Fix

Two changes, applied at both callsites (success path + merge-conflict-recovery path):

1. **Set `STASHED=true` ONLY if `git stash` actually pushed something** — verified by comparing `git stash list` SHAs before and after.
2. **Capture the specific `STASH_REF` at push time.** At pop time, use `git stash apply <ref> + drop <ref>` instead of `git stash pop`, which guarantees we operate on the stash WE pushed and not whatever drifted to the top.

Backward-compatible: falls through to `git stash pop` if `STASH_REF` wasn't captured (defensive fallback).

## Discovered in monofolk

2026-05-08 multi-worktree fleet incident — both healthos + of-mobile agent worktrees blocked simultaneously when their `/session-resume` runs hit the same 2-week-old "pre-merge: UX fixes" stash sitting at top of the global stash stack. Recovery required manual cleanup (rm AUTO_MERGE/MERGE_RR + git-safe unstage + git-safe restore + rm DU phantoms) because `git merge --abort` refused (no MERGE_HEAD).

## Test plan

- [ ] With N stale stashes on the stack, run `worktree-sync --auto` on a tree containing only untracked files. Verify: (a) no stash gets popped, (b) tree is clean after, (c) the stash list is unchanged.
- [ ] With N stale stashes + tracked-file mods, run `worktree-sync --auto`. Verify: (a) the new stash gets pushed, (b) merge runs, (c) the new stash is applied + dropped, (d) stale stashes remain untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)