### PR TITLE
feat: port block-raw-tools.sh from monofolk

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.25",
+  "agency_version": "46.26",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.25",
-    "updated_at": "2026-05-09T14:30:00Z"
+    "framework_version": "46.26",
+    "updated_at": "2026-05-17T10:10:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/hooks/__tests__/block-raw-tools.test.sh
+++ b/agency/hooks/__tests__/block-raw-tools.test.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+# What Problem: agency/hooks/block-raw-tools.sh is a fleet-wide PreToolUse
+# hook that fires on every Bash invocation. Regressions in this file silently
+# block (or wrongly allow) commands across every captain + worktree agent.
+# Manual ad-hoc testing was the only verification before this file existed.
+#
+# How & Why: Minimal smoke harness. Pipes 6 fixture JSON payloads to the
+# hook (mocked PATH for ugrep/bfs presence/absence), asserts exit code +
+# substring of stdout. No bats, no fixtures dir, no mock framework — `PATH`
+# manipulation IS the mock. Designed to grow as the hook grows; keep
+# additions in the same key/value style.
+#
+# Usage:
+#   ./agency/hooks/__tests__/block-raw-tools.test.sh
+# Exits 0 if all pass, 1 on first failure. Prints PASS/FAIL per case.
+#
+# Wire into iteration boundaries touching this hook: run from the iteration
+# QG or pre-commit when block-raw-tools.sh is in the diff.
+#
+# Written: 2026-05-17 monofolk v4.70 (Iteration 4.70.1) per reviewer-test
+# recommendation from /quality-gate run on the ugrep/bfs auto-detect change.
+
+set -uo pipefail  # NOT -e — we want to keep running after a failed assertion
+
+HOOK="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/block-raw-tools.sh"
+if [[ ! -x "$HOOK" ]]; then
+    echo "FATAL: hook not found or not executable: $HOOK" >&2
+    exit 1
+fi
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+# assert_hook <name> <expected_exit> <expected_substring> <stdin_json> [PATH_OVERRIDE]
+# expected_substring of "{}" means "exactly {}" (allow). Otherwise it's a substring match.
+assert_hook() {
+    local name="$1"
+    local want_exit="$2"
+    local want_substr="$3"
+    local stdin_json="$4"
+    local path_override="${5:-}"
+
+    local actual_stdout
+    local actual_exit
+    if [[ -n "$path_override" ]]; then
+        actual_stdout=$(echo "$stdin_json" | PATH="$path_override" "$HOOK" 2>&1)
+    else
+        actual_stdout=$(echo "$stdin_json" | "$HOOK" 2>&1)
+    fi
+    actual_exit=$?
+
+    local ok=1
+    if [[ "$actual_exit" != "$want_exit" ]]; then
+        ok=0
+    fi
+    if [[ "$want_substr" == "{}" ]]; then
+        # allow case: stdout must be exactly "{}"
+        if [[ "$actual_stdout" != "{}" ]]; then
+            ok=0
+        fi
+    else
+        if [[ "$actual_stdout" != *"$want_substr"* ]]; then
+            ok=0
+        fi
+    fi
+
+    if [[ "$ok" == "1" ]]; then
+        PASS=$((PASS + 1))
+        echo "  PASS  $name"
+    else
+        FAIL=$((FAIL + 1))
+        FAILURES+=("$name (want_exit=$want_exit want_substr='$want_substr' got_exit=$actual_exit got_stdout='$actual_stdout')")
+        echo "  FAIL  $name"
+    fi
+}
+
+# Build PATH stubs for the ugrep-reachable / bfs-reachable cases. Tempdir
+# + tiny executable scripts is portable (avoids /bin/true vs /usr/bin/true
+# path differences across macOS versions and Linux distros). The stub
+# binaries do nothing — `command -v` only checks existence + exec bit,
+# never runs them.
+STUB=$(mktemp -d)
+EMPTY_PATH=$(mktemp -d)
+trap 'rm -rf "$STUB" "$EMPTY_PATH"' EXIT
+for tool in ugrep bfs; do
+    printf '#!/bin/sh\nexit 0\n' > "$STUB/$tool"
+    chmod +x "$STUB/$tool"
+done
+STUBBED_PATH="$STUB:/usr/bin:/bin"
+
+# A PATH that DEFINITELY lacks ugrep/bfs (the system default on this box
+# does too, but be explicit so the test is reproducible across machines).
+# Hook prepends /opt/homebrew/bin if present — that dir does not contain
+# ugrep/bfs on our reference machines, but if it does on yours, the
+# "NOT reachable" cases will fail. That's working as intended.
+BARE_PATH="$EMPTY_PATH:/usr/bin:/bin"
+
+echo "Running block-raw-tools.sh smoke tests…"
+echo ""
+
+# --- Auto-detect arms (the new behavior in v4.70) ---
+
+assert_hook "grep blocked when ugrep reachable" \
+    2 "ugrep" \
+    '{"tool_input":{"command":"grep foo bar.txt"}}' \
+    "$STUBBED_PATH"
+
+assert_hook "grep allowed when ugrep NOT reachable" \
+    0 "{}" \
+    '{"tool_input":{"command":"grep foo bar.txt"}}' \
+    "$BARE_PATH"
+
+assert_hook "find blocked when bfs reachable" \
+    2 "bfs" \
+    '{"tool_input":{"command":"find . -name foo"}}' \
+    "$STUBBED_PATH"
+
+assert_hook "find allowed when bfs NOT reachable" \
+    0 "{}" \
+    '{"tool_input":{"command":"find . -name foo"}}' \
+    "$BARE_PATH"
+
+# --- Regression-coverage: unchanged blocks still fire ---
+
+assert_hook "cat still blocked (Read tool exists)" \
+    2 "Read tool" \
+    '{"tool_input":{"command":"cat README.md"}}'
+
+# --- AGENCY_ALLOW_RAW opt-out still wins ---
+
+# Subshell to scope the env override
+opt_out_stdout=$(echo '{"tool_input":{"command":"grep foo bar.txt"}}' | AGENCY_ALLOW_RAW=1 "$HOOK" 2>&1)
+opt_out_exit=$?
+if [[ "$opt_out_exit" == "0" && "$opt_out_stdout" == "{}" ]]; then
+    PASS=$((PASS + 1))
+    echo "  PASS  AGENCY_ALLOW_RAW=1 opt-out wins (grep allowed)"
+else
+    FAIL=$((FAIL + 1))
+    FAILURES+=("AGENCY_ALLOW_RAW=1 opt-out (got_exit=$opt_out_exit got_stdout='$opt_out_stdout')")
+    echo "  FAIL  AGENCY_ALLOW_RAW=1 opt-out wins (grep allowed)"
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+    echo ""
+    echo "Failures:"
+    for f in "${FAILURES[@]}"; do
+        echo "  - $f"
+    done
+    exit 1
+fi
+exit 0

