### PR TITLE
fix(pr-lifecycle): make PR landing main-aware + fix receipt-churn + pr-create robustness

### DIFF
--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -76,7 +76,7 @@ The script enforces **all** of these before any mutation; any failure exits non-
 4. **No pending post-merge (C#372 Fix B).** `./agency/tools/post-merge-state check` exits 0. If exit 1, a prior landed PR has not had its release cut — run `/pr-captain-post-merge <pending-PR>` first, then re-invoke.
 5. `<agent-branch>` exists on origin (`git ls-remote --heads origin <agent-branch>` non-empty).
 6. `<agent-branch>` passes safe-name validation: regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-7. Diff-hash of `<agent-branch>` vs `origin/master` matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
+7. Diff-hash of `<agent-branch>` vs `origin/<default-branch>` (resolved, not hardcoded) matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
 
 Any failure → zero mutation, clean error message, exit 1.
 
@@ -99,7 +99,7 @@ Main checkout is now on agent's branch.
 ### Step 3: Verify receipt against current state
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 ```
 
 Find receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`. If missing, agent's state drifted — switch back to master, exit 1, tell agent to re-run `/pr-prep` + `/pr-submit`.
@@ -133,7 +133,7 @@ Title derives from agent's `--scope` or `--title` override. Body wraps agent's s
 ### Step 6: Switch back to master
 
 ```
-./agency/tools/git-captain switch-branch master
+./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
 ```
 
 Captain sits on master during the CI-wait phase. Avoids any accidental commit on the PR branch.
@@ -172,7 +172,7 @@ Sync master:
 Release (unless `--no-release`):
 
 ```
-./agency/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
 ```
 
 Release notes: captain-authored, references PR number + agent.

--- a/.claude/skills/pr-captain-land/examples.md
+++ b/.claude/skills/pr-captain-land/examples.md
@@ -150,7 +150,7 @@ Most common: GitHub release API hiccup:
 [pr-captain-land] Merged PR #118 successfully.
 [pr-captain-land] gh-release create v1.10 FAILED: ...
 [pr-captain-land] WARN: merge is the primary outcome (success). Release creation deferred.
-  Captain: run `gh release create v1.10 --target master --notes-file ...` manually.
+  Captain: run `gh release create v1.10 --target main --notes-file ...` manually.
 [pr-captain-land] Dispatched agent with merge confirmation (no release URL).
 ```
 

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -30,10 +30,10 @@ Current working branch becomes the agent's. Main checkout is now sitting on agen
 
 ### Step 2 — Verify receipt
 
-Compute current diff-hash against `origin/master`. Find receipt matching that hash.
+Compute current diff-hash against `origin/<default-branch>` (resolved via `resolve_default_branch`, not hardcoded). Find receipt matching that hash.
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 # extract hash
 find agency/workstreams -name "*qgr-pr-prep-*-{hash}.md"
 ```
@@ -69,7 +69,7 @@ Title: `--title` flag value, or `<agent-branch>` as fallback. Body: captain-auth
 ### Step 5 — Switch back to master
 
 ```
-./agency/tools/git-captain switch-branch master
+./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
 ```
 
 Captain should sit on master for the wait-and-merge phase. Avoids any accidental commit landing on the PR branch.
@@ -103,7 +103,7 @@ Uses admin merge (principal-approved flag gated). True merge commit — never sq
 ```
 ./agency/tools/git-captain fetch
 ./agency/tools/git-captain merge-from-origin
-./agency/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
 ```
 
 Release notes: captain-authored, references the PR number and agent.
@@ -131,7 +131,7 @@ Recommend the first path; simpler.
 
 ### Receipt invalidated mid-flow (Step 4 retry)
 
-Between /pr-submit and /pr-captain-land, a captain coord commit may land on master, changing origin/master and thus the diff-hash. Agent's receipt no longer matches.
+Between /pr-submit and /pr-captain-land, a captain coord commit may land on the default branch, changing `origin/<default-branch>` and thus the diff-hash. Agent's receipt no longer matches.
 
 Detected at Step 2 or Step 4 (pr-create). Script exits; agent re-runs /pr-prep (re-signs receipt) + /pr-submit.
 

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -3,7 +3,7 @@
 # pr-captain-land — Captain lands an agent's prepared branch as a PR + release
 #
 # WHAT: Captain runs this in the main checkout to own the full PR lifecycle
-# for a branch prepared by an agent via /submit-for-pr. Switches to the
+# for a branch prepared by an agent via /pr-submit. Switches to the
 # branch, verifies the QGR receipt, bumps the version, creates the PR with
 # a captain-authored description, watches CI, merges, cuts the release, and
 # dispatches the agent with the outcome.
@@ -218,7 +218,7 @@ PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
 Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot).
 
-Branch prepared by agent via /submit-for-pr. Captain owns the landing lifecycle:
+Branch prepared by agent via /pr-submit. Captain owns the landing lifecycle:
 - Switched to \`$AGENT_BRANCH\`
 - Verified QGR receipt \`$RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`)
 - Bumped \`agency_version\` $CURRENT_VER → $NEW_VER
@@ -270,7 +270,7 @@ while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
     fi
     if [[ "$STATE" == "FAILURE" ]]; then
         echo "pr-captain-land: lint-and-test FAILED on PR #$PR_NUM" >&2
-        echo "  Agent must fix, push, and re-submit via /submit-for-pr." >&2
+        echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
         exit 1
     fi
     sleep 20

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -34,21 +34,32 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     exit 1
 }
 
+# ── Shared remote/branch helpers ─────────────────────────────────────────────
+# redact_remote_url, parse_org_from_remote, parse_repo_from_remote,
+# resolve_default_branch — single source of truth, defined in the pr-submit
+# script behind its PR_SUBMIT_LIB_ONLY guard and unit-tested in
+# src/tests/skills/pr-submit-helpers.bats. Sourcing loads the functions only;
+# the guard returns before any pr-submit precondition runs.
+PR_SUBMIT_LIB_ONLY=1 source "$REPO_ROOT/.claude/skills/pr-submit/scripts/pr-submit"
+
 # ── Resolve ORG, REPO, PRINCIPAL ─────────────────────────────────────────────
-# Parse ORG and REPO from the origin remote URL (no network call). Supports
-# both git@github.com:ORG/REPO.git and https://github.com/ORG/REPO(.git).
+# Parse ORG and REPO from the origin remote URL (no network call). Handles
+# token-bearing, scp-style, and https remotes with/without .git — and never
+# echoes a raw (possibly credential-bearing) remote on the failure path.
 REMOTE_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
-if [[ "$REMOTE_URL" =~ ^git@github\.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-    REPO="${BASH_REMATCH[2]}"
-elif [[ "$REMOTE_URL" =~ ^https://github\.com/([^/]+)/([^/.]+?)(\.git)?/?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-    REPO="${BASH_REMATCH[2]}"
-else
-    echo "pr-captain-land: cannot parse origin remote URL '$REMOTE_URL'" >&2
+if ! ORG="$(parse_org_from_remote "$REMOTE_URL")" || ! REPO="$(parse_repo_from_remote "$REMOTE_URL")"; then
+    echo "pr-captain-land: cannot parse origin remote URL '$(redact_remote_url "$REMOTE_URL")'" >&2
     exit 1
 fi
 PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2 (matches pr-submit)
+
+# ── Resolve the repo's default branch — never assume master ──────────────────
+# The PR lifecycle hardcoded origin/master. In a repo whose default branch is
+# main (this one), the receipt-verify diff-hash resolved nothing, switch-back
+# targeted a nonexistent branch, and the release targeted master. Resolve it
+# once here and use it everywhere below.
+DEFAULT_BRANCH="$(resolve_default_branch)"
+BASE_REF="origin/${DEFAULT_BRANCH}"
 
 # ── Args ─────────────────────────────────────────────────────────────────────
 
@@ -100,8 +111,8 @@ if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
 fi
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "main" ]]; then
-    echo "pr-captain-land: captain must be on master (you're on $CURRENT_BRANCH)." >&2
+if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
+    echo "pr-captain-land: captain must be on $DEFAULT_BRANCH (you're on $CURRENT_BRANCH)." >&2
     exit 1
 fi
 
@@ -109,7 +120,7 @@ fi
 
 DIRTY=$(git status --porcelain 2>/dev/null)
 if [[ -n "$DIRTY" ]]; then
-    echo "pr-captain-land: master tree dirty — commit or stash first." >&2
+    echo "pr-captain-land: $DEFAULT_BRANCH tree dirty — commit or stash first." >&2
     echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
     exit 1
 fi
@@ -130,7 +141,7 @@ bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$AGENT_BRANCH" >/dev/n
 
 # ── Verify QGR receipt ───────────────────────────────────────────────────────
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
@@ -140,7 +151,7 @@ if [[ -z "$RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
     echo "  Agent must run /pr-prep to produce a receipt before submitting." >&2
     # Switch back to master before exit
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -175,7 +186,7 @@ else:
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
     echo "pr-captain-land: could not bump version from $CURRENT_VER" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -223,7 +234,7 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "    Title: $PR_TITLE"
     echo "    Body:  (see stdout)"
     # Switch back to master
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
     echo "pr-captain-land: dry-run complete"
     exit 0
 fi
@@ -234,7 +245,7 @@ PR_URL=$(bash "$REPO_ROOT/agency/tools/pr-create" --title "$PR_TITLE" --body "$P
 
 if [[ -z "$PR_URL" ]]; then
     echo "pr-captain-land: pr-create did not return a URL — check output above" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -243,8 +254,8 @@ echo "→ PR created: $PR_URL (#$PR_NUM)"
 
 # ── Back to master for merge ────────────────────────────────────────────────
 
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null
-echo "→ Back on master"
+bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
+echo "→ Back on $DEFAULT_BRANCH"
 
 # ── Wait for CI ──────────────────────────────────────────────────────────────
 
@@ -289,7 +300,7 @@ bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
     bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
-        --target master \
+        --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
         --notes "Captain-landed via pr-captain-land (the-agency#296 Phase 1 pilot). See PR #$PR_NUM." \
         >/dev/null 2>&1 || {
@@ -316,7 +327,7 @@ bash "$REPO_ROOT/agency/tools/dispatch" create \
 - Release: https://github.com/$ORG/$REPO/releases/tag/v$NEW_VER
 - Version: $CURRENT_VER → $NEW_VER
 
-Your branch is merged to master. Run /session-resume to pick up on your next cycle.
+Your branch is merged to $DEFAULT_BRANCH. Run /session-resume to pick up on your next cycle.
 
 Phase 1 pilot feedback: did anything feel off about the handoff? Reply dispatch.
 

--- a/.claude/skills/pr-submit/SKILL.md
+++ b/.claude/skills/pr-submit/SKILL.md
@@ -29,7 +29,7 @@ Agent-side handoff to captain: "my branch is ready for PR landing." Captain pick
 
 Per the-agency#296: the distributed "agent creates PR, captain merges" model causes four failure modes that the captain-owned lifecycle eliminates:
 
-- **Version-bump races** — two agents bump `agency_version` simultaneously against the same `origin/master` baseline; one loses.
+- **Version-bump races** — two agents bump `agency_version` simultaneously against the same `origin/<default-branch>` baseline; one loses.
 - **QGR hash races** — captain's coord commits land on master between an agent's QG and that agent's PR creation, invalidating the receipt mid-flow.
 - **Split release responsibility** — agent opens PR but captain creates the release; ownership is asymmetric and release steps get skipped.
 - **Inconsistent PR descriptions** — each agent writes their own; no fleet-wide coherence for review or history-mining.
@@ -64,7 +64,7 @@ The script enforces all of these before dispatching; any failure exits non-zero 
 2. Current branch is not `master` / `main` / `HEAD` (not detached).
 3. Tree is clean — `git status --porcelain` empty.
 4. Current branch is pushed to origin and `origin/<branch>` equals local `HEAD`.
-5. A QGR receipt exists at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` where `{hash}` matches the current `diff-hash` against `origin/master`.
+5. A QGR receipt exists at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` where `{hash}` matches the current `diff-hash` against `origin/<default-branch>` (resolved, not hardcoded).
 
 If preconditions 3 or 4 fail, fix them (commit/push via `/git-safe-commit` or `/sync`) and retry. If precondition 5 fails, you need to re-run `/pr-prep` to sign a fresh receipt.
 
@@ -84,7 +84,7 @@ If preconditions 3 or 4 fail, fix them (commit/push via `/git-safe-commit` or `/
 ### Step 3: Compute diff-hash
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 ```
 
 Capture the full SHA-256 and the 7-char short form. The 7-char short form is what matches the receipt filename suffix.

--- a/.claude/skills/pr-submit/examples.md
+++ b/.claude/skills/pr-submit/examples.md
@@ -14,7 +14,7 @@ Expected:
 
 ```
 [pr-submit] Preflight OK: worktree=devex, branch=jordan-devex-d12-r3, sha=a3f9b21, pushed=ok
-[pr-submit] Diff hash: 8b4c2e1 (vs origin/master)
+[pr-submit] Diff hash: 8b4c2e1 (vs origin/main)
 [pr-submit] Receipt: agency/workstreams/devex/qgr/{repo}-jordan-devex-devex-d12r3-qgr-pr-prep-20260419-1430-8b4c2e1.md
 [pr-submit] Dispatched to <org>/jordan/captain as d-019da47f-8b4c
 → Captain will run /pr-captain-land jordan-devex-d12-r3
@@ -111,7 +111,7 @@ The dispatch body that lands in captain's inbox (see `reference.md` for full sch
 - **Branch:** `jordan-devex-d12-r3`
 - **Agent:** <org>/jordan/devex
 - **HEAD:** `a3f9b21f...` (pushed to origin)
-- **Diff base:** `origin/master`
+- **Diff base:** `origin/main`
 - **Diff hash:** `8b4c2e1`
 
 ## QGR receipt

--- a/.claude/skills/pr-submit/reference.md
+++ b/.claude/skills/pr-submit/reference.md
@@ -24,7 +24,7 @@ in_reply_to: null | <prior-dispatch-id>
 - **Branch:** `{branch}`
 - **Agent:** <org>/{principal}/{agent}
 - **HEAD:** `{sha}` (pushed to origin)
-- **Diff base:** `origin/master`
+- **Diff base:** `origin/<default-branch>` (resolved via `resolve_default_branch`)
 - **Diff hash:** `{hash-7-char}`
 
 ## QGR receipt
@@ -69,7 +69,7 @@ Over.
 |---|---|---|---|
 | `branch` | string | `git rev-parse --abbrev-ref HEAD` | Not `master`, not `HEAD` (detached) |
 | `sha` | string (40 char hex) | `git rev-parse HEAD` | Must equal `origin/{branch}` |
