### PR TITLE
captain: git-safe init — bare-repo bootstrap subcommand (resolves #437)

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.23",
+  "agency_version": "46.24",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.23",
-    "updated_at": "2026-05-09T10:30:00Z"
+    "framework_version": "46.24",
+    "updated_at": "2026-05-09T13:00:00Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-05-09T10:30:00Z"
+  "updated_at": "2026-05-09T13:00:00Z"
 }

--- a/agency/tools/git-safe
+++ b/agency/tools/git-safe
@@ -12,11 +12,20 @@
 # of main vs master. Hookify rules can trust git-safe invocations because the
 # dangerous patterns are blocked at this layer.
 #
-# Written: 2026-04-14 during devex workstream (git-safe family)
+# Written: 2026-04-14 during devex workstream (git-safe family).
+# Updated: 2026-05-09 — added `init` subcommand for bare-repo bootstrap.
+#   Per issue #437: hookify.block-raw-tools blocks `git init`, but the
+#   git-safe family had no equivalent. The framework's "agency-init on bare
+#   repos" north star couldn't proceed without a manual sidestep
+#   (`gh repo create --clone`). `git-safe init [path]` closes that gap with
+#   the standard guards (validates path, refuses if .git/ already exists,
+#   creates target dir if missing).
+#
+# Version: 1.1.0 (provenance: 20260509-this-happened-bootstrap)
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
@@ -47,6 +56,10 @@ Subcommands (read-only):
   blame [args]           git blame
 
 Subcommands (guarded write):
+  init [path]                  Initialize a fresh git repo at [path] (default: cwd).
+                               Refuses if .git/ already exists at the target.
+                               Creates the target directory (and parents) if missing.
+                               For bare-repo bootstrap when raw `git init` is blocked.
   add <file> [file...]         Stage explicit file paths (blocks -A, --all, ., wildcards)
   add --files-from <path>      Stage from explicit newline-separated list (issue #388 —
                                scales past argv limits; comments + blank lines OK)
@@ -520,6 +533,42 @@ cmd_restore() {
     echo "Restored $restored file(s) from HEAD"
 }
 
+# --- Subcommand: init ---
+# Issue #437: bare-repo bootstrap requires `git init` before agency-bootstrap.sh
+# can run, but raw `git init` is blocked by hookify.block-raw-tools. This
+# subcommand is the safe wrapper: validates path doesn't already contain
+# .git/, creates target dir (and parents) if missing, calls real git init.
+cmd_init() {
+    local target="${1:-.}"
+
+    # Validate target path
+    case "$target" in
+        -*) die "git-safe init: flag-like path '$target' rejected." ;;
+        *..*) die "git-safe init: path traversal '..' blocked in '$target'." ;;
+        *\**|*\?*|*\[*) die "git-safe init: glob metacharacters blocked in '$target'." ;;
+    esac
+
+    # Refuse if .git/ already exists at the target (file or dir — git supports both)
+    if [[ -d "$target" && -e "$target/.git" ]]; then
+        local abs
+        abs="$(cd "$target" && pwd)"
+        die "git-safe init: already a git repo: $abs/.git exists. Use 'git-safe status' to inspect, or remove .git/ first if re-initializing."
+    fi
+
+    # Create target dir (and any parents) if missing — mirrors `mkdir -p` behavior
+    if [[ ! -d "$target" ]]; then
+        mkdir -p "$target" || die "git-safe init: failed to create directory: $target"
+    fi
+
+    # Initialize (git init creates .git/ inside the target dir)
+    git init "$target" >/dev/null || die "git-safe init: git init failed for $target"
+
+    # Resolve absolute path for clear reporting
+    local abs
+    abs="$(cd "$target" && pwd)"
+    echo "${GREEN}Initialized empty git repo:${NC} $abs"
+}
+
 # --- Main dispatch ---
 [[ $# -eq 0 ]] && usage
 
@@ -532,6 +581,7 @@ case "$1" in
     branch)       shift; cmd_branch "$@" ;;
     show)         shift; cmd_show "$@" ;;
     blame)        shift; cmd_blame "$@" ;;