--- a/agency/hooks/block-raw-tools.sh
+++ b/agency/hooks/block-raw-tools.sh
@@ -17,6 +17,17 @@
 # behavior; this hook blocks it mechanically.
 #
 # Written: 2026-04-10 during captain session (35.3 — upstream from monofolk)
+#
+# 2026-05-17 update — grep/find auto-detect (monofolk v4.70):
+# Claude Code v2.1.117 REMOVED the Grep and Glob tools on native macOS/Linux
+# builds, replacing them with embedded `ugrep` and `bfs` binaries "available
+# through the Bash tool" (see Claude Code changelog v2.1.117 + v2.1.126).
+# On platforms where that wire-up works, agents should use `ugrep`/`bfs` via
+# Bash; on platforms where it doesn't (currently 2.1.143 native macOS — the
+# embedded binaries are not on PATH), agents must fall back to raw `grep`/`find`.
+# The hook now auto-detects at decision time: if the embedded replacement is
+# reachable, redirect; if not, allow the raw command through. This self-heals
+# when Anthropic fixes the wire-up.
 
 set -euo pipefail
 
@@ -90,16 +101,32 @@ if [[ "$TRIMMED" =~ ^cat[[:space:]] ]] || [[ "$TRIMMED" == "cat" ]]; then
     exit 2
 fi
 
-# Block raw grep/rg — use Grep tool
+# Block raw grep/rg/egrep/fgrep — redirect to ugrep if reachable (Claude Code
+# 2.1.117+ embedded replacement); otherwise allow through. Auto-detected so
+# this self-heals when the Anthropic wire-up works (or fails) in this env.
 if [[ "$TRIMMED" =~ ^(grep|rg|egrep|fgrep)[[:space:]] ]] || [[ "$TRIMMED" =~ ^(grep|rg|egrep|fgrep)$ ]]; then
-    printf '{"decision":"block","reason":"🔍 BLOCKED: Use the Grep tool instead of `grep`/`rg`. Grep has optimized permissions, regex support, glob filtering, and multiple output modes. If Grep genuinely cannot do what you need, file a bug via /agency-bug explaining why. — OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"}'
-    exit 2
+    if command -v ugrep >/dev/null 2>&1; then
+        printf '{"decision":"block","reason":"🔍 BLOCKED: Use `ugrep` instead of `grep`/`rg`. The Grep tool was removed in Claude Code 2.1.117 on native macOS/Linux builds; `ugrep` is the embedded replacement available through Bash. Run `ugrep --help` for syntax (it accepts most grep flags). If `ugrep` genuinely cannot do what you need, file via /agency-bug. — OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"}'
+        exit 2
+    fi
+    # ugrep not reachable — allow grep/rg/egrep/fgrep through (no working built-in
+    # alternative). NOTE: this hook's PATH may not equal the Bash tool's runtime
+    # PATH; a false-negative here just means we under-block. That's the right
+    # posture for a self-healing fleet hook (degrade to allow, never to crash).
+    printf '{}'
+    exit 0
 fi
 
-# Block raw find — use Glob tool
+# Block raw find — redirect to bfs if reachable (Claude Code 2.1.117+ embedded
+# replacement); otherwise allow through. Same auto-detect rationale as grep above.
 if [[ "$TRIMMED" =~ ^find[[:space:]] ]] || [[ "$TRIMMED" == "find" ]]; then
-    printf '{"decision":"block","reason":"📁 BLOCKED: Use the Glob tool instead of `find`. Glob is fast, supports patterns like **/*.ts, and returns results sorted by modification time. If Glob genuinely cannot do what you need, file a bug via /agency-bug explaining why. — OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"}'
-    exit 2
+    if command -v bfs >/dev/null 2>&1; then
+        printf '{"decision":"block","reason":"📁 BLOCKED: Use `bfs` instead of `find`. The Glob tool was removed in Claude Code 2.1.117 on native macOS/Linux builds; `bfs` is the embedded replacement available through Bash. Run `bfs --help` for syntax (drop-in find replacement). If `bfs` genuinely cannot do what you need, file via /agency-bug. — OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!"}'
+        exit 2
+    fi
+    # bfs not reachable — allow find through (no working built-in alternative)
+    printf '{}'
+    exit 0
 fi
 
 # Block raw sed/awk — use Edit tool


### PR DESCRIPTION
## Source
`agency/hooks/block-raw-tools.sh` → `agency/hooks/block-raw-tools.sh`

Contributed from monofolk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)