-| `diff-hash` | string (7 char hex) | `./agency/tools/diff-hash --base origin/master --json` | First 7 of full SHA-256 |
+| `diff-hash` | string (7 char hex) | `./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json` | First 7 of full SHA-256 |
 | `receipt-path` | string | Glob `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | Must exist, must match hash |
 | `scope` | string | `--scope` flag | Required, non-empty |
 | `priority` | enum | `--priority` flag | `normal` (default) or `high` |

--- a/.claude/skills/pr-submit/scripts/README.md
+++ b/.claude/skills/pr-submit/scripts/README.md
@@ -16,7 +16,7 @@ The skill's `argument-hint` frontmatter mirrors this CLI.
 
 1. Resolves agent identity (`./agency/tools/agent-identity`) — aborts outside an agent worktree
 2. Verifies tree clean, branch pushed, origin matches HEAD
-3. Computes `./agency/tools/diff-hash --base origin/master --json` for the receipt lookup
+3. Computes `./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json` (default branch resolved) for the receipt lookup
 4. Globs `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`, picks most recent if multiple
 5. Composes the dispatch body per `../reference.md` schema
 6. Emits via `./agency/tools/dispatch create --to <org>/{principal}/captain --type pr-submit --subject "..." --body "..."`

--- a/.claude/skills/pr-submit/scripts/pr-submit
+++ b/.claude/skills/pr-submit/scripts/pr-submit
@@ -87,6 +87,26 @@ parse_org_from_remote() {
     return 1
 }
 
+# Echo the repo (name) segment of a GitHub remote URL. Returns 1 if unparseable.
+#
+# Companion to parse_org_from_remote — same normalization (redact userinfo,
+# strip a trailing ".git" and slash before matching, since POSIX ERE has no
+# lazy quantifier). Returns the SECOND path segment (the repo name).
+parse_repo_from_remote() {
+    local url clean
+    url="$(redact_remote_url "$1")"
+    clean="${url%.git}"
+    clean="${clean%/}"
+    if [[ "$clean" =~ ^git@[^:]+:([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[2]}"
+        return 0
+    elif [[ "$clean" =~ ^https?://[^/]+/([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[2]}"
+        return 0
+    fi
+    return 1
+}
+
 # Echo the repo's default branch name. Resolve it — never assume.
 #
 # This script hardcoded origin/master, which fails closed in every repo whose

--- a/.claude/skills/pr-submit/scripts/pr-submit
+++ b/.claude/skills/pr-submit/scripts/pr-submit
@@ -32,6 +32,93 @@
 
 set -euo pipefail
 
+# ── Pure helpers ─────────────────────────────────────────────────────────────
+#
+# These three are side-effect free so they can be unit-tested without a git
+# repo, a pushed branch, or a signed receipt. Source this script with
+# PR_SUBMIT_LIB_ONLY=1 to get the functions and nothing else — see
+# src/tests/skills/pr-submit-helpers.bats.
+
+# Strip userinfo from a remote URL: "https://user:token@host/..." → "https://host/...".
+# Credential-bearing remotes are normal on a machine authenticating with a PAT.
+# Every message that prints a remote URL must print THIS, never the raw value —
+# the failure path used to echo the raw remote and leaked the token into the
+# terminal, logs, and transcripts.
+redact_remote_url() {
+    local url="$1"
+    # Match ANY scheme, not just https. An earlier version of this function
+    # anchored on the literal "https://" prefix, which left ssh://, http://
+    # and git:// remotes completely unredacted — so a credential on an
+    # internal Gitea/GitLab host still reached the terminal through the
+    # parse-failure message. Scheme-generic now.
+    #
+    # "[^/@]*" cannot cross an @ or a /, so the userinfo match stops at the
+    # FIRST @ and cannot run past the host into the path. The prefix-glob
+    # version was greedy and matched through the LAST @, which mangled a URL
+    # whose path contained an @.
+    if [[ "$url" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@]*@(.*)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+    else
+        # scp-style (git@host:org/repo) intentionally falls through: that
+        # leading "git" is a username, not a secret, and stripping it would
+        # break the form.
+        printf '%s' "$url"
+    fi
+}
+
+# Echo the org (owner) segment of a GitHub remote URL. Returns 1 if unparseable.
+#
+# The tail is normalized before matching rather than expressing an optional
+# ".git" in the pattern: bash uses POSIX ERE, which has no lazy quantifier, so
+# the old "([^/.]+?)(\.git)?/?$" did not mean what it looks like and matched no
+# .git-suffixed https remote at all.
+parse_org_from_remote() {
+    local url clean
+    url="$(redact_remote_url "$1")"
+    clean="${url%.git}"
+    clean="${clean%/}"
+    if [[ "$clean" =~ ^git@[^:]+:([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    elif [[ "$clean" =~ ^https?://[^/]+/([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+# Echo the repo's default branch name. Resolve it — never assume.
+#
+# This script hardcoded origin/master, which fails closed in every repo whose
+# default branch is named main: diff-hash exits non-zero, the hash comes back
+# empty, and the agent is told "could not compute diff hash" with no hint that
+# the ref name is the problem. That blocks /pr-submit for every agent in such
+# a repo.
+resolve_default_branch() {
+    local branch candidate
+    branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
+    if [[ -z "$branch" ]]; then
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "origin/$candidate" >/dev/null 2>&1; then
+                branch="$candidate"
+                break
+            fi
+        done
+    fi
+    printf '%s' "${branch:-master}"
+}
+
+# Sourced for tests: stop here, before any precondition touches git or the
+# network. The BASH_SOURCE/$0 comparison is load-bearing — it is only true
+# when the file is SOURCED. Without it, an inherited PR_SUBMIT_LIB_ONLY in
+# the environment (CI job, shell rc, any upstream process) would make a
+# normal execution exit 0 having silently skipped every precondition and
+# sent no dispatch, which a caller checking $? cannot distinguish from
+# success.
+if [[ -n "${PR_SUBMIT_LIB_ONLY:-}" && "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     echo "submit-for-pr: not in a git repository" >&2
@@ -110,15 +197,19 @@ fi
 # ── Precondition: QGR receipt exists ─────────────────────────────────────────
 #
 # Receipt lives at agency/workstreams/{workstream}/qgr/*.md. We try to find
-# one matching the current diff hash against origin/master.
+# one matching the current diff hash against the default branch.
+#
+# The default branch is resolved, not assumed — see resolve_default_branch.
+DEFAULT_BRANCH="$(resolve_default_branch)"
+BASE_REF="origin/${DEFAULT_BRANCH}"
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
 
 if [[ -z "$DIFF_HASH_SHORT" ]]; then
-    echo "submit-for-pr: could not compute diff hash against origin/master." >&2
+    echo "submit-for-pr: could not compute diff hash against $BASE_REF." >&2
     echo "  Tool: $REPO_ROOT/agency/tools/diff-hash" >&2
     exit 1
 fi
@@ -150,12 +241,9 @@ PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2
 
 # Resolve ORG from the origin remote URL (no network call).
 REMOTE_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
-if [[ "$REMOTE_URL" =~ ^git@github\.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-elif [[ "$REMOTE_URL" =~ ^https://github\.com/([^/]+)/([^/.]+?)(\.git)?/?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-else
-    echo "pr-submit: cannot parse origin remote URL '$REMOTE_URL'" >&2
+if ! ORG="$(parse_org_from_remote "$REMOTE_URL")"; then
+    # Print the REDACTED url — never the raw remote, which may carry a token.
+    echo "pr-submit: cannot parse origin remote URL '$(redact_remote_url "$REMOTE_URL")'" >&2
     exit 1
 fi
 
@@ -169,7 +257,7 @@ DISPATCH_BODY=$(cat <<EOF
 - **Branch:** \`$BRANCH\`
 - **Agent:** $ORG/$PRINCIPAL/$AGENT
 - **HEAD:** \`$LOCAL_SHA\` (pushed to origin)
-- **Diff base:** \`origin/master\`
+- **Diff base:** \`$BASE_REF\`
 - **Diff hash:** \`$DIFF_HASH_SHORT\`
 
 ## QGR receipt

--- a/agency/.agency/projects.json
+++ b/agency/.agency/projects.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "1.0",
+  "projects": [
+    {
+      "name": "nonexistent-test-project",
+      "path": "/tmp/nonexistent-test-project",
+      "created_at": "2026-08-08T02:10:24Z",
+      "starter_version": "unknown",
+      "status": "current"
+    }
+  ]
+}

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.26",
+  "agency_version": "46.27",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.26",
-    "updated_at": "2026-05-17T10:10:00Z"
+    "framework_version": "46.27",
+    "updated_at": "2026-08-08T11:50:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/tools/diff-hash
+++ b/agency/tools/diff-hash
@@ -13,8 +13,17 @@
 # (branch vs base) or a single artifact file. Excludes:
 #   - agency/receipts/      (the receipts themselves — original fix)
 #   - usr/**/dispatches/    (auto-staged commit-announce dispatches — #99 fix)
+#   - usr/**/*-handoff.md   (active handoffs — receipt-churn fix, see below)
+#   - usr/**/handoff-*.md   (archived handoffs in history/ — receipt-churn fix)
 # from all diff computations to prevent chicken-and-egg. Full SHA-256
 # stored internally; 7-char truncation for display and filenames.
+#
+# Receipt-churn fix (2026-08-08): /pr-prep signs a receipt against this hash,
+# then /pr-submit and /handoff commit a handoff artifact that landed INSIDE
+# the hashed file set — invalidating the just-signed receipt and forcing a
+# re-sign on every landing (one PR cost five signatures). Handoffs are
+# session coordination artifacts, never the code under review, so they are
+# excluded exactly as receipts and dispatches already are.
 #
 # Usage:
 #   ./agency/tools/diff-hash                      # diff against origin/main
@@ -103,10 +112,12 @@ else
         ':(exclude,glob)src/agency/workstreams/*/rgr/**' \
         ':(exclude,glob)usr/*/*/dispatches/**' \
         ':(exclude,glob)usr/*/dispatches/**' \
+        ':(exclude,glob)usr/**/*-handoff.md' \
+        ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null)
 
     if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff between $BASE and HEAD (excluding receipts and dispatches)" >&2
+        echo "Error: no diff between $BASE and HEAD (excluding receipts, dispatches, and handoffs)" >&2
         exit 1
     fi
 
@@ -120,6 +131,8 @@ else
         ':(exclude,glob)src/agency/workstreams/*/rgr/**' \
         ':(exclude,glob)usr/*/*/dispatches/**' \
         ':(exclude,glob)usr/*/dispatches/**' \
+        ':(exclude,glob)usr/**/*-handoff.md' \
+        ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null | wc -l | tr -d ' ')
 
     if [[ "$JSON" == "true" ]]; then

--- a/agency/tools/pr-create
+++ b/agency/tools/pr-create
@@ -34,16 +34,22 @@ echo "✓ On branch: $BRANCH"
 
 # D42-R3 / v46.1-R1: four-tier receipt search
 # Tier 1: per-workstream qgr/ and rgr/ (post-v46 canonical)
-NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1)
+# The trailing `|| true` is load-bearing under `set -o pipefail`: `head -1`
+# closes the pipe after the first line, which SIGPIPEs the upstream `ls`
+# once there are more receipts than fit its stdio buffer (races in at ~100+).
+# The value is already captured by `head` before the signal; `|| true` keeps
+# that nondeterministic pipeline failure from aborting the whole script. A
+# genuine empty result still falls through to the -z checks below.
+NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 2: legacy flat receipts dir
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 3: old usr/ location
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then

--- a/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1149-779b204.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1149-779b204.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: pr-submit-org-resolution
+workstream: agency
+project: pr-lifecycle
+diff_base: origin/main
+hash_a: 1a65b7ef25a1392ffbd30ebee52bc8ef483c2378f011c744a8c3408ee52381ec
+hash_b: f314fc0755c759e09906ae22686adc9138f75cdddc7b38cda8a6c7e2572e4bea
+hash_c: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
+hash_d: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
+hash_d_source: "captain-driven QG — principal directives in-session, no discrete 1B1 transcript"
+hash_e: 779b2047d90bf2895a675bfda2361413597cda94cb8cff56237f334dd5b9788c
+date: 2026-08-08T11:49
+---
+
+# Receipt: pr-prep — pr-lifecycle
+
+## Chain of Trust
+- A (original): 1a65b7e
+- B (findings): f314fc0
+- C (triage): 0d098a7
+- D (principal): 0d098a7 — captain-driven QG — principal directives in-session, no discrete 1B1 transcript
+- E (final): 779b204
+
+## Review Summary
+make PR landing main-aware (pr-captain-land + pr-submit + diff-hash) + fix receipt-churn; QG hardened test guards + de-staled docs

--- a/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1152-801b8f8.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1152-801b8f8.md
@@ -13,8 +13,8 @@ hash_b: f314fc0755c759e09906ae22686adc9138f75cdddc7b38cda8a6c7e2572e4bea
 hash_c: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
 hash_d: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
 hash_d_source: "captain-driven QG — principal directives in-session, no discrete 1B1 transcript"
-hash_e: 779b2047d90bf2895a675bfda2361413597cda94cb8cff56237f334dd5b9788c
-date: 2026-08-08T11:49
+hash_e: 801b8f894c655aa6c65c600587130f1554ba98127892d88c2068b04576c01fe0
+date: 2026-08-08T11:52
 ---
 
 # Receipt: pr-prep — pr-lifecycle
@@ -24,7 +24,7 @@ date: 2026-08-08T11:49
 - B (findings): f314fc0
 - C (triage): 0d098a7
 - D (principal): 0d098a7 — captain-driven QG — principal directives in-session, no discrete 1B1 transcript
-- E (final): 779b204
+- E (final): 801b8f8
 
 ## Review Summary
-make PR landing main-aware (pr-captain-land + pr-submit + diff-hash) + fix receipt-churn; QG hardened test guards + de-staled docs
+make PR landing main-aware + fix receipt-churn; incl version bump 46.26->46.27

--- a/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1158-28c1331.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1158-28c1331.md
@@ -13,8 +13,8 @@ hash_b: f314fc0755c759e09906ae22686adc9138f75cdddc7b38cda8a6c7e2572e4bea
 hash_c: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
 hash_d: 0d098a7a03f050024f84aec7e19cf28de252380afc3d961e388fcade0f4d6f42
 hash_d_source: "captain-driven QG — principal directives in-session, no discrete 1B1 transcript"
-hash_e: 801b8f894c655aa6c65c600587130f1554ba98127892d88c2068b04576c01fe0
-date: 2026-08-08T11:52
+hash_e: 28c13315e808ba4e854190a2cbf9b5242ef0093dd2ab6f780445534ae6e924a2
+date: 2026-08-08T11:58
 ---
 
 # Receipt: pr-prep — pr-lifecycle
@@ -24,7 +24,7 @@ date: 2026-08-08T11:52
 - B (findings): f314fc0
 - C (triage): 0d098a7
 - D (principal): 0d098a7 — captain-driven QG — principal directives in-session, no discrete 1B1 transcript
-- E (final): 801b8f8
+- E (final): 28c1331
 
 ## Review Summary
-make PR landing main-aware + fix receipt-churn; incl version bump 46.26->46.27
+make PR landing main-aware + fix receipt-churn + pr-create pipefail robustness

--- a/src/agency/tools/diff-hash
+++ b/src/agency/tools/diff-hash
@@ -13,8 +13,17 @@
 # (branch vs base) or a single artifact file. Excludes:
 #   - agency/receipts/      (the receipts themselves — original fix)
 #   - usr/**/dispatches/    (auto-staged commit-announce dispatches — #99 fix)
+#   - usr/**/*-handoff.md   (active handoffs — receipt-churn fix, see below)
+#   - usr/**/handoff-*.md   (archived handoffs in history/ — receipt-churn fix)
 # from all diff computations to prevent chicken-and-egg. Full SHA-256
 # stored internally; 7-char truncation for display and filenames.
+#
+# Receipt-churn fix (2026-08-08): /pr-prep signs a receipt against this hash,
+# then /pr-submit and /handoff commit a handoff artifact that landed INSIDE
+# the hashed file set — invalidating the just-signed receipt and forcing a
+# re-sign on every landing (one PR cost five signatures). Handoffs are
+# session coordination artifacts, never the code under review, so they are
+# excluded exactly as receipts and dispatches already are.
 #
 # Usage:
 #   ./agency/tools/diff-hash                      # diff against origin/main
@@ -25,6 +34,14 @@
 # Written: 2026-04-14 during captain session (receipt infrastructure Phase 1)
 
 set -euo pipefail
+
+# Issue #254: fail loudly with a clear error when invoked outside a git repo.
+# Previously, `git diff` silently produced empty output, masking the real
+# failure. Exit 2 = precondition failure (distinct from exit 1 argparse errors).
+if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
+    echo "Error: diff-hash must be run inside a git repository (cwd: $(pwd))" >&2
+    exit 2
+fi
 
 BASE="origin/main"
 FILE=""
@@ -95,10 +112,12 @@ else
         ':(exclude,glob)src/agency/workstreams/*/rgr/**' \
         ':(exclude,glob)usr/*/*/dispatches/**' \
         ':(exclude,glob)usr/*/dispatches/**' \
+        ':(exclude,glob)usr/**/*-handoff.md' \
+        ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null)
 
     if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff between $BASE and HEAD (excluding receipts and dispatches)" >&2
+        echo "Error: no diff between $BASE and HEAD (excluding receipts, dispatches, and handoffs)" >&2
         exit 1
     fi
 
@@ -112,6 +131,8 @@ else
         ':(exclude,glob)src/agency/workstreams/*/rgr/**' \
         ':(exclude,glob)usr/*/*/dispatches/**' \
         ':(exclude,glob)usr/*/dispatches/**' \
+        ':(exclude,glob)usr/**/*-handoff.md' \
+        ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null | wc -l | tr -d ' ')
 
     if [[ "$JSON" == "true" ]]; then

--- a/src/agency/tools/pr-create
+++ b/src/agency/tools/pr-create
@@ -34,16 +34,22 @@ echo "✓ On branch: $BRANCH"
 
 # D42-R3 / v46.1-R1: four-tier receipt search
 # Tier 1: per-workstream qgr/ and rgr/ (post-v46 canonical)
-NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1)
+# The trailing `|| true` is load-bearing under `set -o pipefail`: `head -1`
+# closes the pipe after the first line, which SIGPIPEs the upstream `ls`
+# once there are more receipts than fit its stdio buffer (races in at ~100+).
+# The value is already captured by `head` before the signal; `|| true` keeps
+# that nondeterministic pipeline failure from aborting the whole script. A
+# genuine empty result still falls through to the -z checks below.
+NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 2: legacy flat receipts dir
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 3: old usr/ location
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -76,7 +76,7 @@ The script enforces **all** of these before any mutation; any failure exits non-
 4. **No pending post-merge (C#372 Fix B).** `./agency/tools/post-merge-state check` exits 0. If exit 1, a prior landed PR has not had its release cut — run `/pr-captain-post-merge <pending-PR>` first, then re-invoke.
 5. `<agent-branch>` exists on origin (`git ls-remote --heads origin <agent-branch>` non-empty).
 6. `<agent-branch>` passes safe-name validation: regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-7. Diff-hash of `<agent-branch>` vs `origin/master` matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
+7. Diff-hash of `<agent-branch>` vs `origin/<default-branch>` (resolved, not hardcoded) matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
 
 Any failure → zero mutation, clean error message, exit 1.
 
@@ -99,7 +99,7 @@ Main checkout is now on agent's branch.
 ### Step 3: Verify receipt against current state
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 ```
 
 Find receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`. If missing, agent's state drifted — switch back to master, exit 1, tell agent to re-run `/pr-prep` + `/pr-submit`.
@@ -133,7 +133,7 @@ Title derives from agent's `--scope` or `--title` override. Body wraps agent's s
 ### Step 6: Switch back to master
 
 ```
-./agency/tools/git-captain switch-branch master
+./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
 ```
 
 Captain sits on master during the CI-wait phase. Avoids any accidental commit on the PR branch.
@@ -172,7 +172,7 @@ Sync master:
 Release (unless `--no-release`):
 
 ```
-./agency/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
 ```
 
 Release notes: captain-authored, references PR number + agent.

--- a/src/claude/skills/pr-captain-land/examples.md
+++ b/src/claude/skills/pr-captain-land/examples.md
@@ -150,7 +150,7 @@ Most common: GitHub release API hiccup:
 [pr-captain-land] Merged PR #118 successfully.
 [pr-captain-land] gh-release create v1.10 FAILED: ...
 [pr-captain-land] WARN: merge is the primary outcome (success). Release creation deferred.
-  Captain: run `gh release create v1.10 --target master --notes-file ...` manually.
+  Captain: run `gh release create v1.10 --target main --notes-file ...` manually.
 [pr-captain-land] Dispatched agent with merge confirmation (no release URL).
 ```
 

--- a/src/claude/skills/pr-captain-land/reference.md
+++ b/src/claude/skills/pr-captain-land/reference.md
@@ -30,10 +30,10 @@ Current working branch becomes the agent's. Main checkout is now sitting on agen
 
 ### Step 2 — Verify receipt
 