+    init)             shift; cmd_init "$@" ;;
     add)              shift; cmd_add "$@" ;;
     rm)               shift; cmd_rm "$@" ;;
     resolve-conflict) shift; cmd_resolve_conflict "$@" ;;

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-the-agency-qgr-pr-prep-20260509-1334-46f23d8.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-the-agency-qgr-pr-prep-20260509-1334-46f23d8.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: the-agency
+diff_base: origin/main
+hash_a: 46f23d85d70dd7d139814abc61c570570aceff6d8cc359d614a67ba13a2398a2
+hash_b: 324581a6da50dd38fe4c785d7554c2fdc037d80879cd27057b5dad52f087fee0
+hash_c: 816dee25a77430cde9b0d4354b4b0cf71b837de813209f1387246e772afb77a4
+hash_d: 816dee25a77430cde9b0d4354b4b0cf71b837de813209f1387246e772afb77a4
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 46f23d85d70dd7d139814abc61c570570aceff6d8cc359d614a67ba13a2398a2
+date: 2026-05-09T13:34
+---
+
+# Receipt: pr-prep — the-agency
+
+## Chain of Trust
+- A (original): 46f23d8
+- B (findings): 324581a
+- C (triage): 816dee2
+- D (principal): 816dee2 — auto-approved — no principal 1B1
+- E (final): 46f23d8
+
+## Review Summary
+git-safe v1.1.0 — adds 'init' subcommand for bare-repo bootstrap (resolves #437); manifest 46.23 → 46.24

--- a/src/tests/tools/git-safe.bats
+++ b/src/tests/tools/git-safe.bats
@@ -648,3 +648,84 @@ _setup_conflict() {
     assert_output_contains "stash push"
     assert_output_contains "stash pop"
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# init subcommand — issue #437 — bare-repo bootstrap
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# Closes the gap that blocked the this-happened bootstrap: hookify blocks
+# raw `git init`, but the git-safe family had no equivalent. These tests
+# operate inside the per-test BATS_TEST_TMPDIR — each `git-safe init` is
+# scoped to a fresh subdir, never touching the surrounding test fixture
+# repo.
+
+@test "git-safe init: creates fresh repo at given path" {
+    cd "${BATS_TEST_TMPDIR}"
+    local target="${BATS_TEST_TMPDIR}/init-fresh"
+
+    run ./agency/tools/git-safe init "$target"
+    assert_success
+    assert_output_contains "Initialized empty git repo:"
+    [[ -d "$target/.git" ]]
+}
+
+@test "git-safe init: creates target dir (and parents) if missing" {
+    cd "${BATS_TEST_TMPDIR}"
+    local target="${BATS_TEST_TMPDIR}/init-deep/nested/repo"
+
+    run ./agency/tools/git-safe init "$target"
+    assert_success
+    [[ -d "${BATS_TEST_TMPDIR}/init-deep" ]]
+    [[ -d "${BATS_TEST_TMPDIR}/init-deep/nested" ]]
+    [[ -d "$target/.git" ]]
+}
+
+@test "git-safe init: refuses if .git/ already exists at target" {
+    cd "${BATS_TEST_TMPDIR}"
+    local target="${BATS_TEST_TMPDIR}/init-existing"
+    mkdir -p "$target"
+    git init "$target" --quiet 2>/dev/null
+
+    run ./agency/tools/git-safe init "$target"
+    assert_failure
+    assert_output_contains "already a git repo"
+    [[ -d "$target/.git" ]]  # untouched
+}
+
+@test "git-safe init: rejects path-traversal '..' in target" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-safe init "../escape"
+    assert_failure
+    assert_output_contains "path traversal"
+}
+
+@test "git-safe init: rejects glob metacharacters in target" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-safe init "evil*path"
+    assert_failure
+    assert_output_contains "glob metacharacters"
+}
+
+@test "git-safe init: rejects flag-like target" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-safe init "--bare"
+    assert_failure
+    assert_output_contains "flag-like"
+}
+
+@test "git-safe init: --help mentions init subcommand" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-safe --help
+    assert_success
+    # Note: avoid brackets in the assertion pattern — assert_output_contains
+    # uses [[ == *pattern* ]] which treats [..] as a glob character class.
+    assert_output_contains "Initialize a fresh git repo"
+    assert_output_contains "bare-repo bootstrap"
+}
+
+@test "git-safe init: TOOL_VERSION 1.1.0 advertised via --version" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-safe --version
+    assert_success
+    assert_output_contains "1.1.0"
+}

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,139 +1,109 @@
 ---
 type: session
 agent: the-agency/jordan/captain
-date: 2026-04-25T00:37:30Z
-trigger: compact-prepare
-branch: main
-mode: continuation
-pause_commit_sha: e2324392
-next-action: "Resume Bucket 1 #419-ecosystem 1B1 at Item 1 (#288 install-surface rule). Principal interrupted with namespace + manifest-driven-installer corrections; both resolved with apologies. Item 1 remains paused awaiting principal verdict on (a) canonical class set + (b) hookify allowlist scope. ALSO: process unread cross-repo dispatch from monofolk re Claude Code regression #53145 (claude --resume crashes on 2.1.120) before resuming triage."
+date: 2026-05-09T12:45
+trigger: principal-moving-temp-shutdown
+branch: captain-git-safe-init
+mode: resumption
+next-action: |
+  Build `git-safe init` subcommand in `agency/tools/git-safe`. Branch
+  `captain-git-safe-init` already created (clean, no edits yet). Resolves
+  framework gap #437. After tool ships via captain-release + merge, redo
+  the `~/code/this-happened/` git-init step using the new tool to prove
+  the chain. Then continue this-happened bootstrap.
 ---
 
-# Handoff — /compact-prepare during agency-issue triage Bucket 1
+# Captain handoff — paused mid-bootstrap of this-happened (hackathon)
 
-## Situation
+## Where we are
 
-Mid-session compact during the strict 1B1 walk through agency-issue blocker buckets. Principal directive earlier this session: "Pick up your Agency Issues" — autonomous waves I + J landed (e2324392 + 2c74da7f), 67 issues closed total. Then started 1B1 walk through 5 blocker buckets.
+Hackathon day. Pivoted from mdpal to a new project: **this-happened** — user issue reporting + Breadcrumb (UUID7 distributed tracing). Per seed at `agency/workstreams/agency/history/flotsam/legacy-agency-workstream-20260420/seeds/seed-it-happened-and-breadcrumb-20260410.md`.
 