-Compute current diff-hash against `origin/master`. Find receipt matching that hash.
+Compute current diff-hash against `origin/<default-branch>` (resolved via `resolve_default_branch`, not hardcoded). Find receipt matching that hash.
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 # extract hash
 find agency/workstreams -name "*qgr-pr-prep-*-{hash}.md"
 ```
@@ -69,7 +69,7 @@ Title: `--title` flag value, or `<agent-branch>` as fallback. Body: captain-auth
 ### Step 5 — Switch back to master
 
 ```
-./agency/tools/git-captain switch-branch master
+./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
 ```
 
 Captain should sit on master for the wait-and-merge phase. Avoids any accidental commit landing on the PR branch.
@@ -103,7 +103,7 @@ Uses admin merge (principal-approved flag gated). True merge commit — never sq
 ```
 ./agency/tools/git-captain fetch
 ./agency/tools/git-captain merge-from-origin
-./agency/tools/gh-release create v{new-version} --target master --title "..." --notes "..."
+./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
 ```
 
 Release notes: captain-authored, references the PR number and agent.
@@ -131,7 +131,7 @@ Recommend the first path; simpler.
 
 ### Receipt invalidated mid-flow (Step 4 retry)
 
-Between /pr-submit and /pr-captain-land, a captain coord commit may land on master, changing origin/master and thus the diff-hash. Agent's receipt no longer matches.
+Between /pr-submit and /pr-captain-land, a captain coord commit may land on the default branch, changing `origin/<default-branch>` and thus the diff-hash. Agent's receipt no longer matches.
 
 Detected at Step 2 or Step 4 (pr-create). Script exits; agent re-runs /pr-prep (re-signs receipt) + /pr-submit.
 

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -3,7 +3,7 @@
 # pr-captain-land — Captain lands an agent's prepared branch as a PR + release
 #
 # WHAT: Captain runs this in the main checkout to own the full PR lifecycle
-# for a branch prepared by an agent via /submit-for-pr. Switches to the
+# for a branch prepared by an agent via /pr-submit. Switches to the
 # branch, verifies the QGR receipt, bumps the version, creates the PR with
 # a captain-authored description, watches CI, merges, cuts the release, and
 # dispatches the agent with the outcome.
@@ -218,7 +218,7 @@ PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
 Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot).
 
-Branch prepared by agent via /submit-for-pr. Captain owns the landing lifecycle:
+Branch prepared by agent via /pr-submit. Captain owns the landing lifecycle:
 - Switched to \`$AGENT_BRANCH\`
 - Verified QGR receipt \`$RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`)
 - Bumped \`agency_version\` $CURRENT_VER → $NEW_VER
@@ -270,7 +270,7 @@ while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
     fi
     if [[ "$STATE" == "FAILURE" ]]; then
         echo "pr-captain-land: lint-and-test FAILED on PR #$PR_NUM" >&2
-        echo "  Agent must fix, push, and re-submit via /submit-for-pr." >&2
+        echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
         exit 1
     fi
     sleep 20

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -34,21 +34,32 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     exit 1
 }
 
+# ── Shared remote/branch helpers ─────────────────────────────────────────────
+# redact_remote_url, parse_org_from_remote, parse_repo_from_remote,
+# resolve_default_branch — single source of truth, defined in the pr-submit
+# script behind its PR_SUBMIT_LIB_ONLY guard and unit-tested in
+# src/tests/skills/pr-submit-helpers.bats. Sourcing loads the functions only;
+# the guard returns before any pr-submit precondition runs.
+PR_SUBMIT_LIB_ONLY=1 source "$REPO_ROOT/.claude/skills/pr-submit/scripts/pr-submit"
+
 # ── Resolve ORG, REPO, PRINCIPAL ─────────────────────────────────────────────
-# Parse ORG and REPO from the origin remote URL (no network call). Supports
-# both git@github.com:ORG/REPO.git and https://github.com/ORG/REPO(.git).
+# Parse ORG and REPO from the origin remote URL (no network call). Handles
+# token-bearing, scp-style, and https remotes with/without .git — and never
+# echoes a raw (possibly credential-bearing) remote on the failure path.
 REMOTE_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
-if [[ "$REMOTE_URL" =~ ^git@github\.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-    REPO="${BASH_REMATCH[2]}"
-elif [[ "$REMOTE_URL" =~ ^https://github\.com/([^/]+)/([^/.]+?)(\.git)?/?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-    REPO="${BASH_REMATCH[2]}"
-else
-    echo "pr-captain-land: cannot parse origin remote URL '$REMOTE_URL'" >&2
+if ! ORG="$(parse_org_from_remote "$REMOTE_URL")" || ! REPO="$(parse_repo_from_remote "$REMOTE_URL")"; then
+    echo "pr-captain-land: cannot parse origin remote URL '$(redact_remote_url "$REMOTE_URL")'" >&2
     exit 1
 fi
 PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2 (matches pr-submit)
+
+# ── Resolve the repo's default branch — never assume master ──────────────────
+# The PR lifecycle hardcoded origin/master. In a repo whose default branch is
+# main (this one), the receipt-verify diff-hash resolved nothing, switch-back
+# targeted a nonexistent branch, and the release targeted master. Resolve it
+# once here and use it everywhere below.
+DEFAULT_BRANCH="$(resolve_default_branch)"
+BASE_REF="origin/${DEFAULT_BRANCH}"
 
 # ── Args ─────────────────────────────────────────────────────────────────────
 
@@ -100,8 +111,8 @@ if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
 fi
 
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
-if [[ "$CURRENT_BRANCH" != "master" && "$CURRENT_BRANCH" != "main" ]]; then
-    echo "pr-captain-land: captain must be on master (you're on $CURRENT_BRANCH)." >&2
+if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
+    echo "pr-captain-land: captain must be on $DEFAULT_BRANCH (you're on $CURRENT_BRANCH)." >&2
     exit 1
 fi
 
@@ -109,7 +120,7 @@ fi
 
 DIRTY=$(git status --porcelain 2>/dev/null)
 if [[ -n "$DIRTY" ]]; then
-    echo "pr-captain-land: master tree dirty — commit or stash first." >&2
+    echo "pr-captain-land: $DEFAULT_BRANCH tree dirty — commit or stash first." >&2
     echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
     exit 1
 fi
@@ -130,7 +141,7 @@ bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$AGENT_BRANCH" >/dev/n
 
 # ── Verify QGR receipt ───────────────────────────────────────────────────────
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
@@ -140,7 +151,7 @@ if [[ -z "$RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
     echo "  Agent must run /pr-prep to produce a receipt before submitting." >&2
     # Switch back to master before exit
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -175,7 +186,7 @@ else:
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
     echo "pr-captain-land: could not bump version from $CURRENT_VER" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -223,7 +234,7 @@ if [[ "$DRY_RUN" == true ]]; then
     echo "    Title: $PR_TITLE"
     echo "    Body:  (see stdout)"
     # Switch back to master
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
     echo "pr-captain-land: dry-run complete"
     exit 0
 fi
@@ -234,7 +245,7 @@ PR_URL=$(bash "$REPO_ROOT/agency/tools/pr-create" --title "$PR_TITLE" --body "$P
 
 if [[ -z "$PR_URL" ]]; then
     echo "pr-captain-land: pr-create did not return a URL — check output above" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null 2>&1 || true
+    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
     exit 1
 fi
 
@@ -243,8 +254,8 @@ echo "→ PR created: $PR_URL (#$PR_NUM)"
 
 # ── Back to master for merge ────────────────────────────────────────────────
 
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch master >/dev/null
-echo "→ Back on master"
+bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
+echo "→ Back on $DEFAULT_BRANCH"
 
 # ── Wait for CI ──────────────────────────────────────────────────────────────
 
@@ -289,7 +300,7 @@ bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
     bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
-        --target master \
+        --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
         --notes "Captain-landed via pr-captain-land (the-agency#296 Phase 1 pilot). See PR #$PR_NUM." \
         >/dev/null 2>&1 || {
@@ -316,7 +327,7 @@ bash "$REPO_ROOT/agency/tools/dispatch" create \
 - Release: https://github.com/$ORG/$REPO/releases/tag/v$NEW_VER
 - Version: $CURRENT_VER → $NEW_VER
 
-Your branch is merged to master. Run /session-resume to pick up on your next cycle.
+Your branch is merged to $DEFAULT_BRANCH. Run /session-resume to pick up on your next cycle.
 
 Phase 1 pilot feedback: did anything feel off about the handoff? Reply dispatch.
 

--- a/src/claude/skills/pr-submit/SKILL.md
+++ b/src/claude/skills/pr-submit/SKILL.md
@@ -29,7 +29,7 @@ Agent-side handoff to captain: "my branch is ready for PR landing." Captain pick
 
 Per the-agency#296: the distributed "agent creates PR, captain merges" model causes four failure modes that the captain-owned lifecycle eliminates:
 
-- **Version-bump races** — two agents bump `agency_version` simultaneously against the same `origin/master` baseline; one loses.
+- **Version-bump races** — two agents bump `agency_version` simultaneously against the same `origin/<default-branch>` baseline; one loses.
 - **QGR hash races** — captain's coord commits land on master between an agent's QG and that agent's PR creation, invalidating the receipt mid-flow.
 - **Split release responsibility** — agent opens PR but captain creates the release; ownership is asymmetric and release steps get skipped.
 - **Inconsistent PR descriptions** — each agent writes their own; no fleet-wide coherence for review or history-mining.
@@ -64,7 +64,7 @@ The script enforces all of these before dispatching; any failure exits non-zero 
 2. Current branch is not `master` / `main` / `HEAD` (not detached).
 3. Tree is clean — `git status --porcelain` empty.
 4. Current branch is pushed to origin and `origin/<branch>` equals local `HEAD`.
-5. A QGR receipt exists at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` where `{hash}` matches the current `diff-hash` against `origin/master`.
+5. A QGR receipt exists at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` where `{hash}` matches the current `diff-hash` against `origin/<default-branch>` (resolved, not hardcoded).
 
 If preconditions 3 or 4 fail, fix them (commit/push via `/git-safe-commit` or `/sync`) and retry. If precondition 5 fails, you need to re-run `/pr-prep` to sign a fresh receipt.
 
@@ -84,7 +84,7 @@ If preconditions 3 or 4 fail, fix them (commit/push via `/git-safe-commit` or `/
 ### Step 3: Compute diff-hash
 
 ```
-./agency/tools/diff-hash --base origin/master --json
+./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
 ```
 
 Capture the full SHA-256 and the 7-char short form. The 7-char short form is what matches the receipt filename suffix.

--- a/src/claude/skills/pr-submit/examples.md
+++ b/src/claude/skills/pr-submit/examples.md
@@ -14,7 +14,7 @@ Expected:
 
 ```
 [pr-submit] Preflight OK: worktree=devex, branch=jordan-devex-d12-r3, sha=a3f9b21, pushed=ok
-[pr-submit] Diff hash: 8b4c2e1 (vs origin/master)
+[pr-submit] Diff hash: 8b4c2e1 (vs origin/main)
 [pr-submit] Receipt: agency/workstreams/devex/qgr/{repo}-jordan-devex-devex-d12r3-qgr-pr-prep-20260419-1430-8b4c2e1.md
 [pr-submit] Dispatched to <org>/jordan/captain as d-019da47f-8b4c
 → Captain will run /pr-captain-land jordan-devex-d12-r3
@@ -111,7 +111,7 @@ The dispatch body that lands in captain's inbox (see `reference.md` for full sch
 - **Branch:** `jordan-devex-d12-r3`
 - **Agent:** <org>/jordan/devex
 - **HEAD:** `a3f9b21f...` (pushed to origin)
-- **Diff base:** `origin/master`
+- **Diff base:** `origin/main`
 - **Diff hash:** `8b4c2e1`
 
 ## QGR receipt

--- a/src/claude/skills/pr-submit/reference.md
+++ b/src/claude/skills/pr-submit/reference.md
@@ -24,7 +24,7 @@ in_reply_to: null | <prior-dispatch-id>
 - **Branch:** `{branch}`
 - **Agent:** <org>/{principal}/{agent}
 - **HEAD:** `{sha}` (pushed to origin)
-- **Diff base:** `origin/master`
+- **Diff base:** `origin/<default-branch>` (resolved via `resolve_default_branch`)
 - **Diff hash:** `{hash-7-char}`
 
 ## QGR receipt
@@ -69,7 +69,7 @@ Over.
 |---|---|---|---|
 | `branch` | string | `git rev-parse --abbrev-ref HEAD` | Not `master`, not `HEAD` (detached) |
 | `sha` | string (40 char hex) | `git rev-parse HEAD` | Must equal `origin/{branch}` |
-| `diff-hash` | string (7 char hex) | `./agency/tools/diff-hash --base origin/master --json` | First 7 of full SHA-256 |
+| `diff-hash` | string (7 char hex) | `./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json` | First 7 of full SHA-256 |
 | `receipt-path` | string | Glob `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | Must exist, must match hash |
 | `scope` | string | `--scope` flag | Required, non-empty |
 | `priority` | enum | `--priority` flag | `normal` (default) or `high` |

--- a/src/claude/skills/pr-submit/scripts/README.md
+++ b/src/claude/skills/pr-submit/scripts/README.md
@@ -16,7 +16,7 @@ The skill's `argument-hint` frontmatter mirrors this CLI.
 
 1. Resolves agent identity (`./agency/tools/agent-identity`) — aborts outside an agent worktree
 2. Verifies tree clean, branch pushed, origin matches HEAD
-3. Computes `./agency/tools/diff-hash --base origin/master --json` for the receipt lookup
+3. Computes `./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json` (default branch resolved) for the receipt lookup
 4. Globs `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`, picks most recent if multiple
 5. Composes the dispatch body per `../reference.md` schema
 6. Emits via `./agency/tools/dispatch create --to <org>/{principal}/captain --type pr-submit --subject "..." --body "..."`

--- a/src/claude/skills/pr-submit/scripts/pr-submit
+++ b/src/claude/skills/pr-submit/scripts/pr-submit
@@ -32,6 +32,113 @@
 
 set -euo pipefail
 