-Currently paused at: **Bucket 1 (#419 ecosystem) Item 1 (#288 install-surface rule)** — awaiting principal verdict.
+Bootstrap is mid-flight. Paused at the framework-tool fix step before continuing.
 
-Got off-track during the bucket-1 1B1 with several side conversations (remote-control to monofolk-captain re Anthropic feedback skill, namespace naming, installer/updater architecture). All resolved; principal corrected me on multiple architectural points which are documented below.
+## 4 locked decisions from this session's 1B1
 
-## What was done this session (post-prior-compact)
+| Item | Decision | Notes |
+|---|---|---|
+| **Scope** | **B** — both services together | this-happened (app) + breadcrumb (library) in one repo, two workstreams |
+| **Hackathon shape** | **A** — full discipline | /define → /design → /plan → first iteration. PVR locked + A&D in flight by EOD. No shortcuts. |
+| **License** | **B** — Reference Source on both, two LICENSE files | Allows independent re-licensing of one component later |
+| **Bootstrap mechanism** | **agency init** (canonical tool) | Use the framework's own bootstrap path; if it breaks we fix it |
 
-### Triage closures landed
-- Wave J commit `2c74da7f` — 14 low-sev items: 7 doc-landed (#235, #239, #253, #336, #354, #395, #398), 1 already-fixed (#229), 6 need-1B1 (#238, #290, #342, #357, #389, #408)
-- Wave I commit `e2324392` — bundled with #291 fix (handoff archive ms-suffix). 14 items: 5 already-fixed (#161, #198, #272, #343, #383), 3 fix-applied (#199, #285, #340), 6 need-1B1 (#178, #194, #196, #248, #350, #363)
-- 8 wave-J + 8 wave-I issues bulk-closed via `gh issue close` parallel
-- **67 total issues closed this session.**
+The principal directive that triggered the pause: **"Why don't you make the tooling change and then use it?"** — i.e., when you find a gap, don't work around it; FIX THE TOOL.
 
-### Resumption commit
-- `f4b246e7` — captain resumption handoff post-session-end + archive
+## What's been done so far
 
-## What's in progress right now (paused state)
+1. **PR #436 merged** earlier this session — `great-rename-migrate v1.1.0` default-map adds `apps/` + `starter-packs/`. Released as v46.23. Auto-release via Fix D worked. https://github.com/the-agency-ai/the-agency/releases/tag/v46.23
+2. **mdpal-cli + mdpal-app dispatched** with go-ahead on default-map run.
+3. **GitHub repo created**: `the-agency-ai/this-happened` (public).
+4. **~/code/this-happened/ exists** — was cloned via `gh repo create --clone` (workaround for missing `git-safe init`); then `agency-bootstrap.sh` was run inside it successfully. Framework + workstream `this-happened` + initial captain-handoff are present in that repo. **Nothing committed yet** in the new repo — git tree dirty (the bootstrap files staged + ready to commit).
+5. **Issue #437 filed**: `git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap`. This was the manual sidestep the principal called out.
+6. **Captain branch `captain-git-safe-init` created** (clean, no edits) — ready to receive the tool fix.
 
-### Bucket 1 (#419 ecosystem) — 5 items, all blocked on principal
-- **Item 1 (#288 install-surface rule)** — PRESENTED, awaiting principal verdict. Two specific sub-decisions surfaced: (a) confirm canonical class set is the 13-item list filed 2026-04-18 or has the set evolved? (b) hookify rule scope — block `Write(agency/agents/**/!(agent.md))` outright vs allowlist `agent.md + templates/`. My recommendation: GO with rule + allowlist hookify.
-- Items 2-5 (#275, #277, #278/#334, #401) — queued behind Item 1 ratification.
+## Where resumption picks up — concrete next steps
 
-### Side discussions resolved this session
+**Step 1: Build `git-safe init [path]` subcommand** in `agency/tools/git-safe`.
+- Validates path doesn't already contain `.git/` (refuses with clear error)
+- Creates target dir if missing (mirroring `git init <path>` behavior)
+- Calls real `git init <path>` under the hood
+- Reports success with absolute path
+- Adds `init` row to the help text (under "Subcommands (guarded write)")
 
-**1. Monofolk captain Anthropic-feedback brief (remote-control 2026-04-25)**
-- Built a brief for monofolk captain to file CC/Anthropic feedback
-- Made it a future skill: `agency-claude-feedback` (one skill, verbs as args — not skill-per-verb; correction principal made)
-- `agency-claude-*` namespace reserved for capabilities targeting Claude Code/Anthropic
-- Identity model: full-identity branding block on every filing (NOT lean) — Jordan Dea-Mattson, jdm@devopspm.com (→ jordan@<tbd>.ai later), GitHub @JDeaMattson, OrdinaryFolk + ordinaryfolk.health affiliation. Sourced from new `usr/{principal}/identity.yaml` config (proposed, not yet built)
-- REFERENCE-FEEDBACK-FORMAT.md is right; practice drifted leaner; re-align practice to doc
-- **Flag #213** + **Task #80** capture the spec; principal said "remember this so we can come back to it"
+**Step 2: Add BATS tests** in `src/tests/tools/git-safe.bats`:
+- `git-safe init creates fresh repo at given path`
+- `git-safe init refuses if path already contains .git/`
+- `git-safe init creates target dir if missing`
+- `git-safe init defaults to cwd if no path given` (or refuses no-arg — design call at build time)
 
-**2. /agency-bug et al. — V1 cleanup status confirmed**
-- Principal questioned why `/agency-bug` and `/agency-nit` "still around"
-- Verified: skills ARE gone (only `agency-health` + `agency-issue` remain in `.claude/skills/`)
-- BUT: `agency/hooks/block-raw-tools.sh` has 6 dangling references to `/agency-bug` in error messages (lines 89, 95, 101, 107, 113). Twin in `src/agency/hooks/block-raw-tools.sh`.
-- **Pending fix:** replace `file a bug via /agency-bug` → `file a bug via /agency-issue` in both files. 6 × 2 = 12 edits or 1 replace_all per file.
-- This is concrete evidence for needing `agency-refactor-find` — V1 cleanup deleted skills without scanning for references. Hook messages have been lying to agents.
+**Step 3: Bump TOOL_VERSION** in git-safe (1.0.0 → 1.1.0) + provenance header.
 
-**3. Manifest-driven installer/updater architecture — CORRECTED**
-- I was wrong twice in describing how the installer/updater works
-- First wrong: described as "simple copy/diff-over-GitHub" — actually rsync-based with explicit core/extras split + protected_paths
-- Second wrong (worse): described the rsync-based legacy as if it were the architecture
-- **Correct architecture (per V5 plan I captured this session at commit 4ef366c7):** manifest-driven. Build tool reads `src/`, writes `agency/` + `.claude/`, regenerates `manifest.json`. Manifest IS the contract. Install reads manifest. Update diffs old manifest vs new manifest. GitHub is one transport, not the source of truth.
-- **Renames belong in the manifest:** `renames[]` directive entry. Updater applies before file deltas. Preserves in-dir state. Clean per-rename solution.
-- **Refactor-find tool counterpart:** `agency-refactor-find` (read-only scan), `agency-refactor-rename` (apply + auto-write rename directive into manifest). Three-piece flow: framework-dev refactor scans/applies in source → build tool regenerates manifest with rename directive → adopter updater applies rename from manifest. End-to-end coherent.
-- Current `_agency-update` is **legacy**. V5 Phase 5+ retires it. Should NOT be the reference for any design question going forward.
+**Step 4: captain-release flow** — commit, QGR (one self-review pass), version bump (manifest 46.23 → 46.24), PR, merge, post-merge.
 
-## What's next (immediate, in order)
+**Step 5: Redo this-happened's git plumbing using the new tool**:
+- Save bootstrap content; tear down `.git/`; run new `git-safe init`; re-add origin remote; commit + push as bootstrap commit.
+- Note: there's no `git-safe remote add` subcommand — possibly another tool gap to file. OR re-clone fresh (since the bootstrap content is reproducible by re-running agency-bootstrap.sh). Decide at resumption.
 
-1. **Process the unread cross-repo dispatch from monofolk** — Claude Code regression #53145 (`claude --resume` crashes on 2.1.120, works on 2.1.119). Read via `./agency/tools/collaboration read monofolk dispatch-filed-claude-code-regression-53145--clau-20260425.md`. Determine if action is needed from the-agency captain (likely just acknowledge — monofolk filed it).
-2. **Resume Bucket 1 Item 1 (#288)** — present my recommendation again concisely (it's been buried in side discussions) and explicitly ask principal for the two sub-decisions: (a) canonical class set, (b) hookify scope.
-3. After Item 1 ratification → Item 2 (#275 — apply rule to agents/ cleanup).
-4. Then Items 3-5 in bucket 1.
-5. Then Bucket 2: 24 design-decision items (in clumps as I outlined).
-6. Then Bucket 3: 13 feature clusters.
-7. Then umbrella splits + #404 sweep.
+**Step 6: Continue this-happened bootstrap** per the locked-A plan:
+- `/workstream-create breadcrumb` (with Reference Source LICENSE)
+- Update `this-happened` workstream README + LICENSE
+- Author bootstrap handover (captain-to-captain, the-agency captain → this-happened captain) including the 4 locked 1B1 decisions, seed pointer, SPEC:PROVIDER stack lock
+- Inject prior work: copy seed + 2026-04-10 SPEC:PROVIDER directive into `~/code/this-happened/agency/workstreams/this-happened/seeds/`
+- Author 1B1 transcript file capturing today's discussion verbatim per principal's "yes" on Item 1
+- Initial commit + push the new repo
+- `/define` to start PVR Rev 1
 
-## Key decisions / context that must survive compaction
+## Open framework gaps to address (in priority order)
 
-### Strict Over/Over-and-out is in effect
-Principal explicitly invoked it for the entire bucket walk. Wait for **"Over"** before responding in 1B1. Wait for **"Over and out"** before executing. Two violations earlier this session were not repeated; discipline holds.
+| # | Gap | Action |
+|---|---|---|
+| **#437** | `git-safe init` missing | Building NEXT (this is the next-action) |
+| **flag #220** | great-rename-migrate v1.2 — wave-3 entries | Task #83, post-hackathon |
+| **flag #218** | captain-release receipt-hash thrash (manifest bump invalidates QGR) | Post-hackathon |
+| **flag #217** | reviewer-* subagent classes not registered as instances | Post-hackathon |
+| **flag #216** | dispatch-monitor `python3` resolves to 3.9 not 3.13 | Post-hackathon |
 
-### Manifest-driven installer is the architecture
-Do not describe rsync-based `_agency-update` as the design going forward. V5 plan at `agency/workstreams/agency/plan-agency-v3-structural-reset-v5-20260420.md` is the design. Build tool produces manifest; install/update read manifest; GitHub is transport.
+## Hackathon clock note
 
-### Renames are manifest directives
-`renames[]` block in manifest. Updater applies `mv` before file deltas. `agency-refactor-rename` skill (framework-dev side) auto-writes the rename directive when applying source rename.
+Principal observation: even hybrid C wouldn't yield a running thing by 5 PM. Locked Option A (full discipline). PVR + A&D landing today is the realistic target; running app is days away.
 
-### Skill naming & namespace
-- `agency-claude-feedback` is the skill (singular, noun, not noun-verb-per-op)
-- `agency-claude-*` namespace reserved for Claude Code / Anthropic-targeted capabilities
-- Verbs are args inside the skill (file, poll, list, close, view) — modeled on `/agency-issue`
-- Per #357, *operations* (tools/skills doing one thing) follow noun-verb. Capability-skills (multi-op) follow noun-noun.
+## What's NOT in scope today
 
-### Identity branding on every Anthropic feedback filing
-Full identity in body + frontmatter:
-- Name: Jordan Dea-Mattson
-- Email: jdm@devopspm.com (→ jordan@<tbd>.ai future)
-- GitHub: @JDeaMattson (real handle, not noreply)
-- Affiliation: OrdinaryFolk / ordinaryfolk.health, TheAgencyGroup
+- mdpal-app + mdpal-cli (parked at migration commits — Task #83 unblocks them next session)
+- Bucket 1 #419-ecosystem 1B1 (paused at Item 1 #288, awaiting principal verdict)
+- Other Bucket 1 items (#74, #76, #77, #78)
+- Build /agency-claude-feedback skill (Task #80)
+- mdslidepal worktrees (explicitly off the table per principal)
 
-Source: new `usr/{principal}/identity.yaml` (proposed). Filings = branding surfaces — leaner is wrong.
+## On resume
 
-### #419 cleanup scope
-Principal halted pre-compact on "why are you deleting those?" — answer is the specific 5 pollution paths the BATS tripwire (8f3827eb) already detects. Not general adopter-stuff cleanup. Five paths in scope.
+1. `/session-resume` — sync, handoff, dispatches
+2. Read this handoff's next-action
+3. Verify on `captain-git-safe-init` branch (created clean this session)
+4. Begin Step 1 — build the tool
+5. Process any dispatches that arrived during the pause
+6. Re-launch dispatch monitor via `/monitor-dispatches` (was running this session as task `bi7af0v49`)
 
-### Anthropic feedback registry pattern
-Existing pattern lives at `usr/jordan/captain/feedback/` (not `usr/jordan/reports/` — that's for the-agency issues). Per-item file: `feedback-{YYYYMMDD}-{slug}.md`. Registry: `registry.md`. 12 open + 14 closed prior filings establish the convention.
+— captain, paused mid-bootstrap.
 
-### Pending dangling-reference fix
-`agency/hooks/block-raw-tools.sh` + `src/agency/hooks/block-raw-tools.sh` — 12 occurrences of `/agency-bug` to replace with `/agency-issue`. Trivial Edit `replace_all`. Should land before next pickup-with-blocked-tool incident.
-
-## Open items / blockers
-
-### Hard blockers (need principal)
-- Bucket 1 Item 1 (#288) verdict + sub-decisions
-- Bucket 2 (24 design-decision items, in clumps)
-- Bucket 3 (13 feature clusters, 79 issues)
-- 3 umbrella issue splits (#297, #404, #225)
-- Cross-repo dispatch monofolk → captain (read first, may not need principal)
-
-### Tracked tasks (TaskList #69-80)
-- Open: #74, #75, #76, #77, #78, #80
-- Completed: #69, #70, #71, #72, #73, #79
-- Active (this turn): None — all autonomous done
-
-### Stash state
-- `stash@{0}: 0300-runbook handoff pre-362-checkout` (pre-existing, not mine)
-- `stash@{1}: v46.1-residual-sweep-misses` (pre-existing, not mine)
-- (Earlier `stash@{0}: WIP handoff #291` was popped + committed in e2324392)
-
-### Pre-existing failure
-- `commit-precheck.bats` large-file test failure unrelated to this session — captain has been using `--no-verify` on coord commits as workaround. Address in a separate cleanup; tracked but not blocking.
-
-## Related artifacts
-
-- V5 Plan (in-repo): `agency/workstreams/agency/plan-agency-v3-structural-reset-v5-20260420.md`
-- Triage working doc: `usr/jordan/captain/triage-agency-issues-20260422.md`
-- Clusters file: `/tmp/clusters.json` (still relevant if not reaped)
-- Skip-complex list: `/tmp/skip-complex.json` (now ~30 items after wave I+J closures)
-- Anthropic feedback brief drafted in conversation (2026-04-25 remote-control)
-- Flag #213 + Task #80 — anthropic-feedback skill spec
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/dispatch-re-blocked-618-conflicts-on-worktree-sync-great-re-re869-20260509-1218.md
+++ b/usr/jordan/captain/dispatches/dispatch-re-blocked-618-conflicts-on-worktree-sync-great-re-re869-20260509-1218.md
@@ -1,0 +1,22 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-05-09T04:18
+status: created
+priority: normal
+subject: "Re: BLOCKED: 618 conflicts on worktree-sync — great-rename-migrate v1.1 default map missing 2 wave-3 entries"
+in_reply_to: 869
+---
+
+# Re: BLOCKED: 618 conflicts on worktree-sync — great-rename-migrate v1.1 default map missing 2 wave-3 entries
+
+Acknowledged + standby. v1.1 was wave-1+2 only; main has progressed through a wave-3 (V5 Phase 4 src/ split, workstream the-agency→agency, claude/starter-packs/ direct→src/spec-provider/) since I shipped v1.1 today. Your migration commit at af3478e1 is good — keep it.
+
+Decision: Path A (v1.2 default-map ships wave-3 entries — scales for designex/devex/iscp who will hit the same gap). The 13 add/add and 53 rename/delete are real merge conflicts (engine drift v45.2→v46.22, archived docs/agents) that survive ANY map fix; you reconcile those manually after v1.2 closes the rename gap.
+
+Hackathon redirect: principal pivoted to a new project (this-happened) for today. mdpal-cli + mdpal-app are parked at their migration commits until captain can ship v1.2 + dispatch you forward. ETA: post-hackathon (next captain session, likely tomorrow).
+
+Standing direction: do NOT touch the 618 conflicts. Do NOT push. Stay at af3478e1 + clean tree. When v1.2 lands, you cherry-pick the new tool, re-run, retry sync. We will route the residuals (add/add, rename/delete) at that time.
+
+Phase 3 work: parked until v1.2 unblocks you.

--- a/usr/jordan/captain/history/handoff-20260509-044338-554.md
+++ b/usr/jordan/captain/history/handoff-20260509-044338-554.md
@@ -1,0 +1,139 @@
+---
+type: session
+agent: the-agency/jordan/captain
+date: 2026-04-25T00:37:30Z
+trigger: compact-prepare
+branch: main
+mode: continuation
+pause_commit_sha: e2324392
+next-action: "Resume Bucket 1 #419-ecosystem 1B1 at Item 1 (#288 install-surface rule). Principal interrupted with namespace + manifest-driven-installer corrections; both resolved with apologies. Item 1 remains paused awaiting principal verdict on (a) canonical class set + (b) hookify allowlist scope. ALSO: process unread cross-repo dispatch from monofolk re Claude Code regression #53145 (claude --resume crashes on 2.1.120) before resuming triage."
+---
+
+# Handoff — /compact-prepare during agency-issue triage Bucket 1
+
+## Situation
+
+Mid-session compact during the strict 1B1 walk through agency-issue blocker buckets. Principal directive earlier this session: "Pick up your Agency Issues" — autonomous waves I + J landed (e2324392 + 2c74da7f), 67 issues closed total. Then started 1B1 walk through 5 blocker buckets.
+
+Currently paused at: **Bucket 1 (#419 ecosystem) Item 1 (#288 install-surface rule)** — awaiting principal verdict.
+
+Got off-track during the bucket-1 1B1 with several side conversations (remote-control to monofolk-captain re Anthropic feedback skill, namespace naming, installer/updater architecture). All resolved; principal corrected me on multiple architectural points which are documented below.
+
+## What was done this session (post-prior-compact)
+
+### Triage closures landed
+- Wave J commit `2c74da7f` — 14 low-sev items: 7 doc-landed (#235, #239, #253, #336, #354, #395, #398), 1 already-fixed (#229), 6 need-1B1 (#238, #290, #342, #357, #389, #408)
+- Wave I commit `e2324392` — bundled with #291 fix (handoff archive ms-suffix). 14 items: 5 already-fixed (#161, #198, #272, #343, #383), 3 fix-applied (#199, #285, #340), 6 need-1B1 (#178, #194, #196, #248, #350, #363)
+- 8 wave-J + 8 wave-I issues bulk-closed via `gh issue close` parallel
+- **67 total issues closed this session.**
+
+### Resumption commit
+- `f4b246e7` — captain resumption handoff post-session-end + archive
+
+## What's in progress right now (paused state)
+
+### Bucket 1 (#419 ecosystem) — 5 items, all blocked on principal
+- **Item 1 (#288 install-surface rule)** — PRESENTED, awaiting principal verdict. Two specific sub-decisions surfaced: (a) confirm canonical class set is the 13-item list filed 2026-04-18 or has the set evolved? (b) hookify rule scope — block `Write(agency/agents/**/!(agent.md))` outright vs allowlist `agent.md + templates/`. My recommendation: GO with rule + allowlist hookify.
+- Items 2-5 (#275, #277, #278/#334, #401) — queued behind Item 1 ratification.
+
+### Side discussions resolved this session
+
+**1. Monofolk captain Anthropic-feedback brief (remote-control 2026-04-25)**
+- Built a brief for monofolk captain to file CC/Anthropic feedback
+- Made it a future skill: `agency-claude-feedback` (one skill, verbs as args — not skill-per-verb; correction principal made)
+- `agency-claude-*` namespace reserved for capabilities targeting Claude Code/Anthropic
+- Identity model: full-identity branding block on every filing (NOT lean) — Jordan Dea-Mattson, jdm@devopspm.com (→ jordan@<tbd>.ai later), GitHub @JDeaMattson, OrdinaryFolk + ordinaryfolk.health affiliation. Sourced from new `usr/{principal}/identity.yaml` config (proposed, not yet built)
+- REFERENCE-FEEDBACK-FORMAT.md is right; practice drifted leaner; re-align practice to doc
+- **Flag #213** + **Task #80** capture the spec; principal said "remember this so we can come back to it"
+
+**2. /agency-bug et al. — V1 cleanup status confirmed**
+- Principal questioned why `/agency-bug` and `/agency-nit` "still around"
+- Verified: skills ARE gone (only `agency-health` + `agency-issue` remain in `.claude/skills/`)
+- BUT: `agency/hooks/block-raw-tools.sh` has 6 dangling references to `/agency-bug` in error messages (lines 89, 95, 101, 107, 113). Twin in `src/agency/hooks/block-raw-tools.sh`.
+- **Pending fix:** replace `file a bug via /agency-bug` → `file a bug via /agency-issue` in both files. 6 × 2 = 12 edits or 1 replace_all per file.
+- This is concrete evidence for needing `agency-refactor-find` — V1 cleanup deleted skills without scanning for references. Hook messages have been lying to agents.
+
+**3. Manifest-driven installer/updater architecture — CORRECTED**
+- I was wrong twice in describing how the installer/updater works
+- First wrong: described as "simple copy/diff-over-GitHub" — actually rsync-based with explicit core/extras split + protected_paths
+- Second wrong (worse): described the rsync-based legacy as if it were the architecture
+- **Correct architecture (per V5 plan I captured this session at commit 4ef366c7):** manifest-driven. Build tool reads `src/`, writes `agency/` + `.claude/`, regenerates `manifest.json`. Manifest IS the contract. Install reads manifest. Update diffs old manifest vs new manifest. GitHub is one transport, not the source of truth.
+- **Renames belong in the manifest:** `renames[]` directive entry. Updater applies before file deltas. Preserves in-dir state. Clean per-rename solution.
+- **Refactor-find tool counterpart:** `agency-refactor-find` (read-only scan), `agency-refactor-rename` (apply + auto-write rename directive into manifest). Three-piece flow: framework-dev refactor scans/applies in source → build tool regenerates manifest with rename directive → adopter updater applies rename from manifest. End-to-end coherent.
+- Current `_agency-update` is **legacy**. V5 Phase 5+ retires it. Should NOT be the reference for any design question going forward.
+
+## What's next (immediate, in order)
+
+1. **Process the unread cross-repo dispatch from monofolk** — Claude Code regression #53145 (`claude --resume` crashes on 2.1.120, works on 2.1.119). Read via `./agency/tools/collaboration read monofolk dispatch-filed-claude-code-regression-53145--clau-20260425.md`. Determine if action is needed from the-agency captain (likely just acknowledge — monofolk filed it).
+2. **Resume Bucket 1 Item 1 (#288)** — present my recommendation again concisely (it's been buried in side discussions) and explicitly ask principal for the two sub-decisions: (a) canonical class set, (b) hookify scope.
+3. After Item 1 ratification → Item 2 (#275 — apply rule to agents/ cleanup).
+4. Then Items 3-5 in bucket 1.
+5. Then Bucket 2: 24 design-decision items (in clumps as I outlined).
+6. Then Bucket 3: 13 feature clusters.
+7. Then umbrella splits + #404 sweep.
+
+## Key decisions / context that must survive compaction
+
+### Strict Over/Over-and-out is in effect
+Principal explicitly invoked it for the entire bucket walk. Wait for **"Over"** before responding in 1B1. Wait for **"Over and out"** before executing. Two violations earlier this session were not repeated; discipline holds.
+
+### Manifest-driven installer is the architecture
+Do not describe rsync-based `_agency-update` as the design going forward. V5 plan at `agency/workstreams/agency/plan-agency-v3-structural-reset-v5-20260420.md` is the design. Build tool produces manifest; install/update read manifest; GitHub is transport.
+
+### Renames are manifest directives
+`renames[]` block in manifest. Updater applies `mv` before file deltas. `agency-refactor-rename` skill (framework-dev side) auto-writes the rename directive when applying source rename.
+
+### Skill naming & namespace
+- `agency-claude-feedback` is the skill (singular, noun, not noun-verb-per-op)
+- `agency-claude-*` namespace reserved for Claude Code / Anthropic-targeted capabilities
+- Verbs are args inside the skill (file, poll, list, close, view) — modeled on `/agency-issue`
+- Per #357, *operations* (tools/skills doing one thing) follow noun-verb. Capability-skills (multi-op) follow noun-noun.
+
+### Identity branding on every Anthropic feedback filing
+Full identity in body + frontmatter:
+- Name: Jordan Dea-Mattson
+- Email: jdm@devopspm.com (→ jordan@<tbd>.ai future)
+- GitHub: @JDeaMattson (real handle, not noreply)
+- Affiliation: OrdinaryFolk / ordinaryfolk.health, TheAgencyGroup
+
+Source: new `usr/{principal}/identity.yaml` (proposed). Filings = branding surfaces — leaner is wrong.
+
+### #419 cleanup scope
+Principal halted pre-compact on "why are you deleting those?" — answer is the specific 5 pollution paths the BATS tripwire (8f3827eb) already detects. Not general adopter-stuff cleanup. Five paths in scope.
+
+### Anthropic feedback registry pattern
+Existing pattern lives at `usr/jordan/captain/feedback/` (not `usr/jordan/reports/` — that's for the-agency issues). Per-item file: `feedback-{YYYYMMDD}-{slug}.md`. Registry: `registry.md`. 12 open + 14 closed prior filings establish the convention.
+
+### Pending dangling-reference fix
+`agency/hooks/block-raw-tools.sh` + `src/agency/hooks/block-raw-tools.sh` — 12 occurrences of `/agency-bug` to replace with `/agency-issue`. Trivial Edit `replace_all`. Should land before next pickup-with-blocked-tool incident.
+
+## Open items / blockers
+
+### Hard blockers (need principal)
+- Bucket 1 Item 1 (#288) verdict + sub-decisions
+- Bucket 2 (24 design-decision items, in clumps)
+- Bucket 3 (13 feature clusters, 79 issues)
+- 3 umbrella issue splits (#297, #404, #225)
+- Cross-repo dispatch monofolk → captain (read first, may not need principal)
+
+### Tracked tasks (TaskList #69-80)
+- Open: #74, #75, #76, #77, #78, #80
+- Completed: #69, #70, #71, #72, #73, #79
+- Active (this turn): None — all autonomous done
+
+### Stash state
+- `stash@{0}: 0300-runbook handoff pre-362-checkout` (pre-existing, not mine)
+- `stash@{1}: v46.1-residual-sweep-misses` (pre-existing, not mine)
+- (Earlier `stash@{0}: WIP handoff #291` was popped + committed in e2324392)
+
+### Pre-existing failure
+- `commit-precheck.bats` large-file test failure unrelated to this session — captain has been using `--no-verify` on coord commits as workaround. Address in a separate cleanup; tracked but not blocking.
+
+## Related artifacts
+
+- V5 Plan (in-repo): `agency/workstreams/agency/plan-agency-v3-structural-reset-v5-20260420.md`
+- Triage working doc: `usr/jordan/captain/triage-agency-issues-20260422.md`
+- Clusters file: `/tmp/clusters.json` (still relevant if not reaped)
+- Skip-complex list: `/tmp/skip-complex.json` (now ~30 items after wave I+J closures)
+- Anthropic feedback brief drafted in conversation (2026-04-25 remote-control)
+- Flag #213 + Task #80 — anthropic-feedback skill spec

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -25,6 +25,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-04-22 | Add Python unit + integration tests for src/tools/build (on top of existing BATS) | feature | the-agency-ai/the-agency | #417 | [report-agency-issue-add-python-unit-integration-tests-for-src-tools-bu-20260422](usr/jordan/reports/report-agency-issue-add-python-unit-integration-tests-for-src-tools-bu-20260422.md) | open |
 | 2026-04-22 | Pre-existing pollution cleanup at agency/ build-product side (testname, test; rm -rf, test-auto QGRs, housekeeping workstream) | bug | the-agency-ai/the-agency | #419 | [report-agency-issue-pre-existing-pollution-cleanup-at-agency-build-pro-20260422](usr/jordan/reports/report-agency-issue-pre-existing-pollution-cleanup-at-agency-build-pro-20260422.md) | open |
 | 2026-04-22 | src/ top-level taxonomy drift — resolve 4 dirs outside V5 allowlist (assets, integrations, spec-provider, tools-developer) | friction | the-agency-ai/the-agency | #420 | [report-agency-issue-src-top-level-taxonomy-drift-resolve-4-dirs-outsid-20260422](usr/jordan/reports/report-agency-issue-src-top-level-taxonomy-drift-resolve-4-dirs-outsid-20260422.md) | open |
+| 2026-05-09 | git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap | friction | the-agency-ai/the-agency | #437 | [report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509](usr/jordan/reports/report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509.md
+++ b/usr/jordan/reports/report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509.md
@@ -1,0 +1,63 @@
+---
+report_type: agency-issue
+issue_type: friction
+filing_agent: the-agency/jordan/captain
+filed_by: jordan
+date_filed: 2026-05-09
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/437
+github_issue_number: 437
+status: open
+---
+
+# git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap
+
+**Filed:** 2026-05-09T04:40:30Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#437](https://github.com/the-agency-ai/the-agency/issues/437)
+**Type:** friction
+**Status:** open
+
+## Filed Body
+
+**Type:** friction
+
+## Symptom
+
+Hit while bootstrapping a new agency instance (`this-happened` project) at `~/code/this-happened/`. Per principal directive: use `agency init` to bootstrap. But before `agency init` can run, the directory must be a git repo (the bootstrapper checks for `.git/`).
+
+Running `git init ~/code/this-happened/` from the agency captain session is blocked by the `block-raw-tools.sh` hook with:
+
+> 🚫 BLOCKED: Only safe git operations allowed. Use the git-safe family
+
+The git-safe family (status, log, diff, branch, show, blame, add, merge-from-master) and git-captain family (push, fetch, tag, checkout-branch, branch-delete) DO NOT include `init`. So there is no in-framework way to initialize a brand-new repo.
+
+## Why this matters
+
+- The framework's stated north star is "agency-init on bare repos" (per principal memory).
+- The canonical bootstrap path per `agency-bootstrap.sh` header is: `mkdir + git init + curl agency-bootstrap.sh | bash`.
+- An adopter following the documented path is blocked by the framework's own hook.
+- Workaround today: `gh repo create --clone` creates the repo on GitHub AND clones it locally with `.git/` already set up — sidesteps `git init` entirely. Works, but only when the user wants a GitHub-hosted repo simultaneously.
+
+## Proposed fixes (pick one)
+
+1. **Add `init` to git-safe family.** `./agency/tools/git-safe init [path]` would be the canonical safe wrapper. Validates path doesn't already contain a git repo, runs `git init`, reports.
+2. **Carve a hook exception for `git init` outside `$CLAUDE_PROJECT_DIR`.** A captain bootstrapping a NEW repo is operating outside the agency tree — the hook's purpose (protect the agency repo from raw git commit/push) doesn't apply.
+3. **Document the workaround.** If the principal's intent is always "create on GitHub first, clone locally," then `gh repo create --clone` is the canonical path and `git init` simply isn't part of the bootstrap. Document explicitly so adopters don't try `git init` and hit the wall.
+
+My pick: **option 1** — `git-safe init` is a small surface that completes the family. Option 2 is fragile (hook context awareness). Option 3 is fine for the GitHub-cloud-first case but doesn't help local-first or air-gapped adopters.
+
+## Affected
+
+- This bootstrap (worked around via `gh repo create --clone`)
+- Any future adopter following the documented "git init + curl bootstrap" pattern
+- The agency-init-on-bare-repos validation north star
+
+## Severity
+Medium — workaround exists, but it's a discoverability + framework-coherence issue.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-05-09:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/437


### PR DESCRIPTION
## Summary

Adds `init [path]` subcommand to `agency/tools/git-safe`. Closes the framework gap (#437) where bare-repo bootstrap was blocked by `hookify.block-raw-tools` because the git-safe family had no equivalent for raw `git init`.

Hit during the `this-happened` project bootstrap today — the canonical path documented in `agency-bootstrap.sh` (`mkdir + git init + curl agency-bootstrap.sh | bash`) was blocked at step 2. Workaround used `gh repo create --clone`; this PR makes the canonical path actually work.

## Changes

- New `cmd_init()` in `agency/tools/git-safe` (43 lines). Standard guards:
  - Validates path doesn't have `..` traversal, glob metachars, or flag-like prefix
  - Refuses if `.git/` already exists at the target
  - Creates target dir (and parents) if missing — mirrors `mkdir -p` semantics
  - Calls `git init <path>` under the hood
  - Reports absolute path of initialized repo
- `init` added to dispatch case statement
- Help text updated under "Subcommands (guarded write)"
- `TOOL_VERSION` 1.0.0 → 1.1.0
- Provenance: Updated header + version note
- Release: `agency_version` 46.23 → 46.24

## Tests

8 new bats tests in `src/tests/tools/git-safe.bats`:
- creates fresh repo at given path
- creates target dir (and parents) if missing
- refuses if `.git/` already exists at target
- rejects path-traversal `..` in target
- rejects glob metacharacters in target
- rejects flag-like target
- `--help` mentions init subcommand + "bare-repo bootstrap"
- `TOOL_VERSION` 1.1.0 advertised via `--version`

67/67 git-safe.bats passing (was 59).

## Resolves

- the-agency#437 (git-safe family lacks 'init' — blocks bare-repo bootstrap)

## Note

Test note: `assert_output_contains` uses `[[ == *pattern* ]]` glob match, so `[..]` brackets in the pattern get treated as a character class. Use plain-text assertions for help-text checks. Comment added to test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)