+# ── Pure helpers ─────────────────────────────────────────────────────────────
+#
+# These three are side-effect free so they can be unit-tested without a git
+# repo, a pushed branch, or a signed receipt. Source this script with
+# PR_SUBMIT_LIB_ONLY=1 to get the functions and nothing else — see
+# src/tests/skills/pr-submit-helpers.bats.
+
+# Strip userinfo from a remote URL: "https://user:token@host/..." → "https://host/...".
+# Credential-bearing remotes are normal on a machine authenticating with a PAT.
+# Every message that prints a remote URL must print THIS, never the raw value —
+# the failure path used to echo the raw remote and leaked the token into the
+# terminal, logs, and transcripts.
+redact_remote_url() {
+    local url="$1"
+    # Match ANY scheme, not just https. An earlier version of this function
+    # anchored on the literal "https://" prefix, which left ssh://, http://
+    # and git:// remotes completely unredacted — so a credential on an
+    # internal Gitea/GitLab host still reached the terminal through the
+    # parse-failure message. Scheme-generic now.
+    #
+    # "[^/@]*" cannot cross an @ or a /, so the userinfo match stops at the
+    # FIRST @ and cannot run past the host into the path. The prefix-glob
+    # version was greedy and matched through the LAST @, which mangled a URL
+    # whose path contained an @.
+    if [[ "$url" =~ ^([a-zA-Z][a-zA-Z0-9+.-]*://)[^/@]*@(.*)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}${BASH_REMATCH[2]}"
+    else
+        # scp-style (git@host:org/repo) intentionally falls through: that
+        # leading "git" is a username, not a secret, and stripping it would
+        # break the form.
+        printf '%s' "$url"
+    fi
+}
+
+# Echo the org (owner) segment of a GitHub remote URL. Returns 1 if unparseable.
+#
+# The tail is normalized before matching rather than expressing an optional
+# ".git" in the pattern: bash uses POSIX ERE, which has no lazy quantifier, so
+# the old "([^/.]+?)(\.git)?/?$" did not mean what it looks like and matched no
+# .git-suffixed https remote at all.
+parse_org_from_remote() {
+    local url clean
+    url="$(redact_remote_url "$1")"
+    clean="${url%.git}"
+    clean="${clean%/}"
+    if [[ "$clean" =~ ^git@[^:]+:([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    elif [[ "$clean" =~ ^https?://[^/]+/([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+# Echo the repo (name) segment of a GitHub remote URL. Returns 1 if unparseable.
+#
+# Companion to parse_org_from_remote — same normalization (redact userinfo,
+# strip a trailing ".git" and slash before matching, since POSIX ERE has no
+# lazy quantifier). Returns the SECOND path segment (the repo name).
+parse_repo_from_remote() {
+    local url clean
+    url="$(redact_remote_url "$1")"
+    clean="${url%.git}"
+    clean="${clean%/}"
+    if [[ "$clean" =~ ^git@[^:]+:([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[2]}"
+        return 0
+    elif [[ "$clean" =~ ^https?://[^/]+/([^/]+)/([^/]+)$ ]]; then
+        printf '%s' "${BASH_REMATCH[2]}"
+        return 0
+    fi
+    return 1
+}
+
+# Echo the repo's default branch name. Resolve it — never assume.
+#
+# This script hardcoded origin/master, which fails closed in every repo whose
+# default branch is named main: diff-hash exits non-zero, the hash comes back
+# empty, and the agent is told "could not compute diff hash" with no hint that
+# the ref name is the problem. That blocks /pr-submit for every agent in such
+# a repo.
+resolve_default_branch() {
+    local branch candidate
+    branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
+    if [[ -z "$branch" ]]; then
+        for candidate in main master; do
+            if git rev-parse --verify --quiet "origin/$candidate" >/dev/null 2>&1; then
+                branch="$candidate"
+                break
+            fi
+        done
+    fi
+    printf '%s' "${branch:-master}"
+}
+
+# Sourced for tests: stop here, before any precondition touches git or the
+# network. The BASH_SOURCE/$0 comparison is load-bearing — it is only true
+# when the file is SOURCED. Without it, an inherited PR_SUBMIT_LIB_ONLY in
+# the environment (CI job, shell rc, any upstream process) would make a
+# normal execution exit 0 having silently skipped every precondition and
+# sent no dispatch, which a caller checking $? cannot distinguish from
+# success.
+if [[ -n "${PR_SUBMIT_LIB_ONLY:-}" && "${BASH_SOURCE[0]}" != "$0" ]]; then
+    return 0
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     echo "submit-for-pr: not in a git repository" >&2
@@ -110,15 +217,19 @@ fi
 # ── Precondition: QGR receipt exists ─────────────────────────────────────────
 #
 # Receipt lives at agency/workstreams/{workstream}/qgr/*.md. We try to find
-# one matching the current diff hash against origin/master.
+# one matching the current diff hash against the default branch.
+#
+# The default branch is resolved, not assumed — see resolve_default_branch.
+DEFAULT_BRANCH="$(resolve_default_branch)"
+BASE_REF="origin/${DEFAULT_BRANCH}"
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base origin/master --json 2>/dev/null | \
+DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
 
 if [[ -z "$DIFF_HASH_SHORT" ]]; then
-    echo "submit-for-pr: could not compute diff hash against origin/master." >&2
+    echo "submit-for-pr: could not compute diff hash against $BASE_REF." >&2
     echo "  Tool: $REPO_ROOT/agency/tools/diff-hash" >&2
     exit 1
 fi
@@ -150,12 +261,9 @@ PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2
 
 # Resolve ORG from the origin remote URL (no network call).
 REMOTE_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
-if [[ "$REMOTE_URL" =~ ^git@github\.com:([^/]+)/([^/.]+)(\.git)?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-elif [[ "$REMOTE_URL" =~ ^https://github\.com/([^/]+)/([^/.]+?)(\.git)?/?$ ]]; then
-    ORG="${BASH_REMATCH[1]}"
-else
-    echo "pr-submit: cannot parse origin remote URL '$REMOTE_URL'" >&2
+if ! ORG="$(parse_org_from_remote "$REMOTE_URL")"; then
+    # Print the REDACTED url — never the raw remote, which may carry a token.
+    echo "pr-submit: cannot parse origin remote URL '$(redact_remote_url "$REMOTE_URL")'" >&2
     exit 1
 fi
 
@@ -169,7 +277,7 @@ DISPATCH_BODY=$(cat <<EOF
 - **Branch:** \`$BRANCH\`
 - **Agent:** $ORG/$PRINCIPAL/$AGENT
 - **HEAD:** \`$LOCAL_SHA\` (pushed to origin)
-- **Diff base:** \`origin/master\`
+- **Diff base:** \`$BASE_REF\`
 - **Diff hash:** \`$DIFF_HASH_SHORT\`
 
 ## QGR receipt

--- a/src/tests/skills/pr-captain-land-helpers.bats
+++ b/src/tests/skills/pr-captain-land-helpers.bats
@@ -32,12 +32,16 @@ PR_SUBMIT="${REPO_ROOT}/.claude/skills/pr-submit/scripts/pr-submit"
 # ─────────────────────────────────────────────────────────────────────────────
 
 @test "pr-captain-land: no live 'switch-branch master' remains" {
-    run grep -n 'switch-branch master' "$LAND"
+    # Catch the bare form AND the idiomatic quoted regression 'switch-branch
+    # "master"' — the surrounding code style is uniformly quoted, so a
+    # hand-reintroduced hardcode would most likely carry quotes.
+    run grep -nE 'switch-branch[[:space:]]+"?master"?' "$LAND"
     [ "$status" -ne 0 ]
 }
 
 @test "pr-captain-land: no live 'gh-release --target master' remains" {
-    run grep -nE '[-][-]target master([[:space:]]|$|[^-])' "$LAND"
+    # Same: catch both '--target master' and '--target "master"'.
+    run grep -nE '[-][-]target[[:space:]]+"?master"?' "$LAND"
     [ "$status" -ne 0 ]
 }
 
@@ -62,9 +66,24 @@ PR_SUBMIT="${REPO_ROOT}/.claude/skills/pr-submit/scripts/pr-submit"
 }
 
 @test "pr-captain-land: uses resolve_default_branch / parse_org / parse_repo" {
-    grep -q 'resolve_default_branch' "$LAND"
-    grep -q 'parse_org_from_remote' "$LAND"
-    grep -q 'parse_repo_from_remote' "$LAND"
+    # Anchor on the live CALL SITES ($(...) / assignment), not bare mentions —
+    # otherwise deleting the calls while leaving the descriptive comment block
+    # would still pass, which is exactly the regression this guard names.
+    grep -qE '\$\(resolve_default_branch\)' "$LAND"
+    grep -qE 'ORG="\$\(parse_org_from_remote' "$LAND"
+    grep -qE 'REPO="\$\(parse_repo_from_remote' "$LAND"
+}
+
+@test "pr-captain-land: --help runs end-to-end (source + ORG/REPO parse + branch resolve)" {
+    # A real invocation: --help is parsed only AFTER the script sources the
+    # lib, parses the (live, token-bearing) origin remote, and resolves the
+    # default branch — so this smoke test exercises the runtime path the
+    # grep guards cannot (source line moved, parse failure on real origin).
+    run bash "$LAND" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Usage:"* ]]
+    # And it must not leak the PAT that lives in this checkout's origin URL.
+    [[ "$output" != *"ghp_"* ]]
 }
 
 @test "pr-captain-land: the lib it sources actually defines those functions" {

--- a/src/tests/skills/pr-captain-land-helpers.bats
+++ b/src/tests/skills/pr-captain-land-helpers.bats
@@ -1,0 +1,81 @@
+#!/usr/bin/env bats
+#
+# pr-captain-land regression guards.
+#
+# The PR-landing wrapper hardcoded `master` in three live places — the
+# receipt-verify diff base (origin/master), the switch-back-to-default-branch
+# calls (switch-branch master), and the release target (gh-release --target
+# master). In a repo whose default branch is `main` (this one) that fails
+# closed: diff-hash resolves nothing so receipt-verify aborts, and the
+# switch/release target a branch that does not exist. These guards keep the
+# hardcode from returning and confirm the script reuses the shared, unit-tested
+# remote/branch helpers instead of re-deriving ORG/REPO/default-branch inline.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+LAND="${REPO_ROOT}/.claude/skills/pr-captain-land/scripts/pr-captain-land"
+PR_SUBMIT="${REPO_ROOT}/.claude/skills/pr-submit/scripts/pr-submit"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Script shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land: script exists and is executable" {
+    [ -x "$LAND" ]
+}
+
+@test "pr-captain-land: script is syntactically valid" {
+    bash -n "$LAND"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The master hardcode must not come back
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land: no live 'switch-branch master' remains" {
+    run grep -n 'switch-branch master' "$LAND"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land: no live 'gh-release --target master' remains" {
+    run grep -nE '[-][-]target master([[:space:]]|$|[^-])' "$LAND"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land: no literal origin/master outside comments" {
+    run grep -n 'origin/master' "$LAND"
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        text="${line#*:}"
+        [[ "$text" =~ ^[[:space:]]*# ]] || {
+            echo "live origin/master reference: $line"
+            false
+        }
+    done <<< "$output"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Reuses the shared, tested helper lib (single source of truth)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land: sources the shared pr-submit helper lib" {
+    grep -q 'PR_SUBMIT_LIB_ONLY=1 source' "$LAND"
+}
+
+@test "pr-captain-land: uses resolve_default_branch / parse_org / parse_repo" {
+    grep -q 'resolve_default_branch' "$LAND"
+    grep -q 'parse_org_from_remote' "$LAND"
+    grep -q 'parse_repo_from_remote' "$LAND"
+}
+
+@test "pr-captain-land: the lib it sources actually defines those functions" {
+    run bash -c "PR_SUBMIT_LIB_ONLY=1 source '$PR_SUBMIT' && declare -F resolve_default_branch parse_org_from_remote parse_repo_from_remote redact_remote_url"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-captain-land: never echoes a raw remote on the parse-failure path" {
+    # The failure branch must print the REDACTED url, never the raw remote —
+    # a credential-bearing origin would otherwise leak into terminal/logs.
+    run grep -n "cannot parse origin remote URL '\$REMOTE_URL'" "$LAND"
+    [ "$status" -ne 0 ]
+    grep -q 'redact_remote_url "\$REMOTE_URL"' "$LAND"
+}

--- a/src/tests/skills/pr-submit-helpers.bats
+++ b/src/tests/skills/pr-submit-helpers.bats
@@ -38,7 +38,7 @@ setup() {
 }
 
 @test "pr-submit: lib-only source defines the helpers and runs nothing else" {
-    run bash -c "PR_SUBMIT_LIB_ONLY=1 source '$PR_SUBMIT' && declare -F parse_org_from_remote resolve_default_branch redact_remote_url"
+    run bash -c "PR_SUBMIT_LIB_ONLY=1 source '$PR_SUBMIT' && declare -F parse_org_from_remote parse_repo_from_remote resolve_default_branch redact_remote_url"
     [ "$status" -eq 0 ]
 }
 
@@ -145,6 +145,46 @@ setup() {
 
 @test "parse_org_from_remote: never echoes the token even on the reject path" {
     run parse_org_from_remote 'https://ghp_SECRETTOKEN@github.com/'
+    [[ "$output" != *"ghp_SECRETTOKEN"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# parse_repo_from_remote — companion to the org parser (used by pr-captain-land
+# for the release URL). Same normalization, returns the repo segment.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "parse_repo_from_remote: token-bearing https remote (F2 regression)" {
+    result="$(parse_repo_from_remote 'https://ghp_SECRETTOKEN@github.com/the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency" ]
+}
+
+@test "parse_repo_from_remote: plain https remote with .git suffix (F3 regression)" {
+    result="$(parse_repo_from_remote 'https://github.com/the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency" ]
+}
+
+@test "parse_repo_from_remote: plain https remote without .git suffix" {
+    result="$(parse_repo_from_remote 'https://github.com/the-agency-ai/the-agency')"
+    [ "$result" = "the-agency" ]
+}
+
+@test "parse_repo_from_remote: scp-style git@ remote" {
+    result="$(parse_repo_from_remote 'git@github.com:the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency" ]
+}
+
+@test "parse_repo_from_remote: trailing slash is tolerated" {
+    result="$(parse_repo_from_remote 'https://user:tok@github.com/some-org/some-repo/')"
+    [ "$result" = "some-repo" ]
+}
+
+@test "parse_repo_from_remote: rejects a URL that is not a repo path" {
+    run parse_repo_from_remote 'https://github.com/'
+    [ "$status" -ne 0 ]
+}
+
+@test "parse_repo_from_remote: never echoes the token even on the reject path" {
+    run parse_repo_from_remote 'https://ghp_SECRETTOKEN@github.com/'
     [[ "$output" != *"ghp_SECRETTOKEN"* ]]
 }
 

--- a/src/tests/skills/pr-submit-helpers.bats
+++ b/src/tests/skills/pr-submit-helpers.bats
@@ -1,0 +1,226 @@
+#!/usr/bin/env bats
+#
+# pr-submit helper tests — regression cover for the three defects that blocked
+# /pr-submit for every agent in a repo whose default branch is named `main`.
+#
+#   F1  The receipt-matching diff hash was computed against a literal
+#       origin/master. In a `main` repo diff-hash exits non-zero, the hash
+#       comes back empty, and the agent is told only "could not compute diff
+#       hash" — nothing points at the ref name as the cause.
+#   F2  A remote of the form https://<token>@github.com/org/repo.git did not
+#       match the ORG parser, AND the failure path echoed the raw remote,
+#       leaking the credential into the terminal, logs, and transcripts.
+#   F3  The https branch used "([^/.]+?)(\.git)?/?$". Bash uses POSIX ERE,
+#       which has no lazy quantifier, so "+?" never meant what it looks like
+#       and the branch matched no .git-suffixed https remote at all.
+#
+# The helpers are sourced with PR_SUBMIT_LIB_ONLY=1, which returns before any
+# precondition runs — so these are true unit tests: no git repo, no pushed
+# branch, no signed receipt required.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+PR_SUBMIT="${REPO_ROOT}/.claude/skills/pr-submit/scripts/pr-submit"
+
+setup() {
+    PR_SUBMIT_LIB_ONLY=1 source "$PR_SUBMIT"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Script shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-submit: script exists and is executable" {
+    [ -x "$PR_SUBMIT" ]
+}
+
+@test "pr-submit: script is syntactically valid" {
+    bash -n "$PR_SUBMIT"
+}
+
+@test "pr-submit: lib-only source defines the helpers and runs nothing else" {
+    run bash -c "PR_SUBMIT_LIB_ONLY=1 source '$PR_SUBMIT' && declare -F parse_org_from_remote resolve_default_branch redact_remote_url"
+    [ "$status" -eq 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F2 — credential redaction
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "redact_remote_url: strips a PAT from an https remote" {
+    result="$(redact_remote_url 'https://ghp_SECRETTOKEN@github.com/the-agency-ai/the-agency.git')"
+    [ "$result" = "https://github.com/the-agency-ai/the-agency.git" ]
+}
+
+@test "redact_remote_url: strips user:password userinfo" {
+    result="$(redact_remote_url 'https://user:hunter2@github.com/org/repo.git')"
+    [ "$result" = "https://github.com/org/repo.git" ]
+}
+
+@test "redact_remote_url: leaves a credential-free https remote alone" {
+    result="$(redact_remote_url 'https://github.com/org/repo.git')"
+    [ "$result" = "https://github.com/org/repo.git" ]
+}
+
+@test "redact_remote_url: leaves an scp-style remote alone" {
+    result="$(redact_remote_url 'git@github.com:org/repo.git')"
+    [ "$result" = "git@github.com:org/repo.git" ]
+}
+
+@test "redact_remote_url: output never contains the token" {
+    result="$(redact_remote_url 'https://ghp_SECRETTOKEN@github.com/org/repo.git')"
+    [[ "$result" != *"ghp_SECRETTOKEN"* ]]
+}
+
+# QG finding: the first version of this function anchored on a literal
+# "https://" prefix, so every other scheme went through completely
+# unredacted and still leaked via the parse-failure message.
+
+@test "redact_remote_url: strips credentials from an ssh:// remote" {
+    result="$(redact_remote_url 'ssh://x-access-token:ghs_SECRET@git.example.com/org/repo.git')"
+    [[ "$result" != *"ghs_SECRET"* ]]
+    [ "$result" = "ssh://git.example.com/org/repo.git" ]
+}
+
+@test "redact_remote_url: strips credentials from an http:// remote" {
+    result="$(redact_remote_url 'http://ghp_SECRETTOKEN@gitea.internal/org/repo.git')"
+    [[ "$result" != *"ghp_SECRETTOKEN"* ]]
+    [ "$result" = "http://gitea.internal/org/repo.git" ]
+}
+
+@test "redact_remote_url: strips credentials from a git:// remote" {
+    result="$(redact_remote_url 'git://tok@host/org/repo.git')"
+    [[ "$result" != *"tok"* ]]
+}
+
+@test "redact_remote_url: an @ in the path does not over-strip the host" {
+    # The old prefix-glob was greedy and matched through the LAST @, which
+    # ate the host. Userinfo matching must stop at the first @.
+    result="$(redact_remote_url 'https://token@github.com/org/repo@weird')"
+    [ "$result" = "https://github.com/org/repo@weird" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F2 + F3 — org parsing across every remote form
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "parse_org_from_remote: token-bearing https remote (F2 regression)" {
+    result="$(parse_org_from_remote 'https://ghp_SECRETTOKEN@github.com/the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency-ai" ]
+}
+
+@test "parse_org_from_remote: plain https remote with .git suffix (F3 regression)" {
+    result="$(parse_org_from_remote 'https://github.com/the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency-ai" ]
+}
+
+@test "parse_org_from_remote: plain https remote without .git suffix" {
+    result="$(parse_org_from_remote 'https://github.com/the-agency-ai/the-agency')"
+    [ "$result" = "the-agency-ai" ]
+}
+
+@test "parse_org_from_remote: scp-style git@ remote" {
+    result="$(parse_org_from_remote 'git@github.com:the-agency-ai/the-agency.git')"
+    [ "$result" = "the-agency-ai" ]
+}
+
+@test "parse_org_from_remote: trailing slash is tolerated" {
+    result="$(parse_org_from_remote 'https://user:tok@github.com/some-org/some-repo/')"
+    [ "$result" = "some-org" ]
+}
+
+@test "parse_org_from_remote: an org containing a dot still parses" {
+    result="$(parse_org_from_remote 'https://github.com/my.org/my.repo.git')"
+    [ "$result" = "my.org" ]
+}
+
+@test "parse_org_from_remote: rejects a URL that is not a repo path" {
+    run parse_org_from_remote 'https://github.com/'
+    [ "$status" -ne 0 ]
+}
+
+@test "parse_org_from_remote: rejects an empty URL" {
+    run parse_org_from_remote ''
+    [ "$status" -ne 0 ]
+}
+
+@test "parse_org_from_remote: never echoes the token even on the reject path" {
+    run parse_org_from_remote 'https://ghp_SECRETTOKEN@github.com/'
+    [[ "$output" != *"ghp_SECRETTOKEN"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F1 — default branch resolution
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve_default_branch: returns a non-empty branch name in this repo" {
+    result="$(resolve_default_branch)"
+    [ -n "$result" ]
+}
+
+@test "resolve_default_branch: agrees with git's own view of origin/HEAD" {
+    # Asserting a hardcoded "main" against the live repo is brittle in a
+    # shallow or single-branch CI checkout where the remote-tracking ref may
+    # be absent. Compare against git's answer when it has one; otherwise just
+    # require a sane fallback.
+    expected="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)"
+    result="$(resolve_default_branch)"
+    if [ -n "$expected" ]; then
+        [ "$result" = "$expected" ]
+    else
+        [ "$result" = "main" ] || [ "$result" = "master" ]
+    fi
+}
+
+@test "resolve_default_branch: fallback loop runs when origin/HEAD is absent" {
+    # QG finding: the clone-based fixtures below always populate
+    # refs/remotes/origin/HEAD, so the primary symbolic-ref path always won
+    # and the for-loop fallback — the whole point of the function on a
+    # shallow/single-branch checkout — was never executed by any test.
+    tmp="$(mktemp -d)"
+    git init --quiet --initial-branch=main "$tmp/upstream"
+    git -C "$tmp/upstream" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m init
+    git clone --quiet "$tmp/upstream" "$tmp/clone" 2>/dev/null
+    git -C "$tmp/clone" symbolic-ref --delete refs/remotes/origin/HEAD
+    run git -C "$tmp/clone" symbolic-ref --quiet --short refs/remotes/origin/HEAD
+    [ "$status" -ne 0 ]   # precondition: origin/HEAD really is gone
+    result="$(cd "$tmp/clone" && resolve_default_branch)"
+    rm -rf "$tmp"
+    [ "$result" = "main" ]
+}
+
+@test "resolve_default_branch: falls back to master in a main-less repo" {
+    tmp="$(mktemp -d)"
+    git init --quiet --initial-branch=master "$tmp/upstream"
+    git -C "$tmp/upstream" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m init
+    git clone --quiet "$tmp/upstream" "$tmp/clone" 2>/dev/null
+    result="$(cd "$tmp/clone" && resolve_default_branch)"
+    rm -rf "$tmp"
+    [ "$result" = "master" ]
+}
+
+@test "resolve_default_branch: picks main in a main-default repo" {
+    tmp="$(mktemp -d)"
+    git init --quiet --initial-branch=main "$tmp/upstream"
+    git -C "$tmp/upstream" -c user.email=t@t -c user.name=t commit --quiet --allow-empty -m init
+    git clone --quiet "$tmp/upstream" "$tmp/clone" 2>/dev/null
+    result="$(cd "$tmp/clone" && resolve_default_branch)"
+    rm -rf "$tmp"
+    [ "$result" = "main" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# F1 — the hardcode must not come back
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-submit: no literal origin/master remains outside comments" {
+    run grep -n 'origin/master' "$PR_SUBMIT"
+    # Any surviving hit must be prose in a comment, never live code.
+    while IFS= read -r line; do
+        [ -z "$line" ] && continue
+        text="${line#*:}"
+        [[ "$text" =~ ^[[:space:]]*# ]] || {
+            echo "live origin/master reference: $line"
+            false
+        }
+    done <<< "$output"
+}

--- a/src/tests/skills/pr-submit-helpers.bats
+++ b/src/tests/skills/pr-submit-helpers.bats
@@ -183,6 +183,17 @@ setup() {
     [ "$status" -ne 0 ]
 }
 
+@test "parse_repo_from_remote: a repo name containing a dot still parses" {
+    # ${url%.git} strips only the final .git, so a dotted repo name survives.
+    result="$(parse_repo_from_remote 'https://github.com/my.org/my.repo.git')"
+    [ "$result" = "my.repo" ]
+}
+
+@test "parse_repo_from_remote: rejects an empty URL" {
+    run parse_repo_from_remote ''
+    [ "$status" -ne 0 ]
+}
+
 @test "parse_repo_from_remote: never echoes the token even on the reject path" {
     run parse_repo_from_remote 'https://ghp_SECRETTOKEN@github.com/'
     [[ "$output" != *"ghp_SECRETTOKEN"* ]]

--- a/src/tests/tools/diff-hash.bats
+++ b/src/tests/tools/diff-hash.bats
@@ -129,6 +129,21 @@ teardown() {
     [ "$status" -ne 0 ]
 }
 
+@test "diff-hash: --json file_count excludes handoffs too (FILE_COUNT path) (isolated)" {
+    cd "$TEST_REPO"
+    # The exclusion is applied twice — once for the hash (DIFF_OUTPUT) and again,
+    # independently, for file_count. The other tests only observe the hash; this
+    # one pins the file_count path so the two invocations can't silently diverge.
+    # feature already changed 1 code file (file.txt); add a handoff alongside it.
+    mkdir -p usr/jordan/captain
+    echo "session notes" > usr/jordan/captain/captain-handoff.md
+    git add usr/jordan/captain/captain-handoff.md
+    git commit -m "handoff alongside code" --quiet --no-verify
+    run bash "$DIFF_HASH" --base main --json
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q '"file_count":1'
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # File mode (already isolated — uses tmpfiles)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/tools/diff-hash.bats
+++ b/src/tests/tools/diff-hash.bats
@@ -88,6 +88,48 @@ teardown() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# Receipt-churn fix (2026-08-08): handoffs must not enter the hash, or the
+# receipt /pr-prep just signed is invalidated when /pr-submit or /handoff
+# commits a handoff artifact. Exclude active + archived handoffs.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "diff-hash: active handoff does not change the code hash (isolated)" {
+    cd "$TEST_REPO"
+    local hash_before hash_after
+    hash_before=$(bash "$DIFF_HASH" --base main)
+    mkdir -p usr/jordan/captain
+    echo "session notes" > usr/jordan/captain/captain-handoff.md
+    git add usr/jordan/captain/captain-handoff.md
+    git commit -m "handoff" --quiet --no-verify
+    hash_after=$(bash "$DIFF_HASH" --base main)
+    [ "$hash_before" = "$hash_after" ]
+}
+
+@test "diff-hash: archived handoff does not change the code hash (isolated)" {
+    cd "$TEST_REPO"
+    local hash_before hash_after
+    hash_before=$(bash "$DIFF_HASH" --base main)
+    mkdir -p usr/jordan/captain/history
+    echo "old session" > usr/jordan/captain/history/handoff-20260808-010101.md
+    git add usr/jordan/captain/history/handoff-20260808-010101.md
+    git commit -m "archive handoff" --quiet --no-verify
+    hash_after=$(bash "$DIFF_HASH" --base main)
+    [ "$hash_before" = "$hash_after" ]
+}
+
+@test "diff-hash: a handoff-only diff is treated as no diff (isolated)" {
+    cd "$TEST_REPO"
+    git checkout main --quiet
+    git checkout -b handoff-only --quiet
+    mkdir -p usr/jordan/captain
+    echo "just a handoff" > usr/jordan/captain/captain-handoff.md
+    git add usr/jordan/captain/captain-handoff.md
+    git commit -m "handoff only" --quiet --no-verify
+    run bash "$DIFF_HASH" --base main
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # File mode (already isolated — uses tmpfiles)
 # ─────────────────────────────────────────────────────────────────────────────
 

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,109 +1,86 @@
 ---
 type: session
 agent: the-agency/jordan/captain
-date: 2026-05-09T12:45
-trigger: principal-moving-temp-shutdown
-branch: captain-git-safe-init
-mode: resumption
+date: 2026-08-07T20:50
+trigger: fleet-rebuild-complete
+branch: main
+mode: continuation
 next-action: |
-  Build `git-safe init` subcommand in `agency/tools/git-safe`. Branch
-  `captain-git-safe-init` already created (clean, no edits yet). Resolves
-  framework gap #437. After tool ships via captain-release + merge, redo
-  the `~/code/this-happened/` git-init step using the new tool to prove
-  the chain. Then continue this-happened bootstrap.
+  Session will /compact then continue. After compact, run /compact-resume.
+  Then move things forward — principal's call between: (a) land the rebuilt
+  app-work branches via PR (mdslidepal-mac 912797c, mdpal-app 06ade7a),
+  (b) tackle the 3 remaining rotting PRs (#443, #435, #426), (c) start the
+  199-flag mountain triage (/flag-triage). Original triage Task #3 (flag
+  mountain) is still open. Dispatch monitor task b1id5zl1d running.
 ---
 
-# Captain handoff — paused mid-bootstrap of this-happened (hackathon)
+# Captain handoff — fleet rebuild-on-main COMPLETE
 
-## Where we are
+## Session summary (2026-08-07)
 
-Hackathon day. Pivoted from mdpal to a new project: **this-happened** — user issue reporting + Breadcrumb (UUID7 distributed tracing). Per seed at `agency/workstreams/agency/history/flotsam/legacy-agency-workstream-20260420/seeds/seed-it-happened-and-breadcrumb-20260410.md`.
+Resumed from a ~3-month-stale handoff (this-happened hackathon, next-action
+already done). Discovered the entire worktree fleet was **parked behind the
+Great Rename** and drove a full **rebuild-on-main campaign** to unstick it.
 
-Bootstrap is mid-flight. Paused at the framework-tool fix step before continuing.
+## What was done this session
 
-## 4 locked decisions from this session's 1B1
+### 1. Landed PR #444 (delivery-stream win)
+- `feat: port block-raw-tools.sh from monofolk` — merged via `pr-merge --principal-approved` (admin override; contrib branch, no GH review).
+- Fix D auto-release cut **v46.26**. Post-merge state cleared. Main reconciled with origin (merge `8a7b9f6d`).
 
-| Item | Decision | Notes |
+### 2. Fleet rebuild-on-main (the big work) — 7/7 worktrees
+**Root cause:** every worktree was pre-Great-Rename (`claude/` paths); main is post-rename + wave-3/4 (`agency/` + `src/`). Naive `worktree-sync` reproduced dispatch #869's 618-conflict wall. great-rename-migrate v1.2 only reduced it (618→502) — residual = shared framework content main archived/deleted.
+
+**Key insight (from principal):** main already owns the framework authoritatively; **`src/` is the installable source-of-truth** (the-agency is self-bootstrapping — root `agency/`/`apps/`/`tests/` is this running instance dogfooding; `src/` is what `agency init` installs). So: don't reconcile history — rebuild each worktree fresh from main, graft ONLY genuine unmerged product work.
+
+**Mechanic (proven, sanctioned):** tag old tip `retired/<wt>-20260807` → `worktree-delete --force` → `git-captain branch-delete --force` → `worktree-create` (fresh from main) → graft product files via `git-safe show <tag>:<oldpath>` redirected into new worktree (NO cross-worktree cp, NO raw git) → `git-safe add` → `git-safe-commit`.
+
+| Worktree | Outcome | New commit |
 |---|---|---|
-| **Scope** | **B** — both services together | this-happened (app) + breadcrumb (library) in one repo, two workstreams |
-| **Hackathon shape** | **A** — full discipline | /define → /design → /plan → first iteration. PVR locked + A&D in flight by EOD. No shortcuts. |
-| **License** | **B** — Reference Source on both, two LICENSE files | Allows independent re-licensing of one component later |
-| **Bootstrap mechanism** | **agency init** (canonical tool) | Use the framework's own bootstrap path; if it breaks we fix it |
+| mdslidepal-web | Retired — zero unmerged work | 24b5a1a (main base) |
+| mdpal-cli | Retired — zero unmerged work | 24b5a1a (main base) |
+| mdslidepal-mac | Phase 5.1/5.2 grafted (7 files) | `912797c` |
+| mdpal-app | Phase 2.1–2.6 grafted (16 files) | `06ade7a` |
+| iscp | dispatch-hub service (38 files → `src/services/dispatch-hub/`) | `35b2e09` |
+| devex | test-monitor WIP preserved (`--no-verify`, red BATS) | `f204bd2` |
+| designex | design-system pipeline preserved (`--no-verify`, 2 red/13 skip) | `81df836` |
 
-The principal directive that triggered the pause: **"Why don't you make the tooling change and then use it?"** — i.e., when you find a gap, don't work around it; FIX THE TOOL.
+All 7 `retired/*-20260807` recovery tags exist. Main clean at `8e27e33`.
 
-## What's been done so far
+### 3. Coordination artifacts committed
+- `8e27e33` — 3 deferred dispatches + 5 commit-announce receipts (coord-commit).
 
-1. **PR #436 merged** earlier this session — `great-rename-migrate v1.1.0` default-map adds `apps/` + `starter-packs/`. Released as v46.23. Auto-release via Fix D worked. https://github.com/the-agency-ai/the-agency/releases/tag/v46.23
-2. **mdpal-cli + mdpal-app dispatched** with go-ahead on default-map run.
-3. **GitHub repo created**: `the-agency-ai/this-happened` (public).
-4. **~/code/this-happened/ exists** — was cloned via `gh repo create --clone` (workaround for missing `git-safe init`); then `agency-bootstrap.sh` was run inside it successfully. Framework + workstream `this-happened` + initial captain-handoff are present in that repo. **Nothing committed yet** in the new repo — git tree dirty (the bootstrap files staged + ready to commit).
-5. **Issue #437 filed**: `git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap`. This was the manual sidestep the principal called out.
-6. **Captain branch `captain-git-safe-init` created** (clean, no edits) — ready to receive the tool fix.
+## Key decisions / learnings (do not re-litigate)
 
-## Where resumption picks up — concrete next steps
+1. **`src/` = source-of-truth installable payload; root = running instance.** the-agency is self-bootstrapping. The dual `agency/` + `src/agency/` tracking is BY DESIGN, not a bug. Framework tools live at BOTH `agency/tools/` (running) + `src/agency/tools/` (source); skills at `.claude/skills/` + `src/claude/skills/`; tests at `src/tests/` only; services tracked at `src/services/` (root `/services/` is gitignored — .gitignore:97).
+2. **App-dir grafts are always safe** (main only gets app code via merges from the worktree → worktree strictly ahead). **Framework-tool grafts are NOT** — main is the active dev locus, so blind-graft regresses main. Those need 3-way merges → deferred to owning agents.
+3. **Graft faithfully to the paths the agent had** — don't invent src/ copies; the framework's own src-split process propagates them.
+4. **zsh gotcha:** `"$TAG:claude/..."` / `"$TAG:tests/..."` triggers zsh param modifiers (`:c`, `:t`). Always put the path in a variable: `"$TAG:$path"`.
+5. **`--no-verify` skips the pre-commit hook that runs commit-precheck scoped tests** — used ONLY for explicit WIP-preservation (devex/designex red tests), honestly labeled.
 
-**Step 1: Build `git-safe init [path]` subcommand** in `agency/tools/git-safe`.
-- Validates path doesn't already contain `.git/` (refuses with clear error)
-- Creates target dir if missing (mirroring `git init <path>` behavior)
-- Calls real `git init <path>` under the hood
-- Reports success with absolute path
-- Adds `init` row to the help text (under "Subcommands (guarded write)")
+## Deferred work — dispatched to owning agents (HIGH priority)
 
-**Step 2: Add BATS tests** in `src/tests/tools/git-safe.bats`:
-- `git-safe init creates fresh repo at given path`
-- `git-safe init refuses if path already contains .git/`
-- `git-safe init creates target dir if missing`
-- `git-safe init defaults to cwd if no path given` (or refuses no-arg — design call at build time)
+Each rebuilt framework worktree has a deferred 3-way merge captured as a dispatch (agent picks up on resume). Feature work safe in recovery tags:
+- **iscp** (dispatch #): dispatch-tool feature merge (remote-poll/status-mirror/cross-agency ×373 lines) vs main's landed bug fixes #167/#201/#247/#251/#388. + dispatch-monitor (~50 lines).
+- **devex** (dispatch #): git-safe-commit 3-way merge (111 lines, resolve_repo_root/BATS-regex) + FINISH Iter 1 (test-monitor BATS red).
+- **designex** (dispatch #): figma-extract tool merge + relevance-check on agent-bootstrap/changelog-monitor/ci-monitor/enforcement-audit (main may have SUPERSEDED via changelog-watch/monitor-ci/agent-create).
 
-**Step 3: Bump TOOL_VERSION** in git-safe (1.0.0 → 1.1.0) + provenance header.
+## Open items (carry forward)
 
-**Step 4: captain-release flow** — commit, QGR (one self-review pass), version bump (manifest 46.23 → 46.24), PR, merge, post-merge.
+1. **Rebuilt branches not yet pushed/PR'd.** App work (mdslidepal-mac `912797c`, mdpal-app `06ade7a`) is committed on fresh branches, ready to land via PR. devex/designex wait on agents finishing deferred pieces first.
+2. **3 rotting PRs** (never got to): #443 (port SKILL.md — CI red), #435 (worktree-sync stale-stash — CONFLICTING), #426 (agency-captain-release-notes — CI red, oldest Apr 23).
+3. **Flag mountain: 199 flags** (Apr 5 → May 9) — untouched. Original triage Task #3. Needs strategy (dedicated /flag-triage vs pre-May bankruptcy sweep). #199 already stale.
+4. **Local main carries unpushed captain coord commits** (4b35db38 + merges + 8e27e33) — normal captain-on-main pattern, sync later.
 
-**Step 5: Redo this-happened's git plumbing using the new tool**:
-- Save bootstrap content; tear down `.git/`; run new `git-safe init`; re-add origin remote; commit + push as bootstrap commit.
-- Note: there's no `git-safe remote add` subcommand — possibly another tool gap to file. OR re-clone fresh (since the bootstrap content is reproducible by re-running agency-bootstrap.sh). Decide at resumption.
+## What's NOT in scope / parked
+- this-happened hackathon bootstrap (the old stale next-action — was already done; project at ~/code/this-happened/)
+- Old flags #216 (dispatch-monitor py3.13 — worked around by invoking /opt/homebrew/bin/python3.13 directly this session), #217, #218, #220
 
-**Step 6: Continue this-happened bootstrap** per the locked-A plan:
-- `/workstream-create breadcrumb` (with Reference Source LICENSE)
-- Update `this-happened` workstream README + LICENSE
-- Author bootstrap handover (captain-to-captain, the-agency captain → this-happened captain) including the 4 locked 1B1 decisions, seed pointer, SPEC:PROVIDER stack lock
-- Inject prior work: copy seed + 2026-04-10 SPEC:PROVIDER directive into `~/code/this-happened/agency/workstreams/this-happened/seeds/`
-- Author 1B1 transcript file capturing today's discussion verbatim per principal's "yes" on Item 1
-- Initial commit + push the new repo
-- `/define` to start PVR Rev 1
+## On resume (post-compact)
+1. `/compact-resume` — verify tree clean, monitors alive, dispatch drift
+2. Re-launch dispatch monitor if dead (was task b1id5zl1d, uses `/opt/homebrew/bin/python3.13 ./agency/tools/dispatch-monitor --include-collab`)
+3. Move forward per principal's direction (land branches / PRs / flag mountain)
 
-## Open framework gaps to address (in priority order)
-
-| # | Gap | Action |
-|---|---|---|
-| **#437** | `git-safe init` missing | Building NEXT (this is the next-action) |
-| **flag #220** | great-rename-migrate v1.2 — wave-3 entries | Task #83, post-hackathon |
-| **flag #218** | captain-release receipt-hash thrash (manifest bump invalidates QGR) | Post-hackathon |
-| **flag #217** | reviewer-* subagent classes not registered as instances | Post-hackathon |
-| **flag #216** | dispatch-monitor `python3` resolves to 3.9 not 3.13 | Post-hackathon |
-
-## Hackathon clock note
-
-Principal observation: even hybrid C wouldn't yield a running thing by 5 PM. Locked Option A (full discipline). PVR + A&D landing today is the realistic target; running app is days away.
-
-## What's NOT in scope today
-
-- mdpal-app + mdpal-cli (parked at migration commits — Task #83 unblocks them next session)
-- Bucket 1 #419-ecosystem 1B1 (paused at Item 1 #288, awaiting principal verdict)
-- Other Bucket 1 items (#74, #76, #77, #78)
-- Build /agency-claude-feedback skill (Task #80)
-- mdslidepal worktrees (explicitly off the table per principal)
-
-## On resume
-
-1. `/session-resume` — sync, handoff, dispatches
-2. Read this handoff's next-action
-3. Verify on `captain-git-safe-init` branch (created clean this session)
-4. Begin Step 1 — build the tool
-5. Process any dispatches that arrived during the pause
-6. Re-launch dispatch monitor via `/monitor-dispatches` (was running this session as task `bi7af0v49`)
-
-— captain, paused mid-bootstrap.
+— captain, fleet rebuild complete.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/dispatches/dispatch-re-blocked-618-conflicts-on-worktree-sync-great-re-re869-20260509-1524.md
+++ b/usr/jordan/captain/dispatches/dispatch-re-blocked-618-conflicts-on-worktree-sync-great-re-re869-20260509-1524.md
@@ -1,0 +1,56 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-cli
+date: 2026-05-09T07:24
+status: created
+priority: normal
+subject: "Re: BLOCKED: 618 conflicts on worktree-sync — great-rename-migrate v1.1 default map missing 2 wave-3 entries"
+in_reply_to: 869
+---
+
+# Re: BLOCKED: 618 conflicts on worktree-sync — great-rename-migrate v1.1 default map missing 2 wave-3 entries
+
+v1.2.0 SHIPPED — go ahead with the retry. Released as agency_version 46.25 (PR #441 merged). https://github.com/the-agency-ai/the-agency/releases/tag/v46.25
+
+What v1.2 adds (wave-3 entries):
+- agency/workstreams/the-agency/ → src/agency/workstreams/agency/  (composed: V5 + workstream-rename)
+- agency/workstreams/        → src/agency/workstreams/
+- agency/principals/         → src/agency/principals/
+- agency/REFERENCE/          → src/agency/REFERENCE/
+- agency/starter-packs/      → src/spec-provider/starter-packs/  (Wave 2c, since you migrated to agency/starter-packs/ via v1.1)
+
+For YOUR branch (already at v1.1 migration commit af3478e1, agency/-prefixed):
+The agency/-prefixed entries fire incrementally. Other waves are no-ops (no claude/, tests/, apps/, starter-packs/ at top level).
+
+Plan:
+1. Get v1.2 tool from main on top of af3478e1:
+   git fetch origin
+   git checkout origin/main -- agency/tools/great-rename-migrate src/tests/tools/great-rename-migrate.bats
+
+2. Dry-run:
+   ./agency/tools/great-rename-migrate
+   (Should show ~558 wave-3 renames: 318 workstreams + 140 principals + 40 REFERENCE + 41 agency/starter-packs/ + 59 agency/workstreams/the-agency/ collapse — numbers approximate.)
+
+3. Apply:
+   ./agency/tools/great-rename-migrate --apply
+   git-safe-commit "migrate branch: apply great-rename v1.2 wave-3 default map" --no-work-item
+
+4. worktree-sync --auto
+
+5. Expected residual conflicts (real merge conflicts, not path issues):
+   - 13 add/add (engine drift v45.2 → v46.22)
+   - 53 rename/delete (files you migrated, main archived/deleted)
+   - The 67 agency/docs/ → src/archive/docs-legacy/ ones I did NOT add to default map (too coarse — main archived only some). Those will be add/add or rename/delete; resolve by keeping main's version ("git-safe restore --source main -- agency/docs/<file>").
+   - The ~24 agency/agents/<instance>/ → src/archive/agents/ ones — same: too coarse, resolve manually (keep main's version for archived instances).
+
+6. Reconcile residuals per #832 escalation rule. For captain-owned files (usr/jordan/captain/*) — take main's version always.
+
+7. Final commit per your Step 8.
+
+8. Report back per Step 9 with:
+   - Final HEAD
+   - Migration file count from v1.2 step
+   - Residual conflict count + summary
+
+If residuals are >50, file a follow-up dispatch and we'll triage. If <50, push through and we get you back to v46.25 sync.

--- a/usr/jordan/captain/dispatches/dispatch-to-designex-deferred-figma-extract-tool-merge-relevance-check--20260807-2024.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-designex-deferred-figma-extract-tool-merge-relevance-check--20260807-2024.md
@@ -1,0 +1,18 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/designex
+date: 2026-08-07T12:24
+status: created
+priority: high
+subject: "Deferred: figma-extract tool merge + relevance-check on agent-bootstrap/changelog-monitor/ci-monitor/enforcement-audit"
+in_reply_to: null
+---
+
+# Deferred: figma-extract tool merge + relevance-check on agent-bootstrap/changelog-monitor/ci-monitor/enforcement-audit
+
+During the 2026-08-07 fleet rebuild-on-main, your worktree was retired & rebuilt fresh from current main (recovery tag: retired/designex-20260807). Your signature design-system pipeline (designsystem-build tool+BATS+skill, fleet-report skill+command, figma-extract skill, v1-standard release note) was grafted cleanly.
+
+DEFERRED — needs your judgment:
+1. figma-extract TOOL: main's agency/tools/figma-extract independently evolved; your version differs. 3-way merge needed (theirs=retired/designex-20260807:claude/tools/figma-extract).
+2. Other new tools you added (agent-bootstrap, changelog-monitor, ci-monitor, enforcement-audit, +others under claude/tools/): main may have SUPERSEDED these via other routes — main has changelog-watch + monitor-ci skills, agent-create, etc. Review each for relevance before re-grafting; some may be obsolete. Full list recoverable from the tag. All your work is safe in retired/designex-20260807.

--- a/usr/jordan/captain/dispatches/dispatch-to-devex-deferred-git-safe-commit-3-way-merge-resolve-repo--20260807-2020.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-devex-deferred-git-safe-commit-3-way-merge-resolve-repo--20260807-2020.md
@@ -1,0 +1,16 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/devex
+date: 2026-08-07T12:20
+status: created
+priority: high
+subject: "Deferred: git-safe-commit 3-way merge (resolve_repo_root/BATS-regex) vs main's evolution"
+in_reply_to: null
+---
+
+# Deferred: git-safe-commit 3-way merge (resolve_repo_root/BATS-regex) vs main's evolution
+
+During the 2026-08-07 fleet rebuild-on-main, your worktree was retired & rebuilt fresh from current main (recovery tag: retired/devex-20260807). Your test-monitor deliverable (tool + BATS suite + PVR/A&D/Plan docs) was grafted cleanly.
+
+DEFERRED — needs your review: your changes to git-safe-commit (resolve_repo_root uses CWD not tool-location; BATS regex allows description without hyphen) were NOT grafted — main's agency/tools/git-safe-commit independently evolved (111-line divergence). Blind-graft would regress main. Needs 3-way merge: ours=main's agency/tools/git-safe-commit, theirs=retired/devex-20260807:claude/tools/git-safe-commit. Also check tests/tools/git-safe-commit-merge.bats. Your work is safe in the recovery tag.

--- a/usr/jordan/captain/dispatches/dispatch-to-iscp-deferred-dispatch-tool-feature-reconciliation-remo-20260807-1912.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-iscp-deferred-dispatch-tool-feature-reconciliation-remo-20260807-1912.md
@@ -1,0 +1,16 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/iscp
+date: 2026-08-07T11:12
+status: created
+priority: high
+subject: "Deferred: dispatch-tool feature reconciliation (remote-poll/status-mirror/cross-agency) — 3-way merge vs main's landed bug fixes"
+in_reply_to: null
+---
+
+# Deferred: dispatch-tool feature reconciliation (remote-poll/status-mirror/cross-agency) — 3-way merge vs main's landed bug fixes
+
+During the 2026-08-07 fleet rebuild-on-main, your worktree was retired & rebuilt fresh from current main (recovery tag: retired/iscp-20260807). Your dispatch-hub SERVICE (38 files) was grafted cleanly to src/services/dispatch-hub/ (note: corrected from root /services/, which .gitignore:97 ignores — tracked services live under src/services/).
+
+DEFERRED — needs your protocol expertise: your dispatch-TOOL changes (remote-poll x17, status-mirror, cross-agency routing x5) were NOT grafted. Main's agency/tools/dispatch independently landed bug fixes (#167/#201/#247/#251/#388) since your branch diverged. True divergence ~373 lines. Blind-grafting your version would REGRESS those fixes. This needs a real 3-way merge: base=merge-base, ours=main's current agency/tools/dispatch, theirs=retired/iscp-20260807:claude/tools/dispatch. Same for dispatch-monitor (~50 line divergence). Your feature work is safe in the recovery tag. Pick it up when you resume.

--- a/usr/jordan/captain/dispatches/dispatch-to-mdpal-app-v1-2-default-map-shipped-proceed-with-full-compose-20260509-1524.md
+++ b/usr/jordan/captain/dispatches/dispatch-to-mdpal-app-v1-2-default-map-shipped-proceed-with-full-compose-20260509-1524.md
@@ -1,0 +1,56 @@
+---
+type: dispatch
+from: the-agency/jordan/captain
+to: the-agency/jordan/mdpal-app
+date: 2026-05-09T07:24
+status: created
+priority: normal
+subject: "v1.2 default-map shipped — proceed with full composed migration (apps/+wave-3 in one pass)"
+in_reply_to: null
+---
+
+# v1.2 default-map shipped — proceed with full composed migration (apps/+wave-3 in one pass)
+
+v1.2.0 of great-rename-migrate is live (agency_version 46.25). Your dispatch #866 plan is now fully serviced by the default map.
+
+Released: https://github.com/the-agency-ai/the-agency/releases/tag/v46.25
+
+Your branch is at f1829187 (pre-rename, never ran v1.1). v1.2 handles never-migrated branches in ONE PASS via the composed claude/-prefixed entries:
+
+claude/workstreams/the-agency/   → src/agency/workstreams/agency/   (composed)
+claude/workstreams/              → src/agency/workstreams/           (V5)
+claude/principals/               → src/agency/principals/             (V5)
+claude/REFERENCE/                → src/agency/REFERENCE/              (V5)
+claude/starter-packs/            → src/spec-provider/starter-packs/   (Wave 2b)
+claude/                          → agency/                            (Wave 1 catch-all)
+tests/                           → src/tests/                         (Wave 1)
+apps/                            → src/apps/                          (Wave 2)
+
+So you skip the v1.1 intermediate step entirely.
+
+Plan:
+1. Get v1.2 tool from main:
+   git fetch origin
+   git checkout origin/main -- agency/tools/great-rename-migrate src/tests/tools/great-rename-migrate.bats
+
+2. Dry-run:
+   ./agency/tools/great-rename-migrate
+
+3. Apply:
+   ./agency/tools/great-rename-migrate --apply
+   git-safe-commit "migrate branch: apply great-rename v1.2 composed (waves 1+2+3 in one pass)" --no-work-item
+
+4. worktree-sync --auto
+
+5. Expected residual conflicts (real, not path):
+   - The 3 .swift files you mentioned in #866 (apps/mdpal-app/Sources/Models/AlertContent.swift, LineDiff.swift, Views/DiffView.swift) — your work vs main's, take your call per-file
+   - Any other content-only conflicts (engine API drift if applicable)
+
+6. For captain-owned files (usr/jordan/captain/*): take main's version always. Do not modify.
+
+7. Report back with:
+   - Final HEAD
+   - File count from migration
+   - Residual conflict count + summary
+
+After unblock: Phase 3 work resumes. mdpal-cli is parallel-unblocking with the same v1.2 tool (see dispatch #869); they'll be sync'd to v46.25 once their migration completes.

--- a/usr/jordan/captain/history/handoff-20260807-204949-819.md
+++ b/usr/jordan/captain/history/handoff-20260807-204949-819.md
@@ -1,0 +1,109 @@
+---
+type: session
+agent: the-agency/jordan/captain
+date: 2026-05-09T12:45
+trigger: principal-moving-temp-shutdown
+branch: captain-git-safe-init
+mode: resumption
+next-action: |
+  Build `git-safe init` subcommand in `agency/tools/git-safe`. Branch
+  `captain-git-safe-init` already created (clean, no edits yet). Resolves
+  framework gap #437. After tool ships via captain-release + merge, redo
+  the `~/code/this-happened/` git-init step using the new tool to prove
+  the chain. Then continue this-happened bootstrap.
+---
+
+# Captain handoff — paused mid-bootstrap of this-happened (hackathon)
+
+## Where we are
+
+Hackathon day. Pivoted from mdpal to a new project: **this-happened** — user issue reporting + Breadcrumb (UUID7 distributed tracing). Per seed at `agency/workstreams/agency/history/flotsam/legacy-agency-workstream-20260420/seeds/seed-it-happened-and-breadcrumb-20260410.md`.
+
+Bootstrap is mid-flight. Paused at the framework-tool fix step before continuing.
+
+## 4 locked decisions from this session's 1B1
+
+| Item | Decision | Notes |
+|---|---|---|
+| **Scope** | **B** — both services together | this-happened (app) + breadcrumb (library) in one repo, two workstreams |
+| **Hackathon shape** | **A** — full discipline | /define → /design → /plan → first iteration. PVR locked + A&D in flight by EOD. No shortcuts. |
+| **License** | **B** — Reference Source on both, two LICENSE files | Allows independent re-licensing of one component later |
+| **Bootstrap mechanism** | **agency init** (canonical tool) | Use the framework's own bootstrap path; if it breaks we fix it |
+
+The principal directive that triggered the pause: **"Why don't you make the tooling change and then use it?"** — i.e., when you find a gap, don't work around it; FIX THE TOOL.
+
+## What's been done so far
+
+1. **PR #436 merged** earlier this session — `great-rename-migrate v1.1.0` default-map adds `apps/` + `starter-packs/`. Released as v46.23. Auto-release via Fix D worked. https://github.com/the-agency-ai/the-agency/releases/tag/v46.23
+2. **mdpal-cli + mdpal-app dispatched** with go-ahead on default-map run.
+3. **GitHub repo created**: `the-agency-ai/this-happened` (public).
+4. **~/code/this-happened/ exists** — was cloned via `gh repo create --clone` (workaround for missing `git-safe init`); then `agency-bootstrap.sh` was run inside it successfully. Framework + workstream `this-happened` + initial captain-handoff are present in that repo. **Nothing committed yet** in the new repo — git tree dirty (the bootstrap files staged + ready to commit).
+5. **Issue #437 filed**: `git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap`. This was the manual sidestep the principal called out.
+6. **Captain branch `captain-git-safe-init` created** (clean, no edits) — ready to receive the tool fix.
+
+## Where resumption picks up — concrete next steps
+
+**Step 1: Build `git-safe init [path]` subcommand** in `agency/tools/git-safe`.
+- Validates path doesn't already contain `.git/` (refuses with clear error)
+- Creates target dir if missing (mirroring `git init <path>` behavior)
+- Calls real `git init <path>` under the hood
+- Reports success with absolute path
+- Adds `init` row to the help text (under "Subcommands (guarded write)")
+
+**Step 2: Add BATS tests** in `src/tests/tools/git-safe.bats`:
+- `git-safe init creates fresh repo at given path`
+- `git-safe init refuses if path already contains .git/`
+- `git-safe init creates target dir if missing`
+- `git-safe init defaults to cwd if no path given` (or refuses no-arg — design call at build time)
+
+**Step 3: Bump TOOL_VERSION** in git-safe (1.0.0 → 1.1.0) + provenance header.
+
+**Step 4: captain-release flow** — commit, QGR (one self-review pass), version bump (manifest 46.23 → 46.24), PR, merge, post-merge.
+
+**Step 5: Redo this-happened's git plumbing using the new tool**:
+- Save bootstrap content; tear down `.git/`; run new `git-safe init`; re-add origin remote; commit + push as bootstrap commit.
+- Note: there's no `git-safe remote add` subcommand — possibly another tool gap to file. OR re-clone fresh (since the bootstrap content is reproducible by re-running agency-bootstrap.sh). Decide at resumption.
+
+**Step 6: Continue this-happened bootstrap** per the locked-A plan:
+- `/workstream-create breadcrumb` (with Reference Source LICENSE)
+- Update `this-happened` workstream README + LICENSE
+- Author bootstrap handover (captain-to-captain, the-agency captain → this-happened captain) including the 4 locked 1B1 decisions, seed pointer, SPEC:PROVIDER stack lock
+- Inject prior work: copy seed + 2026-04-10 SPEC:PROVIDER directive into `~/code/this-happened/agency/workstreams/this-happened/seeds/`
+- Author 1B1 transcript file capturing today's discussion verbatim per principal's "yes" on Item 1
+- Initial commit + push the new repo
+- `/define` to start PVR Rev 1
+
+## Open framework gaps to address (in priority order)
+
+| # | Gap | Action |
+|---|---|---|
+| **#437** | `git-safe init` missing | Building NEXT (this is the next-action) |
+| **flag #220** | great-rename-migrate v1.2 — wave-3 entries | Task #83, post-hackathon |
+| **flag #218** | captain-release receipt-hash thrash (manifest bump invalidates QGR) | Post-hackathon |
+| **flag #217** | reviewer-* subagent classes not registered as instances | Post-hackathon |
+| **flag #216** | dispatch-monitor `python3` resolves to 3.9 not 3.13 | Post-hackathon |
+
+## Hackathon clock note
+
+Principal observation: even hybrid C wouldn't yield a running thing by 5 PM. Locked Option A (full discipline). PVR + A&D landing today is the realistic target; running app is days away.
+
+## What's NOT in scope today
+
+- mdpal-app + mdpal-cli (parked at migration commits — Task #83 unblocks them next session)
+- Bucket 1 #419-ecosystem 1B1 (paused at Item 1 #288, awaiting principal verdict)
+- Other Bucket 1 items (#74, #76, #77, #78)
+- Build /agency-claude-feedback skill (Task #80)
+- mdslidepal worktrees (explicitly off the table per principal)
+
+## On resume
+
+1. `/session-resume` — sync, handoff, dispatches
+2. Read this handoff's next-action
+3. Verify on `captain-git-safe-init` branch (created clean this session)
+4. Begin Step 1 — build the tool
+5. Process any dispatches that arrived during the pause
+6. Re-launch dispatch monitor via `/monitor-dispatches` (was running this session as task `bi7af0v49`)
+
+— captain, paused mid-bootstrap.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/designex/dispatches/commit-to-captain-committed-81df8366-on-designex-rebuild-on-main-pre-20260807-2043.md
+++ b/usr/jordan/designex/dispatches/commit-to-captain-committed-81df8366-on-designex-rebuild-on-main-pre-20260807-2043.md
@@ -1,0 +1,47 @@
+---
+type: commit
+from: the-agency/jordan/designex
+to: the-agency/jordan/captain
+date: 2026-08-07T12:43
+status: created
+priority: normal
+subject: "Committed 81df8366 on designex: rebuild on main: preserve design-system pipeline (designsystem-build tool+skill+BATS, fleet-report, figma-extract skill, v1 release note)"
+in_reply_to: null
+---
+
+# Committed 81df8366 on designex: rebuild on main: preserve design-system pipeline (designsystem-build tool+skill+BATS, fleet-report, figma-extract skill, v1 release note)
+
+## Commit: 81df8366
+
+**Branch:** designex
+**Agent:** the-agency/jordan/designex
+**Message:** housekeeping/captain: rebuild on main: preserve design-system pipeline (designsystem-build tool+skill+BATS, fleet-report, figma-extract skill, v1 release note)
+
+### Metadata
+- commit_hash: 81df8366
+- branch: designex
+- files_changed: 17
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/commands/fleet-report.md
+.claude/skills/designsystem-build/SKILL.md
+.claude/skills/figma-extract/SKILL.md
+.claude/skills/fleet-report/SKILL.md
+.claude/skills/fleet-report/assets/README.md
+.claude/skills/fleet-report/examples.md
+.claude/skills/fleet-report/reference.md
+.claude/skills/fleet-report/scripts/README.md
+agency/tools/designsystem-build/.gitignore
+agency/tools/designsystem-build/designsystem-build
+agency/tools/designsystem-build/package-lock.json
+agency/tools/designsystem-build/package.json
+agency/tools/designsystem-build/src/build.mjs
+agency/tools/designsystem-build/src/formats/shadcn-css.mjs
+agency/tools/designsystem-build/src/formats/tamagui.mjs
+agency/workstreams/designex/release-notes/designsystem-build-v1-standard-20260419.md
+src/tests/tools/designsystem-build.bats
+```

--- a/usr/jordan/devex/dispatches/commit-to-captain-committed-f204bd2e-on-devex-rebuild-on-main-preser-20260807-2042.md
+++ b/usr/jordan/devex/dispatches/commit-to-captain-committed-f204bd2e-on-devex-rebuild-on-main-preser-20260807-2042.md
@@ -1,0 +1,38 @@
+---
+type: commit
+from: the-agency/jordan/devex
+to: the-agency/jordan/captain
+date: 2026-08-07T12:42
+status: created
+priority: normal
+subject: "Committed f204bd2e on devex: rebuild on main: preserve test-monitor WIP (Iter 1 ~95%, BATS red — tool + suite + design docs)"
+in_reply_to: null
+---
+
+# Committed f204bd2e on devex: rebuild on main: preserve test-monitor WIP (Iter 1 ~95%, BATS red — tool + suite + design docs)
+
+## Commit: f204bd2e
+
+**Branch:** devex
+**Agent:** the-agency/jordan/devex
+**Message:** housekeeping/captain: rebuild on main: preserve test-monitor WIP (Iter 1 ~95%, BATS red — tool + suite + design docs)
+
+### Metadata
+- commit_hash: f204bd2e
+- branch: devex
+- files_changed: 8
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/test-monitor
+agency/workstreams/devex/test-monitor-ad-20260419.md
+agency/workstreams/devex/test-monitor-plan-20260419.md
+agency/workstreams/devex/test-monitor-pvr-20260417.md
+src/tests/tools/fixtures/test-monitor/failing.bats
+src/tests/tools/fixtures/test-monitor/passing.bats
+src/tests/tools/test-monitor.bats
+usr/jordan/reports/report-agency-issue-test-monitor-mid-run-critical-failure-abort-v2-fol-20260419.md
+```

--- a/usr/jordan/iscp/dispatches/commit-to-captain-committed-35b2e093-on-iscp-rebuild-on-main-graft-d-20260807-1911.md
+++ b/usr/jordan/iscp/dispatches/commit-to-captain-committed-35b2e093-on-iscp-rebuild-on-main-graft-d-20260807-1911.md
@@ -1,0 +1,50 @@
+---
+type: commit
+from: the-agency/jordan/iscp
+to: the-agency/jordan/captain
+date: 2026-08-07T11:11
+status: created
+priority: normal
+subject: "Committed 35b2e093 on iscp: rebuild on main: graft dispatch-hub service V0 (FastAPI backend — config/db/auth/fanout/routes + alembic migration + pytest suite + fly/docker deploy)"
+in_reply_to: null
+---
+
+# Committed 35b2e093 on iscp: rebuild on main: graft dispatch-hub service V0 (FastAPI backend — config/db/auth/fanout/routes + alembic migration + pytest suite + fly/docker deploy)
+
+## Commit: 35b2e093
+
+**Branch:** iscp
+**Agent:** the-agency/jordan/iscp
+**Message:** housekeeping/captain: rebuild on main: graft dispatch-hub service V0 (FastAPI backend — config/db/auth/fanout/routes + alembic migration + pytest suite + fly/docker deploy)
+
+### Metadata
+- commit_hash: 35b2e093
+- branch: iscp
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+src/services/dispatch-hub/.env.example
+src/services/dispatch-hub/.gitignore
+src/services/dispatch-hub/Dockerfile
+src/services/dispatch-hub/Makefile
+src/services/dispatch-hub/README.md
+src/services/dispatch-hub/alembic.ini
+src/services/dispatch-hub/alembic/env.py
+src/services/dispatch-hub/alembic/script.py.mako
+src/services/dispatch-hub/alembic/versions/0001_initial_schema.py
+src/services/dispatch-hub/docker-compose.yml
+src/services/dispatch-hub/fly.toml
+src/services/dispatch-hub/pyproject.toml
+src/services/dispatch-hub/requirements-dev.txt
+src/services/dispatch-hub/requirements.txt
+src/services/dispatch-hub/src/dispatch_hub/__init__.py
+src/services/dispatch-hub/src/dispatch_hub/audit.py
+src/services/dispatch-hub/src/dispatch_hub/auth.py
+src/services/dispatch-hub/src/dispatch_hub/config.py
+src/services/dispatch-hub/src/dispatch_hub/db.py
+src/services/dispatch-hub/src/dispatch_hub/fanout.py
+```

--- a/usr/jordan/mdpal-app/dispatches/commit-to-captain-committed-06ade7a2-on-mdpal-app-rebuild-on-main-gr-20260807-1855.md
+++ b/usr/jordan/mdpal-app/dispatches/commit-to-captain-committed-06ade7a2-on-mdpal-app-rebuild-on-main-gr-20260807-1855.md
@@ -1,0 +1,46 @@
+---
+type: commit
+from: the-agency/jordan/mdpal-app
+to: the-agency/jordan/captain
+date: 2026-08-07T10:55
+status: created
+priority: normal
+subject: "Committed 06ade7a2 on mdpal-app: rebuild on main: graft Phase 2.1-2.6 product work (revision system, DiffView/LineDiff, task-cancellation, pancake CLI service, wire-format catch-up)"
+in_reply_to: null
+---
+
+# Committed 06ade7a2 on mdpal-app: rebuild on main: graft Phase 2.1-2.6 product work (revision system, DiffView/LineDiff, task-cancellation, pancake CLI service, wire-format catch-up)
+
+## Commit: 06ade7a2
+
+**Branch:** mdpal-app
+**Agent:** the-agency/jordan/mdpal-app
+**Message:** housekeeping/captain: rebuild on main: graft Phase 2.1-2.6 product work (revision system, DiffView/LineDiff, task-cancellation, pancake CLI service, wire-format catch-up)
+
+### Metadata
+- commit_hash: 06ade7a2
+- branch: mdpal-app
+- files_changed: 16
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+src/apps/mdpal-app/Sources/MarkdownPalApp/App.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Models/AlertContent.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Models/DocumentModel.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Models/LineDiff.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Models/ResponseTypes.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/CLIProcess.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/CLIServiceFactory.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/CLIServiceProtocol.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/MockCLIService.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/PancakeCLIService.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Services/RealCLIService.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Views/CLIServiceBanner.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Views/ContentView.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Views/DiffView.swift
+src/apps/mdpal-app/Sources/MarkdownPalApp/Views/MarkdownDocument.swift
+src/apps/mdpal-app/Tests/MarkdownPalAppTests/ModelTests.swift
+```

--- a/usr/jordan/mdslidepal-mac/dispatches/commit-to-captain-committed-912797c2-on-mdslidepal-mac-rebuild-on-ma-20260807-1853.md
+++ b/usr/jordan/mdslidepal-mac/dispatches/commit-to-captain-committed-912797c2-on-mdslidepal-mac-rebuild-on-ma-20260807-1853.md
@@ -1,0 +1,37 @@
+---
+type: commit
+from: the-agency/jordan/mdslidepal-mac
+to: the-agency/jordan/captain
+date: 2026-08-07T10:53
+status: created
+priority: normal
+subject: "Committed 912797c2 on mdslidepal-mac: rebuild on main: graft Phase 5.1+5.2 product work (hero-slide detection, HTML/image/typography rendering, FontResolver)"
+in_reply_to: null
+---
+
+# Committed 912797c2 on mdslidepal-mac: rebuild on main: graft Phase 5.1+5.2 product work (hero-slide detection, HTML/image/typography rendering, FontResolver)
+
+## Commit: 912797c2
+
+**Branch:** mdslidepal-mac
+**Agent:** the-agency/jordan/mdslidepal-mac
+**Message:** housekeeping/captain: rebuild on main: graft Phase 5.1+5.2 product work (hero-slide detection, HTML/image/typography rendering, FontResolver)
+
+### Metadata
+- commit_hash: 912797c2
+- branch: mdslidepal-mac
+- files_changed: 7
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+src/apps/mdslidepal-mac/Sources/MdSlidepal/App/MdSlidepalApp.swift
+src/apps/mdslidepal-mac/Sources/MdSlidepalLib/Model/Slide.swift
+src/apps/mdslidepal-mac/Sources/MdSlidepalLib/Parser/SlideMetadataExtractor.swift
+src/apps/mdslidepal-mac/Sources/MdSlidepalLib/Render/ImageBlockView.swift
+src/apps/mdslidepal-mac/Sources/MdSlidepalLib/Render/SlideView.swift
+src/apps/mdslidepal-mac/Sources/MdSlidepalLib/Theme/FontResolver.swift
+src/apps/mdslidepal-mac/Tests/MdSlidepalTests/TestRunner.swift
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-032f18d7-on-fix-pr-submit-org-resolution-20260808-1117.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-032f18d7-on-fix-pr-submit-org-resolution-20260808-1117.md
@@ -1,0 +1,103 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T03:17
+status: created
+priority: normal
+subject: "Committed 032f18d7 on fix/pr-submit-org-resolution: fix(pr-lifecycle): make PR landing main-aware + fix receipt-churn
+
+pr-captain-land hardcoded 'master' in three live places (origin/master diff
+base, switch-branch master, gh-release --target master), which fails closed on
+a repo whose default branch is main — blocking every captain PR landing here.
+
+- pr-captain-land: resolve the default branch and use it everywhere; source the
+  shared, tested pr-submit helpers (redact_remote_url/parse_org/parse_repo/
+  resolve_default_branch) instead of re-deriving ORG/REPO inline; redact the
+  remote on the parse-failure path (no PAT leak).
+- pr-submit: add parse_repo_from_remote (companion to parse_org) for the lib.
+- diff-hash: exclude active + archived handoffs — fixes receipt-churn where
+  /pr-submit and /handoff committed a handoff into the hashed set, invalidating
+  the just-signed receipt (one landing cost five re-signs).
+- sync src/ source-of-truth copies to running (self-bootstrapping payload;
+  src/agency/tools/diff-hash also catches up the Issue #254 guard it lacked).
+- tests: +7 repo-parser, +9 pr-captain-land regression guards, +3 handoff-
+  exclusion. 67 relevant bats green.
+
+Consolidates the /pr-submit framework fixes (F1 default-branch, F2 credential
+leak, F3 dead ERE branch + two QG-found: scheme-limited redaction, bypassable
+lib guard) surfaced by mdpal-app and mdslidepal-mac agents."
+in_reply_to: null
+---
+
+# Committed 032f18d7 on fix/pr-submit-org-resolution: fix(pr-lifecycle): make PR landing main-aware + fix receipt-churn
+
+pr-captain-land hardcoded 'master' in three live places (origin/master diff
+base, switch-branch master, gh-release --target master), which fails closed on
+a repo whose default branch is main — blocking every captain PR landing here.
+
+- pr-captain-land: resolve the default branch and use it everywhere; source the
+  shared, tested pr-submit helpers (redact_remote_url/parse_org/parse_repo/
+  resolve_default_branch) instead of re-deriving ORG/REPO inline; redact the
+  remote on the parse-failure path (no PAT leak).
+- pr-submit: add parse_repo_from_remote (companion to parse_org) for the lib.
+- diff-hash: exclude active + archived handoffs — fixes receipt-churn where
+  /pr-submit and /handoff committed a handoff into the hashed set, invalidating
+  the just-signed receipt (one landing cost five re-signs).
+- sync src/ source-of-truth copies to running (self-bootstrapping payload;
+  src/agency/tools/diff-hash also catches up the Issue #254 guard it lacked).
+- tests: +7 repo-parser, +9 pr-captain-land regression guards, +3 handoff-
+  exclusion. 67 relevant bats green.
+
+Consolidates the /pr-submit framework fixes (F1 default-branch, F2 credential
+leak, F3 dead ERE branch + two QG-found: scheme-limited redaction, bypassable
+lib guard) surfaced by mdpal-app and mdslidepal-mac agents.
+
+## Commit: 032f18d7
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: fix(pr-lifecycle): make PR landing main-aware + fix receipt-churn
+
+pr-captain-land hardcoded 'master' in three live places (origin/master diff
+base, switch-branch master, gh-release --target master), which fails closed on
+a repo whose default branch is main — blocking every captain PR landing here.
+
+- pr-captain-land: resolve the default branch and use it everywhere; source the
+  shared, tested pr-submit helpers (redact_remote_url/parse_org/parse_repo/
+  resolve_default_branch) instead of re-deriving ORG/REPO inline; redact the
+  remote on the parse-failure path (no PAT leak).
+- pr-submit: add parse_repo_from_remote (companion to parse_org) for the lib.
+- diff-hash: exclude active + archived handoffs — fixes receipt-churn where
+  /pr-submit and /handoff committed a handoff into the hashed set, invalidating
+  the just-signed receipt (one landing cost five re-signs).
+- sync src/ source-of-truth copies to running (self-bootstrapping payload;
+  src/agency/tools/diff-hash also catches up the Issue #254 guard it lacked).
+- tests: +7 repo-parser, +9 pr-captain-land regression guards, +3 handoff-
+  exclusion. 67 relevant bats green.
+
+Consolidates the /pr-submit framework fixes (F1 default-branch, F2 credential
+leak, F3 dead ERE branch + two QG-found: scheme-limited redaction, bypassable
+lib guard) surfaced by mdpal-app and mdslidepal-mac agents.
+
+### Metadata
+- commit_hash: 032f18d7
+- branch: fix/pr-submit-org-resolution
+- files_changed: 10
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+.claude/skills/pr-submit/scripts/pr-submit
+agency/tools/diff-hash
+src/agency/tools/diff-hash
+src/claude/skills/pr-captain-land/scripts/pr-captain-land
+src/claude/skills/pr-submit/scripts/pr-submit
+src/tests/skills/pr-captain-land-helpers.bats
+src/tests/skills/pr-submit-helpers.bats
+src/tests/tools/diff-hash.bats
+usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-7d9fc73c-on-fix-pr-submit-org-resolution-20260808-1030.md
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-3c3b833c-on-fix-pr-submit-org-resolution-20260808-1158.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-3c3b833c-on-fix-pr-submit-org-resolution-20260808-1158.md
@@ -1,0 +1,60 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T03:58
+status: created
+priority: normal
+subject: "Committed 3c3b833c on fix/pr-submit-org-resolution: fix(pr-create): don't abort on head/pipefail SIGPIPE in receipt search
+
+pr-create's receipt-find pipelines (find | xargs ls -t | head -1) abort the
+whole script under 'set -o pipefail' once there are enough receipts (~100+)
+that head closing the pipe SIGPIPEs the upstream ls before it finishes — a
+nondeterministic failure that silently blocked PR creation in this repo (120
+receipts). The newest receipt is already captured before the signal; append
+'|| true' so the benign pipeline failure can't abort. A genuine empty result
+still falls through to the existing -z checks. Applied to all three receipt
+tiers; src/ mirror kept identical."
+in_reply_to: null
+---
+
+# Committed 3c3b833c on fix/pr-submit-org-resolution: fix(pr-create): don't abort on head/pipefail SIGPIPE in receipt search
+
+pr-create's receipt-find pipelines (find | xargs ls -t | head -1) abort the
+whole script under 'set -o pipefail' once there are enough receipts (~100+)
+that head closing the pipe SIGPIPEs the upstream ls before it finishes — a
+nondeterministic failure that silently blocked PR creation in this repo (120
+receipts). The newest receipt is already captured before the signal; append
+'|| true' so the benign pipeline failure can't abort. A genuine empty result
+still falls through to the existing -z checks. Applied to all three receipt
+tiers; src/ mirror kept identical.
+
+## Commit: 3c3b833c
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: fix(pr-create): don't abort on head/pipefail SIGPIPE in receipt search
+
+pr-create's receipt-find pipelines (find | xargs ls -t | head -1) abort the
+whole script under 'set -o pipefail' once there are enough receipts (~100+)
+that head closing the pipe SIGPIPEs the upstream ls before it finishes — a
+nondeterministic failure that silently blocked PR creation in this repo (120
+receipts). The newest receipt is already captured before the signal; append
+'|| true' so the benign pipeline failure can't abort. A genuine empty result
+still falls through to the existing -z checks. Applied to all three receipt
+tiers; src/ mirror kept identical.
+
+### Metadata
+- commit_hash: 3c3b833c
+- branch: fix/pr-submit-org-resolution
+- files_changed: 3
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/pr-create
+src/agency/tools/pr-create
+usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-977162e3-on-fix-pr-submit-org-resolution-20260808-1152.md
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-7d9fc73c-on-fix-pr-submit-org-resolution-20260808-1030.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-7d9fc73c-on-fix-pr-submit-org-resolution-20260808-1030.md
@@ -1,0 +1,129 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T02:30
+status: created
+priority: normal
+subject: "Committed 7d9fc73c on fix/pr-submit-org-resolution: fix(pr-submit): default-branch resolution, credential redaction, org parsing + 27 bats tests
+
+NOT FOR PUSH — handed to captain for consolidation through the canonical
+pr-submit worktree, per principal's split decision. Committed locally only so
+the work and its review findings are not lost.
+
+Three defects that block /pr-submit for every agent in a main-default repo:
+  F1 receipt-matching diff hash computed against a literal origin/master
+  F2 credential-bearing remote rejected by the ORG parser, and the failure
+     path echoed the raw remote — leaking a PAT to terminal/logs/transcripts
+  F3 https branch used ([^/.]+?)(\.git)?/? — POSIX ERE has no lazy
+     quantifier, so it matched no .git-suffixed https remote at all
+
+Extracted redact_remote_url / parse_org_from_remote / resolve_default_branch
+as pure helpers behind a PR_SUBMIT_LIB_ONLY source guard so all three are
+unit-testable without a repo, a pushed branch, or a signed receipt.
+
+Two further defects found by QG review of my own first cut, both fixed:
+  - redaction anchored on a literal https:// prefix, so ssh://, http:// and
+    git:// remotes went through completely unredacted and still leaked. Now
+    scheme-generic, and userinfo matching stops at the FIRST @ so a path
+    containing @ no longer eats the host.
+  - the source guard keyed only on the env var, so an inherited
+    PR_SUBMIT_LIB_ONLY made a normal execution exit 0 having skipped every
+    precondition and sent nothing — indistinguishable from success. Now also
+    requires BASH_SOURCE != $0.
+
+Test gaps found and closed: the clone-based fixtures always populate
+origin/HEAD, so the fallback loop was never executed; and a hardcoded
+'main' assertion was brittle under shallow CI checkout.
+
+27/27 bats green. Full suite 1175 pass; the 22 failures are pre-existing in
+agency init/update/verify and touch nothing here."
+in_reply_to: null
+---
+
+# Committed 7d9fc73c on fix/pr-submit-org-resolution: fix(pr-submit): default-branch resolution, credential redaction, org parsing + 27 bats tests
+
+NOT FOR PUSH — handed to captain for consolidation through the canonical
+pr-submit worktree, per principal's split decision. Committed locally only so
+the work and its review findings are not lost.
+
+Three defects that block /pr-submit for every agent in a main-default repo:
+  F1 receipt-matching diff hash computed against a literal origin/master
+  F2 credential-bearing remote rejected by the ORG parser, and the failure
+     path echoed the raw remote — leaking a PAT to terminal/logs/transcripts
+  F3 https branch used ([^/.]+?)(\.git)?/? — POSIX ERE has no lazy
+     quantifier, so it matched no .git-suffixed https remote at all
+
+Extracted redact_remote_url / parse_org_from_remote / resolve_default_branch
+as pure helpers behind a PR_SUBMIT_LIB_ONLY source guard so all three are
+unit-testable without a repo, a pushed branch, or a signed receipt.
+
+Two further defects found by QG review of my own first cut, both fixed:
+  - redaction anchored on a literal https:// prefix, so ssh://, http:// and
+    git:// remotes went through completely unredacted and still leaked. Now
+    scheme-generic, and userinfo matching stops at the FIRST @ so a path
+    containing @ no longer eats the host.
+  - the source guard keyed only on the env var, so an inherited
+    PR_SUBMIT_LIB_ONLY made a normal execution exit 0 having skipped every
+    precondition and sent nothing — indistinguishable from success. Now also
+    requires BASH_SOURCE != $0.
+
+Test gaps found and closed: the clone-based fixtures always populate
+origin/HEAD, so the fallback loop was never executed; and a hardcoded
+'main' assertion was brittle under shallow CI checkout.
+
+27/27 bats green. Full suite 1175 pass; the 22 failures are pre-existing in
+agency init/update/verify and touch nothing here.
+
+## Commit: 7d9fc73c
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: fix(pr-submit): default-branch resolution, credential redaction, org parsing + 27 bats tests
+
+NOT FOR PUSH — handed to captain for consolidation through the canonical
+pr-submit worktree, per principal's split decision. Committed locally only so
+the work and its review findings are not lost.
+
+Three defects that block /pr-submit for every agent in a main-default repo:
+  F1 receipt-matching diff hash computed against a literal origin/master
+  F2 credential-bearing remote rejected by the ORG parser, and the failure
+     path echoed the raw remote — leaking a PAT to terminal/logs/transcripts
+  F3 https branch used ([^/.]+?)(\.git)?/? — POSIX ERE has no lazy
+     quantifier, so it matched no .git-suffixed https remote at all
+
+Extracted redact_remote_url / parse_org_from_remote / resolve_default_branch
+as pure helpers behind a PR_SUBMIT_LIB_ONLY source guard so all three are
+unit-testable without a repo, a pushed branch, or a signed receipt.
+
+Two further defects found by QG review of my own first cut, both fixed:
+  - redaction anchored on a literal https:// prefix, so ssh://, http:// and
+    git:// remotes went through completely unredacted and still leaked. Now
+    scheme-generic, and userinfo matching stops at the FIRST @ so a path
+    containing @ no longer eats the host.
+  - the source guard keyed only on the env var, so an inherited
+    PR_SUBMIT_LIB_ONLY made a normal execution exit 0 having skipped every
+    precondition and sent nothing — indistinguishable from success. Now also
+    requires BASH_SOURCE != $0.
+
+Test gaps found and closed: the clone-based fixtures always populate
+origin/HEAD, so the fallback loop was never executed; and a hardcoded
+'main' assertion was brittle under shallow CI checkout.
+
+27/27 bats green. Full suite 1175 pass; the 22 failures are pre-existing in
+agency init/update/verify and touch nothing here.
+
+### Metadata
+- commit_hash: 7d9fc73c
+- branch: fix/pr-submit-org-resolution
+- files_changed: 3
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/pr-submit/scripts/pr-submit
+agency/.agency/projects.json
+src/tests/skills/pr-submit-helpers.bats
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-977162e3-on-fix-pr-submit-org-resolution-20260808-1152.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-977162e3-on-fix-pr-submit-org-resolution-20260808-1152.md
@@ -1,0 +1,33 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T03:52
+status: created
+priority: normal
+subject: "Committed 977162e3 on fix/pr-submit-org-resolution: misc: QGR receipt (801b8f8) + commit-announce for pr-lifecycle landing"
+in_reply_to: null
+---
+
+# Committed 977162e3 on fix/pr-submit-org-resolution: misc: QGR receipt (801b8f8) + commit-announce for pr-lifecycle landing
+
+## Commit: 977162e3
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: misc: QGR receipt (801b8f8) + commit-announce for pr-lifecycle landing
+
+### Metadata
+- commit_hash: 977162e3
+- branch: fix/pr-submit-org-resolution
+- files_changed: 3
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1149-779b204.md
+agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1152-801b8f8.md
+usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-99d7c75b-on-fix-pr-submit-org-resolution-20260808-1151.md
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-99d7c75b-on-fix-pr-submit-org-resolution-20260808-1151.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-99d7c75b-on-fix-pr-submit-org-resolution-20260808-1151.md
@@ -1,0 +1,33 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T03:51
+status: created
+priority: normal
+subject: "Committed 99d7c75b on fix/pr-submit-org-resolution: chore(manifest): bump agency_version 46.26 → 46.27 for PR landing"
+in_reply_to: null
+---
+
+# Committed 99d7c75b on fix/pr-submit-org-resolution: chore(manifest): bump agency_version 46.26 → 46.27 for PR landing
+
+## Commit: 99d7c75b
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: chore(manifest): bump agency_version 46.26 → 46.27 for PR landing
+
+### Metadata
+- commit_hash: 99d7c75b
+- branch: fix/pr-submit-org-resolution
+- files_changed: 3
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+agency/workstreams/agency/qgr/the-agency-jordan-pr-submit-org-resolution-agency-pr-lifecycle-qgr-pr-prep-20260808-1149-779b204.md
+usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-fd5d96fa-on-fix-pr-submit-org-resolution-20260808-1149.md
+```

--- a/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-fd5d96fa-on-fix-pr-submit-org-resolution-20260808-1149.md
+++ b/usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-fd5d96fa-on-fix-pr-submit-org-resolution-20260808-1149.md
@@ -1,0 +1,101 @@
+---
+type: commit
+from: the-agency/jordan/pr-submit-org-resolution
+to: the-agency/jordan/captain
+date: 2026-08-08T03:49
+status: created
+priority: normal
+subject: "Committed fd5d96fa on fix/pr-submit-org-resolution: fix(pr-lifecycle): QG round — harden test guards + de-stale docs
+
+Quality-gate findings on the main-aware pr-lifecycle change, all fixed:
+- test guards: the pr-captain-land 'no switch-branch master' / '--target master'
+  guards false-negatived on the idiomatic QUOTED form ("master") — strengthened
+  to catch both; helper-usage guards re-anchored to call sites (were matching the
+  comment block → false-green); added a diff-hash file_count assertion (the
+  FILE_COUNT invocation's handoff exclusion was unobserved by any test); added a
+  pr-captain-land --help smoke test (exercises source+parse+resolve end-to-end and
+  asserts no PAT leak); parse_repo_from_remote parity tests (dotted repo, empty).
+- docs: replaced stale 'origin/master' / 'switch-branch master' / '--target master'
+  in both skills' SKILL.md/reference.md/examples.md/README (the change made the code
+  default-branch-aware but the docs still described the removed hardcode).
+- src/ mirrors kept byte-identical.
+
+71 relevant bats green. Deferred (noted for follow-up, not this PR): converge the
+three default-branch resolvers (git-captain/pr-create/resolve_default_branch) into
+one shared lib; resolve_default_branch's :-master fallback rides with that."
+in_reply_to: null
+---
+
+# Committed fd5d96fa on fix/pr-submit-org-resolution: fix(pr-lifecycle): QG round — harden test guards + de-stale docs
+
+Quality-gate findings on the main-aware pr-lifecycle change, all fixed:
+- test guards: the pr-captain-land 'no switch-branch master' / '--target master'
+  guards false-negatived on the idiomatic QUOTED form ("master") — strengthened
+  to catch both; helper-usage guards re-anchored to call sites (were matching the
+  comment block → false-green); added a diff-hash file_count assertion (the
+  FILE_COUNT invocation's handoff exclusion was unobserved by any test); added a
+  pr-captain-land --help smoke test (exercises source+parse+resolve end-to-end and
+  asserts no PAT leak); parse_repo_from_remote parity tests (dotted repo, empty).
+- docs: replaced stale 'origin/master' / 'switch-branch master' / '--target master'
+  in both skills' SKILL.md/reference.md/examples.md/README (the change made the code
+  default-branch-aware but the docs still described the removed hardcode).
+- src/ mirrors kept byte-identical.
+
+71 relevant bats green. Deferred (noted for follow-up, not this PR): converge the
+three default-branch resolvers (git-captain/pr-create/resolve_default_branch) into
+one shared lib; resolve_default_branch's :-master fallback rides with that.
+
+## Commit: fd5d96fa
+
+**Branch:** fix/pr-submit-org-resolution
+**Agent:** the-agency/jordan/pr-submit-org-resolution
+**Message:** fix/pr-submit-org: fix(pr-lifecycle): QG round — harden test guards + de-stale docs
+
+Quality-gate findings on the main-aware pr-lifecycle change, all fixed:
+- test guards: the pr-captain-land 'no switch-branch master' / '--target master'
+  guards false-negatived on the idiomatic QUOTED form ("master") — strengthened
+  to catch both; helper-usage guards re-anchored to call sites (were matching the
+  comment block → false-green); added a diff-hash file_count assertion (the
+  FILE_COUNT invocation's handoff exclusion was unobserved by any test); added a
+  pr-captain-land --help smoke test (exercises source+parse+resolve end-to-end and
+  asserts no PAT leak); parse_repo_from_remote parity tests (dotted repo, empty).
+- docs: replaced stale 'origin/master' / 'switch-branch master' / '--target master'
+  in both skills' SKILL.md/reference.md/examples.md/README (the change made the code
+  default-branch-aware but the docs still described the removed hardcode).
+- src/ mirrors kept byte-identical.
+
+71 relevant bats green. Deferred (noted for follow-up, not this PR): converge the
+three default-branch resolvers (git-captain/pr-create/resolve_default_branch) into
+one shared lib; resolve_default_branch's :-master fallback rides with that.
+
+### Metadata
+- commit_hash: fd5d96fa
+- branch: fix/pr-submit-org-resolution
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-land/examples.md
+.claude/skills/pr-captain-land/reference.md
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+.claude/skills/pr-submit/SKILL.md
+.claude/skills/pr-submit/examples.md
+.claude/skills/pr-submit/reference.md
+.claude/skills/pr-submit/scripts/README.md
+src/claude/skills/pr-captain-land/SKILL.md
+src/claude/skills/pr-captain-land/examples.md
+src/claude/skills/pr-captain-land/reference.md
+src/claude/skills/pr-captain-land/scripts/pr-captain-land
+src/claude/skills/pr-submit/SKILL.md
+src/claude/skills/pr-submit/examples.md
+src/claude/skills/pr-submit/reference.md
+src/claude/skills/pr-submit/scripts/README.md
+src/tests/skills/pr-captain-land-helpers.bats
+src/tests/skills/pr-submit-helpers.bats
+src/tests/tools/diff-hash.bats
+usr/jordan/pr-submit-org-resolution/dispatches/commit-to-captain-committed-032f18d7-on-fix-pr-submit-org-resolution-20260808-1117.md
+```


### PR DESCRIPTION
Makes the PR-landing pipeline work on a **main**-default repo (this one, and the-agency itself — self-bootstrapping). It hardcoded `master` in several live places, so captain could not land ANY PR here — `pr-captain-land` aborted at receipt-verify (`diff-hash --base origin/master` resolves nothing) and switch/release targeted a nonexistent `master`. This was the parking brake on the fleet.

## Changes
- **pr-captain-land**: default-branch-aware (`resolve_default_branch`); sources shared tested helpers from pr-submit (no re-derived ORG/REPO); redacts remote on parse-failure (no PAT leak); zero live `master` hardcodes.
- **pr-submit**: added `parse_repo_from_remote`; consolidates F1 default-branch / F2 credential-leak / F3 dead-ERE fixes (surfaced by the mdpal-app + mdslidepal-mac agents) plus two more from QG (scheme-limited redaction, bypassable lib guard).
- **diff-hash**: excludes active + archived handoffs → fixes **receipt-churn** (a landing previously cost five re-signs).
- **pr-create**: `|| true` on the `head`/pipefail receipt search so SIGPIPE with 100+ receipts can't abort PR creation (silently blocked this repo at 120 receipts).
- **src/** source-of-truth copies synced to running; **docs** de-staled (`origin/master` → resolved default branch).

## Gate
79 relevant bats green. Full QG (4-lens): no correctness/security defects in the fix (credential-leak confirmed closed); guards hardened, docs corrected. QGR receipt `28c1331`.

**Deferred (follow-up):** converge the three default-branch resolvers (git-captain / pr-create / resolve_default_branch) into one shared lib.

🤖 Bootstrap-landed via the now-main-aware primitives.