### PR TITLE
feat(pr-lifecycle): local-first pr-captain-land v2 + shared default-branch primitive

### DIFF
--- a/.claude/skills/captain-release/reference.md
+++ b/.claude/skills/captain-release/reference.md
@@ -22,12 +22,16 @@ The bump happens AFTER the PR is created (Step 6) so the PR's diff shows the act
 |---|---|---|
 | Branch origin | captain creates the work on a captain-* branch | agent creates work on agent branch, submits via /pr-submit |
 | QG responsibility | captain runs /pr-prep before /captain-release | agent runs /pr-prep before /pr-submit |
-| Version bump | captain does it in this skill's Step 6 | captain does it in /pr-captain-land's Step 4 |
+| Validation gate | captain runs /pr-prep on the captain-* branch | **local**, in a scratch worktree, at /pr-captain-land Step 3 |
+| Version bump | captain does it in this skill's Step 6 | captain does it in /pr-captain-land's Step 4, **inside the scratch worktree** |
+| PR head branch | the captain-* branch itself | a short-lived `_land-<branch>`; the agent's branch is never checked out or modified |
 | PR creation | captain-authored description (this skill) | captain-authored description wrapping agent's scope |
-| Merge | separate subsequent `/pr-captain-merge` invocation | included as Step 7 of /pr-captain-land |
-| Release creation | separate subsequent `/pr-captain-post-merge` | included as Step 8 of /pr-captain-land |
+| Merge | separate subsequent `/pr-captain-merge` invocation | included as Step 8 of /pr-captain-land |
+| Release creation | separate subsequent `/pr-captain-post-merge` | included as Step 8 of /pr-captain-land; cleanup + reconcile are Step 9 |
 
 Rule of thumb: use `/captain-release` for captain-authored work. Use `/pr-captain-land` when captain is landing an agent's prepared branch.
+
+**Note on the version bump race.** Both skills bump `agency_version`, and neither takes a lock. `/pr-captain-land` v2 does its bump in an isolated scratch worktree cut from `origin/<default>`, so it cannot collide with a dirty captain-* checkout — but two bumps derived from the same base still produce the same next version. Do not run a `/captain-release` and a `/pr-captain-land` concurrently.
 
 ## Recovery flows
 

--- a/.claude/skills/captain-sync-all/reference.md
+++ b/.claude/skills/captain-sync-all/reference.md
@@ -46,12 +46,18 @@ When `/pr-captain-post-merge` runs as part of PR land flow, it invokes `/captain
 - Steps 4-7 propagate to fleet.
 - Step 8 (handoff) is included.
 
+## Idempotence with `/pr-captain-land`
+
+`/pr-captain-land` (v2, local-first) does **not** merge the agent's branch into local master. It integrates in a scratch worktree, publishes a PR, and then reconciles local master with a plain `git-captain merge-from-origin` at its Step 9.
+
+That means running `/captain-sync-all` after a land is a **no-op with respect to the landed work** — local master has already fast-forwarded to the server merge, so there is nothing left to double-merge. The reverse order is equally safe. This is deliberate: v1's "merge into local main, then publish" design made the two flows capable of double-integrating the same commits.
+
 ## Frequency
 
 Captain runs `/captain-sync-all` at:
 
 - **Session start** — to reconcile with any overnight/external PR merges.
-- **After each PR land** (automatic via `/pr-captain-post-merge`).
+- **After each PR land** — `/pr-captain-land` already reconciles local master at its Step 9, so this is a cheap confirmation that also propagates to every worktree.
 - **Session end** — optional; ensures next session starts clean.
 - **On demand** when captain notices worktree drift (agent reports "merge conflict on session-resume").
 

--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: pr-captain-land
-description: Captain-only. Land an agent's prepared branch — switch, verify receipt, bump agency_version, create PR, watch CI, merge, release, notify agent. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit (the-agency#296 Phase 1 pilot). The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-1 runtime precondition).
+description: Captain-only. Land an agent's prepared branch LOCAL-FIRST — integrate and validate in a scratch worktree cut from origin/<default>, then bump agency_version, sign a landing receipt, open the PR, confirm CI, merge, release, notify. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit. The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-0 runtime precondition).
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-1 runtime precondition refuses from wrong context.
-argument-hint: "<agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
+when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-0 runtime precondition refuses from wrong context.
+argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release]"
 paths: []
 required_reading:
   - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -16,8 +16,9 @@ required_reading:
   allowed-tools intentionally omitted — inherits Bash(*) from
   .claude/settings.json. Subcommand-level restriction silently blocked
   fleet agents (flag #62/#63; devex dispatch #171). This skill composes
-  git-safe, git-captain, git-push, git-safe-commit, pr-create,
-  pr-captain-merge, gh-release, dispatch, diff-hash, and gh — tool-level
+  git-safe, git-captain, git-push, git-safe-commit, worktree-create,
+  worktree-delete, pr-create, pr-merge, gh-release, dispatch, diff-hash,
+  receipt-sign, receipt-verify, resolve-default-branch, and gh — tool-level
   narrow restriction would work but needs maintenance. Inherit Bash(*).
   Defense in depth is layered via paths: [] + captain- name + runtime
   precondition (see "Captain-only — three-layer defense" below).
@@ -25,223 +26,234 @@ required_reading:
 
 # pr-captain-land
 
-Captain-side skill that lands an agent's prepared branch as a merged PR + GitHub release + fleet notification. Companion to `/pr-submit`. This is the single-writer serialization point for `agency_version` and PR creation — eliminates the version-bump and receipt-hash races the pre-v2 distributed model created.
+Captain-side skill that lands an agent's prepared branch as a merged PR + GitHub release + fleet notification. Companion to `/pr-submit`. The single-writer serialization point for `agency_version` and PR creation.
 
-**Name pattern:** `pr-` prefix groups with the PR skill family (so `/pr<tab>` autocomplete shows the full kit). `captain-` qualifier flags captain-only scope in the skill listing without requiring the reader to open SKILL.md.
+**v2 is LOCAL-FIRST.** The work is integrated and validated locally *before* a PR exists. GitHub is the publish step for already-validated work, not the reviewer.
+
+## The inversion
+
+The v1 flow was PR-first: switch the main checkout to the agent's branch, bump, push, open a PR, and let GitHub CI decide. Three structural problems:
+
+1. **Worktree collision.** Switching the main checkout to a branch the agent still has checked out in its own worktree fails outright. And switching at all makes the captain's checkout a moving target mid-land.
+2. **The wrong gate.** CI was the first thing that could say no. TheAgency's model is local review and validation.
+3. **No clean abort.** Any mid-flight failure left the main checkout parked on someone else's branch.
+
+v2 does not fix the rollback — it removes the thing that needed rolling back:
+
+> **The entire landing happens in a dedicated scratch worktree cut from `origin/<agent-branch>`. Local `main` is never read for content, never merged into, never reset, and never pushed. Rollback at any pre-publish failure is one action: delete the scratch worktree.**
+
+Validating against pristine `origin/<default>` is also strictly more correct than validating on the captain's local main, which routinely carries unpushed coordination commits and other worktrees' merges — none of which belong in the PR under test.
+
+### Invariants
+
+| Invariant | Why |
+|---|---|
+| The agent's branch is **never checked out** in the main checkout | Kills the worktree-collision bug by construction |
+| **`main`/`master` is never pushed** | All changes reach the default branch through a PR |
+| Local `main` is only ever moved by the final, idempotent `merge-from-origin` | No data-loss hazard, no double-integration with `/captain-sync-all` |
+| The agent's receipt is verified **before** the version bump | The bump edits `manifest.json`, which is inside the hashed file set (the #463 churn trap) |
+| `pr-create` is **not** weakened | Captain signs its own landing receipt instead |
 
 ## Why this exists
 
-Per the-agency#296 — one captain, one writer, one serialization point. Every PR, every version bump, every release goes through this skill when driven by an agent's `/pr-submit`.
-
-Pre-v2 (distributed PR ownership) failure modes this skill eliminates:
-
-- Agent A and agent B both run `/pr-prep` + `/pr-create` concurrently → both bump `agency_version` → one loses, the other's release tag is wrong.
-- Captain lands a coord commit on master between an agent's `/pr-prep` and that agent's `/pr-create` → the receipt's diff-hash no longer matches → `pr-create` blocks with a confusing error.
-- Agent opens PR with a one-line body → fleet reviewers can't tell what changed without diving into diff.
-
-Captain-owned: captain is serialized by definition (one captain), captain re-verifies the receipt at the moment of landing, captain authors a fleet-aware PR body that references agent + scope + receipt.
+Per the-agency#296 — one captain, one writer, one serialization point. Pre-v2 distributed PR ownership produced version-bump races (two agents bump `agency_version` concurrently), receipt-hash races (a captain coord commit lands between an agent's `/pr-prep` and its `/pr-create`), and one-line PR bodies that fleet reviewers could not triage.
 
 ## Required reading
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
 - `REFERENCE-CODE-REVIEW-LIFECYCLE.md` — end-to-end PR flow
-- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — five-hash chain, receipt re-verification semantics
-- `REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline (`pr-captain-merge` enforces)
+- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — five-hash chain, landing-receipt semantics
+- `REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
 - `REFERENCE-SAFE-TOOLS.md` — the safe-tool family this skill composes
 
-This skill's `reference.md` is the step-by-step land protocol with failure-mode recovery.
+`reference.md` is the step-by-step protocol with failure-mode recovery. `examples.md` has worked runs.
 
 ## Usage
 
 ```
 /pr-captain-land <agent-branch>
+/pr-captain-land <agent-branch> --rehearse
 /pr-captain-land <agent-branch> --dry-run
 /pr-captain-land <agent-branch> --title "Custom PR title"
+/pr-captain-land <agent-branch> --agent devex
 /pr-captain-land <agent-branch> --no-release
 ```
 
-- `<agent-branch>`: **required.** The branch that `/pr-submit` identified.
-- `--dry-run`: walk the preflight + preview the PR body; no mutation.
-- `--title`: override the default PR title (which derives from the agent's scope).
-- `--no-release`: skip Step 8 (release creation). Used when landing a PR that explicitly shouldn't cut a release (rare).
+- `<agent-branch>`: **required.** The branch `/pr-submit` identified.
+- `--rehearse`: run **steps 0-3 only** — integrate + validate, then delete the scratch. Nothing pushed, no PR, no bump, no receipt. **Rehearse first on any branch you have not landed before.**
+- `--dry-run`: `--rehearse` plus a printout of exactly what would be published.
+- `--title`: override the PR title (defaults to the branch name).
+- `--agent`: who to dispatch (defaults to the branch-name prefix).
+- `--no-release`: skip the GitHub release after merge (rare).
+
+Environment:
+
+- `PR_LAND_VALIDATE_CMD` — override the local validation command wholesale, for repos whose gate is not "package script + `commit-precheck`".
 
 ## Preconditions
 
-The script enforces **all** of these before any mutation; any failure exits non-zero with a clear error and no state change:
+Enforced before any mutation; failure exits non-zero with no state change.
 
-1. Running in the **main checkout** (first entry of `git worktree list`). Not in a `.claude/worktrees/` path.
-2. Current branch is `master` or `main`.
-3. Master tree is clean (`git status --porcelain` empty).
-4. **No pending post-merge (C#372 Fix B).** `./agency/tools/post-merge-state check` exits 0. If exit 1, a prior landed PR has not had its release cut — run `/pr-captain-post-merge <pending-PR>` first, then re-invoke.
-5. `<agent-branch>` exists on origin (`git ls-remote --heads origin <agent-branch>` non-empty).
-6. `<agent-branch>` passes safe-name validation: regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-7. Diff-hash of `<agent-branch>` vs `origin/<default-branch>` (resolved, not hardcoded) matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
+1. Running in the **main checkout** (first entry of `git worktree list`).
+2. Current branch is the resolved default branch.
+3. No leftover scratch worktree named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete`).
+4. `<agent-branch>` exists on origin.
+5. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
+6. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
 
-Any failure → zero mutation, clean error message, exit 1.
+**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues.
 
 ## Flow / Steps
 
-The script at `scripts/pr-captain-land` walks these nine steps. Full failure-mode detail is in `reference.md`.
+Script: `scripts/pr-captain-land`.
 
-### Step 1: Preflight
+### Step 0 — Preflight
 
-Verify all six preconditions. If any fail, exit 1.
+Main-checkout + branch checks, no-leftover-scratch check, `git-captain fetch`, and the default branch resolved via the shared `agency/tools/resolve-default-branch` primitive. **Local main is not read or written.**
 
-### Step 2: Switch to agent branch
+### Step 1 — Verify the branch and its base
 
-```
-./agency/tools/git-captain switch-branch <agent-branch>
-```
-
-Main checkout is now on agent's branch.
-
-### Step 3: Verify receipt against current state
+Branch must exist on origin. Then:
 
 ```
-./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
+git merge-base --is-ancestor origin/<default> origin/<agent-branch>
 ```
 
-Find receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`. If missing, agent's state drifted — switch back to master, exit 1, tell agent to re-run `/pr-prep` + `/pr-submit`.
+If the base has moved, the agent's receipt was signed against an older base and *can never* verify. That is BLOCKED with the real cause and the real fix — "merge `<default>` into your branch, re-run `/pr-prep`, push, re-run `/pr-submit`" — never a bare hash-mismatch error.
 
-### Step 4: Bump `agency_version`
-
-Read `agency/config/manifest.json`. Bump minor (e.g., `1.8 → 1.9`). Refresh `updated_at` to current UTC timestamp.
-
-**Security note:** version-bump is done via Python env-var substitution (`MANIFEST=... NEW_VER=... python3 -c '...os.environ[...]...'`), **not** f-string interpolation. This blocks code-injection via adversarial branch names. (Fix landed in `ccf054ad` per MAR finding F-SEC-1 / CRITICAL-3.)
-
-Commit via `git-safe-commit`:
+### Step 2 — Cut the scratch worktree
 
 ```
-chore(manifest): bump agency_version {old} → {new} for PR landing (captain)
+./agency/tools/worktree-create _land-<branch> --from origin/<agent-branch>
 ```
 
-Push to origin.
+This **is** the local integration: step 1 proved `origin/<default>` is an ancestor, so the scratch tree already represents the agent's work on top of the default branch. Slashes in the branch name collapse to dashes in the scratch name.
 
-### Step 5: Create PR
+### Step 2b — Verify the agent's QGR receipt
 
-```
-./agency/tools/pr-create --title "<title>" --body "<captain-authored fleet-aware body>"
-```
+`diff-hash --base origin/<default>` inside the scratch, find `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`, and `receipt-verify --file` it. **Before any mutation** — verifying after the bump would churn the receipt (#463).
 
-Title derives from agent's `--scope` or `--title` override. Body wraps agent's scope with:
+Failure → delete the scratch, tell the agent to re-run `/pr-prep`.
 
-- "Captain-landed PR via `pr-captain-land` (the-agency#296 Phase 1)"
-- Branch, receipt path, diff-hash, version bump
-- "Release `v{new}` will follow on merge"
+### Step 3 — VALIDATE LOCALLY. This is the gate.
 
-### Step 6: Switch back to master
+In the scratch, in order: build script, widest declared test script (`bats:all`, else `test`), then `commit-precheck`. `PR_LAND_VALIDATE_CMD` replaces all of it.
 
-```
-./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
-```
+- **Failure → delete the scratch, dispatch the agent naming the failing step, exit 1.** Nothing was published.
+- **No resolvable validation command → loud WARNING**, recorded in the landing receipt summary. It is never a silent pass.
 
-Captain sits on master during the CI-wait phase. Avoids any accidental commit on the PR branch.
+`--rehearse` / `--dry-run` stop here and delete the scratch.
 
-### Step 7: Watch CI
+### Step 4 — Bump `agency_version` in the scratch
 
-Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Only gates on `lint-and-test`.
+Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via `git-safe-commit`.
 
-| State | Action |
+**Security note:** the bump uses Python env-var substitution (`MANIFEST=... NEW_VER=... python3 -c '...os.environ[...]...'`), never f-string interpolation. Blocks code injection via adversarial branch names (MAR F-SEC-1 / CRITICAL-3, landed `ccf054ad`).
+
+### Step 5 — Sign the captain LANDING receipt
+
+`pr-create` is not bypassed or weakened. Instead the captain signs a receipt for the state it actually validated, extending the agent's chain:
+
+| Hash | Value |
 |---|---|
-| SUCCESS | proceed to Step 8 |
-| FAILURE | exit 1 — agent must fix + push + resubmit |
-| PENDING / IN_PROGRESS | wait 20s, poll again |
+| A | the agent receipt's `hash_e` (what was reviewed) |
+| B | hash of the local validation log |
+| C | B — nothing to triage, validation was green |
+| D | C — auto-approved, no principal 1B1 |
+| E | diff hash of the bumped tree vs `origin/<default>` |
 
-Max 30 attempts = 10 minutes. On timeout, exit 1.
+Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
-`deploy-preview-backend` is environmental flake and ignored by this skill.
+### Step 6 — Publish
 
-### Step 8: Merge + release
+Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms.
 
-Merge:
+**This is the first irreversible action.** Past here, failures report and leave the scratch in place for inspection rather than rolling back.
 
-```
-./agency/tools/pr-merge {pr-num} --principal-approved
-```
+### Step 7 — CI confirmation on the aggregate rollup
 
-True merge commit — never squash, never rebase (enforced by `pr-captain-merge` / underlying `pr-merge`).
+Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Where branch protection exposes a required-contexts list, narrow to it; otherwise gate on every check in the rollup.
 
-Sync master:
+| Rollup state | Action |
+|---|---|
+| every check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
+| any terminal failure (FAILURE, ERROR, TIMED_OUT, CANCELLED, …) | exit 1, fail fast, name the checks |
+| any check still pending | wait 20s, poll again |
+| **rollup empty** | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
 
-```
-./agency/tools/git-captain fetch
-./agency/tools/git-captain merge-from-origin
-```
+v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so the loop could only ever time out. The gate is now name-agnostic, and a regression test asserts that literal never returns.
 
-Release (unless `--no-release`):
-
-```
-./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
-```
-
-Release notes: captain-authored, references PR number + agent.
-
-### Step 9: Dispatch agent
+### Step 8 — Merge + release
 
 ```
-./agency/tools/dispatch create \
-  --to <agent-address> \
-  --type master-updated \
-  --subject "PR #{num} landed — v{new} released" \
-  --body "<PR URL, release URL, version bump, Phase 1 pilot feedback request>"
+./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-Agent picks up on next `/session-resume` or via dispatch monitor.
+True merge commit — never squash, never rebase.
+
+### Step 9 — Cleanup, notify, reconcile
+
+Delete the scratch worktree and the local land branch; dispatch `master-updated` to the agent; `post-merge-state clear`; then reconcile local main with `git-captain merge-from-origin`.
+
+The reconciliation is a **separate, idempotent** step on purpose: it is the same fast-forward `/captain-sync-all` performs, so running either afterwards is a no-op rather than a double-integration.
 
 ## Failure modes
 
-- **Preflight fails** (Step 1): exit 1, no mutation. Captain resolves (switch to main checkout, clean tree, ensure branch exists, verify agent submitted).
-- **Branch-name validation fails** (Step 1.5): rare — injection attempt or malformed branch. Exit 1. Agent renames.
-- **Receipt mismatch** (Step 3): master drifted. Exit 1 with switch-back-to-master. Agent re-runs `/pr-prep` + `/pr-submit`.
-- **Version-bump push fails** (Step 4): concurrent captain activity or branch-protection edge. Switch back to master, exit 1. Captain investigates.
-- **`pr-create` blocks on receipt** (Step 5): re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
-- **CI failure** (Step 7): version-bump commit stays on agent's branch; agent can fix + push + resubmit via `/pr-submit`. Version doesn't re-bump on retry (captain detects current == target).
-- **CI timeout** (Step 7): exit 1, captain investigates manually.
-- **Merge fails** (Step 8): likely branch-protection edge. Captain falls back to manual `/pr-captain-merge <num> --principal-approved`.
-- **Release creation fails** (Step 8): merge succeeded, release failed. Warn captain, suggest manual `gh release create`. Skill returns 0 because merge is the primary outcome. (MAR follow-up H13 tracks stricter semantics.)
-- **Dispatch emission fails** (Step 9): warn, exit 0. Merge + release are the authoritative record; dispatch is notification.
+| Where | What happens |
+|---|---|
+| Preflight (0) | Exit 1, zero mutation. |
+| Leftover scratch (0) | Exit 1 naming the path and the `worktree-delete` fix. Never auto-deletes someone else's in-flight land. |
+| Stale base (1) | BLOCK naming the real cause; agent merges default + re-preps. |
+| Receipt missing/invalid (2b) | Scratch deleted; agent re-runs `/pr-prep`. |
+| Local validation fails (3) | Scratch deleted, agent dispatched with the failing step. **Nothing published.** |
+| Bump or receipt-sign fails (4-5) | Scratch deleted. Nothing published. |
+| `pr-create` returns no URL (6) | Scratch **kept** for inspection; the land branch is pushed and must be cleaned up manually if abandoned. |
+| CI fails (7) | Exit 1. The local gate passed and the server disagreed — investigate before re-landing. |
+| CI timeout (7) | Exit 1 with the last verdict; check manually. |
+| Empty rollup (7) | Exit 1, distinct message. Merge via `/pr-captain-merge` if that is genuinely expected. |
+| Merge fails (8) | Fall back to `/pr-captain-merge <num> --principal-approved`. |
+| Release fails (8) | Warn — check whether auto-release already cut the tag. Merge is the primary outcome. |
+| Dispatch fails (9) | Warn only. Merge + release are the authoritative record. |
 
 ## What this does NOT do
 
-- **Does not write code.** Agent's branch is the substance; captain lands it as-is (plus the version-bump).
-- **Does not modify agent's existing commits.** Only appends the version-bump commit.
-- **Does not squash or rebase.** `pr-captain-merge` enforces true merge commit per framework discipline.
-- **Does not auto-retry on failure.** Failures need captain attention; no silent retries that mask real issues.
-- **Does not fire from an agent context.** Three-layer defense (below) makes this impossible.
+- **Does not write code.** The agent's branch is the substance.
+- **Does not modify the agent's branch.** The version bump and landing receipt go on the `_land-` branch; `<agent-branch>` is never checked out or pushed.
+- **Does not squash or rebase.**
+- **Does not touch local `main`** until the final reconcile.
+- **Does not auto-retry.**
+- **Does not fire from an agent context.**
 
 ## Captain-only — three-layer defense
 
-Defense in depth against accidental invocation from the wrong context:
+1. **`paths: []`** — no file-path auto-activation. (Contrast `pr-submit`, which has `paths: [.claude/worktrees/**]`.)
+2. **Name contains `captain-`** — scope visible in the skill list.
+3. **Runtime precondition** — Step 0 refuses unless in the main checkout on the default branch.
 
-1. **`paths: []`** (intentionally empty) — no file-path auto-activation. (Contrast with `pr-submit` which has `paths: [.claude/worktrees/**]`.)
-2. **Name contains `captain-`** — any human or agent browsing the skill list sees scope at a glance.
-3. **Runtime precondition** — script's Step 1 refuses unless in main checkout on master.
-
-Any single layer failing is caught by the next. All three must fail simultaneously for an unauthorized invocation to land a PR.
-
-(Historically `disable-model-invocation: true` was a fourth layer. That flag was removed 2026-04-20 because the captain session IS the principal's session — DMI was blocking the captain from invoking captain-* skills. See `REFERENCE-SKILL-CONVENTIONS.md` §1.)
+(Historically `disable-model-invocation: true` was a fourth layer, removed 2026-04-20: the captain session IS the principal's session, and DMI blocked the captain from invoking captain-* skills. See `REFERENCE-SKILL-CONVENTIONS.md` §1.)
 
 ## Status
 
-`active` (v2, agency-skill-version 2 from birth — Phase 1 pilot for the-agency#296). Scripts hardened in `ccf054ad` per MAR findings (Python env-var substitution + branch-name validation). Ready for fleet-wide dogfood on next agent PRs.
+`active` — v2 local-first, per `usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md` (MAR-reviewed). Invariants pinned by `src/tests/skills/pr-captain-land-localfirst.bats`; the v1 master-hardcode guards remain in `src/tests/skills/pr-captain-land-helpers.bats`.
+
+**Rehearse before the first land of any branch.** `--rehearse` exercises steps 0-3 with zero side effects.
 
 ## Related
 
 - `/pr-submit` — agent-side companion; this skill consumes its dispatch
-- `/pr-captain-merge` — the merge primitive this skill calls at Step 8
-- `/pr-prep` — the QG-before-PR-create that signs the receipt this skill re-verifies
-- `/pr-captain-post-merge` — alternative entry for post-merge tasks (release + fleet-notify) when landing was done manually
-- `agency/tools/pr-create` — PR creation tool (receipt-aware)
-- `agency/tools/pr-merge` — safe-merge primitive (underlies `/pr-captain-merge`)
-- `agency/tools/gh-release` — release creation wrapper
-- `agency/tools/dispatch` — ISCP dispatch tool
-- `agency/tools/diff-hash` — receipt-matching hash
-- `reference.md` — full step-by-step protocol + recovery flows
-- `examples.md` — happy-path + failure-mode examples
+- `/pr-captain-merge` — the merge primitive used at Step 8
+- `/pr-prep` — the QG that signs the receipt verified at Step 2b
+- `/pr-captain-post-merge` — post-merge tasks when a landing was done manually
+- `/captain-sync-all` — the daily integration rhythm; idempotent with Step 9
+- `agency/tools/resolve-default-branch` — the shared default-branch primitive (v2)
+- `agency/tools/worktree-create --from <ref>` — how the scratch is cut (v2)
+- `agency/tools/pr-create`, `pr-merge`, `gh-release`, `dispatch`, `diff-hash`, `receipt-sign`, `receipt-verify`
+- `reference.md` — full protocol + recovery flows
+- `examples.md` — happy path, rehearsal, and failure-mode runs
 - the-agency#296 — PR lifecycle ownership design
-- the-agency#298 — skill refactor recommendation
-- the-agency#314 — upstream package MAR summary (this skill's scripts hardened there)
-- the-agency#315 — V1→V2 migration master issue
+- the-agency#393 — session-end dirty handoff (largely mooted by scratch isolation)
+- the-agency#463 — receipt churn from verifying after the bump
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -3,7 +3,7 @@ name: pr-captain-land
 description: Captain-only. Land an agent's prepared branch LOCAL-FIRST — integrate and validate in a scratch worktree cut from origin/<default>, then bump agency_version, sign a landing receipt, open the PR, confirm CI, merge, release, notify. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit. The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-0 runtime precondition).
 agency-skill-version: 2
 when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-0 runtime precondition refuses from wrong context.
-argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release]"
+argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release] [--principal-approved] [--allow-unvalidated]"
 paths: []
 required_reading:
   - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -86,23 +86,28 @@ Before running, Read the files listed in `required_reading:` frontmatter.
 - `--title`: override the PR title (defaults to the branch name).
 - `--agent`: who to dispatch (defaults to the branch-name prefix).
 - `--no-release`: skip the GitHub release after merge (rare).
+- `--principal-approved`: forward `--admin` to `pr-merge`, bypassing branch protection. **Pass only when the principal actually said so.** Without it the merge defers to GitHub's own gates. It is also recorded in the landing receipt's `hash_d_source`.
+- `--allow-unvalidated`: land even when no local validation command resolves. Without it that case **aborts** (see Step 3). Recorded verbatim in the receipt.
 
 Environment:
 
-- `PR_LAND_VALIDATE_CMD` — override the local validation command wholesale, for repos whose gate is not "package script + `commit-precheck`".
+- `PR_LAND_VALIDATE_CMD` — replace the local validation ladder wholesale, for repos whose gate is not a package build/test script. Run with `bash -c` inside the scratch worktree.
 
 ## Preconditions
 
 Enforced before any mutation; failure exits non-zero with no state change.
 
 1. Running in the **main checkout** (first entry of `git worktree list`).
-2. Current branch is the resolved default branch.
-3. No leftover scratch worktree named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete`).
-4. `<agent-branch>` exists on origin.
-5. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-6. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
+2. No leftover scratch worktree **or branch** named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete` + `git-captain branch-delete`).
+3. No pending post-merge state (C#372 Fix B) — a prior merge whose release was never cut must be finished first.
+4. `git-captain fetch` succeeds. **This is fatal, not best-effort**: every guarantee below assumes origin refs are current.
+5. `<agent-branch>` exists on origin.
+6. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
+7. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
 
-**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues.
+**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues. (One caveat: the Step-9 reconcile is a `merge-from-origin`, which does require a clean tree — a dirty checkout means that last step is skipped with a note, and `/captain-sync-all` picks it up later.)
+
+**Which branch the main checkout is on is also not load-bearing** — that was v1 coupling. The script notes it and continues.
 
 ## Flow / Steps
 
@@ -110,7 +115,7 @@ Script: `scripts/pr-captain-land`.
 
 ### Step 0 — Preflight
 
-Main-checkout + branch checks, no-leftover-scratch check, `git-captain fetch`, and the default branch resolved via the shared `agency/tools/resolve-default-branch` primitive. **Local main is not read or written.**
+Main-checkout check, leftover-scratch check (directory **and** branch), pending-post-merge check, and a **fatal** `git-captain fetch`. The default branch is resolved via the shared `agency/tools/resolve-default-branch` primitive, which probes `origin/HEAD` first — a stale local `main` must never outvote the remote's own answer, because every consumer turns the result into `origin/<name>`. **Local main is not read or written.**
 
 ### Step 1 — Verify the branch and its base
 
@@ -138,10 +143,14 @@ Failure → delete the scratch, tell the agent to re-run `/pr-prep`.
 
 ### Step 3 — VALIDATE LOCALLY. This is the gate.
 
-In the scratch, in order: build script, widest declared test script (`bats:all`, else `test`), then `commit-precheck`. `PR_LAND_VALIDATE_CMD` replaces all of it.
+In the scratch, in order: build script, then the widest declared test script (`bats:all`, else `test`). The package manager comes from `agency/tools/pkg-manager`. `PR_LAND_VALIDATE_CMD` replaces all of it.
+
+Each step runs with the captain's credentials scrubbed from the environment (`GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, …). The command comes from the branch under review and its output is tailed to stderr on failure, so a `build` script of `gh auth token` must not be able to put the PAT into the transcript. This is defence in depth, not a sandbox — validating a branch locally means running its code.
 
 - **Failure → delete the scratch, dispatch the agent naming the failing step, exit 1.** Nothing was published.
-- **No resolvable validation command → loud WARNING**, recorded in the landing receipt summary. It is never a silent pass.
+- **No resolvable validation command → ABORT.** A landing with no local gate is the old PR-first flow with extra steps, and it would sign a five-hash receipt attesting to a gate that never ran. Override with `--allow-unvalidated`, which is recorded in the receipt.
+
+`commit-precheck` is deliberately **not** in this ladder: it gates on staged files and the scratch tree is clean here, so it would exit 0 having inspected nothing while still counting as a step. It runs where it means something — `git-safe-commit` invokes it on the Step-4 and Step-5 commits.
 
 `--rehearse` / `--dry-run` stop here and delete the scratch.
 
@@ -160,7 +169,7 @@ Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via
 | A | the agent receipt's `hash_e` (what was reviewed) |
 | B | hash of the local validation log |
 | C | B — nothing to triage, validation was green |
-| D | C — auto-approved, no principal 1B1 |
+| D | C. `hash_d_source` records the truth: `auto-approved — no principal 1B1`, or the `--principal-approved` attestation when that flag was passed |
 | E | diff hash of the bumped tree vs `origin/<default>` |
 
 Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
@@ -173,25 +182,30 @@ Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The l
 
 ### Step 7 — CI confirmation on the aggregate rollup
 
-Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Where branch protection exposes a required-contexts list, narrow to it; otherwise gate on every check in the rollup.
+Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Classification is `agency/tools/ci-rollup-verdict` — a pure function of (rollup, required contexts), table-tested in `src/tests/tools/ci-rollup-verdict.bats`.
 
 | Rollup state | Action |
 |---|---|
-| every check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
+| every gated check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
 | any terminal failure (FAILURE, ERROR, TIMED_OUT, CANCELLED, …) | exit 1, fail fast, name the checks |
-| any check still pending | wait 20s, poll again |
-| **rollup empty** | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
+| any gated check still pending | wait 20s, poll again |
+| a **required** context that has not reported at all | PENDING — 1-of-3 required checks green must not read as green |
+| **rollup empty**, past a 3-minute grace window | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
+
+The grace window matters: GitHub has usually registered no check runs in the first seconds after a PR opens, so treating an empty rollup as immediately fatal would abort nearly every real land.
 
 v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so the loop could only ever time out. The gate is now name-agnostic, and a regression test asserts that literal never returns.
 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
 ./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-True merge commit — never squash, never rebase.
+True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure.
+
+If no release was cut (`--no-release`, or `gh-release` failed), the pending post-merge state is deliberately **left set** — that guard exists precisely for "merged but release not cut".
 
 ### Step 9 — Cleanup, notify, reconcile
 
@@ -204,7 +218,11 @@ The reconciliation is a **separate, idempotent** step on purpose: it is the same
 | Where | What happens |
 |---|---|
 | Preflight (0) | Exit 1, zero mutation. |
-| Leftover scratch (0) | Exit 1 naming the path and the `worktree-delete` fix. Never auto-deletes someone else's in-flight land. |
+| Fetch fails (0) | Exit 1. Stale origin refs would make every downstream check meaningless. |
+| Pending post-merge (0) | Exit 1. Finish the prior release with `/pr-captain-post-merge` first. |
+| Leftover scratch or land branch (0) | Exit 1 naming the path and the cleanup commands. Never auto-deletes someone else's in-flight land — cleanup only touches a scratch this run created. |
+| No local gate resolves (3) | **Abort**, unless `--allow-unvalidated`. |
+| Any `set -e` abort before publish | An EXIT trap deletes the scratch, so an unhandled error cannot strand it and wedge the next land. |
 | Stale base (1) | BLOCK naming the real cause; agent merges default + re-preps. |
 | Receipt missing/invalid (2b) | Scratch deleted; agent re-runs `/pr-prep`. |
 | Local validation fails (3) | Scratch deleted, agent dispatched with the failing step. **Nothing published.** |
@@ -248,6 +266,9 @@ The reconciliation is a **separate, idempotent** step on purpose: it is the same
 - `/pr-captain-post-merge` — post-merge tasks when a landing was done manually
 - `/captain-sync-all` — the daily integration rhythm; idempotent with Step 9
 - `agency/tools/resolve-default-branch` — the shared default-branch primitive (v2)
+- `agency/tools/pkg-manager` — resolves the package manager for the validation ladder (v2)
+- `agency/tools/ci-rollup-verdict` — the CI gate's classification, extracted and table-tested (v2)
+- `agency/tools/agency-version-next` — the `agency_version` bump policy (v2)
 - `agency/tools/worktree-create --from <ref>` — how the scratch is cut (v2)
 - `agency/tools/pr-create`, `pr-merge`, `gh-release`, `dispatch`, `diff-hash`, `receipt-sign`, `receipt-verify`
 - `reference.md` — full protocol + recovery flows

--- a/.claude/skills/pr-captain-land/examples.md
+++ b/.claude/skills/pr-captain-land/examples.md
@@ -40,7 +40,7 @@ pr-captain-land: rehearsal complete — integrated + validated, nothing publishe
     PR title:    jordan-devex-d12-r3
     Head branch: _land-jordan-devex-d12-r3 (pushed from the scratch worktree)
     Base branch: main
-    Agent to notify: jordan
+    Agent to notify: devex
     Release:     yes, v<bumped version>
 ```
 
@@ -102,8 +102,14 @@ The dispatch target defaults to the branch-name prefix, which is a guess. Overri
 /pr-captain-land fix/pr-submit-org-resolution --agent devex
 ```
 
-(That branch would land via scratch worktree `_land-fix-pr-submit-org-resolution` —
-slashes collapse to dashes.)
+The default is the branch-name prefix, checked against the agent registry. For
+`fix/pr-submit-org-resolution` that guess is `fix`, which is not a registered
+agent — the script says so and routes to captain instead. Pass `--agent` and
+the author actually hears that their work landed.
+
+(That branch lands via scratch worktree `_land-fix-pr-submit-org-resolution` —
+slashes *and dots* collapse to dashes, so `captain-grm-v1.2` becomes
+`_land-captain-grm-v1-2`.)
 
 ### Land without cutting a release
 
@@ -202,21 +208,65 @@ pr-captain-land: no status checks found on PR #470.
 
 An empty rollup is never treated as green.
 
-### No local validation command resolved
+### No local validation command resolved — this ABORTS
 
 ```
-WARNING: no local validation command resolved for this repo.
-  Set PR_LAND_VALIDATE_CMD, or declare a build/test script.
-  Landing continues, but local-first validation did NOT happen.
-```
+pr-captain-land: no local validation command resolved for this repo — refusing to land.
+  The local gate is the whole point of this flow; signing a landing receipt
+  for a validation that did not happen would make the receipt a lie.
 
-The landing proceeds, but the warning is also written into the landing
-receipt's summary so the audit trail records that the local gate was empty.
+  Fix one of these:
+    - declare a build/test script in package.json, or
+    - set PR_LAND_VALIDATE_CMD='<your gate>', or
+    - pass --allow-unvalidated to land anyway (recorded in the receipt).
+  Rolled back: scratch worktree _land-some-branch deleted. Nothing was published.
+```
 
 Fix it for the repo:
 
 ```
 PR_LAND_VALIDATE_CMD='make ci' /pr-captain-land some-branch --rehearse
+```
+
+Or, knowingly, land without a gate — the receipt records
+`NO LOCAL VALIDATION RAN (--allow-unvalidated)` so the audit trail is honest:
+
+```
+/pr-captain-land some-branch --allow-unvalidated
+```
+
+### Branch protection blocks the merge
+
+```
+pr-captain-land: pr-merge failed on PR #470:
+  BLOCKED: branch protection requires 1 approving review
+
+  If branch protection is the blocker and the principal approved,
+  re-run with --principal-approved, or merge via /pr-captain-merge.
+```
+
+`--principal-approved` is never asserted on your behalf. It is the captain's
+attestation that the principal actually said yes, and the only route to
+`gh pr merge --admin`.
+
+### A previous land crashed and left a scratch behind
+
+```
+pr-captain-land: land branch _land-devex-x already exists (no worktree).
+  A previous land crashed mid-cleanup. Inspect it, then:
+    ./agency/tools/git-captain branch-delete _land-devex-x --force
+```
+
+Both the directory and the branch are checked, because a crash between
+`worktree add -b` and `worktree remove` leaves only the branch — and
+`worktree-create` then refuses on every retry.
+
+### A prior merge never got its release
+
+```
+pr-captain-land: a previous PR merge has no release yet.
+  {"pr": 468, "base": "main"}
+  Run /pr-captain-post-merge <that-PR> first, then re-run this land.
 ```
 
 ### Running from the wrong place
@@ -235,4 +285,24 @@ note: main checkout is dirty — harmless here (the land runs in a scratch workt
 ```
 
 In v1 this was a hard stop (#393). The land no longer touches local main, so
-uncommitted captain work is simply irrelevant to it.
+uncommitted captain work is simply irrelevant to it. One caveat: the Step-9
+reconcile is a `merge-from-origin`, which does need a clean tree — on a dirty
+checkout it is skipped with a note and `/captain-sync-all` picks it up.
+
+Same for the branch the checkout happens to be on:
+
+```
+note: main checkout is on 'captain-coord-20260810', not 'main' — harmless
+      (the land runs in a scratch worktree).
+```
+
+### Cannot reach origin
+
+```
+pr-captain-land: could not fetch origin.
+  The land validates against origin/<default>; stale refs would make
+  every downstream check meaningless. Fix connectivity/auth and retry.
+```
+
+The fetch is fatal, not best-effort — validating against stale refs and then
+publishing is the failure this whole flow exists to prevent.

--- a/.claude/skills/pr-captain-land/examples.md
+++ b/.claude/skills/pr-captain-land/examples.md
@@ -1,184 +1,238 @@
-# pr-captain-land — examples
+# pr-captain-land — examples (v2, local-first)
 
-## Happy-path examples
+All output below is illustrative but shaped like the real thing. The one habit
+worth forming: **rehearse first.**
 
-### Captain lands agent's PR end-to-end
+---
 
-Captain is on master, main checkout, tree clean. Agent dispatched `/pr-submit` for branch `jordan-devex-d12-r3`:
+## Rehearse before you land
+
+`--rehearse` runs steps 0-3 — fetch, verify the branch and its base, cut the
+scratch worktree, validate locally — then deletes the scratch. Nothing is
+pushed. No PR, no version bump, no receipt, no release, no dispatch.
 
 ```
-/pr-captain-land jordan-devex-d12-r3
+/pr-captain-land jordan-devex-d12-r3 --rehearse
 ```
 
-Expected flow:
-
 ```
-[pr-captain-land] Preflight OK: main-checkout=ok, branch=master, tree=clean, remote-branch=exists, receipt=found
-[pr-captain-land] Switched to jordan-devex-d12-r3
-[pr-captain-land] Receipt verified: hash 8b4c2e1 matches qgr-pr-prep-20260419-1430-8b4c2e1.md
-[pr-captain-land] Bumping agency_version 1.9 → 1.10
-[pr-captain-land] Pushed chore(manifest) commit to origin/jordan-devex-d12-r3
-[pr-captain-land] Created PR #118: "devex: fix worktree-sync MAIN_BRANCH resolution"
-[pr-captain-land] Switched back to master
-[pr-captain-land] CI check (lint-and-test): PENDING... SUCCESS (attempt 4 of 30, 80s)
-[pr-captain-land] Merging PR #118 via pr-merge --principal-approved
-[pr-captain-land] Merged. Syncing master... fetched + merged origin/master
-[pr-captain-land] Released v1.10 on GitHub
-[pr-captain-land] Dispatched <org>/jordan/devex: "PR #118 landed — v1.10 released"
-✓ Land complete. Size: M, ~3-10 minutes (CI wait dominates).
+→ Fetching origin...
+→ Branch origin/jordan-devex-d12-r3 is current with origin/main
+→ Creating scratch worktree _land-jordan-devex-d12-r3 at origin/jordan-devex-d12-r3...
+→ Agent receipt verified: agency/workstreams/devex/qgr/…-8b4c2e1.md (hash: 8b4c2e1)
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+  · commit-precheck
+→ Local validation: PASSED (2 local validation step(s) passed against origin/main)
+
+pr-captain-land: rehearsal complete — integrated + validated, nothing published.
 ```
 
-### Dry-run to preview
-
-Captain wants to see the PR body before committing:
+`--dry-run` is the same run plus a printout of what would be published:
 
 ```
 /pr-captain-land jordan-devex-d12-r3 --dry-run
 ```
 
-Expected: walks Steps 1-4 (precondition check + receipt verify + version-bump preview + PR body compose) and stops before mutation. Prints the proposed PR title, body, and version bump target. Exit 0.
-
-### Custom title override
-
 ```
-/pr-captain-land jordan-devex-d12-r3 --title "[devex] Critical: fix worktree-sync for all fleet agents"
-```
-
-Uses the override instead of the agent's scope.
-
-### Land without release
-
-Rare — a PR that shouldn't cut a release (e.g., a doc-only amendment to a prior release):
-
-```
-/pr-captain-land jordan-captain-d41-r22-doc-fix --no-release
+…
+[DRY-RUN] Would publish:
+    PR title:    jordan-devex-d12-r3
+    Head branch: _land-jordan-devex-d12-r3 (pushed from the scratch worktree)
+    Base branch: main
+    Agent to notify: jordan
+    Release:     yes, v<bumped version>
 ```
 
-Steps 1–7 run; Step 8 skips release creation; Step 9 dispatches agent without a release URL.
+---
 
-## Failure-mode examples
+## Happy path — full land
 
-### Not in main checkout
-
-Captain accidentally invokes from a worktree:
+Captain on `main` in the main checkout. Agent dispatched `/pr-submit` for
+`jordan-devex-d12-r3`.
 
 ```
 /pr-captain-land jordan-devex-d12-r3
 ```
 
 ```
-[pr-captain-land] ERROR: Preflight failed — not in main checkout.
-  Current: /Users/{principal}/code/{repo}/.claude/worktrees/devex
-  Expected: main checkout (first entry of `git worktree list`)
-  Fix: cd to main checkout and re-run, OR use /pr-submit if you're an agent.
+→ Fetching origin...
+→ Branch origin/jordan-devex-d12-r3 is current with origin/main
+→ Creating scratch worktree _land-jordan-devex-d12-r3 at origin/jordan-devex-d12-r3...
+→ Agent receipt verified: agency/workstreams/devex/qgr/…-8b4c2e1.md (hash: 8b4c2e1)
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+  · commit-precheck
+→ Local validation: PASSED (2 local validation step(s) passed against origin/main)
+→ Bumping agency_version 46.25 → 46.26 (in scratch)
+→ Signing captain landing receipt (hash_e: 3f19ad0)...
+→ Pushing _land-jordan-devex-d12-r3...
+→ Creating PR...
+→ PR created: https://github.com/the-agency-ai/the-agency/pull/470 (#470)
+→ Waiting for CI on PR #470 (aggregate status check rollup)...
+→ CI green: bash 3.2 probe,manifest version,smoke
+→ Merging PR #470 (true merge commit)...
+→ Creating release v46.26...
+→ Cleaning up scratch worktree and land branch...
+→ Dispatching devex with merge outcome...
+→ Reconciling local main with origin...
+
+pr-captain-land: complete
+  Branch:  jordan-devex-d12-r3 (via _land-jordan-devex-d12-r3)
+  PR:      https://github.com/the-agency-ai/the-agency/pull/470
+  Release: v46.26
+  Gate:    local (2 local validation step(s) passed against origin/main), CI confirmed
 ```
 
-Exit 1. Zero mutation. (Runtime precondition — Layer 4 of the captain-only defense.)
+Note what did **not** happen: the main checkout never switched branches, the
+agent's branch was never modified, and local `main` moved only at the very end,
+by a plain fast-forward from origin.
 
-### Agent branch name fails validation
-
-Rare — adversarial branch name or typo:
-
-```
-/pr-captain-land "evil; rm -rf /"
-```
+### Custom title
 
 ```
-[pr-captain-land] ERROR: Invalid branch name.
-  Provided: "evil; rm -rf /"
-  Required: regex ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$, no '..', no leading '-'
+/pr-captain-land jordan-devex-d12-r3 --title "[devex] Fix worktree-sync for all fleet agents"
 ```
 
-Exit 1. (Branch-name validation from ccf054ad / MAR finding F-SEC-2.)
+### Explicit agent to notify
 
-### Receipt mismatch (most common legit failure)
-
-Captain's coord commits landed on master between agent's `/pr-prep` and captain's `/pr-captain-land`. Agent's receipt hash no longer matches:
+The dispatch target defaults to the branch-name prefix, which is a guess. Override it:
 
 ```
-[pr-captain-land] Preflight OK
-[pr-captain-land] Switched to jordan-devex-d12-r3
-[pr-captain-land] ERROR: No receipt matches current diff-hash (c1d2e3f).
-  Searched: agency/workstreams/**/qgr/*qgr-pr-prep-*-c1d2e3f.md (0 matches)
-  The agent's receipt was signed against an older origin/master baseline.
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Dispatching agent: "Receipt stale — re-run /pr-prep + /pr-submit."
+/pr-captain-land fix/pr-submit-org-resolution --agent devex
 ```
 
-Exit 1. Captain is back on master, agent is notified, no partial state.
+(That branch would land via scratch worktree `_land-fix-pr-submit-org-resolution` —
+slashes collapse to dashes.)
 
-### CI failure
-
-```
-[pr-captain-land] ... (steps 1-6 succeed)
-[pr-captain-land] CI check (lint-and-test): PENDING... FAILURE (attempt 2 of 30, 40s)
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Dispatching agent: "CI failed — fix and re-submit. Version bump commit (abc1234) stays on your branch."
-```
-
-Exit 1. Version-bump commit is on the agent's branch; they can push more fixes on top. On re-submit, `pr-captain-land` detects current version == target and skips re-bump.
-
-### CI timeout
-
-10-minute wait elapsed with no resolution:
+### Land without cutting a release
 
 ```
-[pr-captain-land] CI check (lint-and-test): still PENDING after 30 attempts (10min)
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Timeout — captain investigate manually. PR #118 open at https://github.com/...
+/pr-captain-land jordan-captain-d41-r22-doc-fix --no-release
 ```
 
-Exit 1. Captain uses `gh pr checks 118` + whatever manual resolution.
+Steps 0-8 run; the release is skipped; the agent dispatch omits the release URL.
 
-### Merge fails after green CI
+---
 
-Unusual — likely branch-protection edge:
+## Failure modes
 
-```
-[pr-captain-land] CI green. Merging via pr-merge --principal-approved.
-[pr-captain-land] ERROR: pr-merge exit 3 (branch protection blocked).
-  Fallback: run /pr-captain-merge 118 --principal-approved manually.
-```
-
-Exit 1. Release is skipped. Captain resolves via the companion skill.
-
-### Release creation fails but merge succeeded
-
-Most common: GitHub release API hiccup:
+### Stale base — the most common block
 
 ```
-[pr-captain-land] Merged PR #118 successfully.
-[pr-captain-land] gh-release create v1.10 FAILED: ...
-[pr-captain-land] WARN: merge is the primary outcome (success). Release creation deferred.
-  Captain: run `gh release create v1.10 --target main --notes-file ...` manually.
-[pr-captain-land] Dispatched agent with merge confirmation (no release URL).
+/pr-captain-land jordan-mdpal-app-phase3
 ```
 
-Exit 0 because merge is authoritative. (MAR follow-up H13 proposes stricter semantics — track there.)
+```
+→ Fetching origin...
 
-### Dispatch emission fails at the end
+BLOCKED: 'jordan-mdpal-app-phase3' does not contain origin/main (4 commit(s) behind).
+
+  Its QGR receipt was signed against an older base, so it can never
+  verify against the current one. This is not a receipt bug.
+
+  Agent action: merge main into jordan-mdpal-app-phase3, re-run /pr-prep,
+                push, then re-run /pr-submit.
+```
+
+Nothing was created. This is the message you want instead of a bare hash
+mismatch — it names the cause and the fix.
+
+### Local validation fails — the whole point of v2
 
 ```
-[pr-captain-land] Merged + released successfully.
-[pr-captain-land] WARN: dispatch emission failed (ISCP tool error).
-  Agent will see the PR landed on next /sync, even without the dispatch.
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+
+── local validation output (tail) ──
+not ok 41 worktree-sync: resolves MAIN_BRANCH from origin/HEAD
+…
+────────────────────────────────────
+
+pr-captain-land: local validation failed at step 'tests' — see output above.
+  Rolled back: scratch worktree _land-jordan-devex-d12-r3 deleted. Nothing was published.
 ```
 
-Exit 0. Merge + release are the authoritative record.
+No PR was opened. No version was bumped. No release exists. The agent gets a
+dispatch naming the failing step and re-preps. In v1 this failure would have
+surfaced on GitHub *after* a version bump had already been pushed to the
+agent's branch.
 
-## Four-layer defense in action
+### Receipt does not match the branch
 
-Each of the four defense layers has caught a different incident in development:
+```
+pr-captain-land: no QGR receipt matching hash 8b4c2e1 on branch jordan-devex-d12-r3.
+  The branch content and the newest receipt disagree.
+  Agent action: re-run /pr-prep, push, re-run /pr-submit.
+```
 
-1. **`disable-model-invocation: true`** — prevented an auto-tool-use accidentally firing during a multi-turn coord dialog
-2. **`paths: []`** — prevented the skill from auto-surfacing when captain opened a file under `.claude/worktrees/*/` (which is where this skill definitely should not fire)
-3. **`captain-` name qualifier** — a new agent browsing the skill list asked "wait, is this captain-only?" → answered by the name before even reading SKILL.md
-4. **Runtime precondition** — caught a case where the first three layers were all bypassed (captain copied the script to a worktree sandbox to test) and the script refused to run because `pwd` wasn't the main checkout
+Scratch deleted. Nothing published.
 
-Defense in depth works.
+### Leftover scratch from a crashed run
 
-## Concurrency note
+```
+pr-captain-land: scratch worktree _land-jordan-devex-d12-r3 already exists at
+  /Users/jdm/code/the-agency/.claude/worktrees/_land-jordan-devex-d12-r3
+  A previous land is still running, or crashed. Inspect it, then:
+    ./agency/tools/worktree-delete _land-jordan-devex-d12-r3 --force
+```
 
-**Never run two `/pr-captain-land` simultaneously.** Phase 1 pilot enforces this by captain discipline (one captain, one sequential skill). Phase 2 adds a lockfile at `$HOME/.agency/{repo}/pr-captain-land.lock`.
+The script never auto-deletes a pre-existing scratch — it could be another land
+in flight.
 
-Captain CAN run other non-land work concurrently (dispatch reads, flag triage, reviewer-agent launches). Just not two lands.
+### CI red after a green local gate
+
+```
+pr-captain-land: CI FAILED on PR #470 — failing checks: smoke
+  The local gate passed but the server disagreed. Investigate before re-landing.
+  Agent must fix, push, and re-submit via /pr-submit.
+```
+
+Worth reading carefully: local and server disagreeing is a signal about the
+validation ladder, not just about the branch.
+
+### No status checks at all
+
+```
+pr-captain-land: no status checks found on PR #470.
+  This is NOT a pass. Either CI is not configured for this repo,
+  or the required-contexts filter matched nothing.
+  Merge manually with /pr-captain-merge if that is expected.
+```
+
+An empty rollup is never treated as green.
+
+### No local validation command resolved
+
+```
+WARNING: no local validation command resolved for this repo.
+  Set PR_LAND_VALIDATE_CMD, or declare a build/test script.
+  Landing continues, but local-first validation did NOT happen.
+```
+
+The landing proceeds, but the warning is also written into the landing
+receipt's summary so the audit trail records that the local gate was empty.
+
+Fix it for the repo:
+
+```
+PR_LAND_VALIDATE_CMD='make ci' /pr-captain-land some-branch --rehearse
+```
+
+### Running from the wrong place
+
+```
+pr-captain-land: must run from main checkout (you're in a worktree).
+  Main checkout: /Users/jdm/code/the-agency
+  Current:       /Users/jdm/code/the-agency/.claude/worktrees/devex
+```
+
+### A dirty main checkout is fine now
+
+```
+note: main checkout is dirty — harmless here (the land runs in a scratch worktree).
+→ Fetching origin...
+```
+
+In v1 this was a hard stop (#393). The land no longer touches local main, so
+uncommitted captain work is simply irrelevant to it.

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -1,158 +1,245 @@
-# pr-captain-land Protocol
+# pr-captain-land Protocol (v2 — local-first)
 
 Full step-by-step execution flow for `/pr-captain-land`, with failure modes and recovery paths. This document is the contract; the script at `scripts/pr-captain-land` implements it.
 
-## Preconditions checklist
+**Protocol version 2.0.** v1 was PR-first: switch the main checkout to the agent's branch, push, open a PR, let GitHub CI gate. v2 inverts that — integrate and validate locally in a scratch worktree, then publish already-validated work.
 
-Before any mutation, the script must verify ALL of these:
+---
+
+## The core idea
+
+Everything happens in a **scratch worktree** at `.claude/worktrees/_land-<branch>`, cut from `origin/<agent-branch>`.
+
+```
+origin/<default> ──ancestor-of──▶ origin/<agent-branch>
+                                        │
+                                        │ worktree-create --from
+                                        ▼
+                         .claude/worktrees/_land-<branch>   ← all work happens here
+                                        │
+                        validate → bump → sign → push → PR
+```
+
+The main checkout stays on the default branch, untouched, for the whole run. **Rollback at any pre-publish failure is `worktree-delete _land-<branch> --force`** — there is no `git reset --hard`, no `merge --abort`, no stash, and nothing that can strand the captain.
+
+Slashes in the agent branch name collapse to dashes in the scratch name (`fix/foo` → `_land-fix-foo`): a worktree directory must not nest under `.claude/worktrees/`, and `_land-fix/foo` as a ref would collide with an existing `_land-fix` ref.
+
+## Preconditions checklist
 
 | # | Check | Failure action |
 |---|---|---|
-| 1 | `pwd` equals main checkout (first `git worktree list` entry) | exit 1, point at /pr-captain-land help |
-| 2 | Current branch is `master` or `main` | exit 1, ask captain to switch |
-| 3 | `git status --porcelain` empty | exit 1, list dirty files |
-| 4 | `<agent-branch>` exists on origin | exit 1, list suggestion |
-| 5 | Diff-hash of `<agent-branch>` matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | exit 1, tell agent to re-prep |
+| 1 | `pwd` is the main checkout (first `git worktree list` entry) | exit 1 naming both paths |
+| 2 | Current branch is the resolved default branch | exit 1, ask captain to switch |
+| 3 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the `worktree-delete` fix |
+| 4 | `<agent-branch>` exists on origin | exit 1 |
+| 5 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
+| 6 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
 
-Any failure => zero mutation, clean error message.
+**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues.
 
-## The 9 steps
+The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode.
 
-### Step 1 — Switch to agent branch
+---
 
-```
-./agency/tools/git-captain switch-branch <agent-branch>
-```
+## The 10 steps
 
-Current working branch becomes the agent's. Main checkout is now sitting on agent's branch.
+### Step 0 — Preflight
 
-**Failure:** switch fails (dirty tree, branch doesn't exist locally). Script exits; captain resolves.
+Precondition checks 1-3, then `git-captain fetch`. No read or write of local main's content.
 
-### Step 2 — Verify receipt
-
-Compute current diff-hash against `origin/<default-branch>` (resolved via `resolve_default_branch`, not hardcoded). Find receipt matching that hash.
+### Step 1 — Verify the branch and its base
 
 ```
-./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
-# extract hash
+git show-ref --verify refs/remotes/origin/<agent-branch>
+git merge-base --is-ancestor origin/<default> origin/<agent-branch>
+```
+
+**Stale base is the important case.** If `origin/<default>` moved after the agent branched, the agent's QGR receipt was signed against an older base and can *never* verify. Reporting that as a hash mismatch sends the captain hunting the wrong problem. The script BLOCKS with the count of commits behind and the actual fix:
+
+> merge `<default>` into `<agent-branch>`, re-run `/pr-prep`, push, re-run `/pr-submit`
+
+### Step 2 — Cut the scratch worktree
+
+```
+./agency/tools/worktree-create _land-<branch> --from origin/<agent-branch>
+```
+
+This **is** the local integration. Step 1 proved `origin/<default>` is an ancestor, so the scratch tree already represents the agent's work on top of the default branch — no merge needed, no merge conflict possible.
+
+`--from` was added to `worktree-create` for this (v2.2.0), along with allowing a leading underscore in worktree names so machine-created scratch worktrees are visually distinct from agent worktrees.
+
+**Note:** `git-captain merge-to-master` is deliberately NOT used. It requires a *local* branch ref and merges into local main — both of which v2 avoids by construction.
+
+### Step 2b — Verify the agent's QGR receipt
+
+```
+(cd _land-<branch> && diff-hash --base origin/<default> --json)
 find agency/workstreams -name "*qgr-pr-prep-*-{hash}.md"
+receipt-verify --file <receipt>
 ```
 
-**Failure:** no matching receipt. Branch state doesn't match what /pr-submit claimed. Switch back to master, exit 1. Agent must re-prep.
+**Ordering is load-bearing.** The version bump in Step 4 edits `agency/config/manifest.json`, which is inside `diff-hash`'s file set. Verifying *after* the bump would invalidate the very receipt being checked and ask the agent to re-prep for a change the captain made — the #463 trap.
 
-### Step 3 — Bump `agency_version`
+The receipt's `hash_e` is captured here; it becomes `hash_a` of the landing receipt.
 
-Read current version from `agency/config/manifest.json`. Bump minor (e.g., 1.8 → 1.9). Write back with `updated_at` refreshed to current UTC timestamp.
+**Failure:** delete the scratch, exit 1, tell the agent to re-run `/pr-prep`.
 
-Commit via `git-safe-commit` with message:
-```
-chore(manifest): bump agency_version {old} → {new} for PR landing (captain)
-```
+### Step 3 — VALIDATE LOCALLY
 
-Push to origin.
+This is the gate. GitHub is not the gate.
 
-**Failure:** push fails (concurrent captain activity, branch protection edge case). Switch back to master, exit 1.
+Resolution ladder, all run inside the scratch:
 
-### Step 4 — Create PR
+1. `PR_LAND_VALIDATE_CMD` if set — replaces everything below.
+2. `<pm> run build`, if `package.json` declares a `build` script.
+3. `<pm> run bats:all`, else `<pm> run test` — the widest declared suite.
+4. `agency/tools/commit-precheck`.
 
-```
-./agency/tools/pr-create --title "{title}" --body "{body}"
-```
+The package manager is resolved by `agency/tools/pkg-manager`, which picks one from the lockfile and only returns it if that manager is installed. Skills never name a package manager inline — adopter repos differ.
 
-Title: `--title` flag value, or `<agent-branch>` as fallback. Body: captain-authored fleet-aware description that wraps the agent's scope with:
-- "Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot)"
-- Branch, receipt path, hash, version bump
-- Release v{new} will follow on merge
+Every step's output is appended to a validation log; the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
 
-**Failure:** pr-create blocks on receipt mismatch (race with a concurrent captain coord commit on master). Re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
-
-### Step 5 — Switch back to master
-
-```
-./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
-```
-
-Captain should sit on master for the wait-and-merge phase. Avoids any accidental commit landing on the PR branch.
-
-### Step 6 — Watch CI
-
-Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Look at the `lint-and-test` check.
-
-| State | Action |
+| Outcome | Action |
 |---|---|
-| SUCCESS | proceed to Step 7 |
-| FAILURE | exit 1 — agent must fix + push + resubmit |
-| PENDING / IN_PROGRESS | wait 20s, poll again |
+| All steps pass | proceed |
+| Any step fails | tail the log, **dispatch the agent** naming the failing step, delete the scratch, exit 1 |
+| No step resolved | loud WARNING, recorded in the receipt summary — never a silent pass |
 
-Max 30 attempts = 10 minutes. On timeout, exit 1.
+`--rehearse` and `--dry-run` stop here, delete the scratch, and exit 0.
 
-**Note on `deploy-preview-backend`**: this check is environmental flake (ordinaryfolk org lookup issue). IGNORED by /pr-captain-land. Only `lint-and-test` is the gate.
+### Step 4 — Bump `agency_version` in the scratch
 
-### Step 7 — Merge
+Read `agency/config/manifest.json`, bump the minor component, refresh `updated_at`, `git-safe add`, `git-safe-commit`.
 
-```
-./agency/tools/pr-merge {pr-num} --principal-approved
-```
+**Security:** the bump uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable.
 
-Uses admin merge (principal-approved flag gated). True merge commit — never squash, never rebase per framework discipline.
+### Step 5 — Sign the captain LANDING receipt
 
-**Failure:** merge conflicts (agent's branch drifted from master during the CI wait). Exit 1; captain resolves.
-
-### Step 8 — Sync master + create release
+`pr-create` is not bypassed and not weakened. The captain signs a receipt for the state it validated:
 
 ```
-./agency/tools/git-captain fetch
-./agency/tools/git-captain merge-from-origin
-./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
+receipt-sign --type qgr --boundary pr-captain-land \
+  --agent captain --workstream agency --project <branch-slug> \
+  --hash-a <agent receipt hash_e> \
+  --hash-b <sha256 of the validation log> \
+  --hash-c <= B>  --hash-d <= C>  \
+  --hash-e <diff hash of the bumped tree vs origin/<default>> \
+  --diff-base origin/<default>
 ```
 
-Release notes: captain-authored, references the PR number and agent.
+A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C (auto-approved, no principal 1B1). E = what is being published.
 
-**Failure (release only):** release creation fails but merge succeeded → warn captain, suggest manual `gh release create`. Skill returns success (merge is the primary outcome).
+The receipt is then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
-### Step 9 — Dispatch agent
+### Step 6 — Publish
 
-Dispatch type: `master-updated`
-Subject: `PR #{num} landed — v{new} released (pr-captain-land)`
-Body: PR URL, release URL, version bump, Phase 1 pilot feedback request
+```
+(cd _land-<branch> && git-push _land-<branch>)
+(cd _land-<branch> && pr-create --title ... --body ... --base <default>)
+```
 
-Agent receives on their next /session-resume.
+`pr-create` re-derives the newest receipt (the landing receipt) and re-verifies it, and independently confirms `manifest.json` differs from `origin/<default>`. Both gates pass on their own terms.
+
+**This is the first irreversible action.** Past this point `abort_land` is no longer correct — work exists on origin. Failures report, name the pushed branch, and leave the scratch in place for inspection.
+
+### Step 7 — CI confirmation on the aggregate rollup
+
+```
+gh pr view <num> --json statusCheckRollup
+```
+
+Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Otherwise every check in the rollup is treated as required.
+
+State normalization handles both node shapes: `CheckRun` (`status` + `conclusion`) and `StatusContext` (`state`).
+
+| Verdict | Action |
+|---|---|
+| every check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
+| any check in {FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE, STALE} | exit 1 immediately, naming the checks |
+| any check pending | wait 20s, poll again |
+| rollup empty after filtering | exit 1 with a **distinct** error |
+| gh output unreadable | treat as transient, retry |
+
+Max 45 attempts × 20s = 15 minutes.
+
+**Why the empty-rollup case is its own error:** "no checks configured" and "all checks green" must never be indistinguishable. A rollup gate that silently passes an unchecked PR is worse than the hardcode it replaced.
+
+**Why the hardcode was wrong:** v1 gated on a check literally named `lint-and-test`. This repo's checks are `bash 3.2 probe`, `manifest version`, and `smoke`. The loop could only ever time out — and a genuinely failing check could never fail fast. `src/tests/skills/pr-captain-land-localfirst.bats` asserts that literal never comes back.
+
+### Step 8 — Merge + release
+
+```
+./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
+```
+
+True merge commit — never squash, never rebase.
+
+### Step 9 — Cleanup, notify, reconcile
+
+1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
+2. `dispatch create --type master-updated` to the agent.
+3. `post-merge-state clear <num>`.
+4. `git-captain merge-from-origin` — reconcile local main with the server merge.
+
+Step 4 is deliberately separate and idempotent: it is exactly what `/captain-sync-all` does, so running either afterwards is a no-op rather than a double-integration.
+
+---
 
 ## Recovery flows
 
-### Version-bump landed but CI failed
+### Local validation failed
 
-The version-bump commit is on agent's branch. Two paths:
+Nothing was published. The scratch is gone. The agent has a dispatch naming the failing step. Agent fixes, re-preps, pushes, re-submits. The captain does nothing else.
 
-- **Agent fixes + pushes** — version bump stays, new fixes layer on top. /pr-captain-land can be re-run after agent re-submits via /pr-submit. Version doesn't bump again (current → same).
-- **Agent wants fresh state** — captain reverts the version-bump commit on agent's branch (separate cleanup).
+This replaces v1's "version-bump landed but CI failed" recovery entirely — there is no orphan bump commit on the agent's branch to clean up, because the bump never touched the agent's branch.
 
-Recommend the first path; simpler.
+### Receipt invalidated between `/pr-submit` and `/pr-captain-land`
 
-### Receipt invalidated mid-flow (Step 4 retry)
+A captain coord commit lands on the default branch, moving `origin/<default>`. Detected at **Step 1** as a stale base — with the correct message — rather than surfacing later as a bare hash mismatch. Agent merges the default branch, re-runs `/pr-prep`, re-submits.
 
-Between /pr-submit and /pr-captain-land, a captain coord commit may land on the default branch, changing `origin/<default-branch>` and thus the diff-hash. Agent's receipt no longer matches.
+### Leftover `_land-` worktree from a crashed run
 
-Detected at Step 2 or Step 4 (pr-create). Script exits; agent re-runs /pr-prep (re-signs receipt) + /pr-submit.
+Step 0 refuses to start and names the path. Inspect it (it may contain a useful validation log or an unpushed bump), then:
 
-### CI green but merge fails
+```
+./agency/tools/worktree-delete _land-<branch> --force
+./agency/tools/git-captain branch-delete _land-<branch> --force
+```
 
-Likely branch-protection edge case. Script exits; captain uses `/pr-captain-merge <num> --principal-approved` manually to resolve.
+The script never auto-deletes a pre-existing scratch — that could be another land in flight.
 
-### Dispatch monitor doesn't pick up /pr-submit
+### `pr-create` returned no URL
 
-Captain manually runs `/pr-captain-land <branch>`. Dispatch integration is auto-convenience, not required for correctness.
+The land branch **is** pushed. The scratch is kept. Either finish manually (`pr-create` from the scratch, then `/pr-captain-merge`), or abandon: delete the remote branch, then the scratch.
+
+### CI red after a green local gate
+
+Genuinely interesting — the local gate and the server disagree. Do not re-land until you know why. Usual causes: a check that only exists on the server (secrets, permissions, matrix OS), or a local validation ladder that resolved nothing (check for the WARNING in the run output and in the landing receipt summary).
+
+### Merge fails after green CI
+
+Branch-protection edge case. `/pr-captain-merge <num> --principal-approved`.
+
+## Rehearsal
+
+```
+/pr-captain-land <agent-branch> --rehearse
+```
+
+Runs steps 0-3 and deletes the scratch. No push, no PR, no bump, no receipt, no release, no dispatch. This is the cheap way to answer "would this branch actually land?" and the recommended first action on any branch class you have not landed before.
+
+`--dry-run` is `--rehearse` plus a printout of what would have been published.
 
 ## Concurrency
 
-**One /pr-captain-land at a time.** Running two simultaneously would race on the version bump. No tool-level lock today; captain discipline enforces. Phase 2 adds a lockfile.
+**One `/pr-captain-land` at a time.** Two concurrent runs would race on the version bump. Two runs *for the same branch* are now blocked mechanically by the leftover-scratch precondition; two runs for *different* branches are still captain discipline. No lockfile yet.
 
-Captain can run other non-land work (dispatch reads, flag triage, reviewer agent launches) concurrently with /pr-captain-land. Just not two /pr-captain-land.
+Concurrency against the captain's own work is much safer than in v1: the land no longer requires a clean main checkout and never moves local main, so captain coord work can proceed alongside it.
 
 ## Protocol versioning
 
-v1.0 — this document. Phase 1 pilot.
-
-v1.1 (planned): parse full dispatch payload instead of just branch name; agent's scope text becomes the PR body core.
-
-v2.0 (planned): dispatch-monitor auto-invocation (captain doesn't type /pr-captain-land; monitor picks up /pr-submit dispatch and fires /pr-captain-land).
+- **v1.0** — Phase 1 pilot (the-agency#296). PR-first; switch-checkout; hardcoded `lint-and-test` CI gate.
+- **v2.0** — local-first. Scratch-worktree integration, local validation gate, captain landing receipt, aggregate CI rollup gate, `--rehearse`, shared `resolve-default-branch` primitive. Per `usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md`, MAR-reviewed.
+- **v2.1 (planned)** — parse the full `/pr-submit` dispatch payload so the agent's scope text becomes the PR body core.
+- **v2.2 (planned)** — dispatch-monitor auto-invocation.

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -28,16 +28,20 @@ Slashes in the agent branch name collapse to dashes in the scratch name (`fix/fo
 
 | # | Check | Failure action |
 |---|---|---|
-| 1 | `pwd` is the main checkout (first `git worktree list` entry) | exit 1 naming both paths |
-| 2 | Current branch is the resolved default branch | exit 1, ask captain to switch |
-| 3 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the `worktree-delete` fix |
-| 4 | `<agent-branch>` exists on origin | exit 1 |
-| 5 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
-| 6 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
+| 1 | `pwd` is the main checkout (first `git worktree list --porcelain` entry) | exit 1 naming both paths |
+| 2 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the cleanup commands |
+| 3 | No existing `refs/heads/_land-<branch>` | exit 1 — a crash between `worktree add -b` and `worktree remove` leaves only the branch, and `worktree-create` then refuses on every retry with no visible reason |
+| 4 | `post-merge-state check` is clean (C#372 Fix B) | exit 1 — finish the prior release first |
+| 5 | `git-captain fetch` succeeds | exit 1 — **fatal, not best-effort** |
+| 6 | `<agent-branch>` exists on origin | exit 1 |
+| 7 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
+| 8 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
 
-**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues.
+**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues. The Step-9 reconcile does need a clean tree, so on a dirty checkout that last fast-forward is skipped with a note and `/captain-sync-all` picks it up.
 
-The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode.
+**Which branch the main checkout is on is also not a precondition.** v1 required the default branch; v2 does not read it, so requiring it only blocked lands while the captain was mid-`/captain-release` on a `captain-*` branch.
+
+The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode. Its probe order is **remote-authoritative**: `origin/HEAD` → `refs/remotes/origin/{main,master}` → local `refs/heads/{main,master}`. Local branches are the offline fallback only. Probing them first (git-captain's historical order) reintroduces issue #107 — a stale local `main` in a `master`-default clone would make every consumer build `origin/main`, a ref that does not exist.
 
 ---
 
@@ -68,6 +72,10 @@ This **is** the local integration. Step 1 proved `origin/<default>` is an ancest
 
 `--from` was added to `worktree-create` for this (v2.2.0), along with allowing a leading underscore in worktree names so machine-created scratch worktrees are visually distinct from agent worktrees.
 
+The slug collapses **both** slashes and dots (`fix/v1.2` → `_land-fix-v1-2`): `worktree-create` validates against `^[a-zA-Z_][a-zA-Z0-9_-]*$`, while the branch-name gate deliberately permits dots. Slugging only slashes made every dotted branch unlandable.
+
+`worktree-create`'s stderr is **not** discarded on the failure path. Swallowing it turned every distinct cause — invalid name, existing branch, disk full — into one opaque "could not create scratch worktree".
+
 **Note:** `git-captain merge-to-master` is deliberately NOT used. It requires a *local* branch ref and merges into local main — both of which v2 avoids by construction.
 
 ### Step 2b — Verify the agent's QGR receipt
@@ -93,17 +101,20 @@ Resolution ladder, all run inside the scratch:
 1. `PR_LAND_VALIDATE_CMD` if set — replaces everything below.
 2. `<pm> run build`, if `package.json` declares a `build` script.
 3. `<pm> run bats:all`, else `<pm> run test` — the widest declared suite.
-4. `agency/tools/commit-precheck`.
 
-The package manager is resolved by `agency/tools/pkg-manager`, which picks one from the lockfile and only returns it if that manager is installed. Skills never name a package manager inline — adopter repos differ.
+The package manager is resolved by `agency/tools/pkg-manager` — `packageManager` field, else lockfile, else npm — and it fails rather than substituting npm for a declared-but-uninstalled manager. Skills never name a package manager inline; adopter repos differ.
 
-Every step's output is appended to a validation log; the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
+**`commit-precheck` is deliberately not in this ladder.** It gates on *staged* files and the scratch tree is clean here, so it exits 0 having inspected nothing — while still counting as a step. That inflated the step count, suppressed the no-validation abort below, and wrote "N local validation step(s) passed" into a signed receipt on the strength of a no-op. It still runs where it means something: `git-safe-commit` invokes it on the Step-4 and Step-5 commits.
+
+Each step runs with the captain's credentials removed from the environment (`GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, `GIT_ASKPASS`, `SSH_AUTH_SOCK`; `GIT_TERMINAL_PROMPT=0`). The command comes from the branch under review, and on failure its output is tailed to stderr — i.e. into the session transcript. Defence in depth, not a sandbox: validating a branch locally means executing its code as the captain's user, which is inherent to the design.
+
+Every step's output is appended to a validation log (mode 0600, removed by the EXIT trap); the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
 
 | Outcome | Action |
 |---|---|
 | All steps pass | proceed |
 | Any step fails | tail the log, **dispatch the agent** naming the failing step, delete the scratch, exit 1 |
-| No step resolved | loud WARNING, recorded in the receipt summary — never a silent pass |
+| No step resolved | **ABORT.** Signing a five-hash receipt for a gate that never ran would make the receipt a lie. `--allow-unvalidated` overrides, and is recorded verbatim in the receipt summary. |
 
 `--rehearse` and `--dry-run` stop here, delete the scratch, and exit 0.
 
@@ -111,7 +122,9 @@ Every step's output is appended to a validation log; the log's SHA-256 becomes `
 
 Read `agency/config/manifest.json`, bump the minor component, refresh `updated_at`, `git-safe add`, `git-safe-commit`.
 
-**Security:** the bump uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable.
+The bump policy itself lives in `agency/tools/agency-version-next` (`46.25 → 46.26`; three-component semver is refused, not guessed). Inline, it was `NEW_VER=$(python3 -c '... sys.exit(1)')`, which under `set -euo pipefail` killed the *caller* before its own error could run — so the friendly "could not bump version" message was unreachable for exactly the input it was written for, and the scratch worktree was stranded.
+
+**Security:** the manifest write uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable. It also writes a trailing newline (`json.dump` does not), so a land no longer adds a spurious "\ No newline at end of file" hunk, and refreshes both the nested and top-level `updated_at`.
 
 ### Step 5 — Sign the captain LANDING receipt
 
@@ -123,11 +136,12 @@ receipt-sign --type qgr --boundary pr-captain-land \
   --hash-a <agent receipt hash_e> \
   --hash-b <sha256 of the validation log> \
   --hash-c <= B>  --hash-d <= C>  \
+  --hash-d-source <"auto-approved — no principal 1B1" | the --principal-approved attestation> \
   --hash-e <diff hash of the bumped tree vs origin/<default>> \
   --diff-base origin/<default>
 ```
 
-A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C (auto-approved, no principal 1B1). E = what is being published.
+A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C, with `hash_d_source` recording whether a principal actually approved — the receipt must not attest to an approval that did not happen. E = what is being published.
 
 The receipt is then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
@@ -148,38 +162,49 @@ The receipt is then committed. Receipts are excluded from `diff-hash`, so commit
 gh pr view <num> --json statusCheckRollup
 ```
 
-Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Otherwise every check in the rollup is treated as required.
+Classification is **not** inline. It lives in `agency/tools/ci-rollup-verdict`, a pure function of (rollup JSON, required contexts) that prints one verdict token — table-tested in `src/tests/tools/ci-rollup-verdict.bats`. Inline it was a python heredoc inside a command substitution inside the polling loop, which no test could reach: every guard written for it was a `grep` for a string, and all of them still passed with the PASS and FAIL state sets swapped.
 
-State normalization handles both node shapes: `CheckRun` (`status` + `conclusion`) and `StatusContext` (`state`).
+Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Anything that is not a non-empty JSON array (the endpoint returns an error *object* on unprotected repos and without admin scope) means no narrowing.
+
+State normalization handles both node shapes: `CheckRun` (`status` + `conclusion` — the conclusion is meaningless until the status is COMPLETED) and `StatusContext` (`state`).
 
 | Verdict | Action |
 |---|---|
-| every check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
+| every gated check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
 | any check in {FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE, STALE} | exit 1 immediately, naming the checks |
-| any check pending | wait 20s, poll again |
-| rollup empty after filtering | exit 1 with a **distinct** error |
+| any gated check pending | wait 20s, poll again |
+| a **required** context absent from the rollup | PENDING, not absent |
+| rollup empty, past the 3-minute grace window | exit 1 with a **distinct** error |
 | gh output unreadable | treat as transient, retry |
 
 Max 45 attempts × 20s = 15 minutes.
 
-**Why the empty-rollup case is its own error:** "no checks configured" and "all checks green" must never be indistinguishable. A rollup gate that silently passes an unchecked PR is worse than the hardcode it replaced.
+**Why a required context that has not reported is PENDING:** narrowing to "required contexts that happen to be present" means 1-of-3 required checks reporting green reads as PASSED, and the PR merges on partial evidence.
+
+**Why the empty-rollup case has a grace window:** GitHub has usually registered no check runs in the first seconds after a PR opens. Treating that as immediately fatal would abort nearly every real land. Past the window it is a hard error — "no checks configured" and "all checks green" must never be indistinguishable.
+
+**Name-mismatch caveat:** branch-protection contexts are often `"workflow / job"` while check runs are named just `job`. When they do not match, the gate reports PENDING and eventually times out rather than merging — the safe direction, but worth knowing when a green PR appears to hang.
 
 **Why the hardcode was wrong:** v1 gated on a check literally named `lint-and-test`. This repo's checks are `bash 3.2 probe`, `manifest version`, and `smoke`. The loop could only ever time out — and a genuinely failing check could never fail fast. `src/tests/skills/pr-captain-land-localfirst.bats` asserts that literal never comes back.
 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
 ./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
 ```
 
 True merge commit — never squash, never rebase.
 
+`--principal-approved` is forwarded **only** when the captain passed it to `/pr-captain-land`. `pr-merge` treats that flag as the captain's attestation that the principal verbally approved, and it is the only route to `gh pr merge --admin`; asserting it unconditionally in a non-interactive script would make branch-protection bypass the fleet's default merge mode. Default behaviour is to defer to GitHub's gates, and the failure message says to re-run with the flag if protection is the blocker.
+
+Both calls capture their output and print the tail on failure. Silencing them at the two most consequential steps left "pr-merge failed — check manually" with nothing to check.
+
 ### Step 9 — Cleanup, notify, reconcile
 
 1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
-2. `dispatch create --type master-updated` to the agent.
-3. `post-merge-state clear <num>`.
+2. `dispatch create --type master-updated` to the agent. The recipient is resolved against the agent registry, not guessed from the branch prefix — `pr-lifecycle-v2` would otherwise yield `pr`, and the dispatch (best-effort by design) would vanish. An unresolvable name routes to captain with a note.
+3. `post-merge-state clear <num>` — **only if a release was actually cut.** Clearing it after `--no-release` or a failed `gh-release` discards exactly the "merged but release not cut" signal the guard exists to carry.
 4. `git-captain merge-from-origin` — reconcile local main with the server merge.
 
 Step 4 is deliberately separate and idempotent: it is exactly what `/captain-sync-all` does, so running either afterwards is a no-op rather than a double-integration.

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -1,30 +1,74 @@
 #!/usr/bin/env bash
 #
-# pr-captain-land — Captain lands an agent's prepared branch as a PR + release
+# pr-captain-land — Captain lands an agent's prepared branch, LOCAL-FIRST
 #
 # WHAT: Captain runs this in the main checkout to own the full PR lifecycle
-# for a branch prepared by an agent via /pr-submit. Switches to the
-# branch, verifies the QGR receipt, bumps the version, creates the PR with
-# a captain-authored description, watches CI, merges, cuts the release, and
-# dispatches the agent with the outcome.
+# for a branch prepared by an agent via /pr-submit. The branch is integrated
+# and validated LOCALLY first; only already-validated work is published.
 #
-# WHY: Addresses the-agency#296 — single serialization point for version
-# bumps + PR creation + release creation. Eliminates version-bump races,
-# QGR hash races, and split responsibility.
+# WHY (the v2 inversion): the previous flow was PR-first — switch the main
+# checkout to the agent's branch, bump, push, open a PR, and let GitHub CI be
+# the gate. That had three structural problems:
 #
-# SCOPE: Phase 1 pilot — sandbox tool in usr/{principal}/captain/tools/. Tested
-# by dogfooding on one captain-driven PR before promotion to .claude/skills/.
+#   1. Switching the main checkout to a branch that is already checked out in
+#      the agent's worktree fails outright (worktree collision), and switching
+#      at all makes the captain's checkout a moving target mid-land.
+#   2. GitHub CI was the FIRST gate. TheAgency's model is local review and
+#      validation; the server is the publish step, not the reviewer.
+#   3. Any mid-flight abort left the main checkout on someone else's branch.
+#
+# The fix is not a better rollback — it is having nothing to roll back. The
+# whole landing runs in a DEDICATED SCRATCH WORKTREE cut from `origin/<agent
+# branch>` (which, per the step-1 receipt gate, already contains the default
+# branch). Local `main` is never read for content, never merged into, never
+# reset, and never pushed. Rollback at any pre-publish failure is one action:
+# delete the scratch worktree.
+#
+# Validating against pristine `origin/<default>` rather than the captain's
+# local main is also STRICTLY more correct: local main routinely carries
+# unpushed coordination commits and other worktrees' merges, none of which
+# belong in the PR under test.
+#
+# FLOW (plan-pr-captain-land-localfirst-20260809 v2, steps 0-9):
+#   0  Preflight — main checkout, fetch, resolve default branch
+#   1  Verify agent branch on origin + base freshness (stale base BLOCKS with
+#      "merge main + re-run /pr-prep", never a bare hash error)
+#   2  Cut scratch worktree `_land-<branch>` at `origin/<agent-branch>`
+#   2b Verify the agent's QGR receipt against the scratch — BEFORE any bump
+#      (the bump touches manifest.json, which is inside the hashed file set;
+#      verifying after would churn the receipt — the #463 trap)
+#   3  VALIDATE LOCALLY in the scratch (build + tests + commit-precheck).
+#      Failure → delete scratch, dispatch the agent, abort.
+#   4  Bump agency_version in the scratch, commit
+#   5  Sign a captain LANDING receipt binding the bumped tree to
+#      origin/<default> (hash_a = the agent receipt's hash_e). This is what
+#      lets pr-create pass — pr-create is NOT weakened.
+#   6  Publish from the scratch: push `_land-<branch>` → pr-create
+#   7  Wait on the AGGREGATE statusCheckRollup (every required context green;
+#      fail-fast on failure; empty rollup is its own distinct error). No
+#      hardcoded check name.
+#   8  pr-merge (true merge commit) → gh-release
+#   9  Cleanup: delete scratch + local/remote land branch, dispatch the agent,
+#      clear post-merge state, reconcile local main via merge-from-origin
+#
+# INVARIANTS this script must never violate:
+#   - The agent's branch is NEVER checked out in the main checkout.
+#   - `main`/`master` is NEVER pushed.
+#   - Local `main` is never reset, force-moved, or committed onto.
 #
 # USAGE:
-#   pr-captain-land <agent-branch> [--dry-run] [--title "..."] [--no-release]
+#   pr-captain-land <agent-branch> [--rehearse] [--dry-run]
+#                                  [--title "..."] [--agent <name>]
+#                                  [--no-release]
 #
-# PRECONDITIONS (tool enforces):
-#   - Running in main checkout on master
-#   - Tree is clean
-#   - <agent-branch> exists on origin
-#   - <agent-branch> has a valid QGR receipt
+#   --rehearse   Run steps 0-3 only (integrate + validate), then delete the
+#                scratch. Nothing is pushed, no PR, no receipt, no bump.
+#                De-risks the first land of any given branch.
+#   --dry-run    --rehearse plus a printout of exactly what would be published.
 #
 # WRITTEN: 2026-04-19 (Phase 1 pilot, the-agency#296)
+# REWRITTEN: 2026-08-09 (devex) — local-first v2 per
+#            usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md
 
 set -euo pipefail
 
@@ -40,6 +84,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 # script behind its PR_SUBMIT_LIB_ONLY guard and unit-tested in
 # src/tests/skills/pr-submit-helpers.bats. Sourcing loads the functions only;
 # the guard returns before any pr-submit precondition runs.
+# resolve_default_branch is itself now a thin wrapper over the shared
+# agency/tools/resolve-default-branch primitive.
 PR_SUBMIT_LIB_ONLY=1 source "$REPO_ROOT/.claude/skills/pr-submit/scripts/pr-submit"
 
 # ── Resolve ORG, REPO, PRINCIPAL ─────────────────────────────────────────────
@@ -53,11 +99,7 @@ if ! ORG="$(parse_org_from_remote "$REMOTE_URL")" || ! REPO="$(parse_repo_from_r
 fi
 PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2 (matches pr-submit)
 
-# ── Resolve the repo's default branch — never assume master ──────────────────
-# The PR lifecycle hardcoded origin/master. In a repo whose default branch is
-# main (this one), the receipt-verify diff-hash resolved nothing, switch-back
-# targeted a nonexistent branch, and the release targeted master. Resolve it
-# once here and use it everywhere below.
+# ── Resolve the repo's default branch — never assume ─────────────────────────
 DEFAULT_BRANCH="$(resolve_default_branch)"
 BASE_REF="origin/${DEFAULT_BRANCH}"
 
@@ -65,18 +107,38 @@ BASE_REF="origin/${DEFAULT_BRANCH}"
 
 AGENT_BRANCH=""
 DRY_RUN=false
+REHEARSE=false
 CUSTOM_TITLE=""
+AGENT_OVERRIDE=""
 SKIP_RELEASE=false
+
+usage() {
+    cat <<'HELP'
+Usage: pr-captain-land <agent-branch> [options]
+
+Local-first landing: the branch is integrated and validated in a scratch
+worktree cut from origin/<default>, and only then published. The main
+checkout is never switched and local main is never touched.
+
+Options:
+  --rehearse        Steps 0-3 only (integrate + validate). No push, no PR,
+                    no version bump, no receipt. Scratch is deleted after.
+  --dry-run         --rehearse plus a printout of what would be published.
+  --title "..."     PR title (default: the agent branch name)
+  --agent <name>    Agent to dispatch (default: inferred from branch prefix)
+  --no-release      Skip the GitHub release after merge
+  --help, -h        Show this help
+HELP
+}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --dry-run) DRY_RUN=true; shift ;;
+        --dry-run) DRY_RUN=true; REHEARSE=true; shift ;;
+        --rehearse) REHEARSE=true; shift ;;
         --title) CUSTOM_TITLE="$2"; shift 2 ;;
+        --agent) AGENT_OVERRIDE="$2"; shift 2 ;;
         --no-release) SKIP_RELEASE=true; shift ;;
-        --help|-h)
-            echo "Usage: $0 <agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
-            exit 0
-            ;;
+        --help|-h) usage; exit 0 ;;
         -*) echo "pr-captain-land: unknown flag: $1" >&2; exit 2 ;;
         *) AGENT_BRANCH="$1"; shift ;;
     esac
@@ -100,7 +162,40 @@ if [[ "$AGENT_BRANCH" == *..* ]] || [[ "$AGENT_BRANCH" == -* ]]; then
     exit 2
 fi
 
-# ── Precondition: in main checkout on master ────────────────────────────────
+# Scratch identity. Slashes collapse to dashes: a worktree directory must not
+# nest under .claude/worktrees/, and `_land-fix/x` as a ref would collide with
+# an existing `_land-fix` ref (git stores refs as directories).
+LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/' '-')"
+SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Rollback — the entire pre-publish rollback story
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Nothing outside the scratch worktree has been modified before step 6, so
+# "undo" is "delete the scratch". No git reset, no merge --abort, no stashing,
+# and crucially nothing that could strand the captain's main checkout.
+destroy_scratch() {
+    [[ -d "$SCRATCH_DIR" ]] || return 0
+    bash "$REPO_ROOT/agency/tools/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    # worktree-delete deliberately leaves the branch behind (it prints advice
+    # instead). For a machine-created scratch branch there is nothing to
+    # preserve, so remove it too.
+    bash "$REPO_ROOT/agency/tools/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
+}
+
+# abort_land <message...> — roll back and exit non-zero.
+abort_land() {
+    echo "" >&2
+    echo "pr-captain-land: $*" >&2
+    destroy_scratch
+    echo "  Rolled back: scratch worktree $LAND_SLUG deleted. Nothing was published." >&2
+    exit 1
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 0 — Preflight
+# ═════════════════════════════════════════════════════════════════════════════
 
 MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
 if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
@@ -116,51 +211,264 @@ if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
     exit 1
 fi
 
-# ── Precondition: clean tree ─────────────────────────────────────────────────
-
-DIRTY=$(git status --porcelain 2>/dev/null)
+# NOTE (#393): a dirty main checkout no longer blocks a land. The landing never
+# reads, commits to, or moves local main — everything happens in the scratch
+# worktree. Uncommitted captain work is simply irrelevant here. It is still
+# worth surfacing, because a dirty tree usually means an unfinished handoff.
+DIRTY=$(git status --porcelain 2>/dev/null || true)
 if [[ -n "$DIRTY" ]]; then
-    echo "pr-captain-land: $DEFAULT_BRANCH tree dirty — commit or stash first." >&2
-    echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
+    echo "note: $DEFAULT_BRANCH checkout is dirty — harmless here (the land runs in a scratch worktree)."
+fi
+
+if [[ -d "$SCRATCH_DIR" ]]; then
+    echo "pr-captain-land: scratch worktree $LAND_SLUG already exists at" >&2
+    echo "  $SCRATCH_DIR" >&2
+    echo "  A previous land is still running, or crashed. Inspect it, then:" >&2
+    echo "    ./agency/tools/worktree-delete $LAND_SLUG --force" >&2
     exit 1
 fi
 
-# ── Precondition: agent branch exists on origin ─────────────────────────────
-
+echo "→ Fetching origin..."
 bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 1 — Verify the agent branch on origin, and that its base is current
+# ═════════════════════════════════════════════════════════════════════════════
 
 if ! git show-ref --verify --quiet "refs/remotes/origin/$AGENT_BRANCH"; then
     echo "pr-captain-land: branch '$AGENT_BRANCH' not found on origin." >&2
+    echo "  The agent must push before /pr-submit." >&2
     exit 1
 fi
 
-# ── Switch to agent branch ───────────────────────────────────────────────────
+# Base freshness. If origin/<default> has moved ahead of what the agent
+# branched from, the agent's QGR receipt describes a diff against an older
+# base — the hash CANNOT match, and reporting that as a bare hash mismatch
+# sends the captain hunting for the wrong problem. Name the real cause.
+if ! git merge-base --is-ancestor "$BASE_REF" "origin/$AGENT_BRANCH" 2>/dev/null; then
+    BEHIND=$(git rev-list --count "origin/$AGENT_BRANCH..$BASE_REF" 2>/dev/null || echo "?")
+    echo "" >&2
+    echo "BLOCKED: '$AGENT_BRANCH' does not contain $BASE_REF ($BEHIND commit(s) behind)." >&2
+    echo "" >&2
+    echo "  Its QGR receipt was signed against an older base, so it can never" >&2
+    echo "  verify against the current one. This is not a receipt bug." >&2
+    echo "" >&2
+    echo "  Agent action: merge $DEFAULT_BRANCH into $AGENT_BRANCH, re-run /pr-prep," >&2
+    echo "                push, then re-run /pr-submit." >&2
+    exit 1
+fi
 
-echo "→ Switching to $AGENT_BRANCH..."
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$AGENT_BRANCH" >/dev/null
+echo "→ Branch origin/$AGENT_BRANCH is current with $BASE_REF"
 
-# ── Verify QGR receipt ───────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 2 — Cut the scratch worktree at origin/<agent-branch>
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# This IS the local integration. The branch is not checked out in the main
+# checkout (invariant), and because the step-1 gate proved origin/<default> is
+# an ancestor, the scratch tree already represents "the agent's work merged
+# into the default branch".
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
+echo "→ Creating scratch worktree $LAND_SLUG at origin/$AGENT_BRANCH..."
+if ! bash "$REPO_ROOT/agency/tools/worktree-create" "$LAND_SLUG" \
+        --from "origin/$AGENT_BRANCH" >/dev/null 2>&1; then
+    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG" >&2
+    destroy_scratch
+    exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 2b — Verify the agent's QGR receipt, BEFORE any mutation
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Ordering is load-bearing (#463): the version bump edits manifest.json, which
+# is inside the hashed file set. Verify first, mutate second — otherwise every
+# land invalidates the receipt it is checking and the agent is asked to re-prep
+# for a change the captain made.
+
+DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
 
-RECEIPT=$(find "$REPO_ROOT/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
-if [[ -z "$RECEIPT" ]]; then
+if [[ -z "$DIFF_HASH_SHORT" ]]; then
+    abort_land "could not compute a diff hash for origin/$AGENT_BRANCH against $BASE_REF."
+fi
+
+AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+if [[ -z "$AGENT_RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
-    echo "  Agent must run /pr-prep to produce a receipt before submitting." >&2
-    # Switch back to master before exit
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+    echo "  The branch content and the newest receipt disagree." >&2
+    echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
+    destroy_scratch
     exit 1
 fi
 
-RECEIPT_REL="${RECEIPT#$REPO_ROOT/}"
-echo "→ Receipt: $RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
+if ! (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
+    echo "pr-captain-land: receipt $AGENT_RECEIPT does not verify against the branch." >&2
+    echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
+    destroy_scratch
+    exit 1
+fi
 
-# ── Bump agency_version on the branch ─────────────────────────────────────
+AGENT_RECEIPT_REL="${AGENT_RECEIPT#$SCRATCH_DIR/}"
+# hash_a of the landing receipt chains to hash_e of the agent's receipt — the
+# captain's gate extends the agent's chain rather than starting a new one.
+AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"')
 
-MANIFEST="$REPO_ROOT/agency/config/manifest.json"
+echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 3 — VALIDATE LOCALLY. This is the gate. GitHub is not the gate.
+# ═════════════════════════════════════════════════════════════════════════════
+
+VALIDATION_LOG="$(mktemp -t pr-captain-land-validate)"
+VALIDATION_SUMMARY=""
+
+# run_validation_step <label> <command...>
+# Appends to the validation log and returns THE COMMAND'S status.
+#
+# The status must be captured explicitly: wrapping the command in a brace group
+# that ends with an `echo` would make the group's status that of the echo, i.e.
+# always 0 — a validation gate that can never fail is worse than no gate.
+run_validation_step() {
+    local label="$1"; shift
+    local st=0
+    echo "  · $label"
+    echo "=== $label ===" >> "$VALIDATION_LOG"
+    "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
+    echo "=== exit: $st ===" >> "$VALIDATION_LOG"
+    return "$st"
+}
+
+# Resolve the package manager via the shared primitive — a skill must never
+# name one inline (it ships to adopter repos that use a different one; see
+# src/tests/skills/skill-validation.bats). Absent one, the JS steps do not run.
+detect_pm() {
+    bash "$SCRATCH_DIR/agency/tools/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
+}
+
+has_pkg_script() {
+    [[ -f "$SCRATCH_DIR/package.json" ]] || return 1
+    SCRIPT_NAME="$1" python3 -c '
+import json, os, sys
+p = json.load(open(os.path.join(os.environ["SCRATCH"], "package.json")))
+sys.exit(0 if os.environ["SCRIPT_NAME"] in (p.get("scripts") or {}) else 1)
+' 2>/dev/null
+}
+
+echo "→ Validating locally in $LAND_SLUG (this is the gate)..."
+
+VALIDATION_STEPS=0
+VALIDATION_FAILED=""
+
+# The validation command can be overridden wholesale for repos whose gate is
+# not expressible as "package script + commit-precheck".
+if [[ -n "${PR_LAND_VALIDATE_CMD:-}" ]]; then
+    VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+    if ! (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD"); then
+        VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
+    fi
+else
+    PM="$(detect_pm)"
+    export SCRATCH="$SCRATCH_DIR"
+
+    if [[ -n "$PM" ]] && has_pkg_script build; then
+        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+        (cd "$SCRATCH_DIR" && run_validation_step "build ($PM run build)" "$PM" run build) \
+            || VALIDATION_FAILED="build"
+    fi
+
+    # Prefer the widest test script the repo declares. bats:all covers the
+    # framework's own suites; `test` is the conventional fallback.
+    if [[ -z "$VALIDATION_FAILED" && -n "$PM" ]]; then
+        for script in bats:all test; do
+            if has_pkg_script "$script"; then
+                VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+                (cd "$SCRATCH_DIR" && run_validation_step "tests ($PM run $script)" "$PM" run "$script") \
+                    || VALIDATION_FAILED="tests"
+                break
+            fi
+        done
+    fi
+
+    # commit-precheck is the same pre-commit gate every agent commit passes
+    # through — cheap, and it catches provenance/format regressions the test
+    # suites do not.
+    if [[ -z "$VALIDATION_FAILED" && -x "$SCRATCH_DIR/agency/tools/commit-precheck" ]]; then
+        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+        (cd "$SCRATCH_DIR" && run_validation_step "commit-precheck" bash "$SCRATCH_DIR/agency/tools/commit-precheck") \
+            || VALIDATION_FAILED="commit-precheck"
+    fi
+fi
+
+if [[ "$VALIDATION_STEPS" -eq 0 ]]; then
+    # Distinct, loud, and NOT a silent pass: a repo with no resolvable local
+    # gate has opted out of the whole point of this flow.
+    echo "WARNING: no local validation command resolved for this repo." >&2
+    echo "  Set PR_LAND_VALIDATE_CMD, or declare a build/test script." >&2
+    echo "  Landing continues, but local-first validation did NOT happen." >&2
+    VALIDATION_SUMMARY="no local validation command resolved (see warning)"
+else
+    VALIDATION_SUMMARY="$VALIDATION_STEPS local validation step(s) passed against $BASE_REF"
+fi
+
+if [[ -n "$VALIDATION_FAILED" ]]; then
+    echo "" >&2
+    echo "── local validation output (tail) ──" >&2
+    tail -40 "$VALIDATION_LOG" >&2
+    echo "────────────────────────────────────" >&2
+
+    # Tell the agent before rolling back — the scratch is about to vanish.
+    AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+    bash "$REPO_ROOT/agency/tools/dispatch" create \
+        --type dispatch \
+        --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
+        --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
+        --body "Captain ran /pr-captain-land on \`$AGENT_BRANCH\` and it failed the LOCAL validation gate before anything was published.
+
+- Failed step: \`$VALIDATION_FAILED\`
+- Validated against: \`$BASE_REF\`
+- Nothing was pushed. No PR. No version bump. No release.
+
+Fix locally, re-run /pr-prep, push, then re-run /pr-submit.
+
+-- $ORG/$PRINCIPAL/captain" \
+        >/dev/null 2>&1 || true
+
+    abort_land "local validation failed at step '$VALIDATION_FAILED' — see output above."
+fi
+
+echo "→ Local validation: PASSED ($VALIDATION_SUMMARY)"
+
+# ── Rehearsal stops here ─────────────────────────────────────────────────────
+
+if [[ "$REHEARSE" == true ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+        echo ""
+        echo "[DRY-RUN] Would publish:"
+        echo "    PR title:    ${CUSTOM_TITLE:-$AGENT_BRANCH}"
+        echo "    Head branch: $LAND_SLUG (pushed from the scratch worktree)"
+        echo "    Base branch: $DEFAULT_BRANCH"
+        echo "    Agent to notify: ${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+        echo "    Release:     $([[ "$SKIP_RELEASE" == true ]] && echo "skipped" || echo "yes, v<bumped version>")"
+    fi
+    destroy_scratch
+    rm -f "$VALIDATION_LOG"
+    echo ""
+    echo "pr-captain-land: rehearsal complete — integrated + validated, nothing published."
+    exit 0
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 4 — Bump agency_version in the scratch
+# ═════════════════════════════════════════════════════════════════════════════
+
+MANIFEST="$SCRATCH_DIR/agency/config/manifest.json"
+if [[ ! -f "$MANIFEST" ]]; then
+    abort_land "manifest.json not found in scratch at $MANIFEST"
+fi
+
 # Security: pass values via env, never string-interpolate into python source
 # (F-SEC-1 / CRITICAL-3 from MAR 2026-04-19). Prevents RCE if manifest is
 # ever attacker-controllable.
@@ -169,7 +477,6 @@ import json, os
 print(json.load(open(os.environ["MANIFEST"]))["agency_version"])
 ')
 
-# Parse and bump — value via env, not f-string
 NEW_VER=$(CURRENT_VER="$CURRENT_VER" python3 -c '
 import os, sys
 v = os.environ["CURRENT_VER"]
@@ -185,16 +492,12 @@ else:
 ')
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
-    echo "pr-captain-land: could not bump version from $CURRENT_VER" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
-    exit 1
+    abort_land "could not bump version from $CURRENT_VER"
 fi
 
-echo "→ Bumping agency_version $CURRENT_VER → $NEW_VER"
+echo "→ Bumping agency_version $CURRENT_VER → $NEW_VER (in scratch)"
 
-if [[ "$DRY_RUN" == false ]]; then
-    # Security: env vars, not string interpolation (F-SEC-1)
-    MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
+MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
 import json, os
 from datetime import datetime, timezone
 path = os.environ["MANIFEST"]
@@ -203,141 +506,304 @@ m["agency_version"] = os.environ["NEW_VER"]
 m["project"]["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 json.dump(m, open(path, "w"), indent=2)
 '
-    bash "$REPO_ROOT/agency/tools/git-safe" add agency/config/manifest.json
-    bash "$REPO_ROOT/agency/tools/git-safe-commit" \
-        "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
-        --no-work-item >/dev/null
 
-    bash "$REPO_ROOT/agency/tools/git-push" "$AGENT_BRANCH" >/dev/null
-    echo "→ Version bumped + pushed"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add agency/config/manifest.json) \
+    || abort_land "could not stage the version bump"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+    "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
+    --no-work-item >/dev/null) \
+    || abort_land "could not commit the version bump"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 5 — Sign the captain LANDING receipt
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# pr-create is NOT weakened to let a captain-bumped branch through. Instead the
+# captain signs a receipt for the state it actually validated. The five-hash
+# chain stays intact and extends the agent's:
+#   A = the agent receipt's hash_e   (what was reviewed)
+#   B = hash of the local validation log
+#   C = B                            (nothing to triage — validation was green)
+#   D = C                            (auto-approved; no principal 1B1)
+#   E = diff hash of the bumped tree against origin/<default>
+#
+# Receipts live outside diff-hash's file set, so committing this receipt does
+# not invalidate the hash it carries.
+
+LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+                 python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
+                 echo "")
+if [[ -z "$LAND_HASH_FULL" ]]; then
+    abort_land "could not compute the post-bump diff hash for the landing receipt"
 fi
 
-# ── Create PR ────────────────────────────────────────────────────────────────
+VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" | cut -d' ' -f1)
+# project must be filename-safe: it becomes part of the receipt name.
+LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
+
+echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-sign" \
+    --type qgr \
+    --boundary pr-captain-land \
+    --org "$ORG" \
+    --principal "$PRINCIPAL" \
+    --agent captain \
+    --workstream agency \
+    --project "$LAND_PROJECT" \
+    --hash-a "${AGENT_HASH_E:-$DIFF_HASH_FULL}" \
+    --hash-b "$VALIDATION_HASH" \
+    --hash-c "$VALIDATION_HASH" \
+    --hash-d "$VALIDATION_HASH" \
+    --hash-e "$LAND_HASH_FULL" \
+    --diff-base "$BASE_REF" \
+    --summary "Local-first landing of $AGENT_BRANCH. Integrated in scratch worktree $LAND_SLUG cut from origin/$AGENT_BRANCH; $VALIDATION_SUMMARY; agency_version $CURRENT_VER → $NEW_VER. Chains to agent receipt $AGENT_RECEIPT_REL." \
+    >/dev/null) || abort_land "could not sign the landing receipt"
+
+LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | head -1 || echo "")
+if [[ -z "$LANDING_RECEIPT" ]]; then
+    abort_land "landing receipt was signed but could not be located"
+fi
+LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
+
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add "$LANDING_RECEIPT_REL") \
+    || abort_land "could not stage the landing receipt"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+    "misc(pr-captain-land): landing receipt for $AGENT_BRANCH (${LAND_HASH_FULL:0:7})" \
+    --no-work-item >/dev/null) \
+    || abort_land "could not commit the landing receipt"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 6 — Publish (first irreversible action)
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Past this point `abort_land` is no longer correct: work exists on origin.
+# Failures below report and leave the scratch in place for inspection.
+
+echo "→ Pushing $LAND_SLUG..."
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-push" "$LAND_SLUG" >/dev/null) \
+    || abort_land "could not push $LAND_SLUG"
 
 PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
-Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot).
+Captain-landed via \`/pr-captain-land\` — **local-first** flow.
 
-Branch prepared by agent via /pr-submit. Captain owns the landing lifecycle:
-- Switched to \`$AGENT_BRANCH\`
-- Verified QGR receipt \`$RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`)
-- Bumped \`agency_version\` $CURRENT_VER → $NEW_VER
-- Will merge when CI is green
-- Will create release v$NEW_VER
+The work was integrated and validated locally BEFORE this PR existed. CI here
+is confirmation, not the gate.
+
+- Source branch: \`$AGENT_BRANCH\` (untouched; this PR rides \`$LAND_SLUG\`)
+- Integrated in a scratch worktree cut from \`origin/$AGENT_BRANCH\`, verified to contain \`$BASE_REF\`
+- Agent QGR receipt: \`$AGENT_RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`) — verified before any mutation
+- Local validation: $VALIDATION_SUMMARY
+- Captain landing receipt: \`$LANDING_RECEIPT_REL\` (hash \`${LAND_HASH_FULL:0:7}\`)
+- \`agency_version\`: $CURRENT_VER → $NEW_VER
+- Release v$NEW_VER cut on merge
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )
 
-if [[ "$DRY_RUN" == true ]]; then
-    echo "→ [DRY-RUN] Would create PR:"
-    echo "    Title: $PR_TITLE"
-    echo "    Body:  (see stdout)"
-    # Switch back to master
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
-    echo "pr-captain-land: dry-run complete"
-    exit 0
-fi
-
 echo "→ Creating PR..."
-PR_URL=$(bash "$REPO_ROOT/agency/tools/pr-create" --title "$PR_TITLE" --body "$PR_BODY" 2>&1 | \
+PR_URL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/pr-create" \
+            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) | \
          tail -1 | grep -oE 'https://github.com/[^ ]+' || echo "")
 
 if [[ -z "$PR_URL" ]]; then
-    echo "pr-captain-land: pr-create did not return a URL — check output above" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+    echo "pr-captain-land: pr-create did not return a URL — check output above." >&2
+    echo "  Scratch worktree kept for inspection: $SCRATCH_DIR" >&2
+    echo "  Branch $LAND_SLUG is pushed; delete it if you abandon this land." >&2
     exit 1
 fi
 
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 echo "→ PR created: $PR_URL (#$PR_NUM)"
 
-# ── Back to master for merge ────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 7 — CI wait on the AGGREGATE status check rollup
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# The old implementation waited on a single hardcoded check name
+# ("lint-and-test") that does not exist in this repo — so the loop always timed
+# out at 10 minutes regardless of CI's actual verdict, and a genuinely failing
+# check could never fail fast. Gate on the whole rollup instead:
+#
+#   - every check must reach a terminal SUCCESS-like state
+#   - any terminal failure state aborts immediately
+#   - an EMPTY rollup is its own distinct error, not a silent pass — "no checks
+#     configured" and "all checks green" must never look alike
+#
+# Where branch protection exposes a required-contexts list, narrow to it.
 
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
-echo "→ Back on $DEFAULT_BRANCH"
+REQUIRED_CONTEXTS=$(bash "$REPO_ROOT/agency/tools/gh-api" \
+    "/repos/$ORG/$REPO/branches/$DEFAULT_BRANCH/protection/required_status_checks/contexts" \
+    2>/dev/null || echo "")
 
-# ── Wait for CI ──────────────────────────────────────────────────────────────
-
-echo "→ Waiting for CI..."
+echo "→ Waiting for CI on PR #$PR_NUM (aggregate status check rollup)..."
 ATTEMPTS=0
-MAX_ATTEMPTS=30  # 30 × 20s = 10 minutes
+MAX_ATTEMPTS=45  # 45 × 20s = 15 minutes
+CI_VERDICT=""
+
 while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
-    STATE=$(gh pr view "$PR_NUM" --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name=="lint-and-test") | .conclusion' 2>/dev/null || echo "")
-    if [[ "$STATE" == "SUCCESS" ]]; then
-        echo "→ lint-and-test: PASSED"
-        break
-    fi
-    if [[ "$STATE" == "FAILURE" ]]; then
-        echo "pr-captain-land: lint-and-test FAILED on PR #$PR_NUM" >&2
-        echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
-        exit 1
-    fi
+    ROLLUP=$(bash "$REPO_ROOT/agency/tools/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
+
+    CI_VERDICT=$(ROLLUP_JSON="$ROLLUP" REQUIRED="$REQUIRED_CONTEXTS" python3 <<'PY'
+import json, os, sys
+
+raw = os.environ.get("ROLLUP_JSON") or ""
+try:
+    checks = (json.loads(raw) or {}).get("statusCheckRollup") or []
+except (ValueError, AttributeError):
+    print("UNREADABLE")
+    sys.exit(0)
+
+# Narrow to branch-protection required contexts when we could read them.
+try:
+    required = json.loads(os.environ.get("REQUIRED") or "[]")
+    required = set(required) if isinstance(required, list) else set()
+except ValueError:
+    required = set()
+
+
+def name_of(c):
+    return c.get("name") or c.get("context") or "(unnamed)"
+
+
+def state_of(c):
+    # CheckRun: status + conclusion. StatusContext: state.
+    if c.get("status") is not None or c.get("conclusion") is not None:
+        if (c.get("status") or "").upper() != "COMPLETED":
+            return "PENDING"
+        return (c.get("conclusion") or "PENDING").upper()
+    return (c.get("state") or "PENDING").upper()
+
+
+if required:
+    checks = [c for c in checks if name_of(c) in required]
+
+if not checks:
+    print("NO_CHECKS")
+    sys.exit(0)
+
+PASS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+FAIL = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"}
+
+failed = [name_of(c) for c in checks if state_of(c) in FAIL]
+if failed:
+    print("FAILED " + ",".join(failed))
+    sys.exit(0)
+
+pending = [name_of(c) for c in checks if state_of(c) not in PASS]
+if pending:
+    print("PENDING " + ",".join(pending))
+    sys.exit(0)
+
+print("PASSED " + ",".join(name_of(c) for c in checks))
+PY
+)
+
+    case "$CI_VERDICT" in
+        PASSED*)
+            echo "→ CI green: ${CI_VERDICT#PASSED }"
+            break
+            ;;
+        FAILED*)
+            echo "pr-captain-land: CI FAILED on PR #$PR_NUM — failing checks: ${CI_VERDICT#FAILED }" >&2
+            echo "  The local gate passed but the server disagreed. Investigate before re-landing." >&2
+            echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
+            exit 1
+            ;;
+        NO_CHECKS)
+            echo "pr-captain-land: no status checks found on PR #$PR_NUM." >&2
+            echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
+            echo "  or the required-contexts filter matched nothing." >&2
+            echo "  Merge manually with /pr-captain-merge if that is expected." >&2
+            exit 1
+            ;;
+        UNREADABLE)
+            : # transient gh/network hiccup — retry
+            ;;
+    esac
+
     sleep 20
     ATTEMPTS=$((ATTEMPTS + 1))
 done
 
-if [[ $ATTEMPTS -eq $MAX_ATTEMPTS ]]; then
-    echo "pr-captain-land: CI timeout on PR #$PR_NUM — check manually" >&2
+if [[ "$CI_VERDICT" != PASSED* ]]; then
+    echo "pr-captain-land: CI timeout on PR #$PR_NUM after $((MAX_ATTEMPTS * 20))s — check manually." >&2
+    echo "  Last verdict: ${CI_VERDICT:-none}" >&2
     exit 1
 fi
 
-# ── Merge ────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 8 — Merge + release
+# ═════════════════════════════════════════════════════════════════════════════
 
-echo "→ Merging PR #$PR_NUM..."
-bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved >/dev/null 2>&1 || {
+echo "→ Merging PR #$PR_NUM (true merge commit)..."
+bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved --delete-branch >/dev/null 2>&1 || {
     echo "pr-captain-land: pr-merge failed — check manually" >&2
     exit 1
 }
 
-# ── Sync master ──────────────────────────────────────────────────────────────
-
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1
-bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1
-
-# ── Create release ───────────────────────────────────────────────────────────
+bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
 
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
     bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
         --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
-        --notes "Captain-landed via pr-captain-land (the-agency#296 Phase 1 pilot). See PR #$PR_NUM." \
+        --notes "Captain-landed via /pr-captain-land (local-first). See PR #$PR_NUM." \
         >/dev/null 2>&1 || {
-        echo "pr-captain-land: gh-release failed — create manually" >&2
+        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER" >&2
     }
 fi
 
-# ── Dispatch agent with outcome ─────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 9 — Cleanup + notify + reconcile
+# ═════════════════════════════════════════════════════════════════════════════
 
-# Agent is encoded in the branch name or retrievable from the branch's commits
-# For Phase 1 pilot: assume branch name hints at agent (e.g., captain-X, devex-Y)
-# Full lookup happens when promoted to .claude/skills/
+echo "→ Cleaning up scratch worktree and land branch..."
+destroy_scratch
+rm -f "$VALIDATION_LOG"
+# The REMOTE copy of the land branch is deleted by `pr-merge --delete-branch`
+# above. It is deliberately NOT retried here: git-push takes a branch name
+# positionally and has no delete mode, so a "belt and braces" call would
+# re-PUSH the branch rather than remove it.
 
-AGENT_HINT="${AGENT_BRANCH%%-*}"  # naive parse: prefix before first dash
-echo "→ Dispatching $AGENT_HINT agent with merge outcome..."
-
+AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+echo "→ Dispatching $AGENT_NAME with merge outcome..."
 bash "$REPO_ROOT/agency/tools/dispatch" create \
     --type master-updated \
-    --to "$ORG/$PRINCIPAL/$AGENT_HINT" \
+    --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \
-    --body "Captain-landed your branch \`$AGENT_BRANCH\` via the-agency#296 Phase 1 pilot flow.
+    --body "Captain landed your branch \`$AGENT_BRANCH\` via the local-first flow.
 
-- PR: $PR_URL
+- PR: $PR_URL (head branch \`$LAND_SLUG\`, now deleted)
 - Release: https://github.com/$ORG/$REPO/releases/tag/v$NEW_VER
 - Version: $CURRENT_VER → $NEW_VER
+- Local validation before publish: $VALIDATION_SUMMARY
+- Captain landing receipt: \`$LANDING_RECEIPT_REL\`
 
-Your branch is merged to $DEFAULT_BRANCH. Run /session-resume to pick up on your next cycle.
-
-Phase 1 pilot feedback: did anything feel off about the handoff? Reply dispatch.
+Your branch \`$AGENT_BRANCH\` was never checked out or modified by the landing —
+it is merged into $DEFAULT_BRANCH through the land branch. Run /session-resume to
+sync and pick up your next cycle.
 
 -- $ORG/$PRINCIPAL/captain" \
     >/dev/null 2>&1 || true
 
-# ── Done ─────────────────────────────────────────────────────────────────────
+bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+
+# Reconcile local main with the server merge. This is a separate, idempotent
+# step ON PURPOSE: it is a normal merge-from-origin, identical to what
+# /captain-sync-all does, so running either afterwards is a no-op rather than a
+# double-integration. Local main is only ever moved by this reconciliation —
+# never by the landing itself.
+echo "→ Reconciling local $DEFAULT_BRANCH with origin..."
+bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1 || {
+    echo "note: could not fast-forward local $DEFAULT_BRANCH — run /captain-sync-all." >&2
+}
 
 echo ""
 echo "pr-captain-land: complete"
+echo "  Branch:  $AGENT_BRANCH (via $LAND_SLUG)"
 echo "  PR:      $PR_URL"
 echo "  Release: v$NEW_VER"
-echo "  Merged:  ✓"
+echo "  Gate:    local ($VALIDATION_SUMMARY), CI confirmed"

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -111,6 +111,8 @@ REHEARSE=false
 CUSTOM_TITLE=""
 AGENT_OVERRIDE=""
 SKIP_RELEASE=false
+ALLOW_UNVALIDATED=false
+PRINCIPAL_APPROVED=false
 
 usage() {
     cat <<'HELP'
@@ -127,7 +129,20 @@ Options:
   --title "..."     PR title (default: the agent branch name)
   --agent <name>    Agent to dispatch (default: inferred from branch prefix)
   --no-release      Skip the GitHub release after merge
+  --principal-approved
+                    Forward --admin to pr-merge, bypassing branch protection.
+                    Pass ONLY when the principal actually said so. Without it
+                    the merge defers to GitHub's own gates.
+  --allow-unvalidated
+                    Land even when no local validation command resolves.
+                    Recorded verbatim in the landing receipt.
   --help, -h        Show this help
+
+Environment:
+  PR_LAND_VALIDATE_CMD   Replaces the whole local validation ladder with this
+                         command, run with `bash -c` inside the scratch
+                         worktree. Use for repos whose gate is not a package
+                         build/test script.
 HELP
 }
 
@@ -135,9 +150,15 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --dry-run) DRY_RUN=true; REHEARSE=true; shift ;;
         --rehearse) REHEARSE=true; shift ;;
-        --title) CUSTOM_TITLE="$2"; shift 2 ;;
-        --agent) AGENT_OVERRIDE="$2"; shift 2 ;;
+        --title)
+            [[ -n "${2:-}" ]] || { echo "pr-captain-land: --title needs a value" >&2; exit 2; }
+            CUSTOM_TITLE="$2"; shift 2 ;;
+        --agent)
+            [[ -n "${2:-}" ]] || { echo "pr-captain-land: --agent needs a value" >&2; exit 2; }
+            AGENT_OVERRIDE="$2"; shift 2 ;;
         --no-release) SKIP_RELEASE=true; shift ;;
+        --allow-unvalidated) ALLOW_UNVALIDATED=true; shift ;;
+        --principal-approved) PRINCIPAL_APPROVED=true; shift ;;
         --help|-h) usage; exit 0 ;;
         -*) echo "pr-captain-land: unknown flag: $1" >&2; exit 2 ;;
         *) AGENT_BRANCH="$1"; shift ;;
@@ -162,11 +183,37 @@ if [[ "$AGENT_BRANCH" == *..* ]] || [[ "$AGENT_BRANCH" == -* ]]; then
     exit 2
 fi
 
-# Scratch identity. Slashes collapse to dashes: a worktree directory must not
-# nest under .claude/worktrees/, and `_land-fix/x` as a ref would collide with
-# an existing `_land-fix` ref (git stores refs as directories).
-LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/' '-')"
+# --agent lands in the same dispatch --to routing as the branch-derived name,
+# so it gets the same character class. It had none.
+if [[ -n "$AGENT_OVERRIDE" ]] && ! [[ "$AGENT_OVERRIDE" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; then
+    echo "pr-captain-land: invalid --agent '$AGENT_OVERRIDE' — must be [a-zA-Z0-9][a-zA-Z0-9_.-]*" >&2
+    exit 2
+fi
+
+# Scratch identity.
+#
+# BOTH slashes and dots collapse to dashes. Slashes because a worktree
+# directory must not nest under .claude/worktrees/, and `_land-fix/x` as a ref
+# would collide with an existing `_land-fix` ref (git stores refs as
+# directories). Dots because `worktree-create` validates its name against
+# ^[a-zA-Z_][a-zA-Z0-9_-]*$ — the branch-name gate above deliberately PERMITS
+# dots, so slugging only slashes made every dotted branch (v1.2, 46.20)
+# unlandable, and the failure surfaced as an opaque "could not create scratch
+# worktree". Keep this in sync with LAND_PROJECT below, which uses the same
+# translation for the receipt filename.
+LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
+
+# Trusted tool root.
+#
+# Every tool that VERIFIES or PUBLISHES must come from the captain's own
+# checkout, never from the tree under review. A branch that edits
+# receipt-verify to `exit 0`, or diff-hash to return a constant, would
+# otherwise pass its own gate — and pr-create, the tool that enforces
+# "valid receipt + version bumped", would be supplied by the very branch it
+# is meant to police. Tools are invoked as "$TOOLS/<name>" with the cwd set
+# to the scratch, so they operate ON the branch without being FROM it.
+TOOLS="$REPO_ROOT/agency/tools"
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Rollback — the entire pre-publish rollback story
@@ -175,14 +222,44 @@ SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
 # Nothing outside the scratch worktree has been modified before step 6, so
 # "undo" is "delete the scratch". No git reset, no merge --abort, no stashing,
 # and crucially nothing that could strand the captain's main checkout.
+#
+# Set once this invocation actually created the scratch. Until then
+# destroy_scratch must not touch anything: the most likely reason step 2 fails
+# is that a PREVIOUS run's `_land-<x>` branch still exists, and force-deleting
+# that on the way out would destroy the state step 0 just told the captain to
+# go inspect.
+SCRATCH_IS_OURS=false
+
 destroy_scratch() {
-    [[ -d "$SCRATCH_DIR" ]] || return 0
-    bash "$REPO_ROOT/agency/tools/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    [[ "$SCRATCH_IS_OURS" == true ]] || return 0
+    if [[ -d "$SCRATCH_DIR" ]]; then
+        bash "$TOOLS/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    fi
     # worktree-delete deliberately leaves the branch behind (it prints advice
     # instead). For a machine-created scratch branch there is nothing to
-    # preserve, so remove it too.
-    bash "$REPO_ROOT/agency/tools/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    # preserve, so remove it too — and do it even when the directory is
+    # already gone, otherwise a half-cleaned run leaves a branch that wedges
+    # every future land of this branch at worktree-create.
+    bash "$TOOLS/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
 }
+
+# ── Unconditional cleanup ────────────────────────────────────────────────────
+#
+# `set -euo pipefail` means any unhandled non-zero status exits immediately,
+# skipping the explicit abort_land calls. Without a trap, every such abort
+# between step 2 and step 6 — and every Ctrl-C — strands the scratch worktree,
+# and step 0 then refuses all future lands of that branch. The trap is
+# disarmed at the publish boundary, where deleting the scratch stops being the
+# right answer.
+PUBLISHED=false
+on_exit() {
+    local st=$?
+    rm -f "${VALIDATION_LOG:-}" 2>/dev/null || true
+    if [[ "$PUBLISHED" == false && $st -ne 0 ]]; then
+        destroy_scratch
+    fi
+}
+trap on_exit EXIT INT TERM
 
 # abort_land <message...> — roll back and exit non-zero.
 abort_land() {
@@ -197,7 +274,9 @@ abort_land() {
 # Step 0 — Preflight
 # ═════════════════════════════════════════════════════════════════════════════
 
-MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+# --porcelain, not the columnar form: `awk '{print $1}'` truncates any repo
+# path containing a space, and the guard then misfires.
+MAIN_CHECKOUT=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
 if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
     echo "pr-captain-land: must run from main checkout (you're in a worktree)." >&2
     echo "  Main checkout: $MAIN_CHECKOUT" >&2
@@ -205,10 +284,13 @@ if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
     exit 1
 fi
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+# Which branch the main checkout happens to be on is NOT load-bearing in v2 —
+# the land never reads, commits to, or moves it. Requiring the default branch
+# here is leftover v1 coupling that would refuse a land while the captain is
+# mid-/captain-release on a captain-* branch. Note it, do not block on it.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
-    echo "pr-captain-land: captain must be on $DEFAULT_BRANCH (you're on $CURRENT_BRANCH)." >&2
-    exit 1
+    echo "note: main checkout is on '$CURRENT_BRANCH', not '$DEFAULT_BRANCH' — harmless (the land runs in a scratch worktree)."
 fi
 
 # NOTE (#393): a dirty main checkout no longer blocks a land. The landing never
@@ -220,16 +302,70 @@ if [[ -n "$DIRTY" ]]; then
     echo "note: $DEFAULT_BRANCH checkout is dirty — harmless here (the land runs in a scratch worktree)."
 fi
 
+# Leftover scratch state from a crashed run. BOTH the directory and the branch
+# are checked: a run that died between `worktree add -b` and `worktree remove`
+# leaves only the branch, and worktree-create then refuses ("--from given but
+# branch already exists") on every retry with no way to see why.
 if [[ -d "$SCRATCH_DIR" ]]; then
     echo "pr-captain-land: scratch worktree $LAND_SLUG already exists at" >&2
     echo "  $SCRATCH_DIR" >&2
     echo "  A previous land is still running, or crashed. Inspect it, then:" >&2
     echo "    ./agency/tools/worktree-delete $LAND_SLUG --force" >&2
+    echo "    ./agency/tools/git-captain branch-delete $LAND_SLUG --force" >&2
+    exit 1
+fi
+if git show-ref --verify --quiet "refs/heads/$LAND_SLUG"; then
+    echo "pr-captain-land: land branch $LAND_SLUG already exists (no worktree)." >&2
+    echo "  A previous land crashed mid-cleanup. Inspect it, then:" >&2
+    echo "    ./agency/tools/git-captain branch-delete $LAND_SLUG --force" >&2
     exit 1
 fi
 
+# C#372 Fix B: a previously merged PR whose release was never cut leaves
+# pending state. Landing another PR on top of it loses the trail, and main
+# CI's release-tag-check stays red with nothing tracking why.
+if [[ -x "$TOOLS/post-merge-state" ]] && ! bash "$TOOLS/post-merge-state" check >/dev/null 2>&1; then
+    echo "pr-captain-land: a previous PR merge has no release yet." >&2
+    bash "$TOOLS/post-merge-state" get 2>/dev/null | sed 's/^/  /' >&2 || true
+    echo "  Run /pr-captain-post-merge <that-PR> first, then re-run this land." >&2
+    exit 1
+fi
+
+# Fetch is FATAL, not best-effort. Every guarantee below — base freshness, the
+# receipt's diff_base, "validated against pristine origin/<default>" — assumes
+# the origin refs are current. Swallowing the failure means an offline or
+# auth-expired captain validates against stale refs and still publishes.
 echo "→ Fetching origin..."
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+if ! bash "$TOOLS/git-captain" fetch >/dev/null 2>&1; then
+    echo "pr-captain-land: could not fetch origin." >&2
+    echo "  The land validates against origin/<default>; stale refs would make" >&2
+    echo "  every downstream check meaningless. Fix connectivity/auth and retry." >&2
+    exit 1
+fi
+
+# Who to notify. The branch-name prefix is a GUESS — `pr-lifecycle-v2` yields
+# `pr`, `feature/x-y` yields `feature/x`. Both dispatch calls are best-effort
+# (`|| true`), so a wrong name means the agent is silently never told their
+# work landed. Resolve against the actual agent registry and say so when the
+# guess does not land.
+resolve_agent_name() {
+    local candidate="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+    if [[ -f "$REPO_ROOT/.claude/agents/$PRINCIPAL/$candidate.md" ]] || \
+       [[ -f "$REPO_ROOT/.claude/agents/$candidate.md" ]]; then
+        printf '%s' "$candidate"
+        return 0
+    fi
+    if [[ -n "$AGENT_OVERRIDE" ]]; then
+        echo "note: --agent '$AGENT_OVERRIDE' has no registration; dispatching to it anyway." >&2
+        printf '%s' "$AGENT_OVERRIDE"
+        return 0
+    fi
+    # Unregistered guess: route to captain rather than into the void, and be
+    # explicit that the notification did not reach the author.
+    echo "note: could not resolve an agent from branch '$AGENT_BRANCH' (guessed '$candidate')." >&2
+    echo "  Dispatching to captain instead. Pass --agent <name> to route correctly." >&2
+    printf '%s' "captain"
+}
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Step 1 — Verify the agent branch on origin, and that its base is current
@@ -270,10 +406,12 @@ echo "→ Branch origin/$AGENT_BRANCH is current with $BASE_REF"
 # into the default branch".
 
 echo "→ Creating scratch worktree $LAND_SLUG at origin/$AGENT_BRANCH..."
-if ! bash "$REPO_ROOT/agency/tools/worktree-create" "$LAND_SLUG" \
-        --from "origin/$AGENT_BRANCH" >/dev/null 2>&1; then
-    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG" >&2
-    destroy_scratch
+# stdout is noise; stderr is the diagnosis. Discarding both turned every
+# distinct failure (invalid name, existing branch, disk full) into one opaque
+# "could not create scratch worktree".
+SCRATCH_IS_OURS=true
+if ! bash "$TOOLS/worktree-create" "$LAND_SLUG" --from "origin/$AGENT_BRANCH" >/dev/null; then
+    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG (see above)" >&2
     exit 1
 fi
 
@@ -286,7 +424,7 @@ fi
 # land invalidates the receipt it is checking and the agent is asked to re-prep
 # for a change the captain made.
 
-DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
@@ -295,7 +433,10 @@ if [[ -z "$DIFF_HASH_SHORT" ]]; then
     abort_land "could not compute a diff hash for origin/$AGENT_BRANCH against $BASE_REF."
 fi
 
-AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+# `sort` before `head` so two receipts sharing a 7-char short hash resolve
+# deterministically rather than by filesystem order. The name carries a
+# timestamp, so the last one sorts newest.
+AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | sort | tail -1 || echo "")
 if [[ -z "$AGENT_RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
     echo "  The branch content and the newest receipt disagree." >&2
@@ -304,17 +445,23 @@ if [[ -z "$AGENT_RECEIPT" ]]; then
     exit 1
 fi
 
-if ! (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
+# receipt-verify comes from the CAPTAIN'S checkout, not the branch's. A branch
+# that edits its own copy to `exit 0` would otherwise pass its own gate.
+if ! (cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
     echo "pr-captain-land: receipt $AGENT_RECEIPT does not verify against the branch." >&2
     echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
     destroy_scratch
     exit 1
 fi
 
-AGENT_RECEIPT_REL="${AGENT_RECEIPT#$SCRATCH_DIR/}"
+AGENT_RECEIPT_REL="${AGENT_RECEIPT#"$SCRATCH_DIR"/}"
 # hash_a of the landing receipt chains to hash_e of the agent's receipt — the
 # captain's gate extends the agent's chain rather than starting a new one.
-AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"')
+#
+# `|| true` is load-bearing: under `set -euo pipefail` a receipt with no
+# hash_e line makes grep exit 1, the assignment fails, and the script dies
+# SILENTLY — which also made the ${AGENT_HASH_E:-...} fallback below dead code.
+AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" 2>/dev/null | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"' || true)
 
 echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
 
@@ -322,7 +469,11 @@ echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
 # Step 3 — VALIDATE LOCALLY. This is the gate. GitHub is not the gate.
 # ═════════════════════════════════════════════════════════════════════════════
 
-VALIDATION_LOG="$(mktemp -t pr-captain-land-validate)"
+# `mktemp -t <prefix>` is a BSD-ism: GNU coreutils requires a template with at
+# least three X's and errors out. The framework ships to Linux adopters, and a
+# failure here happens AFTER the scratch worktree exists.
+VALIDATION_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-validate.XXXXXX")"
+chmod 600 "$VALIDATION_LOG" 2>/dev/null || true
 VALIDATION_SUMMARY=""
 
 # run_validation_step <label> <command...>
@@ -331,12 +482,21 @@ VALIDATION_SUMMARY=""
 # The status must be captured explicitly: wrapping the command in a brace group
 # that ends with an `echo` would make the group's status that of the echo, i.e.
 # always 0 — a validation gate that can never fail is worse than no gate.
+#
+# The command comes from the branch under review, so it runs with the
+# captain's credentials scrubbed out of the environment. A `build` script of
+# `gh auth token` would otherwise write the captain's PAT into this log — and
+# the log is tailed to stderr on failure, i.e. into the session transcript.
+# This is defence in depth, not a sandbox: the branch still executes code as
+# the captain's user, which is inherent to validating it locally at all.
 run_validation_step() {
     local label="$1"; shift
     local st=0
     echo "  · $label"
     echo "=== $label ===" >> "$VALIDATION_LOG"
-    "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
+    env -u GH_TOKEN -u GITHUB_TOKEN -u GH_ENTERPRISE_TOKEN -u GIT_ASKPASS \
+        -u SSH_AUTH_SOCK GIT_TERMINAL_PROMPT=0 \
+        "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
     echo "=== exit: $st ===" >> "$VALIDATION_LOG"
     return "$st"
 }
@@ -345,12 +505,12 @@ run_validation_step() {
 # name one inline (it ships to adopter repos that use a different one; see
 # src/tests/skills/skill-validation.bats). Absent one, the JS steps do not run.
 detect_pm() {
-    bash "$SCRATCH_DIR/agency/tools/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
+    bash "$TOOLS/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
 }
 
 has_pkg_script() {
     [[ -f "$SCRATCH_DIR/package.json" ]] || return 1
-    SCRIPT_NAME="$1" python3 -c '
+    SCRIPT_NAME="$1" SCRATCH="$SCRATCH_DIR" python3 -c '
 import json, os, sys
 p = json.load(open(os.path.join(os.environ["SCRATCH"], "package.json")))
 sys.exit(0 if os.environ["SCRIPT_NAME"] in (p.get("scripts") or {}) else 1)
@@ -363,15 +523,13 @@ VALIDATION_STEPS=0
 VALIDATION_FAILED=""
 
 # The validation command can be overridden wholesale for repos whose gate is
-# not expressible as "package script + commit-precheck".
+# not expressible as "package build + test script". See --help.
 if [[ -n "${PR_LAND_VALIDATE_CMD:-}" ]]; then
     VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
-    if ! (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD"); then
-        VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
-    fi
+    (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD") \
+        || VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
 else
     PM="$(detect_pm)"
-    export SCRATCH="$SCRATCH_DIR"
 
     if [[ -n "$PM" ]] && has_pkg_script build; then
         VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
@@ -391,24 +549,33 @@ else
             fi
         done
     fi
-
-    # commit-precheck is the same pre-commit gate every agent commit passes
-    # through — cheap, and it catches provenance/format regressions the test
-    # suites do not.
-    if [[ -z "$VALIDATION_FAILED" && -x "$SCRATCH_DIR/agency/tools/commit-precheck" ]]; then
-        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
-        (cd "$SCRATCH_DIR" && run_validation_step "commit-precheck" bash "$SCRATCH_DIR/agency/tools/commit-precheck") \
-            || VALIDATION_FAILED="commit-precheck"
-    fi
 fi
 
+# NOTE on commit-precheck: it is deliberately NOT part of this ladder. It gates
+# on STAGED files, and the scratch tree is clean here — so it would exit 0
+# having inspected nothing, while still counting as a step. That inflated the
+# step count, suppressed the "no validation resolved" abort below, and wrote
+# "N local validation step(s) passed" into a signed receipt on the strength of
+# a no-op. It still runs, where it means something: git-safe-commit invokes it
+# on the version-bump and landing-receipt commits in steps 4 and 5.
+
 if [[ "$VALIDATION_STEPS" -eq 0 ]]; then
-    # Distinct, loud, and NOT a silent pass: a repo with no resolvable local
-    # gate has opted out of the whole point of this flow.
-    echo "WARNING: no local validation command resolved for this repo." >&2
-    echo "  Set PR_LAND_VALIDATE_CMD, or declare a build/test script." >&2
-    echo "  Landing continues, but local-first validation did NOT happen." >&2
-    VALIDATION_SUMMARY="no local validation command resolved (see warning)"
+    # FAIL CLOSED. A landing with no local gate is not a local-first landing —
+    # it is the old PR-first flow with extra steps, and it would go on to sign
+    # a five-hash receipt attesting to a validation that never ran.
+    if [[ "$ALLOW_UNVALIDATED" != true ]]; then
+        abort_land "no local validation command resolved for this repo — refusing to land.
+  The local gate is the whole point of this flow; signing a landing receipt
+  for a validation that did not happen would make the receipt a lie.
+
+  Fix one of these:
+    - declare a build/test script in package.json, or
+    - set PR_LAND_VALIDATE_CMD='<your gate>', or
+    - pass --allow-unvalidated to land anyway (recorded in the receipt)."
+    fi
+    echo "WARNING: no local validation command resolved; --allow-unvalidated given." >&2
+    echo "  Local-first validation did NOT happen. This is recorded in the receipt." >&2
+    VALIDATION_SUMMARY="NO LOCAL VALIDATION RAN (--allow-unvalidated)"
 else
     VALIDATION_SUMMARY="$VALIDATION_STEPS local validation step(s) passed against $BASE_REF"
 fi
@@ -420,8 +587,8 @@ if [[ -n "$VALIDATION_FAILED" ]]; then
     echo "────────────────────────────────────" >&2
 
     # Tell the agent before rolling back — the scratch is about to vanish.
-    AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
-    bash "$REPO_ROOT/agency/tools/dispatch" create \
+    AGENT_NAME="$(resolve_agent_name)"
+    bash "$TOOLS/dispatch" create \
         --type dispatch \
         --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
         --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
@@ -450,7 +617,7 @@ if [[ "$REHEARSE" == true ]]; then
         echo "    PR title:    ${CUSTOM_TITLE:-$AGENT_BRANCH}"
         echo "    Head branch: $LAND_SLUG (pushed from the scratch worktree)"
         echo "    Base branch: $DEFAULT_BRANCH"
-        echo "    Agent to notify: ${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+        echo "    Agent to notify: $(resolve_agent_name)"
         echo "    Release:     $([[ "$SKIP_RELEASE" == true ]] && echo "skipped" || echo "yes, v<bumped version>")"
     fi
     destroy_scratch
@@ -473,23 +640,25 @@ fi
 # (F-SEC-1 / CRITICAL-3 from MAR 2026-04-19). Prevents RCE if manifest is
 # ever attacker-controllable.
 CURRENT_VER=$(MANIFEST="$MANIFEST" python3 -c '
-import json, os
-print(json.load(open(os.environ["MANIFEST"]))["agency_version"])
-')
-
-NEW_VER=$(CURRENT_VER="$CURRENT_VER" python3 -c '
-import os, sys
-v = os.environ["CURRENT_VER"]
-parts = v.split(".")
-if len(parts) == 2:
-    major, minor = int(parts[0]), int(parts[1])
-    print(f"{major}.{minor+1}")
-elif len(parts) == 1:
-    print(f"{int(parts[0])+1}")
-else:
-    print(v)
+import json, os, sys
+m = json.load(open(os.environ["MANIFEST"]))
+v = m.get("agency_version")
+if not v:
     sys.exit(1)
-')
+print(v)
+' || true)
+
+if [[ -z "$CURRENT_VER" ]]; then
+    abort_land "manifest.json has no agency_version — cannot bump."
+fi
+
+# The bump policy lives in agency/tools/agency-version-next. Inline, it was
+# `NEW_VER=$(python3 -c '... sys.exit(1)')`, which under `set -euo pipefail`
+# killed THIS script before the friendly error below could run — so the abort
+# was unreachable for exactly the input it was written for, and the scratch
+# worktree was left stranded.
+NEW_VER=$(bash "$TOOLS/agency-version-next" "$CURRENT_VER") || \
+    abort_land "could not bump agency_version from '$CURRENT_VER' (see above)."
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
     abort_land "could not bump version from $CURRENT_VER"
@@ -502,14 +671,24 @@ import json, os
 from datetime import datetime, timezone
 path = os.environ["MANIFEST"]
 m = json.load(open(path))
+stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 m["agency_version"] = os.environ["NEW_VER"]
-m["project"]["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-json.dump(m, open(path, "w"), indent=2)
-'
+# Both timestamps: the nested one was already maintained, the top-level one
+# exists and was being left stale by every land.
+if isinstance(m.get("project"), dict):
+    m["project"]["updated_at"] = stamp
+if "updated_at" in m:
+    m["updated_at"] = stamp
+with open(path, "w") as fh:
+    json.dump(m, fh, indent=2)
+    # The file on disk ends with a newline; json.dump does not write one, so
+    # without this every land adds a spurious "\ No newline at end of file".
+    fh.write("\n")
+' || abort_land "could not write the version bump into manifest.json"
 
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add agency/config/manifest.json) \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe" add agency/config/manifest.json) \
     || abort_land "could not stage the version bump"
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe-commit" \
     "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
     --no-work-item >/dev/null) \
     || abort_land "could not commit the version bump"
@@ -524,25 +703,37 @@ json.dump(m, open(path, "w"), indent=2)
 #   A = the agent receipt's hash_e   (what was reviewed)
 #   B = hash of the local validation log
 #   C = B                            (nothing to triage — validation was green)
-#   D = C                            (auto-approved; no principal 1B1)
+#   D = C, or the principal-approval marker when --principal-approved is given
 #   E = diff hash of the bumped tree against origin/<default>
 #
 # Receipts live outside diff-hash's file set, so committing this receipt does
 # not invalidate the hash it carries.
 
-LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 if [[ -z "$LAND_HASH_FULL" ]]; then
     abort_land "could not compute the post-bump diff hash for the landing receipt"
 fi
 
-VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" | cut -d' ' -f1)
+VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" 2>/dev/null | cut -d' ' -f1 || true)
+if [[ -z "$VALIDATION_HASH" ]]; then
+    abort_land "could not hash the validation log — refusing to sign a receipt with no hash_b"
+fi
+
+# hash_d is the principal-approval link. It must not claim an approval that
+# did not happen: it equals hash_c unless the captain actually passed
+# --principal-approved, in which case the source string records that.
+if [[ "$PRINCIPAL_APPROVED" == true ]]; then
+    HASH_D_SOURCE="principal-approved flag passed by captain at land time"
+else
+    HASH_D_SOURCE="auto-approved — no principal 1B1"
+fi
 # project must be filename-safe: it becomes part of the receipt name.
 LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 
 echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-sign" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-sign" \
     --type qgr \
     --boundary pr-captain-land \
     --org "$ORG" \
@@ -555,19 +746,20 @@ echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
     --hash-c "$VALIDATION_HASH" \
     --hash-d "$VALIDATION_HASH" \
     --hash-e "$LAND_HASH_FULL" \
+    --hash-d-source "$HASH_D_SOURCE" \
     --diff-base "$BASE_REF" \
     --summary "Local-first landing of $AGENT_BRANCH. Integrated in scratch worktree $LAND_SLUG cut from origin/$AGENT_BRANCH; $VALIDATION_SUMMARY; agency_version $CURRENT_VER → $NEW_VER. Chains to agent receipt $AGENT_RECEIPT_REL." \
     >/dev/null) || abort_land "could not sign the landing receipt"
 
-LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | head -1 || echo "")
+LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | sort | tail -1 || echo "")
 if [[ -z "$LANDING_RECEIPT" ]]; then
     abort_land "landing receipt was signed but could not be located"
 fi
-LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
+LANDING_RECEIPT_REL="${LANDING_RECEIPT#"$SCRATCH_DIR"/}"
 
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add "$LANDING_RECEIPT_REL") \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe" add "$LANDING_RECEIPT_REL") \
     || abort_land "could not stage the landing receipt"
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe-commit" \
     "misc(pr-captain-land): landing receipt for $AGENT_BRANCH (${LAND_HASH_FULL:0:7})" \
     --no-work-item >/dev/null) \
     || abort_land "could not commit the landing receipt"
@@ -580,8 +772,21 @@ LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
 # Failures below report and leave the scratch in place for inspection.
 
 echo "→ Pushing $LAND_SLUG..."
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-push" "$LAND_SLUG" >/dev/null) \
-    || abort_land "could not push $LAND_SLUG"
+if ! (cd "$SCRATCH_DIR" && bash "$TOOLS/git-push" "$LAND_SLUG" >/dev/null); then
+    # The push may have partially succeeded, so say so before rolling back —
+    # otherwise an orphaned remote branch exists with nothing referencing it.
+    echo "pr-captain-land: could not push $LAND_SLUG." >&2
+    echo "  If the remote branch was created anyway, delete it:" >&2
+    echo "    gh api -X DELETE repos/$ORG/$REPO/git/refs/heads/$LAND_SLUG" >&2
+    abort_land "push failed"
+fi
+
+# ── Publish boundary ────────────────────────────────────────────────────────
+# Work now exists on origin. Deleting the scratch stops being "rollback" and
+# starts being "destroy the only local record of what was published", so the
+# EXIT trap's cleanup is disarmed here. Everything below reports and leaves
+# state for inspection.
+PUBLISHED=true
 
 PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
@@ -603,18 +808,34 @@ EOF
 )
 
 echo "→ Creating PR..."
-PR_URL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/pr-create" \
-            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) | \
-         tail -1 | grep -oE 'https://github.com/[^ ]+' || echo "")
+# pr-create runs from the CAPTAIN'S tools with the cwd in the scratch: the
+# branch supplies the content, never the tool that gates it. Otherwise a
+# branch could ship its own pr-create and the "pr-create is not weakened"
+# guarantee would be unenforceable.
+#
+# The URL is matched anywhere in the output, not just on the last line — gh
+# emits warnings on the same stream, and scraping `tail -1` sent a
+# successfully created PR down the "did not return a URL" path, leaving an
+# orphan PR for the operator to find.
+PR_OUT=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/pr-create" \
+            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) || true)
+PR_URL=$(printf '%s\n' "$PR_OUT" | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1 || true)
 
 if [[ -z "$PR_URL" ]]; then
-    echo "pr-captain-land: pr-create did not return a URL — check output above." >&2
+    echo "$PR_OUT" >&2
+    echo "" >&2
+    echo "pr-captain-land: pr-create did not return a PR URL — see output above." >&2
     echo "  Scratch worktree kept for inspection: $SCRATCH_DIR" >&2
-    echo "  Branch $LAND_SLUG is pushed; delete it if you abandon this land." >&2
+    echo "  Branch $LAND_SLUG IS pushed; delete it if you abandon this land." >&2
     exit 1
 fi
 
-PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+PR_NUM=$(printf '%s' "$PR_URL" | grep -oE '[0-9]+$' || true)
+if [[ -z "$PR_NUM" ]]; then
+    echo "pr-captain-land: could not read a PR number from '$PR_URL'." >&2
+    echo "  The PR exists; finish it manually with /pr-captain-merge." >&2
+    exit 1
+fi
 echo "→ PR created: $PR_URL (#$PR_NUM)"
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -633,72 +854,34 @@ echo "→ PR created: $PR_URL (#$PR_NUM)"
 #
 # Where branch protection exposes a required-contexts list, narrow to it.
 
-REQUIRED_CONTEXTS=$(bash "$REPO_ROOT/agency/tools/gh-api" \
+# The branch-protection required-contexts list, when readable. The endpoint
+# 404s on unprotected repos and without admin scope; ci-rollup-verdict treats
+# anything that is not a non-empty JSON array as "no narrowing".
+REQUIRED_CONTEXTS=$(bash "$TOOLS/gh-api" \
     "/repos/$ORG/$REPO/branches/$DEFAULT_BRANCH/protection/required_status_checks/contexts" \
     2>/dev/null || echo "")
 
 echo "→ Waiting for CI on PR #$PR_NUM (aggregate status check rollup)..."
 ATTEMPTS=0
 MAX_ATTEMPTS=45  # 45 × 20s = 15 minutes
+# GitHub has usually not registered any check runs in the first seconds after
+# a PR is opened, so the rollup is legitimately empty then. Treating that as
+# the fatal NO_CHECKS case would abort almost every real land. NO_CHECKS is
+# only believed once the grace window has passed — at which point "no CI
+# configured" is the honest reading, and it is still never a pass.
+NO_CHECKS_GRACE=9  # 9 × 20s = 3 minutes
 CI_VERDICT=""
 
 while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
-    ROLLUP=$(bash "$REPO_ROOT/agency/tools/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
+    ROLLUP=$(bash "$TOOLS/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
 
-    CI_VERDICT=$(ROLLUP_JSON="$ROLLUP" REQUIRED="$REQUIRED_CONTEXTS" python3 <<'PY'
-import json, os, sys
-
-raw = os.environ.get("ROLLUP_JSON") or ""
-try:
-    checks = (json.loads(raw) or {}).get("statusCheckRollup") or []
-except (ValueError, AttributeError):
-    print("UNREADABLE")
-    sys.exit(0)
-
-# Narrow to branch-protection required contexts when we could read them.
-try:
-    required = json.loads(os.environ.get("REQUIRED") or "[]")
-    required = set(required) if isinstance(required, list) else set()
-except ValueError:
-    required = set()
-
-
-def name_of(c):
-    return c.get("name") or c.get("context") or "(unnamed)"
-
-
-def state_of(c):
-    # CheckRun: status + conclusion. StatusContext: state.
-    if c.get("status") is not None or c.get("conclusion") is not None:
-        if (c.get("status") or "").upper() != "COMPLETED":
-            return "PENDING"
-        return (c.get("conclusion") or "PENDING").upper()
-    return (c.get("state") or "PENDING").upper()
-
-
-if required:
-    checks = [c for c in checks if name_of(c) in required]
-
-if not checks:
-    print("NO_CHECKS")
-    sys.exit(0)
-
-PASS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
-FAIL = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"}
-
-failed = [name_of(c) for c in checks if state_of(c) in FAIL]
-if failed:
-    print("FAILED " + ",".join(failed))
-    sys.exit(0)
-
-pending = [name_of(c) for c in checks if state_of(c) not in PASS]
-if pending:
-    print("PENDING " + ",".join(pending))
-    sys.exit(0)
-
-print("PASSED " + ",".join(name_of(c) for c in checks))
-PY
-)
+    # Classification lives in agency/tools/ci-rollup-verdict — a pure function
+    # of (rollup, required contexts), table-tested in
+    # src/tests/tools/ci-rollup-verdict.bats. Inline, it was a python heredoc
+    # that no test could reach, and every guard written for it still passed
+    # with the PASS and FAIL sets swapped.
+    CI_VERDICT=$(printf '%s' "$ROLLUP" | \
+        python3 "$TOOLS/ci-rollup-verdict" --required "$REQUIRED_CONTEXTS" 2>/dev/null || echo "UNREADABLE")
 
     case "$CI_VERDICT" in
         PASSED*)
@@ -712,14 +895,16 @@ PY
             exit 1
             ;;
         NO_CHECKS)
-            echo "pr-captain-land: no status checks found on PR #$PR_NUM." >&2
-            echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
-            echo "  or the required-contexts filter matched nothing." >&2
-            echo "  Merge manually with /pr-captain-merge if that is expected." >&2
-            exit 1
+            if [[ $ATTEMPTS -ge $NO_CHECKS_GRACE ]]; then
+                echo "pr-captain-land: no status checks found on PR #$PR_NUM after $((NO_CHECKS_GRACE * 20))s." >&2
+                echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
+                echo "  or the required-contexts filter matched nothing." >&2
+                echo "  Merge manually with /pr-captain-merge if that is expected." >&2
+                exit 1
+            fi
             ;;
-        UNREADABLE)
-            : # transient gh/network hiccup — retry
+        PENDING*|UNREADABLE)
+            : # still running, or a transient gh/network hiccup — retry
             ;;
     esac
 
@@ -737,23 +922,50 @@ fi
 # Step 8 — Merge + release
 # ═════════════════════════════════════════════════════════════════════════════
 
+# --principal-approved is NOT asserted unconditionally. pr-merge treats it as
+# the captain's attestation that the principal verbally approved, and it is
+# the only route to `gh pr merge --admin`. Hardcoding it in a non-interactive
+# script would turn a deliberate human gate into a constant and make branch-
+# protection bypass the fleet's default merge mode. Default: defer to GitHub.
+MERGE_ARGS="--delete-branch"
+if [[ "$PRINCIPAL_APPROVED" == true ]]; then
+    MERGE_ARGS="--principal-approved --delete-branch"
+fi
+
 echo "→ Merging PR #$PR_NUM (true merge commit)..."
-bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved --delete-branch >/dev/null 2>&1 || {
-    echo "pr-captain-land: pr-merge failed — check manually" >&2
+MERGE_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-merge.XXXXXX")"
+# shellcheck disable=SC2086  # MERGE_ARGS is a controlled, space-separated flag list
+if ! bash "$TOOLS/pr-merge" "$PR_NUM" $MERGE_ARGS >"$MERGE_LOG" 2>&1; then
+    # Silencing this was indefensible at the single most consequential step.
+    echo "pr-captain-land: pr-merge failed on PR #$PR_NUM:" >&2
+    tail -30 "$MERGE_LOG" >&2
+    rm -f "$MERGE_LOG"
+    if [[ "$PRINCIPAL_APPROVED" == false ]]; then
+        echo "" >&2
+        echo "  If branch protection is the blocker and the principal approved," >&2
+        echo "  re-run with --principal-approved, or merge via /pr-captain-merge." >&2
+    fi
     exit 1
-}
+fi
+rm -f "$MERGE_LOG"
 
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+bash "$TOOLS/git-captain" fetch >/dev/null 2>&1 || true
 
+RELEASE_CUT=false
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
-    bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
+    RELEASE_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-release.XXXXXX")"
+    if bash "$TOOLS/gh-release" create "v$NEW_VER" \
         --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
         --notes "Captain-landed via /pr-captain-land (local-first). See PR #$PR_NUM." \
-        >/dev/null 2>&1 || {
-        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER" >&2
-    }
+        >"$RELEASE_LOG" 2>&1; then
+        RELEASE_CUT=true
+    else
+        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER:" >&2
+        tail -20 "$RELEASE_LOG" >&2
+    fi
+    rm -f "$RELEASE_LOG"
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -768,9 +980,9 @@ rm -f "$VALIDATION_LOG"
 # positionally and has no delete mode, so a "belt and braces" call would
 # re-PUSH the branch rather than remove it.
 
-AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."
-bash "$REPO_ROOT/agency/tools/dispatch" create \
+bash "$TOOLS/dispatch" create \
     --type master-updated \
     --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \
@@ -789,7 +1001,16 @@ sync and pick up your next cycle.
 -- $ORG/$PRINCIPAL/captain" \
     >/dev/null 2>&1 || true
 
-bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+# post-merge-state is the C#372 Fix B guard for "merged but release not cut".
+# Clearing it when the release was skipped or failed discards exactly the
+# signal it exists to carry, and main CI's release-tag-check then goes red
+# with nothing tracking why.
+if [[ "$RELEASE_CUT" == true ]]; then
+    bash "$TOOLS/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+else
+    echo "note: leaving post-merge state pending for PR #$PR_NUM — no release was cut." >&2
+    echo "  Run /pr-captain-post-merge $PR_NUM once the release exists." >&2
+fi
 
 # Reconcile local main with the server merge. This is a separate, idempotent
 # step ON PURPOSE: it is a normal merge-from-origin, identical to what
@@ -797,7 +1018,7 @@ bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 
 # double-integration. Local main is only ever moved by this reconciliation —
 # never by the landing itself.
 echo "→ Reconciling local $DEFAULT_BRANCH with origin..."
-bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1 || {
+bash "$TOOLS/git-captain" merge-from-origin >/dev/null 2>&1 || {
     echo "note: could not fast-forward local $DEFAULT_BRANCH — run /captain-sync-all." >&2
 }
 

--- a/.claude/skills/pr-captain-merge/SKILL.md
+++ b/.claude/skills/pr-captain-merge/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-captain-merge
 description: Captain-only. Merge a PR safely — true merge commit (never squash, never rebase), branch protection respected, --principal-approved gate for --admin override. Prevents the "accidentally squashed via the wide GitHub UI button" failure mode that has burned the fleet.
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, after PR has passed CI and principal has approved (verbally or via GitHub review). Invoked by captain directly or as a step within /pr-captain-land. NEVER from a worktree. Intended for explicit invocation — runtime precondition in underlying `agency/tools/pr-merge` refuses from wrong context.
+when_to_use: Captain on master in main checkout, after PR has passed CI and principal has approved (verbally or via GitHub review). Invoked by captain directly or as Step 8 within /pr-captain-land (after that skill's local validation gate and CI confirmation). NEVER from a worktree. Intended for explicit invocation — runtime precondition in underlying `agency/tools/pr-merge` refuses from wrong context.
 argument-hint: "<pr-number> [--principal-approved] [--delete-branch] [--dry-run]"
 paths: []
 required_reading:
@@ -156,7 +156,7 @@ Defense in depth against accidental invocation from the wrong context:
 
 ## Related
 
-- `/pr-captain-land` — composite skill that calls this as its merge step
+- `/pr-captain-land` — the local-first landing flow; calls this as its Step 8 merge, on a `_land-<branch>` head
 - `/pr-prep` — the QG-before-PR-create (agent-side)
 - `/pr-submit` — agent hands branch to captain for landing
 - `/pr-captain-post-merge` (TBD refactored to `/pr-captain-post-merge`) — release + fleet-notify after merge

--- a/.claude/skills/pr-captain-merge/examples.md
+++ b/.claude/skills/pr-captain-merge/examples.md
@@ -131,7 +131,7 @@ Exit 2.
 
 ## Integration examples
 
-### As Step 7 of `/pr-captain-land`
+### As Step 8 of `/pr-captain-land`
 
 When captain runs the full captain-owned PR lifecycle:
 
@@ -139,14 +139,18 @@ When captain runs the full captain-owned PR lifecycle:
 /pr-captain-land <agent-branch>
 ```
 
-Internally, Step 7 invokes `pr-captain-merge`:
+By the time the merge runs, the work has already passed the **local** validation gate
+(Step 3) and CI has confirmed it (Step 7). The merge is Step 8:
+
 ```
-→ CI green, merging PR #45...
-→ Merged: https://github.com/org/repo/pull/45
-→ Step 8: creating release v1.10...
+→ CI green: bash 3.2 probe,manifest version,smoke
+→ Merging PR #45 (true merge commit)...
+→ Creating release v1.10...
 ```
 
-The `--principal-approved` flag propagates from `pr-captain-land`'s caller.
+The PR head is the captain's short-lived `_land-<branch>`, so `--delete-branch` is
+passed; the agent's own branch is untouched. `--principal-approved` propagates from
+`pr-captain-land`'s caller.
 
 ### Before `/pr-captain-post-merge`
 

--- a/.claude/skills/pr-captain-merge/reference.md
+++ b/.claude/skills/pr-captain-merge/reference.md
@@ -26,12 +26,14 @@ This skill's unique protocol is thin — most of the behavior is in `agency/tool
 
 ## Composition with `pr-captain-land`
 
-When captain runs `/pr-captain-land`, this skill is invoked as Step 7 of the 9-step land flow. In that composition:
+When captain runs `/pr-captain-land` (v2, local-first), the merge happens at **Step 8**, after the local validation gate (Step 3) and the aggregate-CI confirmation (Step 7). In that composition:
 
-- `--principal-approved` is passed if captain initiated `/pr-captain-land` with the flag (principal authorized the full lifecycle, not just the merge)
-- Exit codes propagate to `/pr-captain-land`'s step handler — Step 8 (release) does not run if this Step 7 fails
+- The PR being merged rides a captain-created `_land-<branch>` head branch, not the agent's branch. The agent's branch is never checked out or pushed by the landing.
+- `--delete-branch` is passed so the short-lived land branch is removed on merge.
+- `--principal-approved` is passed because the principal authorized the full lifecycle, not just the merge.
+- Exit codes propagate; the release (also Step 8) does not run if the merge fails.
 
-See `pr-captain-land/references/land-protocol.md` for the full integration.
+See `.claude/skills/pr-captain-land/reference.md` for the full integration.
 
 ## Why the tool is separate from the skill
 

--- a/.claude/skills/pr-captain-post-merge/SKILL.md
+++ b/.claude/skills/pr-captain-post-merge/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-captain-post-merge
 description: Captain-only. After a PR has merged on GitHub, verify the merge, merge origin/master locally, sync all worktrees, create the GitHub release (every PR is a release), and clean up the PR branch. Formerly `/post-merge` — v2 rename to noun-actor-verb.
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, immediately after a PR has merged on GitHub. Triggered when principal says "merged" / "done" / indicates a PR landed, or as Step 8 of /pr-captain-land. NEVER from a worktree. NEVER auto-invoked.
+when_to_use: Captain on master in main checkout, immediately after a PR has merged on GitHub. Triggered when principal says "merged" / "done" / indicates a PR landed, or to finish a land that failed after its merge (/pr-captain-land performs this work inline at Steps 8-9). NEVER from a worktree. NEVER auto-invoked.
 argument-hint: "<pr-number>"
 paths: []
 required_reading:
@@ -197,7 +197,7 @@ Post-merge complete:
 ## Related
 
 - `/pr-captain-merge` — the merge itself, runs before this skill
-- `/pr-captain-land` — the full captain-owned PR lifecycle (this skill is Step 8 of that flow)
+- `/pr-captain-land` — the full captain-owned, local-first PR lifecycle; it performs this skill's work inline at Steps 8-9, so use this one only for manual or partially-failed landings
 - `/sync-all` — the fleet-sync sub-skill this calls in Step 5
 - `/release` (TBD refactored to `/captain-release`) — alternate entry point that runs /pr-captain-merge + this skill in one flow
 - `agency/tools/gh-release` — the release-creation tool

--- a/.claude/skills/pr-captain-post-merge/examples.md
+++ b/.claude/skills/pr-captain-post-merge/examples.md
@@ -127,19 +127,20 @@ Exit 2.
 
 ## Integration examples
 
-### As Step 8 of `/pr-captain-land`
+### Relationship to `/pr-captain-land`
 
-When captain runs the full captain-owned PR lifecycle:
+`/pr-captain-land` (v2, local-first) does this work inline — Step 8 merges and releases,
+Step 9 cleans up, dispatches the agent, clears post-merge state, and reconciles local
+main. You do not chain this skill after a successful land.
+
+Reach for it when a land was done manually, or when `/pr-captain-land` failed *after*
+the merge and the tail still needs running:
 
 ```
-/pr-captain-land <agent-branch>
+/pr-captain-post-merge <pr-number>
 ```
 
-Internally:
-- Step 7 invokes `/pr-captain-merge`
-- Step 8 invokes `/pr-captain-post-merge`
-
-Output from `/pr-captain-land` includes the combined report.
+It is idempotent with the landing's Step 9 and with `/captain-sync-all`.
 
 ### Chained with `/collaborate` for cross-repo notice
 

--- a/.claude/skills/pr-captain-post-merge/reference.md
+++ b/.claude/skills/pr-captain-post-merge/reference.md
@@ -33,14 +33,11 @@ GitHub Actions workflow `release-tag-check` runs on every push to master. If a m
 
 ## Composition with `/pr-captain-land`
 
-When captain runs `/pr-captain-land`, this skill is invoked as Step 8. In that composition:
+`/pr-captain-land` (v2, local-first) performs this skill's work inline rather than delegating: its **Step 8** merges and cuts the release, and its **Step 9** cleans up, dispatches the agent, clears post-merge state, and reconciles local main via `merge-from-origin`.
 
-- The merge (Step 7 of `/pr-captain-land`) has already happened via `/pr-captain-merge`
-- Steps 1-2 of this skill are skipped (parent skill has verified)
-- Steps 3-8 run in sequence
-- Exit code propagates; if Step 6 (release creation) fails, the full land flow fails
+Use this skill directly when a landing was done manually, or when `/pr-captain-land` failed after the merge (release creation is the usual culprit) and the post-merge tail still needs to run. It is idempotent with `/pr-captain-land`'s Step 9 and with `/captain-sync-all`.
 
-See `.claude/skills/pr-captain-land/references/land-protocol.md` for the full integration.
+See `.claude/skills/pr-captain-land/reference.md` for the full landing protocol.
 
 ## Recovery flows
 

--- a/.claude/skills/pr-submit/scripts/pr-submit
+++ b/.claude/skills/pr-submit/scripts/pr-submit
@@ -186,6 +186,22 @@ if [[ -z "$SCOPE" ]]; then
     exit 2
 fi
 
+# Validate the priority at parse time.
+#
+# It is expanded below as ${PRIORITY:+--priority "$PRIORITY"} — and the
+# expansion itself is unquoted, so the result undergoes word splitting and the
+# inner quotes are literal characters rather than grouping. A value like
+# 'high --reply-to 5' therefore injects extra flags into `dispatch create`,
+# and 'a b' arrives as two mangled words. Constrain the value instead of
+# relying on the caller.
+case "$PRIORITY" in
+    low|normal|high|urgent) ;;
+    *)
+        echo "submit-for-pr: invalid --priority '$PRIORITY' (expected low|normal|high|urgent)" >&2
+        exit 2
+        ;;
+esac
+
 # ── Precondition: not in main checkout ───────────────────────────────────────
 
 MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
@@ -340,7 +356,7 @@ EOF
     --to "$ORG/$PRINCIPAL/captain" \
     --subject "Ready for PR landing: $BRANCH — $SCOPE" \
     --body "$DISPATCH_BODY" \
-    ${PRIORITY:+--priority "$PRIORITY"} >/dev/null
+    --priority "$PRIORITY" >/dev/null
 
 echo "submit-for-pr: submitted"
 echo "  branch:   $BRANCH"

--- a/.claude/skills/pr-submit/scripts/pr-submit
+++ b/.claude/skills/pr-submit/scripts/pr-submit
@@ -114,18 +114,31 @@ parse_repo_from_remote() {
 # empty, and the agent is told "could not compute diff hash" with no hint that
 # the ref name is the problem. That blocks /pr-submit for every agent in such
 # a repo.
+#
+# The resolution ladder itself now lives in `agency/tools/resolve-default-branch`
+# — one tested primitive instead of seven drifting copies. This function stays
+# as a THIN WRAPPER on purpose: it is part of the sourced-lib contract
+# (PR_SUBMIT_LIB_ONLY), and `pr-captain-land` calls it by name. Renaming or
+# deleting it would break that consumer silently.
+#
+# Default (non-strict) mode is deliberate here: pr-submit's historical
+# behaviour was to fall back rather than abort. The fallback is now `main`
+# rather than `master` (#463 QG finding).
 resolve_default_branch() {
-    local branch candidate
-    branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
-    if [[ -z "$branch" ]]; then
-        for candidate in main master; do
-            if git rev-parse --verify --quiet "origin/$candidate" >/dev/null 2>&1; then
-                branch="$candidate"
-                break
-            fi
-        done
+    local self_dir tool target branch
+    # Locate the primitive relative to THIS FILE, not to the cwd repo — the
+    # function is routinely called with the cwd inside some other repository
+    # (the helper unit tests do exactly that, and so does any adopter checkout
+    # being inspected). Resolving against cwd would look for the tool in the
+    # wrong tree and silently degrade to the fallback.
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    tool="$self_dir/../../../../agency/tools/resolve-default-branch"
+    # The repo being asked about IS the cwd repo — pass it explicitly.
+    target="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    if [[ -x "$tool" ]]; then
+        branch="$("$tool" -C "$target" 2>/dev/null || true)"
     fi
-    printf '%s' "${branch:-master}"
+    printf '%s' "${branch:-main}"
 }
 
 # Sourced for tests: stop here, before any precondition touches git or the
@@ -291,16 +304,19 @@ $SCOPE
 
 ## Captain action requested
 
-Run /pr-captain-land on branch \`$BRANCH\`:
+Run /pr-captain-land on branch \`$BRANCH\` (local-first):
 
-1. Switch to \`$BRANCH\`
-2. Verify receipt against current state
-3. Bump \`agency_version\` in manifest (serialized — single writer)
-4. Create PR with captain-authored fleet-aware description
-5. Watch CI (\`lint-and-test\` gate)
-6. Merge when green
-7. Create GitHub release v{agency_version}
-8. Dispatch back with merge confirmation + release tag
+1. Cut a scratch worktree \`_land-$BRANCH\` at \`origin/$BRANCH\` — my branch is never checked out
+2. Verify this QGR receipt against that tree, BEFORE any mutation
+3. Validate locally in the scratch (build + tests + commit-precheck) — this is the gate
+4. Bump \`agency_version\` in the scratch (serialized — single writer)
+5. Sign a captain landing receipt chained to this one
+6. Push the scratch branch and open the PR
+7. Wait on the aggregate status check rollup, merge when green
+8. Create GitHub release v{agency_version}, dispatch back with confirmation
+
+If local validation fails, nothing is published and I get a dispatch naming the
+failing step.
 
 ## What I (agent) will NOT do
 

--- a/agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+++ b/agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -12,22 +12,46 @@ These serve different purposes at different points. They do not replace each oth
 
 ### Captain PR Lifecycle
 
-The captain (coordination session on master) manages the full PR cycle:
+The captain (coordination session on the default branch, in the main checkout) owns the PR cycle end to end. The whole lifecycle is **local-first**: work is reviewed and validated locally, and GitHub is where already-validated work is published.
 
 ```
-1. /sync-all — merge worktree work into master
-2. Rebuild PR branches (reset -> squash -> stage -> commit)
-3. /captain-review --all — review all PR branches locally (runs against git diff, no GitHub PR needed)
-4. If issues found: dispatch to worktree agents via dispatch files
-5. Worktree agents fix issues -> land on master via /iteration-complete
-6. If no issues (or after fixes land): rebuild PR branches (now includes fixes + review files)
-7. Push and create draft PRs (review results visible in the diff)
-8. Human review -> convert to ready-for-review -> merge
+1. /captain-sync-all — fetch, merge origin, merge worktree work, sync worktrees (never pushes)
+2. /captain-review --all — review branches locally (runs against git diff, no GitHub PR needed)
+3. If issues found: dispatch to worktree agents; they fix and re-run /iteration-complete
+4. Agent runs /pr-prep (QG + signed QGR receipt), pushes, then /pr-submit (dispatches captain)
+5. Captain runs /pr-captain-land <branch> — see below
 ```
 
-Reviews run **locally** against `git diff origin/master...<branch>`. No GitHub PR is required. Reviews happen BEFORE PRs are created. The review results are committed to the repo and included in the PR diff.
+Reviews run **locally** against `git diff origin/<default>...<branch>`. No GitHub PR is required. Reviews happen BEFORE PRs are created. Review results are committed and appear in the PR diff.
 
-If all PRs are clean (zero issues >= 80 confidence), skip steps 4-5 and proceed directly to step 6.
+#### `/pr-captain-land` — local-first landing
+
+The landing does **not** switch the main checkout to the agent's branch, and does **not** merge into or push local `main`. Instead:
+
+```
+0-1. Fetch; verify the branch on origin and that origin/<default> is an ancestor of it
+     (stale base BLOCKS with "merge <default> + re-run /pr-prep", not a hash error)
+2.   Cut a scratch worktree  _land-<branch>  at  origin/<agent-branch>
+2b.  Verify the agent's QGR receipt against that tree — BEFORE any mutation
+3.   VALIDATE LOCALLY in the scratch (build + tests + commit-precheck). THIS IS THE GATE.
+     Failure → delete the scratch, dispatch the agent, nothing published.
+4-5. Bump agency_version in the scratch; sign a captain landing receipt chained to the
+     agent's (hash_a = agent hash_e). pr-create is not weakened.
+6.   Push the scratch branch, open the PR (_land-<branch> → default)
+7.   Wait on the AGGREGATE statusCheckRollup — every required context green. An empty
+     rollup is a distinct error, never a silent pass. No hardcoded check name.
+8.   pr-merge (true merge commit) → gh-release
+9.   Delete the scratch + land branch, dispatch the agent, clear post-merge state, and
+     reconcile local main with an idempotent merge-from-origin
+```
+
+**Rollback at any pre-publish failure is deleting the scratch worktree.** No `git reset --hard`, no merge abort, no stranded main checkout. A dirty main checkout does not block a land, because the land never touches it.
+
+`/pr-captain-land <branch> --rehearse` runs steps 0-3 only — integrate and validate with zero side effects. Rehearse before the first land of any unfamiliar branch.
+
+Only one `/pr-captain-land` at a time (they would race on the version bump). Two runs for the *same* branch are blocked mechanically by the leftover-scratch precondition.
+
+Full protocol: `.claude/skills/pr-captain-land/reference.md`.
 
 ### Code Review Dispatch
 

--- a/agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
+++ b/agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
@@ -55,7 +55,7 @@ Organized alphabetically by name.
 | phase-complete | Run full QG after completing a phase — review, fix, test, report, commit | 2 | agent | active | QUALITY-GATE, RECEIPT-INFRASTRUCTURE |
 | plan-complete | Complete a plan — final deep QG, finalize artifacts, produce reference doc | 1 | agent | active | QUALITY-GATE, DEVELOPMENT-METHODOLOGY |
 | pr-captain-post-merge | Captain-only. Post-PR-merge flow — verify merge, sync master, /sync-all, cut release, cleanup branch | 2 | captain | active | GIT-MERGE-NOT-REBASE, WORKTREE-DISCIPLINE, SAFE-TOOLS |
-| pr-captain-land | Captain lands agent's prepared branch — PR + CI + merge + release + notify | 2 | captain | pilot | QUALITY-GATE, WORKTREE-DISCIPLINE |
+| pr-captain-land | Captain lands agent's prepared branch LOCAL-FIRST — scratch-worktree integrate + local validation gate, then PR + CI confirm + merge + release + notify | 2 | captain | active | QUALITY-GATE, WORKTREE-DISCIPLINE |
 | pr-captain-merge | Captain-only. Merge PR safely — true merge commit (never squash/rebase), --principal-approved gate | 2 | captain | active | GIT-MERGE-NOT-REBASE, SAFE-TOOLS, CODE-REVIEW-LIFECYCLE |
 | pr-prep | Run QG before creating PR — review, fix, test, report, produce QGR receipt | 1 | agent | active | QUALITY-GATE, CODE-REVIEW-LIFECYCLE |
 | pr-respond | Fetch PR review comments, compose threaded replies, resolve threads | 1 | agent | active | CODE-REVIEW-LIFECYCLE |

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.27",
+  "agency_version": "46.28",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
-    "framework_version": "46.27",
-    "updated_at": "2026-08-08T11:50:00Z"
+    "framework_version": "46.28",
+    "updated_at": "2026-08-10T00:45:00Z"
   },
   "source": {
     "type": "local",

--- a/agency/tools/_sync-main-ref
+++ b/agency/tools/_sync-main-ref
@@ -1,42 +1,62 @@
 #!/bin/bash
 #
-# _sync-main-ref — Update local refs/heads/main to match origin/main without
-# requiring a checkout of main. Workaround for the bootstrap case where the
-# captain's tools haven't yet propagated to the local main branch.
+# _sync-main-ref — Update the local default-branch ref to match its origin
+# counterpart without requiring a checkout. Workaround for the bootstrap case
+# where the captain's tools haven't yet propagated to the local main branch.
 #
 # This is a captain-internal helper. After D41-R5 lands and the proper
 # git-captain has sync-main + merge-continue available everywhere, this can
 # be removed.
 #
-# Safety: refuses to run if local main has commits not on origin/main
+# Safety: refuses to run if the local branch has commits not on origin
 # (would lose work). Only fast-forwards.
+#
+# The branch name is RESOLVED, never hardcoded. This tool used to say
+# `origin/main` in five places, which made it a no-op-with-an-error in any
+# repo whose default branch is `master` — the exact class of failure the
+# shared `resolve-default-branch` primitive exists to end.
 #
 set -euo pipefail
 
-cd "$(dirname "$0")/../.."
+# Resolve the script dir BEFORE changing directory — a later `dirname "$0"`
+# would be interpreted relative to the new cwd and silently point elsewhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR/../.."
 
 # Fetch first
 git fetch origin --quiet
 
-local_main=$(git rev-parse refs/heads/main 2>/dev/null) || {
-    echo "ERROR: refs/heads/main does not exist" >&2; exit 1
+# --strict: this tool moves a ref. Guessing the wrong branch name here would
+# either fail confusingly or, worse, fast-forward the wrong ref. Fail loud.
+if ! DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" --strict 2>/dev/null)"; then
+    echo "ERROR: cannot determine default branch (checked local + origin/HEAD + origin/{main,master})" >&2
+    echo "  Fix: git remote set-head origin -a" >&2
+    exit 1
+fi
+
+local_ref="refs/heads/$DEFAULT_BRANCH"
+origin_ref="refs/remotes/origin/$DEFAULT_BRANCH"
+
+local_main=$(git rev-parse "$local_ref" 2>/dev/null) || {
+    echo "ERROR: $local_ref does not exist" >&2; exit 1
 }
-origin_main=$(git rev-parse refs/remotes/origin/main 2>/dev/null) || {
-    echo "ERROR: refs/remotes/origin/main does not exist" >&2; exit 1
+origin_main=$(git rev-parse "$origin_ref" 2>/dev/null) || {
+    echo "ERROR: $origin_ref does not exist" >&2; exit 1
 }
 
 if [[ "$local_main" == "$origin_main" ]]; then
-    echo "Already at origin/main ($origin_main)"
+    echo "Already at origin/$DEFAULT_BRANCH ($origin_main)"
     exit 0
 fi
 
 # Verify origin is ahead of local (FF safe). i.e., local must be ancestor of origin.
 if ! git merge-base --is-ancestor "$local_main" "$origin_main"; then
-    echo "ERROR: local main has commits not on origin/main — refusing to update ref" >&2
+    echo "ERROR: local $DEFAULT_BRANCH has commits not on origin/$DEFAULT_BRANCH — refusing to update ref" >&2
     echo "  local:  $local_main" >&2
     echo "  origin: $origin_main" >&2
     exit 1
 fi
 
-git update-ref refs/heads/main "$origin_main"
-echo "Updated local main: $local_main -> $origin_main"
+git update-ref "$local_ref" "$origin_main"
+echo "Updated local $DEFAULT_BRANCH: $local_main -> $origin_main"

--- a/agency/tools/agency-version-next
+++ b/agency/tools/agency-version-next
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# What Problem: the "bump agency_version" rule was open-coded as inline Python
+# inside pr-captain-land, and described again in prose in /captain-release.
+# Two consequences, both real:
+#
+#   1. The inline form `NEW_VER=$(python3 -c '... sys.exit(1)')` aborts the
+#      CALLER under `set -euo pipefail` before it can report anything. The
+#      friendly "could not bump version from X" error immediately below it was
+#      unreachable for exactly the input it was written for (a three-component
+#      semver), and the abort left the landing's scratch worktree stranded.
+#   2. A bump policy that lives in a skill cannot be tested, and cannot be
+#      shared with the other place that performs it.
+#
+# How & Why: one pure primitive that ECHOES the next version. No file I/O, no
+# git, no side effects — just the policy. Callers do
+# `NEW=$(agency-version-next "$CUR") || abort ...` and get a real error path.
+#
+# NOT to be confused with `agency/tools/version-next`, which is a different
+# tool for a different version string: it manages the VERSION file's
+# MAJOR.MINOR.PATCH-YYYYMMDD-NNNNNN build identifier. This one handles
+# manifest.json's `agency_version`, which is `day.release`. The `agency-`
+# prefix matches `agency-version`, the read-side tool for the same field.
+#
+# Policy (agency_version is `day.release`, e.g. 46.25):
+#   "46.25" → "46.26"     two components: bump the second
+#   "46.9"  → "46.10"     numeric, not lexical
+#   "46"    → "47"        one component: bump it
+#   anything else         → exit 1 with a message on stderr, nothing on stdout
+#
+# Three-component semver is deliberately REFUSED rather than guessed: the
+# framework's manifest is day.release and a silent reinterpretation of a
+# semver string would produce a wrong release tag.
+#
+# Usage:
+#   ./agency/tools/agency-version-next 46.25          # → 46.26
+#   NEW=$(./agency/tools/agency-version-next "$CUR") || die "..."
+#
+# Exit codes:
+#   0  next version on stdout
+#   1  unparseable / unsupported version (message on stderr, stdout empty)
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — extracted from pr-captain-land during the QG
+#          for the local-first rewrite.
+
+set -euo pipefail
+
+VERSION="1.0.0"
+
+case "${1:-}" in
+    --version|-v) echo "agency-version-next $VERSION"; exit 0 ;;
+    --help|-h)
+        cat <<'HELP'
+agency-version-next — echo the next agency_version
+
+Usage:
+  agency-version-next <current-version>
+
+  46.25 → 46.26      two components: the second is bumped numerically
+  46    → 47         one component
+  1.2.3 → exit 1     three-component semver is refused, not guessed
+
+Exit 1 (with an empty stdout) on anything unparseable, so callers can write
+  NEW=$(agency-version-next "$CUR") || die "..."
+and actually reach their error path.
+HELP
+        exit 0
+        ;;
+esac
+
+if [[ $# -ne 1 ]]; then
+    echo "agency-version-next: exactly one argument required" >&2
+    echo "Usage: agency-version-next <current-version>" >&2
+    exit 2
+fi
+
+CURRENT="$1"
+
+if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+    MAJOR="${BASH_REMATCH[1]}"
+    MINOR="${BASH_REMATCH[2]}"
+    # 10# forces base-10: a zero-padded component like "08" would otherwise be
+    # read as octal and either mis-bump or fail outright.
+    printf '%s.%s\n' "$MAJOR" "$(( 10#$MINOR + 1 ))"
+    exit 0
+fi
+
+if [[ "$CURRENT" =~ ^([0-9]+)$ ]]; then
+    printf '%s\n' "$(( 10#${BASH_REMATCH[1]} + 1 ))"
+    exit 0
+fi
+
+echo "agency-version-next: cannot bump '$CURRENT' — expected <n> or <n>.<n>" >&2
+if [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "  Three-component semver is not the agency_version format (day.release)." >&2
+    echo "  Refusing to guess which component to bump." >&2
+fi
+exit 1

--- a/agency/tools/ci-rollup-verdict
+++ b/agency/tools/ci-rollup-verdict
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""ci-rollup-verdict — classify a GitHub PR status-check rollup into one verdict.
+
+What Problem: pr-captain-land's CI gate was a hardcoded check name
+("lint-and-test") that does not exist in this repo, so the wait loop could
+only ever time out and a genuinely failing check could never fail fast.
+Replacing it with an aggregate-rollup gate put ~50 lines of classification
+logic — two node shapes, five terminal states, a required-contexts filter,
+an empty-rollup case — inside a shell heredoc inside a command substitution
+inside a while loop. That is untestable by construction, and the guards
+written for it were all `grep`-for-a-string: every one of them still passes
+if the PASS and FAIL sets are swapped.
+
+How & Why: the classification is a pure function of (rollup JSON, required
+contexts). Extracted here so it can be table-tested with no network, no git,
+and no PR. The caller keeps only the polling loop.
+
+Verdicts (one line on stdout):
+  PASSED <names>    every gated check reached a terminal success state
+  FAILED <names>    at least one gated check reached a terminal failure state
+  PENDING <names>   at least one gated check has not finished, or a required
+                    context has not reported at all
+  NO_CHECKS         nothing to gate on — NOT a pass
+  UNREADABLE        the input was not parseable rollup JSON
+
+Two rules worth stating out loud, because both are ways a naive gate says
+"green" when it should not:
+
+  1. A *required* context that has not posted yet is PENDING, not absent.
+     Filtering the rollup down to "required contexts that happen to be
+     present" means 1-of-3 required checks reporting green reads as PASSED.
+  2. An empty rollup is NO_CHECKS, never PASSED. "No CI configured" and
+     "all checks green" must not be indistinguishable.
+
+Usage:
+  gh pr view N --json statusCheckRollup | ci-rollup-verdict
+  gh pr view N --json statusCheckRollup | ci-rollup-verdict --required '["build","test"]'
+  ci-rollup-verdict --file rollup.json
+
+Exit codes:
+  0  verdict printed (read the verdict, not the exit code)
+  2  usage error
+
+Written: 2026-08-09 (devex) — extracted from pr-captain-land during the QG
+         for the local-first rewrite, in response to "all three CI-gate
+         guards are tautological".
+"""
+
+import json
+import os
+import sys
+
+# Runtime guard deliberately set BELOW the repo's declared 3.13 floor.
+#
+# The floor exists so tools can use modern syntax without surprise. This tool
+# uses nothing past 3.8 — stdlib json and f-strings. It sits on the critical
+# path of every PR landing, and `#!/usr/bin/env python3` resolves to Apple's
+# stock 3.9 on a stock macOS PATH. Asserting 3.13 here would make the CI gate
+# refuse to run on the very machine that lands the PRs: failing closed for a
+# reason that has nothing to do with CI. Guard the version this code actually
+# needs, and let the 3.13 floor be enforced where it buys something.
+if sys.version_info < (3, 8):
+    sys.stderr.write(
+        f"ci-rollup-verdict: requires Python 3.8+, found "
+        f"{sys.version_info.major}.{sys.version_info.minor}\n"
+    )
+    sys.exit(2)
+
+# Terminal states. A check in neither set has not finished.
+PASS_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+FAIL_STATES = {
+    "FAILURE",
+    "ERROR",
+    "TIMED_OUT",
+    "CANCELLED",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+    "STALE",
+}
+
+USAGE = """Usage: ci-rollup-verdict [--required <json-array>] [--file <path>]
+
+Reads `gh pr view --json statusCheckRollup` output on stdin (or --file) and
+prints exactly one verdict line: PASSED / FAILED / PENDING / NO_CHECKS /
+UNREADABLE.
+
+  --required <json>  JSON array of branch-protection required context names.
+                     When given, ONLY those contexts are gated on, and any
+                     required context missing from the rollup counts as
+                     PENDING. Anything that is not a non-empty JSON array
+                     (an error object, "null", "[]") is ignored.
+  --file <path>      Read the rollup JSON from a file instead of stdin.
+"""
+
+
+def name_of(check):
+    """CheckRun uses `name`; StatusContext uses `context`."""
+    return check.get("name") or check.get("context") or "(unnamed)"
+
+
+def state_of(check):
+    """Normalize both rollup node shapes to a single state token.
+
+    CheckRun carries `status` (QUEUED/IN_PROGRESS/COMPLETED) plus `conclusion`,
+    and the conclusion is meaningless until the status is COMPLETED — reading
+    it early is how an in-progress check gets counted green.
+    StatusContext carries only `state` (pending/success/failure/error).
+    """
+    if check.get("status") is not None or check.get("conclusion") is not None:
+        if str(check.get("status") or "").upper() != "COMPLETED":
+            return "PENDING"
+        return str(check.get("conclusion") or "PENDING").upper()
+    return str(check.get("state") or "PENDING").upper()
+
+
+def parse_required(raw):
+    """Return a set of required context names, or an empty set if unusable.
+
+    The branch-protection endpoint 404s (returning an error OBJECT, not an
+    array) on repos without protection or without admin scope. Anything that
+    is not a non-empty list of strings means "no narrowing".
+    """
+    if not raw:
+        return set()
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError):
+        return set()
+    if not isinstance(value, list):
+        return set()
+    return {str(v) for v in value if isinstance(v, str)}
+
+
+def verdict(rollup_json, required_raw=""):
+    """Classify. Pure — this is the whole point of the extraction."""
+    try:
+        parsed = json.loads(rollup_json)
+    except (ValueError, TypeError):
+        return "UNREADABLE"
+    if not isinstance(parsed, dict):
+        return "UNREADABLE"
+
+    checks = parsed.get("statusCheckRollup")
+    if checks is None:
+        checks = []
+    if not isinstance(checks, list):
+        return "UNREADABLE"
+    checks = [c for c in checks if isinstance(c, dict)]
+
+    required = parse_required(required_raw)
+
+    if required:
+        present = {name_of(c) for c in checks}
+        missing = sorted(required - present)
+        checks = [c for c in checks if name_of(c) in required]
+        if missing:
+            # A required context that has not reported is PENDING, not
+            # absent. Without this, 1-of-3 required checks green reads
+            # as PASSED and the PR merges on partial evidence.
+            waiting = missing + [
+                name_of(c) for c in checks if state_of(c) not in PASS_STATES
+            ]
+            failed_now = [name_of(c) for c in checks if state_of(c) in FAIL_STATES]
+            if failed_now:
+                return "FAILED " + ",".join(sorted(failed_now))
+            return "PENDING " + ",".join(sorted(set(waiting)))
+
+    if not checks:
+        return "NO_CHECKS"
+
+    failed = sorted({name_of(c) for c in checks if state_of(c) in FAIL_STATES})
+    if failed:
+        return "FAILED " + ",".join(failed)
+
+    pending = sorted({name_of(c) for c in checks if state_of(c) not in PASS_STATES})
+    if pending:
+        return "PENDING " + ",".join(pending)
+
+    return "PASSED " + ",".join(sorted({name_of(c) for c in checks}))
+
+
+def main(argv):
+    required_raw = os.environ.get("CI_ROLLUP_REQUIRED", "")
+    path = None
+
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("--help", "-h"):
+            sys.stdout.write(USAGE)
+            return 0
+        if arg == "--version":
+            sys.stdout.write("ci-rollup-verdict 1.0.0\n")
+            return 0
+        if arg == "--required":
+            if i + 1 >= len(argv):
+                sys.stderr.write("ci-rollup-verdict: --required needs a value\n")
+                return 2
+            required_raw = argv[i + 1]
+            i += 2
+            continue
+        if arg == "--file":
+            if i + 1 >= len(argv):
+                sys.stderr.write("ci-rollup-verdict: --file needs a path\n")
+                return 2
+            path = argv[i + 1]
+            i += 2
+            continue
+        sys.stderr.write(f"ci-rollup-verdict: unknown argument: {arg}\n")
+        sys.stderr.write(USAGE)
+        return 2
+
+    if path is not None:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read()
+        except OSError as exc:
+            sys.stderr.write(f"ci-rollup-verdict: cannot read {path}: {exc}\n")
+            return 2
+    else:
+        raw = sys.stdin.read()
+
+    sys.stdout.write(verdict(raw, required_raw) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/agency/tools/git-captain
+++ b/agency/tools/git-captain
@@ -33,32 +33,18 @@ fi
 
 die() { echo "${RED}[ERROR]${NC} $1" >&2; exit 1; }
 
-# Detect main branch name
+# Detect main branch name.
+#
+# Thin wrapper over the shared primitive — the resolution order (local
+# refs/heads/{main,master} → origin/HEAD → refs/remotes/origin/{main,master})
+# used to live inline here and in six other tools, each subtly different.
+# `--strict` preserves this tool's historical FAIL-CLOSED contract: git-captain
+# `die`s rather than guessing, because its callers go on to merge and push.
 detect_main_branch() {
-    # Issue #268: fall back to origin/HEAD or origin/{main,master} when the
-    # local main/master branch is missing — otherwise recovery breaks exactly
-    # when it's needed (local main deleted but origin still has it).
-    if git show-ref --verify refs/heads/main &>/dev/null; then
-        echo "main"
-    elif git show-ref --verify refs/heads/master &>/dev/null; then
-        echo "master"
-    elif git show-ref --verify refs/remotes/origin/HEAD &>/dev/null; then
-        # origin/HEAD is a symbolic ref pointing at the default remote branch
-        # (e.g., refs/remotes/origin/main). Strip the "origin/" prefix.
-        local ref
-        ref=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||')
-        if [[ -n "$ref" ]]; then
-            echo "$ref"
-            return 0
-        fi
-        die "Cannot resolve origin/HEAD symbolic ref."
-    elif git show-ref --verify refs/remotes/origin/main &>/dev/null; then
-        echo "main"
-    elif git show-ref --verify refs/remotes/origin/master &>/dev/null; then
-        echo "master"
-    else
+    local branch
+    branch=$("$SCRIPT_DIR/resolve-default-branch" --strict 2>/dev/null) || \
         die "Cannot find main or master branch (checked local + origin/HEAD + origin/{main,master})."
-    fi
+    echo "$branch"
 }
 
 usage() {

--- a/agency/tools/pkg-manager
+++ b/agency/tools/pkg-manager
@@ -8,21 +8,24 @@
 # shipped to adopter repos that may use a different one.
 #
 # How & Why: one zero-pip primitive that ECHOES the package manager to use for
-# a directory, chosen by lockfile and confirmed to be installed. Skills call
-# this instead of naming a manager; the knowledge lives in agency/tools/ where
-# it belongs.
+# a directory. Skills call this instead of naming a manager; the knowledge
+# lives in agency/tools/ where it belongs.
 #
-# Resolution order — most specific lockfile first, then the universal fallback:
-#   pnpm-lock.yaml            → pnpm
-#   yarn.lock                 → yarn
-#   bun.lockb / bun.lock      → bun
-#   package-lock.json         → npm
-#   package.json (no lock)    → npm
-#   no package.json           → (nothing, exit 1)
+# Resolution order — the repo's own declaration first, then lockfiles, then
+# the universal fallback:
+#   packageManager: "pnpm@9..."  → that manager   (the npm-standard field)
+#   pnpm-lock.yaml               → pnpm
+#   yarn.lock                    → yarn
+#   bun.lockb / bun.lock         → bun
+#   package-lock.json            → npm
+#   package.json, nothing else   → npm            (universal fallback)
+#   no package.json              → nothing, exit 1
 #
-# A manager named by a lockfile but NOT installed is skipped rather than
-# returned — echoing a command that cannot run just moves the failure
-# somewhere less legible.
+# When the repo NAMES a manager (field or lockfile) and it is not installed,
+# this FAILS (exit 1) rather than quietly substituting npm. Running `npm run
+# build` against a pnpm workspace does not do what the caller asked; it
+# produces a confusing failure attributed to the wrong thing. The npm fallback
+# applies only where the repo expressed no preference.
 #
 # Usage:
 #   ./agency/tools/pkg-manager              # resolve for the current directory
@@ -30,7 +33,7 @@
 #
 # Exit codes:
 #   0  resolved (name on stdout)
-#   1  no package.json, or no usable manager installed
+#   1  no package.json, or the named manager is not installed
 #   2  usage error
 #
 # Written: 2026-08-09 (devex) — extracted while building the local-first
@@ -38,12 +41,20 @@
 
 set -euo pipefail
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 DIR="."
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -C) DIR="${2:-}"; shift 2 ;;
+        -C)
+            # A bare trailing `-C` must be a usage error with a message. Left
+            # to `shift 2` it fails under `set -e` and the tool dies exit 1
+            # with no output — indistinguishable from "no package.json".
+            if [[ -z "${2:-}" ]]; then
+                echo "pkg-manager: -C requires a directory argument" >&2
+                exit 2
+            fi
+            DIR="$2"; shift 2 ;;
         --version|-v) echo "pkg-manager $VERSION"; exit 0 ;;
         --help|-h)
             cat <<'HELP'
@@ -52,9 +63,12 @@ pkg-manager — echo the JS package manager to use for a directory
 Usage:
   pkg-manager [-C <dir>]
 
-Echoes one of: pnpm, yarn, bun, npm. Chosen by lockfile, and only if that
-manager is actually installed. Exits 1 with no output when the directory has
-no package.json or no usable manager is present.
+Echoes one of: pnpm, yarn, bun, npm. Chosen from package.json's
+"packageManager" field, else the lockfile, else npm.
+
+Exit 1 with no output when the directory has no package.json, or when the
+repo names a manager that is not installed — substituting npm for a declared
+pnpm/yarn/bun workspace would run the wrong tool and blame the wrong thing.
 HELP
             exit 0
             ;;
@@ -66,24 +80,46 @@ if [[ ! -f "$DIR/package.json" ]]; then
     exit 1
 fi
 
-# Echo $1 and exit 0 if it is installed; otherwise fall through.
-# The explicit `return 0` is load-bearing under `set -e`: without it a
-# not-installed probe makes the enclosing `if` compound exit non-zero, which
-# aborts the script instead of trying the next candidate — the exact
-# "lockfile names an uninstalled manager" case this function exists for.
-try() {
+# require <manager> — the repo asked for this one. Echo it or fail loudly.
+require() {
     if command -v "$1" >/dev/null 2>&1; then
         printf '%s\n' "$1"
         exit 0
     fi
-    return 0
+    echo "pkg-manager: this project declares '$1' but it is not installed." >&2
+    echo "  Install it, or the caller's build/test step will run the wrong tool." >&2
+    exit 1
 }
 
-if [[ -f "$DIR/pnpm-lock.yaml" ]]; then try pnpm; fi
-if [[ -f "$DIR/yarn.lock" ]]; then try yarn; fi
-if [[ -f "$DIR/bun.lockb" || -f "$DIR/bun.lock" ]]; then try bun; fi
+# 1: the npm-standard `packageManager` field — an explicit declaration beats
+# lockfile archaeology, and monorepos often carry it with no lockfile checked
+# in (this repo is one).
+DECLARED="$(DIR="$DIR" python3 -c '
+import json, os, sys
+try:
+    p = json.load(open(os.path.join(os.environ["DIR"], "package.json")))
+except Exception:
+    sys.exit(0)
+value = p.get("packageManager")
+if isinstance(value, str) and value:
+    print(value.split("@", 1)[0].strip())
+' 2>/dev/null || true)"
 
-# package-lock.json, or no lockfile at all: npm is the universal fallback.
-try npm
+case "$DECLARED" in
+    pnpm|yarn|bun|npm) require "$DECLARED" ;;
+esac
 
+# 2: lockfiles, most specific first.
+[[ -f "$DIR/pnpm-lock.yaml" ]] && require pnpm
+[[ -f "$DIR/yarn.lock" ]] && require yarn
+{ [[ -f "$DIR/bun.lockb" ]] || [[ -f "$DIR/bun.lock" ]]; } && require bun
+[[ -f "$DIR/package-lock.json" ]] && require npm
+
+# 3: no declaration, no lockfile — npm is the universal fallback.
+if command -v npm >/dev/null 2>&1; then
+    printf '%s\n' npm
+    exit 0
+fi
+
+echo "pkg-manager: no package manager installed (npm not found)" >&2
 exit 1

--- a/agency/tools/pkg-manager
+++ b/agency/tools/pkg-manager
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# What Problem: lockfile-sniffing to pick a JS package manager was open-coded
+# in worktree-create and was about to be open-coded again in pr-captain-land's
+# local validation gate. Two copies is how the default-branch resolver became
+# seven. Worse, a skill that names a specific package manager inline fails the
+# "skills must not hardcode a package manager" validation gate
+# (src/tests/skills/skill-validation.bats) — correctly, because a skill is
+# shipped to adopter repos that may use a different one.
+#
+# How & Why: one zero-pip primitive that ECHOES the package manager to use for
+# a directory, chosen by lockfile and confirmed to be installed. Skills call
+# this instead of naming a manager; the knowledge lives in agency/tools/ where
+# it belongs.
+#
+# Resolution order — most specific lockfile first, then the universal fallback:
+#   pnpm-lock.yaml            → pnpm
+#   yarn.lock                 → yarn
+#   bun.lockb / bun.lock      → bun
+#   package-lock.json         → npm
+#   package.json (no lock)    → npm
+#   no package.json           → (nothing, exit 1)
+#
+# A manager named by a lockfile but NOT installed is skipped rather than
+# returned — echoing a command that cannot run just moves the failure
+# somewhere less legible.
+#
+# Usage:
+#   ./agency/tools/pkg-manager              # resolve for the current directory
+#   ./agency/tools/pkg-manager -C <dir>     # resolve for <dir>
+#
+# Exit codes:
+#   0  resolved (name on stdout)
+#   1  no package.json, or no usable manager installed
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — extracted while building the local-first
+#          pr-captain-land validation gate.
+
+set -euo pipefail
+
+VERSION="1.0.0"
+DIR="."
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C) DIR="${2:-}"; shift 2 ;;
+        --version|-v) echo "pkg-manager $VERSION"; exit 0 ;;
+        --help|-h)
+            cat <<'HELP'
+pkg-manager — echo the JS package manager to use for a directory
+
+Usage:
+  pkg-manager [-C <dir>]
+
+Echoes one of: pnpm, yarn, bun, npm. Chosen by lockfile, and only if that
+manager is actually installed. Exits 1 with no output when the directory has
+no package.json or no usable manager is present.
+HELP
+            exit 0
+            ;;
+        *) echo "pkg-manager: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$DIR/package.json" ]]; then
+    exit 1
+fi
+
+# Echo $1 and exit 0 if it is installed; otherwise fall through.
+# The explicit `return 0` is load-bearing under `set -e`: without it a
+# not-installed probe makes the enclosing `if` compound exit non-zero, which
+# aborts the script instead of trying the next candidate — the exact
+# "lockfile names an uninstalled manager" case this function exists for.
+try() {
+    if command -v "$1" >/dev/null 2>&1; then
+        printf '%s\n' "$1"
+        exit 0
+    fi
+    return 0
+}
+
+if [[ -f "$DIR/pnpm-lock.yaml" ]]; then try pnpm; fi
+if [[ -f "$DIR/yarn.lock" ]]; then try yarn; fi
+if [[ -f "$DIR/bun.lockb" || -f "$DIR/bun.lock" ]]; then try bun; fi
+
+# package-lock.json, or no lockfile at all: npm is the universal fallback.
+try npm
+
+exit 1

--- a/agency/tools/pr-create
+++ b/agency/tools/pr-create
@@ -77,22 +77,16 @@ fi
 # Detect the default branch so this works on repos using 'master' as well.
 # Issue #107 (monofolk hotfix): the hardcoded 'origin/main' caused false
 # "version not bumped" failures on repos where origin/master is the default.
-# Detection order:
-#   1. git symbolic-ref refs/remotes/origin/HEAD   (GitHub HEAD metadata)
-#   2. existence of refs/remotes/origin/main
-#   3. existence of refs/remotes/origin/master
-#   4. hard fail with clear message
-DEFAULT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
-if [[ -z "$DEFAULT_BRANCH" ]]; then
-    if git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/main; then
-        DEFAULT_BRANCH="main"
-    elif git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/master; then
-        DEFAULT_BRANCH="master"
-    else
-        echo "BLOCKED: could not determine default branch (origin/main or origin/master)." >&2
-        echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
-        exit 1
-    fi
+#
+# The detection ladder used to be inline here (and in six other tools). It now
+# lives in the shared `resolve-default-branch` primitive. `--strict` preserves
+# this tool's FAIL-CLOSED contract: a guessed base ref here would silently
+# mis-evaluate the version-bump gate, so an unresolvable default branch must
+# block, not fall back.
+if ! DEFAULT_BRANCH=$("$SCRIPT_DIR/resolve-default-branch" -C "$REPO_ROOT" --strict 2>/dev/null); then
+    echo "BLOCKED: could not determine default branch (origin/main or origin/master)." >&2
+    echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
+    exit 1
 fi
 DEFAULT_REF="origin/$DEFAULT_BRANCH"
 

--- a/agency/tools/resolve-default-branch
+++ b/agency/tools/resolve-default-branch
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# What Problem: seven copies of "figure out the default branch" had drifted
+# across the tool tree (git-captain, pr-create, pr-submit, _sync-main-ref,
+# dispatch, pr-build, worktree-sync). Each encoded a slightly different
+# policy — different probe order, different fallback, different failure
+# mode. A bug fixed in one copy stayed broken in the other six, and the
+# hardcoded `origin/main` / `master` variants failed closed in exactly the
+# repos where the name differed (issue #107, issue #268, #463).
+#
+# How & Why: one zero-pip bash primitive that ECHOES the repo's default
+# branch name (bare name, no `origin/` prefix). The probe order is the
+# UNION of the three live resolvers, so no consumer loses a case it used
+# to handle:
+#
+#   1. local refs/heads/main            (git-captain's first probe)
+#   2. local refs/heads/master          (git-captain's second probe)
+#   3. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
+#   4. refs/remotes/origin/main
+#   5. refs/remotes/origin/master
+#   6. fallback → "main"                (default mode only)
+#
+# The two policies the consumers actually differ on are preserved by a
+# flag, not by forking the logic:
+#   - default mode  — falls back to "main" and exits 0. For consumers that
+#     want a best guess (pr-submit's historical behaviour, but with the
+#     modern `main` fallback rather than `master`).
+#   - --strict      — prints NOTHING and exits 1 when nothing resolves, so
+#     fail-closed consumers (git-captain, pr-create) keep failing loud
+#     instead of silently guessing.
+#
+# Slash-bearing default branch names (e.g. `release/stable`) round-trip
+# correctly: the origin/HEAD symbolic ref is read in full-ref form and the
+# `refs/remotes/origin/` prefix is stripped with a literal prefix removal,
+# never a greedy pattern.
+#
+# Usage:
+#   ./agency/tools/resolve-default-branch                # echo name, fallback main
+#   ./agency/tools/resolve-default-branch --strict       # exit 1 if unresolved
+#   ./agency/tools/resolve-default-branch -C /path/repo  # resolve in another repo
+#
+# Exit codes:
+#   0  resolved (name on stdout)
+#   1  --strict and nothing resolved  |  not a git repository
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — plan-pr-captain-land-localfirst-20260809 v2,
+#          MAR must-fix "shared primitive = superset with --strict".
+
+set -euo pipefail
+
+VERSION="1.0.0"
+
+STRICT=false
+REPO_DIR=""
+
+usage() {
+    cat <<'HELP'
+resolve-default-branch — echo this repo's default branch name
+
+Usage:
+  resolve-default-branch [--strict] [-C <dir>]
+
+Options:
+  --strict        Exit 1 (printing nothing) when the default branch cannot
+                  be resolved, instead of falling back to "main".
+  -C <dir>        Resolve in <dir> instead of the current directory.
+  --version       Print version and exit
+  --help, -h      Show this help
+
+Resolution order (union of the historical resolvers):
+  refs/heads/main → refs/heads/master → origin/HEAD → refs/remotes/origin/main
+  → refs/remotes/origin/master → "main" (default mode only)
+
+Output is the BARE branch name — no "origin/" prefix. Callers that need a
+remote ref build it themselves: BASE_REF="origin/$(resolve-default-branch)".
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --strict) STRICT=true; shift ;;
+        -C) REPO_DIR="${2:-}"; shift 2 ;;
+        --version|-v) echo "resolve-default-branch $VERSION"; exit 0 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "resolve-default-branch: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# All probes run through this so -C is honoured uniformly. Bash 3.2: no
+# arrays-of-args needed, git -C takes an empty-safe path via the guard below.
+git_probe() {
+    if [[ -n "$REPO_DIR" ]]; then
+        git -C "$REPO_DIR" "$@"
+    else
+        git "$@"
+    fi
+}
+
+if ! git_probe rev-parse --git-dir >/dev/null 2>&1; then
+    echo "resolve-default-branch: not a git repository${REPO_DIR:+ ($REPO_DIR)}" >&2
+    exit 1
+fi
+
+BRANCH=""
+
+# 1 + 2: local branch refs. git-captain probed these first because recovery
+# has to work when origin is unreachable.
+if git_probe show-ref --verify --quiet refs/heads/main; then
+    BRANCH="main"
+elif git_probe show-ref --verify --quiet refs/heads/master; then
+    BRANCH="master"
+else
+    # 3: origin/HEAD — GitHub's own answer, and the only probe that can name
+    # a default branch that is neither main nor master.
+    SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [[ -n "$SYMREF" ]]; then
+        # Literal prefix strip — survives slashes in the branch name.
+        BRANCH="${SYMREF#refs/remotes/origin/}"
+        # A symbolic ref that did not carry the expected prefix is not a
+        # usable branch name; fall through to the remaining probes.
+        if [[ "$BRANCH" == "$SYMREF" ]]; then
+            BRANCH=""
+        fi
+    fi
+
+    # 4 + 5: remote-tracking refs.
+    if [[ -z "$BRANCH" ]]; then
+        if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
+            BRANCH="main"
+        elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
+            BRANCH="master"
+        fi
+    fi
+fi
+
+if [[ -z "$BRANCH" ]]; then
+    if [[ "$STRICT" == true ]]; then
+        echo "resolve-default-branch: cannot determine default branch." >&2
+        echo "  Checked: refs/heads/{main,master}, origin/HEAD, refs/remotes/origin/{main,master}" >&2
+        echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
+        exit 1
+    fi
+    # 6: deliberate, tested fallback. `main` (not `master`) — flagged in the
+    # #463 QG as the modern, safer default.
+    BRANCH="main"
+fi
+
+printf '%s\n' "$BRANCH"

--- a/agency/tools/resolve-default-branch
+++ b/agency/tools/resolve-default-branch
@@ -8,16 +8,33 @@
 # repos where the name differed (issue #107, issue #268, #463).
 #
 # How & Why: one zero-pip bash primitive that ECHOES the repo's default
-# branch name (bare name, no `origin/` prefix). The probe order is the
-# UNION of the three live resolvers, so no consumer loses a case it used
-# to handle:
+# branch name (bare name, no `origin/` prefix). The probe set is the UNION
+# of the three live resolvers, so no consumer loses a case it used to
+# handle — but the ORDER is the remote-authoritative one:
 #
-#   1. local refs/heads/main            (git-captain's first probe)
-#   2. local refs/heads/master          (git-captain's second probe)
-#   3. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
-#   4. refs/remotes/origin/main
-#   5. refs/remotes/origin/master
+#   1. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
+#   2. refs/remotes/origin/main
+#   3. refs/remotes/origin/master
+#   4. local refs/heads/main            (offline fallback)
+#   5. local refs/heads/master          (offline fallback)
 #   6. fallback → "main"                (default mode only)
+#
+# Probing LOCAL branches first — git-captain's historical order — looks like
+# a harmless superset and is not. Every other consumer turns this answer
+# into a REMOTE ref (`origin/$(resolve-default-branch)`). A clone whose
+# default is `master` or `trunk` but which also carries a stale local `main`
+# would resolve to `main`, and then:
+#   - pr-create diffs against a nonexistent origin/main, sees no manifest
+#     change, and emits a false "BLOCKED: agency_version not bumped"
+#     (issue #107, reintroduced through the local-refs door);
+#   - _sync-main-ref dies on a missing refs/remotes/origin/main;
+#   - pr-captain-land blocks with a bogus "branch does not contain
+#     origin/main".
+# A local branch named `main` is not evidence that `main` is the default.
+#
+# Probes 1-3 stay correct offline: origin/HEAD and the remote-tracking refs
+# are local data, no network required. Probes 4-5 preserve git-captain's
+# issue-#268 recovery case (remote refs pruned/absent, local branch intact).
 #
 # The two policies the consumers actually differ on are preserved by a
 # flag, not by forking the logic:
@@ -67,9 +84,13 @@ Options:
   --version       Print version and exit
   --help, -h      Show this help
 
-Resolution order (union of the historical resolvers):
-  refs/heads/main → refs/heads/master → origin/HEAD → refs/remotes/origin/main
-  → refs/remotes/origin/master → "main" (default mode only)
+Resolution order (union of the historical resolvers, remote-authoritative):
+  origin/HEAD → refs/remotes/origin/main → refs/remotes/origin/master
+  → refs/heads/main → refs/heads/master → "main" (default mode only)
+
+The remote refs come first because callers turn this answer into
+"origin/<name>". Local branches are the offline fallback, not the source
+of truth.
 
 Output is the BARE branch name — no "origin/" prefix. Callers that need a
 remote ref build it themselves: BASE_REF="origin/$(resolve-default-branch)".
@@ -79,7 +100,16 @@ HELP
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --strict) STRICT=true; shift ;;
-        -C) REPO_DIR="${2:-}"; shift 2 ;;
+        -C)
+            # A bare trailing `-C` must be a usage error with a message. Left
+            # to `shift 2` it fails under `set -e` and the script dies exit 1
+            # with no output — indistinguishable from "not a git repository".
+            if [[ -z "${2:-}" ]]; then
+                echo "resolve-default-branch: -C requires a directory argument" >&2
+                exit 2
+            fi
+            REPO_DIR="$2"; shift 2
+            ;;
         --version|-v) echo "resolve-default-branch $VERSION"; exit 0 ;;
         --help|-h) usage; exit 0 ;;
         *) echo "resolve-default-branch: unknown argument: $1" >&2; usage >&2; exit 2 ;;
@@ -103,33 +133,35 @@ fi
 
 BRANCH=""
 
-# 1 + 2: local branch refs. git-captain probed these first because recovery
-# has to work when origin is unreachable.
-if git_probe show-ref --verify --quiet refs/heads/main; then
-    BRANCH="main"
-elif git_probe show-ref --verify --quiet refs/heads/master; then
-    BRANCH="master"
-else
-    # 3: origin/HEAD — GitHub's own answer, and the only probe that can name
-    # a default branch that is neither main nor master.
-    SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
-    if [[ -n "$SYMREF" ]]; then
-        # Literal prefix strip — survives slashes in the branch name.
-        BRANCH="${SYMREF#refs/remotes/origin/}"
-        # A symbolic ref that did not carry the expected prefix is not a
-        # usable branch name; fall through to the remaining probes.
-        if [[ "$BRANCH" == "$SYMREF" ]]; then
-            BRANCH=""
-        fi
+# 1: origin/HEAD — the remote's own answer, and the only probe that can name
+# a default branch that is neither main nor master.
+SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+if [[ -n "$SYMREF" ]]; then
+    # Literal prefix strip — survives slashes in the branch name.
+    BRANCH="${SYMREF#refs/remotes/origin/}"
+    # A symbolic ref that did not carry the expected prefix is not a usable
+    # branch name; fall through to the remaining probes.
+    if [[ "$BRANCH" == "$SYMREF" ]]; then
+        BRANCH=""
     fi
+fi
 
-    # 4 + 5: remote-tracking refs.
-    if [[ -z "$BRANCH" ]]; then
-        if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
-            BRANCH="main"
-        elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
-            BRANCH="master"
-        fi
+# 2 + 3: remote-tracking refs.
+if [[ -z "$BRANCH" ]]; then
+    if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
+        BRANCH="main"
+    elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
+        BRANCH="master"
+    fi
+fi
+
+# 4 + 5: local branch refs — the offline/recovery fallback (issue #268:
+# remote refs pruned or origin never fetched, local branch still intact).
+if [[ -z "$BRANCH" ]]; then
+    if git_probe show-ref --verify --quiet refs/heads/main; then
+        BRANCH="main"
+    elif git_probe show-ref --verify --quiet refs/heads/master; then
+        BRANCH="master"
     fi
 fi
 

--- a/agency/tools/workstream-create
+++ b/agency/tools/workstream-create
@@ -95,6 +95,23 @@ if [ -z "$NAME" ]; then
   exit 1
 fi
 
+# Validate the name before it becomes a path.
+#
+# This was unvalidated, so `workstream-create 'test; rm -rf /'` cheerfully
+# created a directory literally named `test; rm -rf` under agency/workstreams/.
+# The injection-safety tests in src/tests/tools/scaffolding.bats call exactly
+# that, against the real repo — so every full test run left that directory
+# behind, and src/tests/tools/purge-pollution-guard.bats then (correctly)
+# went red about it. Same character class as worktree-create.
+if ! [[ "$NAME" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
+  log_error "Invalid workstream name: '$NAME'"
+  echo ""
+  echo "Name must start with a letter and contain only letters, numbers," >&2
+  echo "hyphens, and underscores. No slashes, spaces, dots, or shell" >&2
+  echo "metacharacters — the name becomes a directory path." >&2
+  exit 1
+fi
+
 DIR="agency/workstreams/$NAME"
 TIMESTAMP=$(./agency/tools/now 2>/dev/null || date '+%Y-%m-%d %H:%M')
 

--- a/agency/tools/worktree-create
+++ b/agency/tools/worktree-create
@@ -31,7 +31,7 @@
 
 set -euo pipefail
 
-VERSION="2.1.0"
+VERSION="2.2.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source helpers
@@ -68,8 +68,8 @@ compute_worktree_name() {
 show_help() {
     cat <<HELP
 Usage:
-  worktree-create <name> [--branch <branch>]
-  worktree-create --workstream <ws> --agent <ag> [--branch <branch>]
+  worktree-create <name> [--branch <branch>] [--from <ref>]
+  worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
   worktree-create --compute-only --workstream <ws> --agent <ag>
 
 Creates a git worktree at .claude/worktrees/<name>/
@@ -78,6 +78,10 @@ Options:
   --workstream <ws> Workstream name (pairs with --agent to compute name)
   --agent <ag>      Agent name (pairs with --workstream to compute name)
   --branch <name>   Branch name (default: same as worktree name)
+  --from <ref>      Start point for a NEW branch (default: current HEAD).
+                    Accepts any committish, including a remote-tracking ref
+                    such as origin/main or origin/some-agent-branch. Ignored
+                    when --branch names an existing local branch.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help
@@ -114,12 +118,14 @@ NAME=""
 BRANCH=""
 WORKSTREAM=""
 AGENT=""
+FROM_REF=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version|-v) echo "worktree-create $VERSION"; exit 0 ;;
         --help|-h) show_help; exit 0 ;;
         --branch) BRANCH="$2"; shift 2 ;;
+        --from) FROM_REF="$2"; shift 2 ;;
         --workstream) WORKSTREAM="$2"; shift 2 ;;
         --agent) AGENT="$2"; shift 2 ;;
         -*) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -147,9 +153,16 @@ if [[ -z "$NAME" ]]; then
     exit 1
 fi
 
-# Validate name
-if ! [[ "$NAME" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
-    echo "Error: name must start with a letter and contain only letters, numbers, hyphens, dashes" >&2
+# Validate name.
+#
+# A leading underscore is allowed so machine-created, short-lived worktrees can
+# be namespaced apart from human agent worktrees at a glance — `pr-captain-land`
+# cuts `_land-<branch>` scratch worktrees and deletes them at the end of the
+# landing. The rest of the character class is unchanged: still no slashes (they
+# would nest directories under .claude/worktrees/ and collide with git's ref
+# directory rules), no dots, no spaces.
+if ! [[ "$NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*$ ]]; then
+    echo "Error: name must start with a letter or underscore and contain only letters, numbers, underscores, hyphens" >&2
     exit 1
 fi
 
@@ -166,14 +179,30 @@ fi
 # Create worktree
 echo "Creating worktree: $NAME"
 echo "  Branch: $BRANCH"
+[[ -n "$FROM_REF" ]] && echo "  From:   $FROM_REF"
 echo "  Path: .claude/worktrees/$NAME/"
 
 mkdir -p "$PROJECT_ROOT/.claude/worktrees"
 
-# Create branch + worktree (from current HEAD)
+# Create branch + worktree
 if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
-    # Branch exists — use it
+    # Branch exists — use it. --from would be a lie here (the branch already has
+    # a tip); say so instead of silently ignoring it.
+    if [[ -n "$FROM_REF" ]]; then
+        echo "Error: --from $FROM_REF given but branch '$BRANCH' already exists" >&2
+        echo "  Refusing to guess. Delete the branch or drop --from." >&2
+        exit 1
+    fi
     git -C "$PROJECT_ROOT" worktree add "$WORKTREE_DIR" "$BRANCH"
+elif [[ -n "$FROM_REF" ]]; then
+    # Create new branch at an explicit start point (e.g. origin/main, or an
+    # agent's remote branch — the local-first landing flow cuts its scratch
+    # worktree from pristine origin refs, never from a local tip).
+    if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
+        echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+        exit 1
+    fi
+    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
 else
     # Create new branch from HEAD
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR"

--- a/agency/tools/worktree-create
+++ b/agency/tools/worktree-create
@@ -80,8 +80,11 @@ Options:
   --branch <name>   Branch name (default: same as worktree name)
   --from <ref>      Start point for a NEW branch (default: current HEAD).
                     Accepts any committish, including a remote-tracking ref
-                    such as origin/main or origin/some-agent-branch. Ignored
-                    when --branch names an existing local branch.
+                    such as origin/main or origin/some-agent-branch. It is an
+                    ERROR to pass --from when the branch already exists — the
+                    branch has a tip already, and silently ignoring the flag
+                    would put the worktree somewhere the caller did not ask
+                    for.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help

--- a/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-pr-lifecycle-v2-qgr-pr-prep-20260810-0030-2de6ec5.md
+++ b/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-pr-lifecycle-v2-qgr-pr-prep-20260810-0030-2de6ec5.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: devex
+workstream: devex
+project: pr-lifecycle-v2
+diff_base: origin/main
+hash_a: 84b7eee8b463d1ef93fe2844bfc56673511808f67effad0f7225bab1bb0cf1f7
+hash_b: 0c3e0da8631e325bdb9e6305830e4681951f45a2539747c456e44a9ebf78a474
+hash_c: bc23cc49c5ebc6d2c401ae0c2a486feb65998de9ac195226f02611f4937440c6
+hash_d: bc23cc49c5ebc6d2c401ae0c2a486feb65998de9ac195226f02611f4937440c6
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 2de6ec5cd4c6ff33e6e19892ffa2e460eb06de2058dbd057e39d9f346c458f6b
+date: 2026-08-10T00:30
+---
+
+# Receipt: pr-prep — pr-lifecycle-v2
+
+## Chain of Trust
+- A (original): 84b7eee
+- B (findings): 0c3e0da
+- C (triage): bc23cc4
+- D (principal): bc23cc4 — auto-approved — no principal 1B1
+- E (final): 2de6ec5
+
+## Review Summary
+pr-captain-land local-first v2 + resolve-default-branch/pkg-manager/ci-rollup-verdict/agency-version-next primitives. 4 parallel reviewers; 32 findings, all fixed. Touched suites 377 pass / 0 fail. Full suite 1398 pass / 323 fail — zero new failures vs main baseline (333), 10 pre-existing fixed. 25 agency/ <-> src/ mirror pairs byte-identical.

--- a/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-pr-lifecycle-v2-qgr-pr-prep-20260810-0036-a516c7e.md
+++ b/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-pr-lifecycle-v2-qgr-pr-prep-20260810-0036-a516c7e.md
@@ -13,8 +13,8 @@ hash_b: 0c3e0da8631e325bdb9e6305830e4681951f45a2539747c456e44a9ebf78a474
 hash_c: bc23cc49c5ebc6d2c401ae0c2a486feb65998de9ac195226f02611f4937440c6
 hash_d: bc23cc49c5ebc6d2c401ae0c2a486feb65998de9ac195226f02611f4937440c6
 hash_d_source: "auto-approved — no principal 1B1"
-hash_e: 2de6ec5cd4c6ff33e6e19892ffa2e460eb06de2058dbd057e39d9f346c458f6b
-date: 2026-08-10T00:30
+hash_e: a516c7e564dd2d26eb25194e74a5f990910c3f89b9dd95412c0dd56d9bb20ed9
+date: 2026-08-10T00:36
 ---
 
 # Receipt: pr-prep — pr-lifecycle-v2
@@ -24,7 +24,7 @@ date: 2026-08-10T00:30
 - B (findings): 0c3e0da
 - C (triage): bc23cc4
 - D (principal): bc23cc4 — auto-approved — no principal 1B1
-- E (final): 2de6ec5
+- E (final): a516c7e
 
 ## Review Summary
-pr-captain-land local-first v2 + resolve-default-branch/pkg-manager/ci-rollup-verdict/agency-version-next primitives. 4 parallel reviewers; 32 findings, all fixed. Touched suites 377 pass / 0 fail. Full suite 1398 pass / 323 fail — zero new failures vs main baseline (333), 10 pre-existing fixed. 25 agency/ <-> src/ mirror pairs byte-identical.
+local-first pr-captain-land v2 + shared resolve-default-branch primitive + 3 CI/version/pkg primitives (incl version bump 46.27->46.28)

--- a/src/agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+++ b/src/agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -12,22 +12,46 @@ These serve different purposes at different points. They do not replace each oth
 
 ### Captain PR Lifecycle
 
-The captain (coordination session on master) manages the full PR cycle:
+The captain (coordination session on the default branch, in the main checkout) owns the PR cycle end to end. The whole lifecycle is **local-first**: work is reviewed and validated locally, and GitHub is where already-validated work is published.
 
 ```
-1. /sync-all — merge worktree work into master
-2. Rebuild PR branches (reset -> squash -> stage -> commit)
-3. /captain-review --all — review all PR branches locally (runs against git diff, no GitHub PR needed)
-4. If issues found: dispatch to worktree agents via dispatch files
-5. Worktree agents fix issues -> land on master via /iteration-complete
-6. If no issues (or after fixes land): rebuild PR branches (now includes fixes + review files)
-7. Push and create draft PRs (review results visible in the diff)
-8. Human review -> convert to ready-for-review -> merge
+1. /captain-sync-all — fetch, merge origin, merge worktree work, sync worktrees (never pushes)
+2. /captain-review --all — review branches locally (runs against git diff, no GitHub PR needed)
+3. If issues found: dispatch to worktree agents; they fix and re-run /iteration-complete
+4. Agent runs /pr-prep (QG + signed QGR receipt), pushes, then /pr-submit (dispatches captain)
+5. Captain runs /pr-captain-land <branch> — see below
 ```
 
-Reviews run **locally** against `git diff origin/master...<branch>`. No GitHub PR is required. Reviews happen BEFORE PRs are created. The review results are committed to the repo and included in the PR diff.
+Reviews run **locally** against `git diff origin/<default>...<branch>`. No GitHub PR is required. Reviews happen BEFORE PRs are created. Review results are committed and appear in the PR diff.
 
-If all PRs are clean (zero issues >= 80 confidence), skip steps 4-5 and proceed directly to step 6.
+#### `/pr-captain-land` — local-first landing
+
+The landing does **not** switch the main checkout to the agent's branch, and does **not** merge into or push local `main`. Instead:
+
+```
+0-1. Fetch; verify the branch on origin and that origin/<default> is an ancestor of it
+     (stale base BLOCKS with "merge <default> + re-run /pr-prep", not a hash error)
+2.   Cut a scratch worktree  _land-<branch>  at  origin/<agent-branch>
+2b.  Verify the agent's QGR receipt against that tree — BEFORE any mutation
+3.   VALIDATE LOCALLY in the scratch (build + tests + commit-precheck). THIS IS THE GATE.
+     Failure → delete the scratch, dispatch the agent, nothing published.
+4-5. Bump agency_version in the scratch; sign a captain landing receipt chained to the
+     agent's (hash_a = agent hash_e). pr-create is not weakened.
+6.   Push the scratch branch, open the PR (_land-<branch> → default)
+7.   Wait on the AGGREGATE statusCheckRollup — every required context green. An empty
+     rollup is a distinct error, never a silent pass. No hardcoded check name.
+8.   pr-merge (true merge commit) → gh-release
+9.   Delete the scratch + land branch, dispatch the agent, clear post-merge state, and
+     reconcile local main with an idempotent merge-from-origin
+```
+
+**Rollback at any pre-publish failure is deleting the scratch worktree.** No `git reset --hard`, no merge abort, no stranded main checkout. A dirty main checkout does not block a land, because the land never touches it.
+
+`/pr-captain-land <branch> --rehearse` runs steps 0-3 only — integrate and validate with zero side effects. Rehearse before the first land of any unfamiliar branch.
+
+Only one `/pr-captain-land` at a time (they would race on the version bump). Two runs for the *same* branch are blocked mechanically by the leftover-scratch precondition.
+
+Full protocol: `.claude/skills/pr-captain-land/reference.md`.
 
 ### Code Review Dispatch
 

--- a/src/agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
+++ b/src/agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
@@ -55,7 +55,7 @@ Organized alphabetically by name.
 | phase-complete | Run full QG after completing a phase — review, fix, test, report, commit | 2 | agent | active | QUALITY-GATE, RECEIPT-INFRASTRUCTURE |
 | plan-complete | Complete a plan — final deep QG, finalize artifacts, produce reference doc | 1 | agent | active | QUALITY-GATE, DEVELOPMENT-METHODOLOGY |
 | pr-captain-post-merge | Captain-only. Post-PR-merge flow — verify merge, sync master, /sync-all, cut release, cleanup branch | 2 | captain | active | GIT-MERGE-NOT-REBASE, WORKTREE-DISCIPLINE, SAFE-TOOLS |
-| pr-captain-land | Captain lands agent's prepared branch — PR + CI + merge + release + notify | 2 | captain | pilot | QUALITY-GATE, WORKTREE-DISCIPLINE |
+| pr-captain-land | Captain lands agent's prepared branch LOCAL-FIRST — scratch-worktree integrate + local validation gate, then PR + CI confirm + merge + release + notify | 2 | captain | active | QUALITY-GATE, WORKTREE-DISCIPLINE |
 | pr-captain-merge | Captain-only. Merge PR safely — true merge commit (never squash/rebase), --principal-approved gate | 2 | captain | active | GIT-MERGE-NOT-REBASE, SAFE-TOOLS, CODE-REVIEW-LIFECYCLE |
 | pr-prep | Run QG before creating PR — review, fix, test, report, produce QGR receipt | 1 | agent | active | QUALITY-GATE, CODE-REVIEW-LIFECYCLE |
 | pr-respond | Fetch PR review comments, compose threaded replies, resolve threads | 1 | agent | active | CODE-REVIEW-LIFECYCLE |

--- a/src/agency/tools/_sync-main-ref
+++ b/src/agency/tools/_sync-main-ref
@@ -1,42 +1,62 @@
 #!/bin/bash
 #
-# _sync-main-ref — Update local refs/heads/main to match origin/main without
-# requiring a checkout of main. Workaround for the bootstrap case where the
-# captain's tools haven't yet propagated to the local main branch.
+# _sync-main-ref — Update the local default-branch ref to match its origin
+# counterpart without requiring a checkout. Workaround for the bootstrap case
+# where the captain's tools haven't yet propagated to the local main branch.
 #
 # This is a captain-internal helper. After D41-R5 lands and the proper
 # git-captain has sync-main + merge-continue available everywhere, this can
 # be removed.
 #
-# Safety: refuses to run if local main has commits not on origin/main
+# Safety: refuses to run if the local branch has commits not on origin
 # (would lose work). Only fast-forwards.
+#
+# The branch name is RESOLVED, never hardcoded. This tool used to say
+# `origin/main` in five places, which made it a no-op-with-an-error in any
+# repo whose default branch is `master` — the exact class of failure the
+# shared `resolve-default-branch` primitive exists to end.
 #
 set -euo pipefail
 
-cd "$(dirname "$0")/../.."
+# Resolve the script dir BEFORE changing directory — a later `dirname "$0"`
+# would be interpreted relative to the new cwd and silently point elsewhere.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+cd "$SCRIPT_DIR/../.."
 
 # Fetch first
 git fetch origin --quiet
 
-local_main=$(git rev-parse refs/heads/main 2>/dev/null) || {
-    echo "ERROR: refs/heads/main does not exist" >&2; exit 1
+# --strict: this tool moves a ref. Guessing the wrong branch name here would
+# either fail confusingly or, worse, fast-forward the wrong ref. Fail loud.
+if ! DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" --strict 2>/dev/null)"; then
+    echo "ERROR: cannot determine default branch (checked local + origin/HEAD + origin/{main,master})" >&2
+    echo "  Fix: git remote set-head origin -a" >&2
+    exit 1
+fi
+
+local_ref="refs/heads/$DEFAULT_BRANCH"
+origin_ref="refs/remotes/origin/$DEFAULT_BRANCH"
+
+local_main=$(git rev-parse "$local_ref" 2>/dev/null) || {
+    echo "ERROR: $local_ref does not exist" >&2; exit 1
 }
-origin_main=$(git rev-parse refs/remotes/origin/main 2>/dev/null) || {
-    echo "ERROR: refs/remotes/origin/main does not exist" >&2; exit 1
+origin_main=$(git rev-parse "$origin_ref" 2>/dev/null) || {
+    echo "ERROR: $origin_ref does not exist" >&2; exit 1
 }
 
 if [[ "$local_main" == "$origin_main" ]]; then
-    echo "Already at origin/main ($origin_main)"
+    echo "Already at origin/$DEFAULT_BRANCH ($origin_main)"
     exit 0
 fi
 
 # Verify origin is ahead of local (FF safe). i.e., local must be ancestor of origin.
 if ! git merge-base --is-ancestor "$local_main" "$origin_main"; then
-    echo "ERROR: local main has commits not on origin/main — refusing to update ref" >&2
+    echo "ERROR: local $DEFAULT_BRANCH has commits not on origin/$DEFAULT_BRANCH — refusing to update ref" >&2
     echo "  local:  $local_main" >&2
     echo "  origin: $origin_main" >&2
     exit 1
 fi
 
-git update-ref refs/heads/main "$origin_main"
-echo "Updated local main: $local_main -> $origin_main"
+git update-ref "$local_ref" "$origin_main"
+echo "Updated local $DEFAULT_BRANCH: $local_main -> $origin_main"

--- a/src/agency/tools/agency-version-next
+++ b/src/agency/tools/agency-version-next
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# What Problem: the "bump agency_version" rule was open-coded as inline Python
+# inside pr-captain-land, and described again in prose in /captain-release.
+# Two consequences, both real:
+#
+#   1. The inline form `NEW_VER=$(python3 -c '... sys.exit(1)')` aborts the
+#      CALLER under `set -euo pipefail` before it can report anything. The
+#      friendly "could not bump version from X" error immediately below it was
+#      unreachable for exactly the input it was written for (a three-component
+#      semver), and the abort left the landing's scratch worktree stranded.
+#   2. A bump policy that lives in a skill cannot be tested, and cannot be
+#      shared with the other place that performs it.
+#
+# How & Why: one pure primitive that ECHOES the next version. No file I/O, no
+# git, no side effects — just the policy. Callers do
+# `NEW=$(agency-version-next "$CUR") || abort ...` and get a real error path.
+#
+# NOT to be confused with `agency/tools/version-next`, which is a different
+# tool for a different version string: it manages the VERSION file's
+# MAJOR.MINOR.PATCH-YYYYMMDD-NNNNNN build identifier. This one handles
+# manifest.json's `agency_version`, which is `day.release`. The `agency-`
+# prefix matches `agency-version`, the read-side tool for the same field.
+#
+# Policy (agency_version is `day.release`, e.g. 46.25):
+#   "46.25" → "46.26"     two components: bump the second
+#   "46.9"  → "46.10"     numeric, not lexical
+#   "46"    → "47"        one component: bump it
+#   anything else         → exit 1 with a message on stderr, nothing on stdout
+#
+# Three-component semver is deliberately REFUSED rather than guessed: the
+# framework's manifest is day.release and a silent reinterpretation of a
+# semver string would produce a wrong release tag.
+#
+# Usage:
+#   ./agency/tools/agency-version-next 46.25          # → 46.26
+#   NEW=$(./agency/tools/agency-version-next "$CUR") || die "..."
+#
+# Exit codes:
+#   0  next version on stdout
+#   1  unparseable / unsupported version (message on stderr, stdout empty)
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — extracted from pr-captain-land during the QG
+#          for the local-first rewrite.
+
+set -euo pipefail
+
+VERSION="1.0.0"
+
+case "${1:-}" in
+    --version|-v) echo "agency-version-next $VERSION"; exit 0 ;;
+    --help|-h)
+        cat <<'HELP'
+agency-version-next — echo the next agency_version
+
+Usage:
+  agency-version-next <current-version>
+
+  46.25 → 46.26      two components: the second is bumped numerically
+  46    → 47         one component
+  1.2.3 → exit 1     three-component semver is refused, not guessed
+
+Exit 1 (with an empty stdout) on anything unparseable, so callers can write
+  NEW=$(agency-version-next "$CUR") || die "..."
+and actually reach their error path.
+HELP
+        exit 0
+        ;;
+esac
+
+if [[ $# -ne 1 ]]; then
+    echo "agency-version-next: exactly one argument required" >&2
+    echo "Usage: agency-version-next <current-version>" >&2
+    exit 2
+fi
+
+CURRENT="$1"
+
+if [[ "$CURRENT" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
+    MAJOR="${BASH_REMATCH[1]}"
+    MINOR="${BASH_REMATCH[2]}"
+    # 10# forces base-10: a zero-padded component like "08" would otherwise be
+    # read as octal and either mis-bump or fail outright.
+    printf '%s.%s\n' "$MAJOR" "$(( 10#$MINOR + 1 ))"
+    exit 0
+fi
+
+if [[ "$CURRENT" =~ ^([0-9]+)$ ]]; then
+    printf '%s\n' "$(( 10#${BASH_REMATCH[1]} + 1 ))"
+    exit 0
+fi
+
+echo "agency-version-next: cannot bump '$CURRENT' — expected <n> or <n>.<n>" >&2
+if [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "  Three-component semver is not the agency_version format (day.release)." >&2
+    echo "  Refusing to guess which component to bump." >&2
+fi
+exit 1

--- a/src/agency/tools/ci-rollup-verdict
+++ b/src/agency/tools/ci-rollup-verdict
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""ci-rollup-verdict — classify a GitHub PR status-check rollup into one verdict.
+
+What Problem: pr-captain-land's CI gate was a hardcoded check name
+("lint-and-test") that does not exist in this repo, so the wait loop could
+only ever time out and a genuinely failing check could never fail fast.
+Replacing it with an aggregate-rollup gate put ~50 lines of classification
+logic — two node shapes, five terminal states, a required-contexts filter,
+an empty-rollup case — inside a shell heredoc inside a command substitution
+inside a while loop. That is untestable by construction, and the guards
+written for it were all `grep`-for-a-string: every one of them still passes
+if the PASS and FAIL sets are swapped.
+
+How & Why: the classification is a pure function of (rollup JSON, required
+contexts). Extracted here so it can be table-tested with no network, no git,
+and no PR. The caller keeps only the polling loop.
+
+Verdicts (one line on stdout):
+  PASSED <names>    every gated check reached a terminal success state
+  FAILED <names>    at least one gated check reached a terminal failure state
+  PENDING <names>   at least one gated check has not finished, or a required
+                    context has not reported at all
+  NO_CHECKS         nothing to gate on — NOT a pass
+  UNREADABLE        the input was not parseable rollup JSON
+
+Two rules worth stating out loud, because both are ways a naive gate says
+"green" when it should not:
+
+  1. A *required* context that has not posted yet is PENDING, not absent.
+     Filtering the rollup down to "required contexts that happen to be
+     present" means 1-of-3 required checks reporting green reads as PASSED.
+  2. An empty rollup is NO_CHECKS, never PASSED. "No CI configured" and
+     "all checks green" must not be indistinguishable.
+
+Usage:
+  gh pr view N --json statusCheckRollup | ci-rollup-verdict
+  gh pr view N --json statusCheckRollup | ci-rollup-verdict --required '["build","test"]'
+  ci-rollup-verdict --file rollup.json
+
+Exit codes:
+  0  verdict printed (read the verdict, not the exit code)
+  2  usage error
+
+Written: 2026-08-09 (devex) — extracted from pr-captain-land during the QG
+         for the local-first rewrite, in response to "all three CI-gate
+         guards are tautological".
+"""
+
+import json
+import os
+import sys
+
+# Runtime guard deliberately set BELOW the repo's declared 3.13 floor.
+#
+# The floor exists so tools can use modern syntax without surprise. This tool
+# uses nothing past 3.8 — stdlib json and f-strings. It sits on the critical
+# path of every PR landing, and `#!/usr/bin/env python3` resolves to Apple's
+# stock 3.9 on a stock macOS PATH. Asserting 3.13 here would make the CI gate
+# refuse to run on the very machine that lands the PRs: failing closed for a
+# reason that has nothing to do with CI. Guard the version this code actually
+# needs, and let the 3.13 floor be enforced where it buys something.
+if sys.version_info < (3, 8):
+    sys.stderr.write(
+        f"ci-rollup-verdict: requires Python 3.8+, found "
+        f"{sys.version_info.major}.{sys.version_info.minor}\n"
+    )
+    sys.exit(2)
+
+# Terminal states. A check in neither set has not finished.
+PASS_STATES = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+FAIL_STATES = {
+    "FAILURE",
+    "ERROR",
+    "TIMED_OUT",
+    "CANCELLED",
+    "ACTION_REQUIRED",
+    "STARTUP_FAILURE",
+    "STALE",
+}
+
+USAGE = """Usage: ci-rollup-verdict [--required <json-array>] [--file <path>]
+
+Reads `gh pr view --json statusCheckRollup` output on stdin (or --file) and
+prints exactly one verdict line: PASSED / FAILED / PENDING / NO_CHECKS /
+UNREADABLE.
+
+  --required <json>  JSON array of branch-protection required context names.
+                     When given, ONLY those contexts are gated on, and any
+                     required context missing from the rollup counts as
+                     PENDING. Anything that is not a non-empty JSON array
+                     (an error object, "null", "[]") is ignored.
+  --file <path>      Read the rollup JSON from a file instead of stdin.
+"""
+
+
+def name_of(check):
+    """CheckRun uses `name`; StatusContext uses `context`."""
+    return check.get("name") or check.get("context") or "(unnamed)"
+
+
+def state_of(check):
+    """Normalize both rollup node shapes to a single state token.
+
+    CheckRun carries `status` (QUEUED/IN_PROGRESS/COMPLETED) plus `conclusion`,
+    and the conclusion is meaningless until the status is COMPLETED — reading
+    it early is how an in-progress check gets counted green.
+    StatusContext carries only `state` (pending/success/failure/error).
+    """
+    if check.get("status") is not None or check.get("conclusion") is not None:
+        if str(check.get("status") or "").upper() != "COMPLETED":
+            return "PENDING"
+        return str(check.get("conclusion") or "PENDING").upper()
+    return str(check.get("state") or "PENDING").upper()
+
+
+def parse_required(raw):
+    """Return a set of required context names, or an empty set if unusable.
+
+    The branch-protection endpoint 404s (returning an error OBJECT, not an
+    array) on repos without protection or without admin scope. Anything that
+    is not a non-empty list of strings means "no narrowing".
+    """
+    if not raw:
+        return set()
+    try:
+        value = json.loads(raw)
+    except (ValueError, TypeError):
+        return set()
+    if not isinstance(value, list):
+        return set()
+    return {str(v) for v in value if isinstance(v, str)}
+
+
+def verdict(rollup_json, required_raw=""):
+    """Classify. Pure — this is the whole point of the extraction."""
+    try:
+        parsed = json.loads(rollup_json)
+    except (ValueError, TypeError):
+        return "UNREADABLE"
+    if not isinstance(parsed, dict):
+        return "UNREADABLE"
+
+    checks = parsed.get("statusCheckRollup")
+    if checks is None:
+        checks = []
+    if not isinstance(checks, list):
+        return "UNREADABLE"
+    checks = [c for c in checks if isinstance(c, dict)]
+
+    required = parse_required(required_raw)
+
+    if required:
+        present = {name_of(c) for c in checks}
+        missing = sorted(required - present)
+        checks = [c for c in checks if name_of(c) in required]
+        if missing:
+            # A required context that has not reported is PENDING, not
+            # absent. Without this, 1-of-3 required checks green reads
+            # as PASSED and the PR merges on partial evidence.
+            waiting = missing + [
+                name_of(c) for c in checks if state_of(c) not in PASS_STATES
+            ]
+            failed_now = [name_of(c) for c in checks if state_of(c) in FAIL_STATES]
+            if failed_now:
+                return "FAILED " + ",".join(sorted(failed_now))
+            return "PENDING " + ",".join(sorted(set(waiting)))
+
+    if not checks:
+        return "NO_CHECKS"
+
+    failed = sorted({name_of(c) for c in checks if state_of(c) in FAIL_STATES})
+    if failed:
+        return "FAILED " + ",".join(failed)
+
+    pending = sorted({name_of(c) for c in checks if state_of(c) not in PASS_STATES})
+    if pending:
+        return "PENDING " + ",".join(pending)
+
+    return "PASSED " + ",".join(sorted({name_of(c) for c in checks}))
+
+
+def main(argv):
+    required_raw = os.environ.get("CI_ROLLUP_REQUIRED", "")
+    path = None
+
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg in ("--help", "-h"):
+            sys.stdout.write(USAGE)
+            return 0
+        if arg == "--version":
+            sys.stdout.write("ci-rollup-verdict 1.0.0\n")
+            return 0
+        if arg == "--required":
+            if i + 1 >= len(argv):
+                sys.stderr.write("ci-rollup-verdict: --required needs a value\n")
+                return 2
+            required_raw = argv[i + 1]
+            i += 2
+            continue
+        if arg == "--file":
+            if i + 1 >= len(argv):
+                sys.stderr.write("ci-rollup-verdict: --file needs a path\n")
+                return 2
+            path = argv[i + 1]
+            i += 2
+            continue
+        sys.stderr.write(f"ci-rollup-verdict: unknown argument: {arg}\n")
+        sys.stderr.write(USAGE)
+        return 2
+
+    if path is not None:
+        try:
+            with open(path, encoding="utf-8") as handle:
+                raw = handle.read()
+        except OSError as exc:
+            sys.stderr.write(f"ci-rollup-verdict: cannot read {path}: {exc}\n")
+            return 2
+    else:
+        raw = sys.stdin.read()
+
+    sys.stdout.write(verdict(raw, required_raw) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/src/agency/tools/git-captain
+++ b/src/agency/tools/git-captain
@@ -33,15 +33,18 @@ fi
 
 die() { echo "${RED}[ERROR]${NC} $1" >&2; exit 1; }
 
-# Detect main branch name
+# Detect main branch name.
+#
+# Thin wrapper over the shared primitive — the resolution order (local
+# refs/heads/{main,master} → origin/HEAD → refs/remotes/origin/{main,master})
+# used to live inline here and in six other tools, each subtly different.
+# `--strict` preserves this tool's historical FAIL-CLOSED contract: git-captain
+# `die`s rather than guessing, because its callers go on to merge and push.
 detect_main_branch() {
-    if git show-ref --verify refs/heads/main &>/dev/null; then
-        echo "main"
-    elif git show-ref --verify refs/heads/master &>/dev/null; then
-        echo "master"
-    else
-        die "Cannot find main or master branch."
-    fi
+    local branch
+    branch=$("$SCRIPT_DIR/resolve-default-branch" --strict 2>/dev/null) || \
+        die "Cannot find main or master branch (checked local + origin/HEAD + origin/{main,master})."
+    echo "$branch"
 }
 
 usage() {

--- a/src/agency/tools/pkg-manager
+++ b/src/agency/tools/pkg-manager
@@ -8,21 +8,24 @@
 # shipped to adopter repos that may use a different one.
 #
 # How & Why: one zero-pip primitive that ECHOES the package manager to use for
-# a directory, chosen by lockfile and confirmed to be installed. Skills call
-# this instead of naming a manager; the knowledge lives in agency/tools/ where
-# it belongs.
+# a directory. Skills call this instead of naming a manager; the knowledge
+# lives in agency/tools/ where it belongs.
 #
-# Resolution order — most specific lockfile first, then the universal fallback:
-#   pnpm-lock.yaml            → pnpm
-#   yarn.lock                 → yarn
-#   bun.lockb / bun.lock      → bun
-#   package-lock.json         → npm
-#   package.json (no lock)    → npm
-#   no package.json           → (nothing, exit 1)
+# Resolution order — the repo's own declaration first, then lockfiles, then
+# the universal fallback:
+#   packageManager: "pnpm@9..."  → that manager   (the npm-standard field)
+#   pnpm-lock.yaml               → pnpm
+#   yarn.lock                    → yarn
+#   bun.lockb / bun.lock         → bun
+#   package-lock.json            → npm
+#   package.json, nothing else   → npm            (universal fallback)
+#   no package.json              → nothing, exit 1
 #
-# A manager named by a lockfile but NOT installed is skipped rather than
-# returned — echoing a command that cannot run just moves the failure
-# somewhere less legible.
+# When the repo NAMES a manager (field or lockfile) and it is not installed,
+# this FAILS (exit 1) rather than quietly substituting npm. Running `npm run
+# build` against a pnpm workspace does not do what the caller asked; it
+# produces a confusing failure attributed to the wrong thing. The npm fallback
+# applies only where the repo expressed no preference.
 #
 # Usage:
 #   ./agency/tools/pkg-manager              # resolve for the current directory
@@ -30,7 +33,7 @@
 #
 # Exit codes:
 #   0  resolved (name on stdout)
-#   1  no package.json, or no usable manager installed
+#   1  no package.json, or the named manager is not installed
 #   2  usage error
 #
 # Written: 2026-08-09 (devex) — extracted while building the local-first
@@ -38,12 +41,20 @@
 
 set -euo pipefail
 
-VERSION="1.0.0"
+VERSION="1.1.0"
 DIR="."
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        -C) DIR="${2:-}"; shift 2 ;;
+        -C)
+            # A bare trailing `-C` must be a usage error with a message. Left
+            # to `shift 2` it fails under `set -e` and the tool dies exit 1
+            # with no output — indistinguishable from "no package.json".
+            if [[ -z "${2:-}" ]]; then
+                echo "pkg-manager: -C requires a directory argument" >&2
+                exit 2
+            fi
+            DIR="$2"; shift 2 ;;
         --version|-v) echo "pkg-manager $VERSION"; exit 0 ;;
         --help|-h)
             cat <<'HELP'
@@ -52,9 +63,12 @@ pkg-manager — echo the JS package manager to use for a directory
 Usage:
   pkg-manager [-C <dir>]
 
-Echoes one of: pnpm, yarn, bun, npm. Chosen by lockfile, and only if that
-manager is actually installed. Exits 1 with no output when the directory has
-no package.json or no usable manager is present.
+Echoes one of: pnpm, yarn, bun, npm. Chosen from package.json's
+"packageManager" field, else the lockfile, else npm.
+
+Exit 1 with no output when the directory has no package.json, or when the
+repo names a manager that is not installed — substituting npm for a declared
+pnpm/yarn/bun workspace would run the wrong tool and blame the wrong thing.
 HELP
             exit 0
             ;;
@@ -66,24 +80,46 @@ if [[ ! -f "$DIR/package.json" ]]; then
     exit 1
 fi
 
-# Echo $1 and exit 0 if it is installed; otherwise fall through.
-# The explicit `return 0` is load-bearing under `set -e`: without it a
-# not-installed probe makes the enclosing `if` compound exit non-zero, which
-# aborts the script instead of trying the next candidate — the exact
-# "lockfile names an uninstalled manager" case this function exists for.
-try() {
+# require <manager> — the repo asked for this one. Echo it or fail loudly.
+require() {
     if command -v "$1" >/dev/null 2>&1; then
         printf '%s\n' "$1"
         exit 0
     fi
-    return 0
+    echo "pkg-manager: this project declares '$1' but it is not installed." >&2
+    echo "  Install it, or the caller's build/test step will run the wrong tool." >&2
+    exit 1
 }
 
-if [[ -f "$DIR/pnpm-lock.yaml" ]]; then try pnpm; fi
-if [[ -f "$DIR/yarn.lock" ]]; then try yarn; fi
-if [[ -f "$DIR/bun.lockb" || -f "$DIR/bun.lock" ]]; then try bun; fi
+# 1: the npm-standard `packageManager` field — an explicit declaration beats
+# lockfile archaeology, and monorepos often carry it with no lockfile checked
+# in (this repo is one).
+DECLARED="$(DIR="$DIR" python3 -c '
+import json, os, sys
+try:
+    p = json.load(open(os.path.join(os.environ["DIR"], "package.json")))
+except Exception:
+    sys.exit(0)
+value = p.get("packageManager")
+if isinstance(value, str) and value:
+    print(value.split("@", 1)[0].strip())
+' 2>/dev/null || true)"
 
-# package-lock.json, or no lockfile at all: npm is the universal fallback.
-try npm
+case "$DECLARED" in
+    pnpm|yarn|bun|npm) require "$DECLARED" ;;
+esac
 
+# 2: lockfiles, most specific first.
+[[ -f "$DIR/pnpm-lock.yaml" ]] && require pnpm
+[[ -f "$DIR/yarn.lock" ]] && require yarn
+{ [[ -f "$DIR/bun.lockb" ]] || [[ -f "$DIR/bun.lock" ]]; } && require bun
+[[ -f "$DIR/package-lock.json" ]] && require npm
+
+# 3: no declaration, no lockfile — npm is the universal fallback.
+if command -v npm >/dev/null 2>&1; then
+    printf '%s\n' npm
+    exit 0
+fi
+
+echo "pkg-manager: no package manager installed (npm not found)" >&2
 exit 1

--- a/src/agency/tools/pkg-manager
+++ b/src/agency/tools/pkg-manager
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# What Problem: lockfile-sniffing to pick a JS package manager was open-coded
+# in worktree-create and was about to be open-coded again in pr-captain-land's
+# local validation gate. Two copies is how the default-branch resolver became
+# seven. Worse, a skill that names a specific package manager inline fails the
+# "skills must not hardcode a package manager" validation gate
+# (src/tests/skills/skill-validation.bats) — correctly, because a skill is
+# shipped to adopter repos that may use a different one.
+#
+# How & Why: one zero-pip primitive that ECHOES the package manager to use for
+# a directory, chosen by lockfile and confirmed to be installed. Skills call
+# this instead of naming a manager; the knowledge lives in agency/tools/ where
+# it belongs.
+#
+# Resolution order — most specific lockfile first, then the universal fallback:
+#   pnpm-lock.yaml            → pnpm
+#   yarn.lock                 → yarn
+#   bun.lockb / bun.lock      → bun
+#   package-lock.json         → npm
+#   package.json (no lock)    → npm
+#   no package.json           → (nothing, exit 1)
+#
+# A manager named by a lockfile but NOT installed is skipped rather than
+# returned — echoing a command that cannot run just moves the failure
+# somewhere less legible.
+#
+# Usage:
+#   ./agency/tools/pkg-manager              # resolve for the current directory
+#   ./agency/tools/pkg-manager -C <dir>     # resolve for <dir>
+#
+# Exit codes:
+#   0  resolved (name on stdout)
+#   1  no package.json, or no usable manager installed
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — extracted while building the local-first
+#          pr-captain-land validation gate.
+
+set -euo pipefail
+
+VERSION="1.0.0"
+DIR="."
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        -C) DIR="${2:-}"; shift 2 ;;
+        --version|-v) echo "pkg-manager $VERSION"; exit 0 ;;
+        --help|-h)
+            cat <<'HELP'
+pkg-manager — echo the JS package manager to use for a directory
+
+Usage:
+  pkg-manager [-C <dir>]
+
+Echoes one of: pnpm, yarn, bun, npm. Chosen by lockfile, and only if that
+manager is actually installed. Exits 1 with no output when the directory has
+no package.json or no usable manager is present.
+HELP
+            exit 0
+            ;;
+        *) echo "pkg-manager: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+if [[ ! -f "$DIR/package.json" ]]; then
+    exit 1
+fi
+
+# Echo $1 and exit 0 if it is installed; otherwise fall through.
+# The explicit `return 0` is load-bearing under `set -e`: without it a
+# not-installed probe makes the enclosing `if` compound exit non-zero, which
+# aborts the script instead of trying the next candidate — the exact
+# "lockfile names an uninstalled manager" case this function exists for.
+try() {
+    if command -v "$1" >/dev/null 2>&1; then
+        printf '%s\n' "$1"
+        exit 0
+    fi
+    return 0
+}
+
+if [[ -f "$DIR/pnpm-lock.yaml" ]]; then try pnpm; fi
+if [[ -f "$DIR/yarn.lock" ]]; then try yarn; fi
+if [[ -f "$DIR/bun.lockb" || -f "$DIR/bun.lock" ]]; then try bun; fi
+
+# package-lock.json, or no lockfile at all: npm is the universal fallback.
+try npm
+
+exit 1

--- a/src/agency/tools/pr-create
+++ b/src/agency/tools/pr-create
@@ -77,22 +77,16 @@ fi
 # Detect the default branch so this works on repos using 'master' as well.
 # Issue #107 (monofolk hotfix): the hardcoded 'origin/main' caused false
 # "version not bumped" failures on repos where origin/master is the default.
-# Detection order:
-#   1. git symbolic-ref refs/remotes/origin/HEAD   (GitHub HEAD metadata)
-#   2. existence of refs/remotes/origin/main
-#   3. existence of refs/remotes/origin/master
-#   4. hard fail with clear message
-DEFAULT_BRANCH=$(git -C "$REPO_ROOT" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||' || true)
-if [[ -z "$DEFAULT_BRANCH" ]]; then
-    if git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/main; then
-        DEFAULT_BRANCH="main"
-    elif git -C "$REPO_ROOT" show-ref --verify --quiet refs/remotes/origin/master; then
-        DEFAULT_BRANCH="master"
-    else
-        echo "BLOCKED: could not determine default branch (origin/main or origin/master)." >&2
-        echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
-        exit 1
-    fi
+#
+# The detection ladder used to be inline here (and in six other tools). It now
+# lives in the shared `resolve-default-branch` primitive. `--strict` preserves
+# this tool's FAIL-CLOSED contract: a guessed base ref here would silently
+# mis-evaluate the version-bump gate, so an unresolvable default branch must
+# block, not fall back.
+if ! DEFAULT_BRANCH=$("$SCRIPT_DIR/resolve-default-branch" -C "$REPO_ROOT" --strict 2>/dev/null); then
+    echo "BLOCKED: could not determine default branch (origin/main or origin/master)." >&2
+    echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
+    exit 1
 fi
 DEFAULT_REF="origin/$DEFAULT_BRANCH"
 

--- a/src/agency/tools/resolve-default-branch
+++ b/src/agency/tools/resolve-default-branch
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# What Problem: seven copies of "figure out the default branch" had drifted
+# across the tool tree (git-captain, pr-create, pr-submit, _sync-main-ref,
+# dispatch, pr-build, worktree-sync). Each encoded a slightly different
+# policy — different probe order, different fallback, different failure
+# mode. A bug fixed in one copy stayed broken in the other six, and the
+# hardcoded `origin/main` / `master` variants failed closed in exactly the
+# repos where the name differed (issue #107, issue #268, #463).
+#
+# How & Why: one zero-pip bash primitive that ECHOES the repo's default
+# branch name (bare name, no `origin/` prefix). The probe order is the
+# UNION of the three live resolvers, so no consumer loses a case it used
+# to handle:
+#
+#   1. local refs/heads/main            (git-captain's first probe)
+#   2. local refs/heads/master          (git-captain's second probe)
+#   3. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
+#   4. refs/remotes/origin/main
+#   5. refs/remotes/origin/master
+#   6. fallback → "main"                (default mode only)
+#
+# The two policies the consumers actually differ on are preserved by a
+# flag, not by forking the logic:
+#   - default mode  — falls back to "main" and exits 0. For consumers that
+#     want a best guess (pr-submit's historical behaviour, but with the
+#     modern `main` fallback rather than `master`).
+#   - --strict      — prints NOTHING and exits 1 when nothing resolves, so
+#     fail-closed consumers (git-captain, pr-create) keep failing loud
+#     instead of silently guessing.
+#
+# Slash-bearing default branch names (e.g. `release/stable`) round-trip
+# correctly: the origin/HEAD symbolic ref is read in full-ref form and the
+# `refs/remotes/origin/` prefix is stripped with a literal prefix removal,
+# never a greedy pattern.
+#
+# Usage:
+#   ./agency/tools/resolve-default-branch                # echo name, fallback main
+#   ./agency/tools/resolve-default-branch --strict       # exit 1 if unresolved
+#   ./agency/tools/resolve-default-branch -C /path/repo  # resolve in another repo
+#
+# Exit codes:
+#   0  resolved (name on stdout)
+#   1  --strict and nothing resolved  |  not a git repository
+#   2  usage error
+#
+# Written: 2026-08-09 (devex) — plan-pr-captain-land-localfirst-20260809 v2,
+#          MAR must-fix "shared primitive = superset with --strict".
+
+set -euo pipefail
+
+VERSION="1.0.0"
+
+STRICT=false
+REPO_DIR=""
+
+usage() {
+    cat <<'HELP'
+resolve-default-branch — echo this repo's default branch name
+
+Usage:
+  resolve-default-branch [--strict] [-C <dir>]
+
+Options:
+  --strict        Exit 1 (printing nothing) when the default branch cannot
+                  be resolved, instead of falling back to "main".
+  -C <dir>        Resolve in <dir> instead of the current directory.
+  --version       Print version and exit
+  --help, -h      Show this help
+
+Resolution order (union of the historical resolvers):
+  refs/heads/main → refs/heads/master → origin/HEAD → refs/remotes/origin/main
+  → refs/remotes/origin/master → "main" (default mode only)
+
+Output is the BARE branch name — no "origin/" prefix. Callers that need a
+remote ref build it themselves: BASE_REF="origin/$(resolve-default-branch)".
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --strict) STRICT=true; shift ;;
+        -C) REPO_DIR="${2:-}"; shift 2 ;;
+        --version|-v) echo "resolve-default-branch $VERSION"; exit 0 ;;
+        --help|-h) usage; exit 0 ;;
+        *) echo "resolve-default-branch: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+# All probes run through this so -C is honoured uniformly. Bash 3.2: no
+# arrays-of-args needed, git -C takes an empty-safe path via the guard below.
+git_probe() {
+    if [[ -n "$REPO_DIR" ]]; then
+        git -C "$REPO_DIR" "$@"
+    else
+        git "$@"
+    fi
+}
+
+if ! git_probe rev-parse --git-dir >/dev/null 2>&1; then
+    echo "resolve-default-branch: not a git repository${REPO_DIR:+ ($REPO_DIR)}" >&2
+    exit 1
+fi
+
+BRANCH=""
+
+# 1 + 2: local branch refs. git-captain probed these first because recovery
+# has to work when origin is unreachable.
+if git_probe show-ref --verify --quiet refs/heads/main; then
+    BRANCH="main"
+elif git_probe show-ref --verify --quiet refs/heads/master; then
+    BRANCH="master"
+else
+    # 3: origin/HEAD — GitHub's own answer, and the only probe that can name
+    # a default branch that is neither main nor master.
+    SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+    if [[ -n "$SYMREF" ]]; then
+        # Literal prefix strip — survives slashes in the branch name.
+        BRANCH="${SYMREF#refs/remotes/origin/}"
+        # A symbolic ref that did not carry the expected prefix is not a
+        # usable branch name; fall through to the remaining probes.
+        if [[ "$BRANCH" == "$SYMREF" ]]; then
+            BRANCH=""
+        fi
+    fi
+
+    # 4 + 5: remote-tracking refs.
+    if [[ -z "$BRANCH" ]]; then
+        if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
+            BRANCH="main"
+        elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
+            BRANCH="master"
+        fi
+    fi
+fi
+
+if [[ -z "$BRANCH" ]]; then
+    if [[ "$STRICT" == true ]]; then
+        echo "resolve-default-branch: cannot determine default branch." >&2
+        echo "  Checked: refs/heads/{main,master}, origin/HEAD, refs/remotes/origin/{main,master}" >&2
+        echo "  Fix: git remote set-head origin -a   # to set origin/HEAD" >&2
+        exit 1
+    fi
+    # 6: deliberate, tested fallback. `main` (not `master`) — flagged in the
+    # #463 QG as the modern, safer default.
+    BRANCH="main"
+fi
+
+printf '%s\n' "$BRANCH"

--- a/src/agency/tools/resolve-default-branch
+++ b/src/agency/tools/resolve-default-branch
@@ -8,16 +8,33 @@
 # repos where the name differed (issue #107, issue #268, #463).
 #
 # How & Why: one zero-pip bash primitive that ECHOES the repo's default
-# branch name (bare name, no `origin/` prefix). The probe order is the
-# UNION of the three live resolvers, so no consumer loses a case it used
-# to handle:
+# branch name (bare name, no `origin/` prefix). The probe set is the UNION
+# of the three live resolvers, so no consumer loses a case it used to
+# handle — but the ORDER is the remote-authoritative one:
 #
-#   1. local refs/heads/main            (git-captain's first probe)
-#   2. local refs/heads/master          (git-captain's second probe)
-#   3. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
-#   4. refs/remotes/origin/main
-#   5. refs/remotes/origin/master
+#   1. origin/HEAD symbolic ref         (pr-create / pr-submit first probe)
+#   2. refs/remotes/origin/main
+#   3. refs/remotes/origin/master
+#   4. local refs/heads/main            (offline fallback)
+#   5. local refs/heads/master          (offline fallback)
 #   6. fallback → "main"                (default mode only)
+#
+# Probing LOCAL branches first — git-captain's historical order — looks like
+# a harmless superset and is not. Every other consumer turns this answer
+# into a REMOTE ref (`origin/$(resolve-default-branch)`). A clone whose
+# default is `master` or `trunk` but which also carries a stale local `main`
+# would resolve to `main`, and then:
+#   - pr-create diffs against a nonexistent origin/main, sees no manifest
+#     change, and emits a false "BLOCKED: agency_version not bumped"
+#     (issue #107, reintroduced through the local-refs door);
+#   - _sync-main-ref dies on a missing refs/remotes/origin/main;
+#   - pr-captain-land blocks with a bogus "branch does not contain
+#     origin/main".
+# A local branch named `main` is not evidence that `main` is the default.
+#
+# Probes 1-3 stay correct offline: origin/HEAD and the remote-tracking refs
+# are local data, no network required. Probes 4-5 preserve git-captain's
+# issue-#268 recovery case (remote refs pruned/absent, local branch intact).
 #
 # The two policies the consumers actually differ on are preserved by a
 # flag, not by forking the logic:
@@ -67,9 +84,13 @@ Options:
   --version       Print version and exit
   --help, -h      Show this help
 
-Resolution order (union of the historical resolvers):
-  refs/heads/main → refs/heads/master → origin/HEAD → refs/remotes/origin/main
-  → refs/remotes/origin/master → "main" (default mode only)
+Resolution order (union of the historical resolvers, remote-authoritative):
+  origin/HEAD → refs/remotes/origin/main → refs/remotes/origin/master
+  → refs/heads/main → refs/heads/master → "main" (default mode only)
+
+The remote refs come first because callers turn this answer into
+"origin/<name>". Local branches are the offline fallback, not the source
+of truth.
 
 Output is the BARE branch name — no "origin/" prefix. Callers that need a
 remote ref build it themselves: BASE_REF="origin/$(resolve-default-branch)".
@@ -79,7 +100,16 @@ HELP
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --strict) STRICT=true; shift ;;
-        -C) REPO_DIR="${2:-}"; shift 2 ;;
+        -C)
+            # A bare trailing `-C` must be a usage error with a message. Left
+            # to `shift 2` it fails under `set -e` and the script dies exit 1
+            # with no output — indistinguishable from "not a git repository".
+            if [[ -z "${2:-}" ]]; then
+                echo "resolve-default-branch: -C requires a directory argument" >&2
+                exit 2
+            fi
+            REPO_DIR="$2"; shift 2
+            ;;
         --version|-v) echo "resolve-default-branch $VERSION"; exit 0 ;;
         --help|-h) usage; exit 0 ;;
         *) echo "resolve-default-branch: unknown argument: $1" >&2; usage >&2; exit 2 ;;
@@ -103,33 +133,35 @@ fi
 
 BRANCH=""
 
-# 1 + 2: local branch refs. git-captain probed these first because recovery
-# has to work when origin is unreachable.
-if git_probe show-ref --verify --quiet refs/heads/main; then
-    BRANCH="main"
-elif git_probe show-ref --verify --quiet refs/heads/master; then
-    BRANCH="master"
-else
-    # 3: origin/HEAD — GitHub's own answer, and the only probe that can name
-    # a default branch that is neither main nor master.
-    SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
-    if [[ -n "$SYMREF" ]]; then
-        # Literal prefix strip — survives slashes in the branch name.
-        BRANCH="${SYMREF#refs/remotes/origin/}"
-        # A symbolic ref that did not carry the expected prefix is not a
-        # usable branch name; fall through to the remaining probes.
-        if [[ "$BRANCH" == "$SYMREF" ]]; then
-            BRANCH=""
-        fi
+# 1: origin/HEAD — the remote's own answer, and the only probe that can name
+# a default branch that is neither main nor master.
+SYMREF="$(git_probe symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null || true)"
+if [[ -n "$SYMREF" ]]; then
+    # Literal prefix strip — survives slashes in the branch name.
+    BRANCH="${SYMREF#refs/remotes/origin/}"
+    # A symbolic ref that did not carry the expected prefix is not a usable
+    # branch name; fall through to the remaining probes.
+    if [[ "$BRANCH" == "$SYMREF" ]]; then
+        BRANCH=""
     fi
+fi
 
-    # 4 + 5: remote-tracking refs.
-    if [[ -z "$BRANCH" ]]; then
-        if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
-            BRANCH="main"
-        elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
-            BRANCH="master"
-        fi
+# 2 + 3: remote-tracking refs.
+if [[ -z "$BRANCH" ]]; then
+    if git_probe show-ref --verify --quiet refs/remotes/origin/main; then
+        BRANCH="main"
+    elif git_probe show-ref --verify --quiet refs/remotes/origin/master; then
+        BRANCH="master"
+    fi
+fi
+
+# 4 + 5: local branch refs — the offline/recovery fallback (issue #268:
+# remote refs pruned or origin never fetched, local branch still intact).
+if [[ -z "$BRANCH" ]]; then
+    if git_probe show-ref --verify --quiet refs/heads/main; then
+        BRANCH="main"
+    elif git_probe show-ref --verify --quiet refs/heads/master; then
+        BRANCH="master"
     fi
 fi
 

--- a/src/agency/tools/workstream-create
+++ b/src/agency/tools/workstream-create
@@ -95,6 +95,23 @@ if [ -z "$NAME" ]; then
   exit 1
 fi
 
+# Validate the name before it becomes a path.
+#
+# This was unvalidated, so `workstream-create 'test; rm -rf /'` cheerfully
+# created a directory literally named `test; rm -rf` under agency/workstreams/.
+# The injection-safety tests in src/tests/tools/scaffolding.bats call exactly
+# that, against the real repo — so every full test run left that directory
+# behind, and src/tests/tools/purge-pollution-guard.bats then (correctly)
+# went red about it. Same character class as worktree-create.
+if ! [[ "$NAME" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
+  log_error "Invalid workstream name: '$NAME'"
+  echo ""
+  echo "Name must start with a letter and contain only letters, numbers," >&2
+  echo "hyphens, and underscores. No slashes, spaces, dots, or shell" >&2
+  echo "metacharacters — the name becomes a directory path." >&2
+  exit 1
+fi
+
 DIR="agency/workstreams/$NAME"
 TIMESTAMP=$(./agency/tools/now 2>/dev/null || date '+%Y-%m-%d %H:%M')
 

--- a/src/agency/tools/worktree-create
+++ b/src/agency/tools/worktree-create
@@ -31,7 +31,7 @@
 
 set -euo pipefail
 
-VERSION="2.1.0"
+VERSION="2.2.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Source helpers
@@ -68,8 +68,8 @@ compute_worktree_name() {
 show_help() {
     cat <<HELP
 Usage:
-  worktree-create <name> [--branch <branch>]
-  worktree-create --workstream <ws> --agent <ag> [--branch <branch>]
+  worktree-create <name> [--branch <branch>] [--from <ref>]
+  worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
   worktree-create --compute-only --workstream <ws> --agent <ag>
 
 Creates a git worktree at .claude/worktrees/<name>/
@@ -78,6 +78,10 @@ Options:
   --workstream <ws> Workstream name (pairs with --agent to compute name)
   --agent <ag>      Agent name (pairs with --workstream to compute name)
   --branch <name>   Branch name (default: same as worktree name)
+  --from <ref>      Start point for a NEW branch (default: current HEAD).
+                    Accepts any committish, including a remote-tracking ref
+                    such as origin/main or origin/some-agent-branch. Ignored
+                    when --branch names an existing local branch.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help
@@ -114,12 +118,14 @@ NAME=""
 BRANCH=""
 WORKSTREAM=""
 AGENT=""
+FROM_REF=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --version|-v) echo "worktree-create $VERSION"; exit 0 ;;
         --help|-h) show_help; exit 0 ;;
         --branch) BRANCH="$2"; shift 2 ;;
+        --from) FROM_REF="$2"; shift 2 ;;
         --workstream) WORKSTREAM="$2"; shift 2 ;;
         --agent) AGENT="$2"; shift 2 ;;
         -*) echo "Unknown option: $1" >&2; exit 1 ;;
@@ -147,9 +153,16 @@ if [[ -z "$NAME" ]]; then
     exit 1
 fi
 
-# Validate name
-if ! [[ "$NAME" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
-    echo "Error: name must start with a letter and contain only letters, numbers, hyphens, dashes" >&2
+# Validate name.
+#
+# A leading underscore is allowed so machine-created, short-lived worktrees can
+# be namespaced apart from human agent worktrees at a glance — `pr-captain-land`
+# cuts `_land-<branch>` scratch worktrees and deletes them at the end of the
+# landing. The rest of the character class is unchanged: still no slashes (they
+# would nest directories under .claude/worktrees/ and collide with git's ref
+# directory rules), no dots, no spaces.
+if ! [[ "$NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*$ ]]; then
+    echo "Error: name must start with a letter or underscore and contain only letters, numbers, underscores, hyphens" >&2
     exit 1
 fi
 
@@ -166,14 +179,30 @@ fi
 # Create worktree
 echo "Creating worktree: $NAME"
 echo "  Branch: $BRANCH"
+[[ -n "$FROM_REF" ]] && echo "  From:   $FROM_REF"
 echo "  Path: .claude/worktrees/$NAME/"
 
 mkdir -p "$PROJECT_ROOT/.claude/worktrees"
 
-# Create branch + worktree (from current HEAD)
+# Create branch + worktree
 if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
-    # Branch exists — use it
+    # Branch exists — use it. --from would be a lie here (the branch already has
+    # a tip); say so instead of silently ignoring it.
+    if [[ -n "$FROM_REF" ]]; then
+        echo "Error: --from $FROM_REF given but branch '$BRANCH' already exists" >&2
+        echo "  Refusing to guess. Delete the branch or drop --from." >&2
+        exit 1
+    fi
     git -C "$PROJECT_ROOT" worktree add "$WORKTREE_DIR" "$BRANCH"
+elif [[ -n "$FROM_REF" ]]; then
+    # Create new branch at an explicit start point (e.g. origin/main, or an
+    # agent's remote branch — the local-first landing flow cuts its scratch
+    # worktree from pristine origin refs, never from a local tip).
+    if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
+        echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
+        exit 1
+    fi
+    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
 else
     # Create new branch from HEAD
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR"

--- a/src/agency/tools/worktree-create
+++ b/src/agency/tools/worktree-create
@@ -80,8 +80,11 @@ Options:
   --branch <name>   Branch name (default: same as worktree name)
   --from <ref>      Start point for a NEW branch (default: current HEAD).
                     Accepts any committish, including a remote-tracking ref
-                    such as origin/main or origin/some-agent-branch. Ignored
-                    when --branch names an existing local branch.
+                    such as origin/main or origin/some-agent-branch. It is an
+                    ERROR to pass --from when the branch already exists — the
+                    branch has a tip already, and silently ignoring the flag
+                    would put the worktree somewhere the caller did not ask
+                    for.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help

--- a/src/claude/skills/captain-release/reference.md
+++ b/src/claude/skills/captain-release/reference.md
@@ -22,12 +22,16 @@ The bump happens AFTER the PR is created (Step 6) so the PR's diff shows the act
 |---|---|---|
 | Branch origin | captain creates the work on a captain-* branch | agent creates work on agent branch, submits via /pr-submit |
 | QG responsibility | captain runs /pr-prep before /captain-release | agent runs /pr-prep before /pr-submit |
-| Version bump | captain does it in this skill's Step 6 | captain does it in /pr-captain-land's Step 4 |
+| Validation gate | captain runs /pr-prep on the captain-* branch | **local**, in a scratch worktree, at /pr-captain-land Step 3 |
+| Version bump | captain does it in this skill's Step 6 | captain does it in /pr-captain-land's Step 4, **inside the scratch worktree** |
+| PR head branch | the captain-* branch itself | a short-lived `_land-<branch>`; the agent's branch is never checked out or modified |
 | PR creation | captain-authored description (this skill) | captain-authored description wrapping agent's scope |
-| Merge | separate subsequent `/pr-captain-merge` invocation | included as Step 7 of /pr-captain-land |
-| Release creation | separate subsequent `/pr-captain-post-merge` | included as Step 8 of /pr-captain-land |
+| Merge | separate subsequent `/pr-captain-merge` invocation | included as Step 8 of /pr-captain-land |
+| Release creation | separate subsequent `/pr-captain-post-merge` | included as Step 8 of /pr-captain-land; cleanup + reconcile are Step 9 |
 
 Rule of thumb: use `/captain-release` for captain-authored work. Use `/pr-captain-land` when captain is landing an agent's prepared branch.
+
+**Note on the version bump race.** Both skills bump `agency_version`, and neither takes a lock. `/pr-captain-land` v2 does its bump in an isolated scratch worktree cut from `origin/<default>`, so it cannot collide with a dirty captain-* checkout — but two bumps derived from the same base still produce the same next version. Do not run a `/captain-release` and a `/pr-captain-land` concurrently.
 
 ## Recovery flows
 

--- a/src/claude/skills/captain-sync-all/reference.md
+++ b/src/claude/skills/captain-sync-all/reference.md
@@ -46,12 +46,18 @@ When `/pr-captain-post-merge` runs as part of PR land flow, it invokes `/captain
 - Steps 4-7 propagate to fleet.
 - Step 8 (handoff) is included.
 
+## Idempotence with `/pr-captain-land`
+
+`/pr-captain-land` (v2, local-first) does **not** merge the agent's branch into local master. It integrates in a scratch worktree, publishes a PR, and then reconciles local master with a plain `git-captain merge-from-origin` at its Step 9.
+
+That means running `/captain-sync-all` after a land is a **no-op with respect to the landed work** — local master has already fast-forwarded to the server merge, so there is nothing left to double-merge. The reverse order is equally safe. This is deliberate: v1's "merge into local main, then publish" design made the two flows capable of double-integrating the same commits.
+
 ## Frequency
 
 Captain runs `/captain-sync-all` at:
 
 - **Session start** — to reconcile with any overnight/external PR merges.
-- **After each PR land** (automatic via `/pr-captain-post-merge`).
+- **After each PR land** — `/pr-captain-land` already reconciles local master at its Step 9, so this is a cheap confirmation that also propagates to every worktree.
 - **Session end** — optional; ensures next session starts clean.
 - **On demand** when captain notices worktree drift (agent reports "merge conflict on session-resume").
 

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: pr-captain-land
-description: Captain-only. Land an agent's prepared branch — switch, verify receipt, bump agency_version, create PR, watch CI, merge, release, notify agent. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit (the-agency#296 Phase 1 pilot). The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-1 runtime precondition).
+description: Captain-only. Land an agent's prepared branch LOCAL-FIRST — integrate and validate in a scratch worktree cut from origin/<default>, then bump agency_version, sign a landing receipt, open the PR, confirm CI, merge, release, notify. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit. The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-0 runtime precondition).
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-1 runtime precondition refuses from wrong context.
-argument-hint: "<agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
+when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-0 runtime precondition refuses from wrong context.
+argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release]"
 paths: []
 required_reading:
   - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -16,8 +16,9 @@ required_reading:
   allowed-tools intentionally omitted — inherits Bash(*) from
   .claude/settings.json. Subcommand-level restriction silently blocked
   fleet agents (flag #62/#63; devex dispatch #171). This skill composes
-  git-safe, git-captain, git-push, git-safe-commit, pr-create,
-  pr-captain-merge, gh-release, dispatch, diff-hash, and gh — tool-level
+  git-safe, git-captain, git-push, git-safe-commit, worktree-create,
+  worktree-delete, pr-create, pr-merge, gh-release, dispatch, diff-hash,
+  receipt-sign, receipt-verify, resolve-default-branch, and gh — tool-level
   narrow restriction would work but needs maintenance. Inherit Bash(*).
   Defense in depth is layered via paths: [] + captain- name + runtime
   precondition (see "Captain-only — three-layer defense" below).
@@ -25,223 +26,234 @@ required_reading:
 
 # pr-captain-land
 
-Captain-side skill that lands an agent's prepared branch as a merged PR + GitHub release + fleet notification. Companion to `/pr-submit`. This is the single-writer serialization point for `agency_version` and PR creation — eliminates the version-bump and receipt-hash races the pre-v2 distributed model created.
+Captain-side skill that lands an agent's prepared branch as a merged PR + GitHub release + fleet notification. Companion to `/pr-submit`. The single-writer serialization point for `agency_version` and PR creation.
 
-**Name pattern:** `pr-` prefix groups with the PR skill family (so `/pr<tab>` autocomplete shows the full kit). `captain-` qualifier flags captain-only scope in the skill listing without requiring the reader to open SKILL.md.
+**v2 is LOCAL-FIRST.** The work is integrated and validated locally *before* a PR exists. GitHub is the publish step for already-validated work, not the reviewer.
+
+## The inversion
+
+The v1 flow was PR-first: switch the main checkout to the agent's branch, bump, push, open a PR, and let GitHub CI decide. Three structural problems:
+
+1. **Worktree collision.** Switching the main checkout to a branch the agent still has checked out in its own worktree fails outright. And switching at all makes the captain's checkout a moving target mid-land.
+2. **The wrong gate.** CI was the first thing that could say no. TheAgency's model is local review and validation.
+3. **No clean abort.** Any mid-flight failure left the main checkout parked on someone else's branch.
+
+v2 does not fix the rollback — it removes the thing that needed rolling back:
+
+> **The entire landing happens in a dedicated scratch worktree cut from `origin/<agent-branch>`. Local `main` is never read for content, never merged into, never reset, and never pushed. Rollback at any pre-publish failure is one action: delete the scratch worktree.**
+
+Validating against pristine `origin/<default>` is also strictly more correct than validating on the captain's local main, which routinely carries unpushed coordination commits and other worktrees' merges — none of which belong in the PR under test.
+
+### Invariants
+
+| Invariant | Why |
+|---|---|
+| The agent's branch is **never checked out** in the main checkout | Kills the worktree-collision bug by construction |
+| **`main`/`master` is never pushed** | All changes reach the default branch through a PR |
+| Local `main` is only ever moved by the final, idempotent `merge-from-origin` | No data-loss hazard, no double-integration with `/captain-sync-all` |
+| The agent's receipt is verified **before** the version bump | The bump edits `manifest.json`, which is inside the hashed file set (the #463 churn trap) |
+| `pr-create` is **not** weakened | Captain signs its own landing receipt instead |
 
 ## Why this exists
 
-Per the-agency#296 — one captain, one writer, one serialization point. Every PR, every version bump, every release goes through this skill when driven by an agent's `/pr-submit`.
-
-Pre-v2 (distributed PR ownership) failure modes this skill eliminates:
-
-- Agent A and agent B both run `/pr-prep` + `/pr-create` concurrently → both bump `agency_version` → one loses, the other's release tag is wrong.
-- Captain lands a coord commit on master between an agent's `/pr-prep` and that agent's `/pr-create` → the receipt's diff-hash no longer matches → `pr-create` blocks with a confusing error.
-- Agent opens PR with a one-line body → fleet reviewers can't tell what changed without diving into diff.
-
-Captain-owned: captain is serialized by definition (one captain), captain re-verifies the receipt at the moment of landing, captain authors a fleet-aware PR body that references agent + scope + receipt.
+Per the-agency#296 — one captain, one writer, one serialization point. Pre-v2 distributed PR ownership produced version-bump races (two agents bump `agency_version` concurrently), receipt-hash races (a captain coord commit lands between an agent's `/pr-prep` and its `/pr-create`), and one-line PR bodies that fleet reviewers could not triage.
 
 ## Required reading
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
 - `REFERENCE-CODE-REVIEW-LIFECYCLE.md` — end-to-end PR flow
-- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — five-hash chain, receipt re-verification semantics
-- `REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline (`pr-captain-merge` enforces)
+- `REFERENCE-RECEIPT-INFRASTRUCTURE.md` — five-hash chain, landing-receipt semantics
+- `REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
 - `REFERENCE-SAFE-TOOLS.md` — the safe-tool family this skill composes
 
-This skill's `reference.md` is the step-by-step land protocol with failure-mode recovery.
+`reference.md` is the step-by-step protocol with failure-mode recovery. `examples.md` has worked runs.
 
 ## Usage
 
 ```
 /pr-captain-land <agent-branch>
+/pr-captain-land <agent-branch> --rehearse
 /pr-captain-land <agent-branch> --dry-run
 /pr-captain-land <agent-branch> --title "Custom PR title"
+/pr-captain-land <agent-branch> --agent devex
 /pr-captain-land <agent-branch> --no-release
 ```
 
-- `<agent-branch>`: **required.** The branch that `/pr-submit` identified.
-- `--dry-run`: walk the preflight + preview the PR body; no mutation.
-- `--title`: override the default PR title (which derives from the agent's scope).
-- `--no-release`: skip Step 8 (release creation). Used when landing a PR that explicitly shouldn't cut a release (rare).
+- `<agent-branch>`: **required.** The branch `/pr-submit` identified.
+- `--rehearse`: run **steps 0-3 only** — integrate + validate, then delete the scratch. Nothing pushed, no PR, no bump, no receipt. **Rehearse first on any branch you have not landed before.**
+- `--dry-run`: `--rehearse` plus a printout of exactly what would be published.
+- `--title`: override the PR title (defaults to the branch name).
+- `--agent`: who to dispatch (defaults to the branch-name prefix).
+- `--no-release`: skip the GitHub release after merge (rare).
+
+Environment:
+
+- `PR_LAND_VALIDATE_CMD` — override the local validation command wholesale, for repos whose gate is not "package script + `commit-precheck`".
 
 ## Preconditions
 
-The script enforces **all** of these before any mutation; any failure exits non-zero with a clear error and no state change:
+Enforced before any mutation; failure exits non-zero with no state change.
 
-1. Running in the **main checkout** (first entry of `git worktree list`). Not in a `.claude/worktrees/` path.
-2. Current branch is `master` or `main`.
-3. Master tree is clean (`git status --porcelain` empty).
-4. **No pending post-merge (C#372 Fix B).** `./agency/tools/post-merge-state check` exits 0. If exit 1, a prior landed PR has not had its release cut — run `/pr-captain-post-merge <pending-PR>` first, then re-invoke.
-5. `<agent-branch>` exists on origin (`git ls-remote --heads origin <agent-branch>` non-empty).
-6. `<agent-branch>` passes safe-name validation: regex `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-7. Diff-hash of `<agent-branch>` vs `origin/<default-branch>` (resolved, not hardcoded) matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`.
+1. Running in the **main checkout** (first entry of `git worktree list`).
+2. Current branch is the resolved default branch.
+3. No leftover scratch worktree named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete`).
+4. `<agent-branch>` exists on origin.
+5. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
+6. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
 
-Any failure → zero mutation, clean error message, exit 1.
+**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues.
 
 ## Flow / Steps
 
-The script at `scripts/pr-captain-land` walks these nine steps. Full failure-mode detail is in `reference.md`.
+Script: `scripts/pr-captain-land`.
 
-### Step 1: Preflight
+### Step 0 — Preflight
 
-Verify all six preconditions. If any fail, exit 1.
+Main-checkout + branch checks, no-leftover-scratch check, `git-captain fetch`, and the default branch resolved via the shared `agency/tools/resolve-default-branch` primitive. **Local main is not read or written.**
 
-### Step 2: Switch to agent branch
+### Step 1 — Verify the branch and its base
 
-```
-./agency/tools/git-captain switch-branch <agent-branch>
-```
-
-Main checkout is now on agent's branch.
-
-### Step 3: Verify receipt against current state
+Branch must exist on origin. Then:
 
 ```
-./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
+git merge-base --is-ancestor origin/<default> origin/<agent-branch>
 ```
 
-Find receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`. If missing, agent's state drifted — switch back to master, exit 1, tell agent to re-run `/pr-prep` + `/pr-submit`.
+If the base has moved, the agent's receipt was signed against an older base and *can never* verify. That is BLOCKED with the real cause and the real fix — "merge `<default>` into your branch, re-run `/pr-prep`, push, re-run `/pr-submit`" — never a bare hash-mismatch error.
 
-### Step 4: Bump `agency_version`
-
-Read `agency/config/manifest.json`. Bump minor (e.g., `1.8 → 1.9`). Refresh `updated_at` to current UTC timestamp.
-
-**Security note:** version-bump is done via Python env-var substitution (`MANIFEST=... NEW_VER=... python3 -c '...os.environ[...]...'`), **not** f-string interpolation. This blocks code-injection via adversarial branch names. (Fix landed in `ccf054ad` per MAR finding F-SEC-1 / CRITICAL-3.)
-
-Commit via `git-safe-commit`:
+### Step 2 — Cut the scratch worktree
 
 ```
-chore(manifest): bump agency_version {old} → {new} for PR landing (captain)
+./agency/tools/worktree-create _land-<branch> --from origin/<agent-branch>
 ```
 
-Push to origin.
+This **is** the local integration: step 1 proved `origin/<default>` is an ancestor, so the scratch tree already represents the agent's work on top of the default branch. Slashes in the branch name collapse to dashes in the scratch name.
 
-### Step 5: Create PR
+### Step 2b — Verify the agent's QGR receipt
 
-```
-./agency/tools/pr-create --title "<title>" --body "<captain-authored fleet-aware body>"
-```
+`diff-hash --base origin/<default>` inside the scratch, find `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md`, and `receipt-verify --file` it. **Before any mutation** — verifying after the bump would churn the receipt (#463).
 
-Title derives from agent's `--scope` or `--title` override. Body wraps agent's scope with:
+Failure → delete the scratch, tell the agent to re-run `/pr-prep`.
 
-- "Captain-landed PR via `pr-captain-land` (the-agency#296 Phase 1)"
-- Branch, receipt path, diff-hash, version bump
-- "Release `v{new}` will follow on merge"
+### Step 3 — VALIDATE LOCALLY. This is the gate.
 
-### Step 6: Switch back to master
+In the scratch, in order: build script, widest declared test script (`bats:all`, else `test`), then `commit-precheck`. `PR_LAND_VALIDATE_CMD` replaces all of it.
 
-```
-./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
-```
+- **Failure → delete the scratch, dispatch the agent naming the failing step, exit 1.** Nothing was published.
+- **No resolvable validation command → loud WARNING**, recorded in the landing receipt summary. It is never a silent pass.
 
-Captain sits on master during the CI-wait phase. Avoids any accidental commit on the PR branch.
+`--rehearse` / `--dry-run` stop here and delete the scratch.
 
-### Step 7: Watch CI
+### Step 4 — Bump `agency_version` in the scratch
 
-Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Only gates on `lint-and-test`.
+Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via `git-safe-commit`.
 
-| State | Action |
+**Security note:** the bump uses Python env-var substitution (`MANIFEST=... NEW_VER=... python3 -c '...os.environ[...]...'`), never f-string interpolation. Blocks code injection via adversarial branch names (MAR F-SEC-1 / CRITICAL-3, landed `ccf054ad`).
+
+### Step 5 — Sign the captain LANDING receipt
+
+`pr-create` is not bypassed or weakened. Instead the captain signs a receipt for the state it actually validated, extending the agent's chain:
+
+| Hash | Value |
 |---|---|
-| SUCCESS | proceed to Step 8 |
-| FAILURE | exit 1 — agent must fix + push + resubmit |
-| PENDING / IN_PROGRESS | wait 20s, poll again |
+| A | the agent receipt's `hash_e` (what was reviewed) |
+| B | hash of the local validation log |
+| C | B — nothing to triage, validation was green |
+| D | C — auto-approved, no principal 1B1 |
+| E | diff hash of the bumped tree vs `origin/<default>` |
 
-Max 30 attempts = 10 minutes. On timeout, exit 1.
+Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
-`deploy-preview-backend` is environmental flake and ignored by this skill.
+### Step 6 — Publish
 
-### Step 8: Merge + release
+Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms.
 
-Merge:
+**This is the first irreversible action.** Past here, failures report and leave the scratch in place for inspection rather than rolling back.
 
-```
-./agency/tools/pr-merge {pr-num} --principal-approved
-```
+### Step 7 — CI confirmation on the aggregate rollup
 
-True merge commit — never squash, never rebase (enforced by `pr-captain-merge` / underlying `pr-merge`).
+Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Where branch protection exposes a required-contexts list, narrow to it; otherwise gate on every check in the rollup.
 
-Sync master:
+| Rollup state | Action |
+|---|---|
+| every check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
+| any terminal failure (FAILURE, ERROR, TIMED_OUT, CANCELLED, …) | exit 1, fail fast, name the checks |
+| any check still pending | wait 20s, poll again |
+| **rollup empty** | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
 
-```
-./agency/tools/git-captain fetch
-./agency/tools/git-captain merge-from-origin
-```
+v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so the loop could only ever time out. The gate is now name-agnostic, and a regression test asserts that literal never returns.
 
-Release (unless `--no-release`):
-
-```
-./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
-```
-
-Release notes: captain-authored, references PR number + agent.
-
-### Step 9: Dispatch agent
+### Step 8 — Merge + release
 
 ```
-./agency/tools/dispatch create \
-  --to <agent-address> \
-  --type master-updated \
-  --subject "PR #{num} landed — v{new} released" \
-  --body "<PR URL, release URL, version bump, Phase 1 pilot feedback request>"
+./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-Agent picks up on next `/session-resume` or via dispatch monitor.
+True merge commit — never squash, never rebase.
+
+### Step 9 — Cleanup, notify, reconcile
+
+Delete the scratch worktree and the local land branch; dispatch `master-updated` to the agent; `post-merge-state clear`; then reconcile local main with `git-captain merge-from-origin`.
+
+The reconciliation is a **separate, idempotent** step on purpose: it is the same fast-forward `/captain-sync-all` performs, so running either afterwards is a no-op rather than a double-integration.
 
 ## Failure modes
 
-- **Preflight fails** (Step 1): exit 1, no mutation. Captain resolves (switch to main checkout, clean tree, ensure branch exists, verify agent submitted).
-- **Branch-name validation fails** (Step 1.5): rare — injection attempt or malformed branch. Exit 1. Agent renames.
-- **Receipt mismatch** (Step 3): master drifted. Exit 1 with switch-back-to-master. Agent re-runs `/pr-prep` + `/pr-submit`.
-- **Version-bump push fails** (Step 4): concurrent captain activity or branch-protection edge. Switch back to master, exit 1. Captain investigates.
-- **`pr-create` blocks on receipt** (Step 5): re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
-- **CI failure** (Step 7): version-bump commit stays on agent's branch; agent can fix + push + resubmit via `/pr-submit`. Version doesn't re-bump on retry (captain detects current == target).
-- **CI timeout** (Step 7): exit 1, captain investigates manually.
-- **Merge fails** (Step 8): likely branch-protection edge. Captain falls back to manual `/pr-captain-merge <num> --principal-approved`.
-- **Release creation fails** (Step 8): merge succeeded, release failed. Warn captain, suggest manual `gh release create`. Skill returns 0 because merge is the primary outcome. (MAR follow-up H13 tracks stricter semantics.)
-- **Dispatch emission fails** (Step 9): warn, exit 0. Merge + release are the authoritative record; dispatch is notification.
+| Where | What happens |
+|---|---|
+| Preflight (0) | Exit 1, zero mutation. |
+| Leftover scratch (0) | Exit 1 naming the path and the `worktree-delete` fix. Never auto-deletes someone else's in-flight land. |
+| Stale base (1) | BLOCK naming the real cause; agent merges default + re-preps. |
+| Receipt missing/invalid (2b) | Scratch deleted; agent re-runs `/pr-prep`. |
+| Local validation fails (3) | Scratch deleted, agent dispatched with the failing step. **Nothing published.** |
+| Bump or receipt-sign fails (4-5) | Scratch deleted. Nothing published. |
+| `pr-create` returns no URL (6) | Scratch **kept** for inspection; the land branch is pushed and must be cleaned up manually if abandoned. |
+| CI fails (7) | Exit 1. The local gate passed and the server disagreed — investigate before re-landing. |
+| CI timeout (7) | Exit 1 with the last verdict; check manually. |
+| Empty rollup (7) | Exit 1, distinct message. Merge via `/pr-captain-merge` if that is genuinely expected. |
+| Merge fails (8) | Fall back to `/pr-captain-merge <num> --principal-approved`. |
+| Release fails (8) | Warn — check whether auto-release already cut the tag. Merge is the primary outcome. |
+| Dispatch fails (9) | Warn only. Merge + release are the authoritative record. |
 
 ## What this does NOT do
 
-- **Does not write code.** Agent's branch is the substance; captain lands it as-is (plus the version-bump).
-- **Does not modify agent's existing commits.** Only appends the version-bump commit.
-- **Does not squash or rebase.** `pr-captain-merge` enforces true merge commit per framework discipline.
-- **Does not auto-retry on failure.** Failures need captain attention; no silent retries that mask real issues.
-- **Does not fire from an agent context.** Three-layer defense (below) makes this impossible.
+- **Does not write code.** The agent's branch is the substance.
+- **Does not modify the agent's branch.** The version bump and landing receipt go on the `_land-` branch; `<agent-branch>` is never checked out or pushed.
+- **Does not squash or rebase.**
+- **Does not touch local `main`** until the final reconcile.
+- **Does not auto-retry.**
+- **Does not fire from an agent context.**
 
 ## Captain-only — three-layer defense
 
-Defense in depth against accidental invocation from the wrong context:
+1. **`paths: []`** — no file-path auto-activation. (Contrast `pr-submit`, which has `paths: [.claude/worktrees/**]`.)
+2. **Name contains `captain-`** — scope visible in the skill list.
+3. **Runtime precondition** — Step 0 refuses unless in the main checkout on the default branch.
 
-1. **`paths: []`** (intentionally empty) — no file-path auto-activation. (Contrast with `pr-submit` which has `paths: [.claude/worktrees/**]`.)
-2. **Name contains `captain-`** — any human or agent browsing the skill list sees scope at a glance.
-3. **Runtime precondition** — script's Step 1 refuses unless in main checkout on master.
-
-Any single layer failing is caught by the next. All three must fail simultaneously for an unauthorized invocation to land a PR.
-
-(Historically `disable-model-invocation: true` was a fourth layer. That flag was removed 2026-04-20 because the captain session IS the principal's session — DMI was blocking the captain from invoking captain-* skills. See `REFERENCE-SKILL-CONVENTIONS.md` §1.)
+(Historically `disable-model-invocation: true` was a fourth layer, removed 2026-04-20: the captain session IS the principal's session, and DMI blocked the captain from invoking captain-* skills. See `REFERENCE-SKILL-CONVENTIONS.md` §1.)
 
 ## Status
 
-`active` (v2, agency-skill-version 2 from birth — Phase 1 pilot for the-agency#296). Scripts hardened in `ccf054ad` per MAR findings (Python env-var substitution + branch-name validation). Ready for fleet-wide dogfood on next agent PRs.
+`active` — v2 local-first, per `usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md` (MAR-reviewed). Invariants pinned by `src/tests/skills/pr-captain-land-localfirst.bats`; the v1 master-hardcode guards remain in `src/tests/skills/pr-captain-land-helpers.bats`.
+
+**Rehearse before the first land of any branch.** `--rehearse` exercises steps 0-3 with zero side effects.
 
 ## Related
 
 - `/pr-submit` — agent-side companion; this skill consumes its dispatch
-- `/pr-captain-merge` — the merge primitive this skill calls at Step 8
-- `/pr-prep` — the QG-before-PR-create that signs the receipt this skill re-verifies
-- `/pr-captain-post-merge` — alternative entry for post-merge tasks (release + fleet-notify) when landing was done manually
-- `agency/tools/pr-create` — PR creation tool (receipt-aware)
-- `agency/tools/pr-merge` — safe-merge primitive (underlies `/pr-captain-merge`)
-- `agency/tools/gh-release` — release creation wrapper
-- `agency/tools/dispatch` — ISCP dispatch tool
-- `agency/tools/diff-hash` — receipt-matching hash
-- `reference.md` — full step-by-step protocol + recovery flows
-- `examples.md` — happy-path + failure-mode examples
+- `/pr-captain-merge` — the merge primitive used at Step 8
+- `/pr-prep` — the QG that signs the receipt verified at Step 2b
+- `/pr-captain-post-merge` — post-merge tasks when a landing was done manually
+- `/captain-sync-all` — the daily integration rhythm; idempotent with Step 9
+- `agency/tools/resolve-default-branch` — the shared default-branch primitive (v2)
+- `agency/tools/worktree-create --from <ref>` — how the scratch is cut (v2)
+- `agency/tools/pr-create`, `pr-merge`, `gh-release`, `dispatch`, `diff-hash`, `receipt-sign`, `receipt-verify`
+- `reference.md` — full protocol + recovery flows
+- `examples.md` — happy path, rehearsal, and failure-mode runs
 - the-agency#296 — PR lifecycle ownership design
-- the-agency#298 — skill refactor recommendation
-- the-agency#314 — upstream package MAR summary (this skill's scripts hardened there)
-- the-agency#315 — V1→V2 migration master issue
+- the-agency#393 — session-end dirty handoff (largely mooted by scratch isolation)
+- the-agency#463 — receipt churn from verifying after the bump
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -3,7 +3,7 @@ name: pr-captain-land
 description: Captain-only. Land an agent's prepared branch LOCAL-FIRST — integrate and validate in a scratch worktree cut from origin/<default>, then bump agency_version, sign a landing receipt, open the PR, confirm CI, merge, release, notify. The single-writer serialization point for agency_version and PR creation. Companion to /pr-submit. The `captain-` qualifier in the name signals scope at a glance (complements `paths: []` scoping and the Step-0 runtime precondition).
 agency-skill-version: 2
 when_to_use: Captain on master in main checkout, after a /pr-submit dispatch from an agent. NEVER from a worktree. Intended for explicit captain invocation — the Step-0 runtime precondition refuses from wrong context.
-argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release]"
+argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release] [--principal-approved] [--allow-unvalidated]"
 paths: []
 required_reading:
   - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
@@ -86,23 +86,28 @@ Before running, Read the files listed in `required_reading:` frontmatter.
 - `--title`: override the PR title (defaults to the branch name).
 - `--agent`: who to dispatch (defaults to the branch-name prefix).
 - `--no-release`: skip the GitHub release after merge (rare).
+- `--principal-approved`: forward `--admin` to `pr-merge`, bypassing branch protection. **Pass only when the principal actually said so.** Without it the merge defers to GitHub's own gates. It is also recorded in the landing receipt's `hash_d_source`.
+- `--allow-unvalidated`: land even when no local validation command resolves. Without it that case **aborts** (see Step 3). Recorded verbatim in the receipt.
 
 Environment:
 
-- `PR_LAND_VALIDATE_CMD` — override the local validation command wholesale, for repos whose gate is not "package script + `commit-precheck`".
+- `PR_LAND_VALIDATE_CMD` — replace the local validation ladder wholesale, for repos whose gate is not a package build/test script. Run with `bash -c` inside the scratch worktree.
 
 ## Preconditions
 
 Enforced before any mutation; failure exits non-zero with no state change.
 
 1. Running in the **main checkout** (first entry of `git worktree list`).
-2. Current branch is the resolved default branch.
-3. No leftover scratch worktree named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete`).
-4. `<agent-branch>` exists on origin.
-5. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
-6. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
+2. No leftover scratch worktree **or branch** named `_land-<branch>` (a previous land crashed — inspect, then `worktree-delete` + `git-captain branch-delete`).
+3. No pending post-merge state (C#372 Fix B) — a prior merge whose release was never cut must be finished first.
+4. `git-captain fetch` succeeds. **This is fatal, not best-effort**: every guarantee below assumes origin refs are current.
+5. `<agent-branch>` exists on origin.
+6. `<agent-branch>` passes safe-name validation: `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-`.
+7. `origin/<default>` is an **ancestor** of `origin/<agent-branch>` — the base is current.
 
-**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues.
+**A dirty main checkout no longer blocks a land (#393).** The landing never touches local main, so uncommitted captain work is irrelevant. The script notes it and continues. (One caveat: the Step-9 reconcile is a `merge-from-origin`, which does require a clean tree — a dirty checkout means that last step is skipped with a note, and `/captain-sync-all` picks it up later.)
+
+**Which branch the main checkout is on is also not load-bearing** — that was v1 coupling. The script notes it and continues.
 
 ## Flow / Steps
 
@@ -110,7 +115,7 @@ Script: `scripts/pr-captain-land`.
 
 ### Step 0 — Preflight
 
-Main-checkout + branch checks, no-leftover-scratch check, `git-captain fetch`, and the default branch resolved via the shared `agency/tools/resolve-default-branch` primitive. **Local main is not read or written.**
+Main-checkout check, leftover-scratch check (directory **and** branch), pending-post-merge check, and a **fatal** `git-captain fetch`. The default branch is resolved via the shared `agency/tools/resolve-default-branch` primitive, which probes `origin/HEAD` first — a stale local `main` must never outvote the remote's own answer, because every consumer turns the result into `origin/<name>`. **Local main is not read or written.**
 
 ### Step 1 — Verify the branch and its base
 
@@ -138,10 +143,14 @@ Failure → delete the scratch, tell the agent to re-run `/pr-prep`.
 
 ### Step 3 — VALIDATE LOCALLY. This is the gate.
 
-In the scratch, in order: build script, widest declared test script (`bats:all`, else `test`), then `commit-precheck`. `PR_LAND_VALIDATE_CMD` replaces all of it.
+In the scratch, in order: build script, then the widest declared test script (`bats:all`, else `test`). The package manager comes from `agency/tools/pkg-manager`. `PR_LAND_VALIDATE_CMD` replaces all of it.
+
+Each step runs with the captain's credentials scrubbed from the environment (`GH_TOKEN`, `GITHUB_TOKEN`, `SSH_AUTH_SOCK`, …). The command comes from the branch under review and its output is tailed to stderr on failure, so a `build` script of `gh auth token` must not be able to put the PAT into the transcript. This is defence in depth, not a sandbox — validating a branch locally means running its code.
 
 - **Failure → delete the scratch, dispatch the agent naming the failing step, exit 1.** Nothing was published.
-- **No resolvable validation command → loud WARNING**, recorded in the landing receipt summary. It is never a silent pass.
+- **No resolvable validation command → ABORT.** A landing with no local gate is the old PR-first flow with extra steps, and it would sign a five-hash receipt attesting to a gate that never ran. Override with `--allow-unvalidated`, which is recorded in the receipt.
+
+`commit-precheck` is deliberately **not** in this ladder: it gates on staged files and the scratch tree is clean here, so it would exit 0 having inspected nothing while still counting as a step. It runs where it means something — `git-safe-commit` invokes it on the Step-4 and Step-5 commits.
 
 `--rehearse` / `--dry-run` stop here and delete the scratch.
 
@@ -160,7 +169,7 @@ Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via
 | A | the agent receipt's `hash_e` (what was reviewed) |
 | B | hash of the local validation log |
 | C | B — nothing to triage, validation was green |
-| D | C — auto-approved, no principal 1B1 |
+| D | C. `hash_d_source` records the truth: `auto-approved — no principal 1B1`, or the `--principal-approved` attestation when that flag was passed |
 | E | diff hash of the bumped tree vs `origin/<default>` |
 
 Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
@@ -173,25 +182,30 @@ Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The l
 
 ### Step 7 — CI confirmation on the aggregate rollup
 
-Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Where branch protection exposes a required-contexts list, narrow to it; otherwise gate on every check in the rollup.
+Poll `gh pr view <num> --json statusCheckRollup` every 20s, up to 15 minutes. Classification is `agency/tools/ci-rollup-verdict` — a pure function of (rollup, required contexts), table-tested in `src/tests/tools/ci-rollup-verdict.bats`.
 
 | Rollup state | Action |
 |---|---|
-| every check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
+| every gated check terminal and SUCCESS / NEUTRAL / SKIPPED | proceed |
 | any terminal failure (FAILURE, ERROR, TIMED_OUT, CANCELLED, …) | exit 1, fail fast, name the checks |
-| any check still pending | wait 20s, poll again |
-| **rollup empty** | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
+| any gated check still pending | wait 20s, poll again |
+| a **required** context that has not reported at all | PENDING — 1-of-3 required checks green must not read as green |
+| **rollup empty**, past a 3-minute grace window | exit 1 with a **distinct** error — "no checks configured" must never look like "all green" |
+
+The grace window matters: GitHub has usually registered no check runs in the first seconds after a PR opens, so treating an empty rollup as immediately fatal would abort nearly every real land.
 
 v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so the loop could only ever time out. The gate is now name-agnostic, and a regression test asserts that literal never returns.
 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
 ./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-True merge commit — never squash, never rebase.
+True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure.
+
+If no release was cut (`--no-release`, or `gh-release` failed), the pending post-merge state is deliberately **left set** — that guard exists precisely for "merged but release not cut".
 
 ### Step 9 — Cleanup, notify, reconcile
 
@@ -204,7 +218,11 @@ The reconciliation is a **separate, idempotent** step on purpose: it is the same
 | Where | What happens |
 |---|---|
 | Preflight (0) | Exit 1, zero mutation. |
-| Leftover scratch (0) | Exit 1 naming the path and the `worktree-delete` fix. Never auto-deletes someone else's in-flight land. |
+| Fetch fails (0) | Exit 1. Stale origin refs would make every downstream check meaningless. |
+| Pending post-merge (0) | Exit 1. Finish the prior release with `/pr-captain-post-merge` first. |
+| Leftover scratch or land branch (0) | Exit 1 naming the path and the cleanup commands. Never auto-deletes someone else's in-flight land — cleanup only touches a scratch this run created. |
+| No local gate resolves (3) | **Abort**, unless `--allow-unvalidated`. |
+| Any `set -e` abort before publish | An EXIT trap deletes the scratch, so an unhandled error cannot strand it and wedge the next land. |
 | Stale base (1) | BLOCK naming the real cause; agent merges default + re-preps. |
 | Receipt missing/invalid (2b) | Scratch deleted; agent re-runs `/pr-prep`. |
 | Local validation fails (3) | Scratch deleted, agent dispatched with the failing step. **Nothing published.** |
@@ -248,6 +266,9 @@ The reconciliation is a **separate, idempotent** step on purpose: it is the same
 - `/pr-captain-post-merge` — post-merge tasks when a landing was done manually
 - `/captain-sync-all` — the daily integration rhythm; idempotent with Step 9
 - `agency/tools/resolve-default-branch` — the shared default-branch primitive (v2)
+- `agency/tools/pkg-manager` — resolves the package manager for the validation ladder (v2)
+- `agency/tools/ci-rollup-verdict` — the CI gate's classification, extracted and table-tested (v2)
+- `agency/tools/agency-version-next` — the `agency_version` bump policy (v2)
 - `agency/tools/worktree-create --from <ref>` — how the scratch is cut (v2)
 - `agency/tools/pr-create`, `pr-merge`, `gh-release`, `dispatch`, `diff-hash`, `receipt-sign`, `receipt-verify`
 - `reference.md` — full protocol + recovery flows

--- a/src/claude/skills/pr-captain-land/examples.md
+++ b/src/claude/skills/pr-captain-land/examples.md
@@ -40,7 +40,7 @@ pr-captain-land: rehearsal complete — integrated + validated, nothing publishe
     PR title:    jordan-devex-d12-r3
     Head branch: _land-jordan-devex-d12-r3 (pushed from the scratch worktree)
     Base branch: main
-    Agent to notify: jordan
+    Agent to notify: devex
     Release:     yes, v<bumped version>
 ```
 
@@ -102,8 +102,14 @@ The dispatch target defaults to the branch-name prefix, which is a guess. Overri
 /pr-captain-land fix/pr-submit-org-resolution --agent devex
 ```
 
-(That branch would land via scratch worktree `_land-fix-pr-submit-org-resolution` —
-slashes collapse to dashes.)
+The default is the branch-name prefix, checked against the agent registry. For
+`fix/pr-submit-org-resolution` that guess is `fix`, which is not a registered
+agent — the script says so and routes to captain instead. Pass `--agent` and
+the author actually hears that their work landed.
+
+(That branch lands via scratch worktree `_land-fix-pr-submit-org-resolution` —
+slashes *and dots* collapse to dashes, so `captain-grm-v1.2` becomes
+`_land-captain-grm-v1-2`.)
 
 ### Land without cutting a release
 
@@ -202,21 +208,65 @@ pr-captain-land: no status checks found on PR #470.
 
 An empty rollup is never treated as green.
 
-### No local validation command resolved
+### No local validation command resolved — this ABORTS
 
 ```
-WARNING: no local validation command resolved for this repo.
-  Set PR_LAND_VALIDATE_CMD, or declare a build/test script.
-  Landing continues, but local-first validation did NOT happen.
-```
+pr-captain-land: no local validation command resolved for this repo — refusing to land.
+  The local gate is the whole point of this flow; signing a landing receipt
+  for a validation that did not happen would make the receipt a lie.
 
-The landing proceeds, but the warning is also written into the landing
-receipt's summary so the audit trail records that the local gate was empty.
+  Fix one of these:
+    - declare a build/test script in package.json, or
+    - set PR_LAND_VALIDATE_CMD='<your gate>', or
+    - pass --allow-unvalidated to land anyway (recorded in the receipt).
+  Rolled back: scratch worktree _land-some-branch deleted. Nothing was published.
+```
 
 Fix it for the repo:
 
 ```
 PR_LAND_VALIDATE_CMD='make ci' /pr-captain-land some-branch --rehearse
+```
+
+Or, knowingly, land without a gate — the receipt records
+`NO LOCAL VALIDATION RAN (--allow-unvalidated)` so the audit trail is honest:
+
+```
+/pr-captain-land some-branch --allow-unvalidated
+```
+
+### Branch protection blocks the merge
+
+```
+pr-captain-land: pr-merge failed on PR #470:
+  BLOCKED: branch protection requires 1 approving review
+
+  If branch protection is the blocker and the principal approved,
+  re-run with --principal-approved, or merge via /pr-captain-merge.
+```
+
+`--principal-approved` is never asserted on your behalf. It is the captain's
+attestation that the principal actually said yes, and the only route to
+`gh pr merge --admin`.
+
+### A previous land crashed and left a scratch behind
+
+```
+pr-captain-land: land branch _land-devex-x already exists (no worktree).
+  A previous land crashed mid-cleanup. Inspect it, then:
+    ./agency/tools/git-captain branch-delete _land-devex-x --force
+```
+
+Both the directory and the branch are checked, because a crash between
+`worktree add -b` and `worktree remove` leaves only the branch — and
+`worktree-create` then refuses on every retry.
+
+### A prior merge never got its release
+
+```
+pr-captain-land: a previous PR merge has no release yet.
+  {"pr": 468, "base": "main"}
+  Run /pr-captain-post-merge <that-PR> first, then re-run this land.
 ```
 
 ### Running from the wrong place
@@ -235,4 +285,24 @@ note: main checkout is dirty — harmless here (the land runs in a scratch workt
 ```
 
 In v1 this was a hard stop (#393). The land no longer touches local main, so
-uncommitted captain work is simply irrelevant to it.
+uncommitted captain work is simply irrelevant to it. One caveat: the Step-9
+reconcile is a `merge-from-origin`, which does need a clean tree — on a dirty
+checkout it is skipped with a note and `/captain-sync-all` picks it up.
+
+Same for the branch the checkout happens to be on:
+
+```
+note: main checkout is on 'captain-coord-20260810', not 'main' — harmless
+      (the land runs in a scratch worktree).
+```
+
+### Cannot reach origin
+
+```
+pr-captain-land: could not fetch origin.
+  The land validates against origin/<default>; stale refs would make
+  every downstream check meaningless. Fix connectivity/auth and retry.
+```
+
+The fetch is fatal, not best-effort — validating against stale refs and then
+publishing is the failure this whole flow exists to prevent.

--- a/src/claude/skills/pr-captain-land/examples.md
+++ b/src/claude/skills/pr-captain-land/examples.md
@@ -1,184 +1,238 @@
-# pr-captain-land — examples
+# pr-captain-land — examples (v2, local-first)
 
-## Happy-path examples
+All output below is illustrative but shaped like the real thing. The one habit
+worth forming: **rehearse first.**
 
-### Captain lands agent's PR end-to-end
+---
 
-Captain is on master, main checkout, tree clean. Agent dispatched `/pr-submit` for branch `jordan-devex-d12-r3`:
+## Rehearse before you land
+
+`--rehearse` runs steps 0-3 — fetch, verify the branch and its base, cut the
+scratch worktree, validate locally — then deletes the scratch. Nothing is
+pushed. No PR, no version bump, no receipt, no release, no dispatch.
 
 ```
-/pr-captain-land jordan-devex-d12-r3
+/pr-captain-land jordan-devex-d12-r3 --rehearse
 ```
 
-Expected flow:
-
 ```
-[pr-captain-land] Preflight OK: main-checkout=ok, branch=master, tree=clean, remote-branch=exists, receipt=found
-[pr-captain-land] Switched to jordan-devex-d12-r3
-[pr-captain-land] Receipt verified: hash 8b4c2e1 matches qgr-pr-prep-20260419-1430-8b4c2e1.md
-[pr-captain-land] Bumping agency_version 1.9 → 1.10
-[pr-captain-land] Pushed chore(manifest) commit to origin/jordan-devex-d12-r3
-[pr-captain-land] Created PR #118: "devex: fix worktree-sync MAIN_BRANCH resolution"
-[pr-captain-land] Switched back to master
-[pr-captain-land] CI check (lint-and-test): PENDING... SUCCESS (attempt 4 of 30, 80s)
-[pr-captain-land] Merging PR #118 via pr-merge --principal-approved
-[pr-captain-land] Merged. Syncing master... fetched + merged origin/master
-[pr-captain-land] Released v1.10 on GitHub
-[pr-captain-land] Dispatched <org>/jordan/devex: "PR #118 landed — v1.10 released"
-✓ Land complete. Size: M, ~3-10 minutes (CI wait dominates).
+→ Fetching origin...
+→ Branch origin/jordan-devex-d12-r3 is current with origin/main
+→ Creating scratch worktree _land-jordan-devex-d12-r3 at origin/jordan-devex-d12-r3...
+→ Agent receipt verified: agency/workstreams/devex/qgr/…-8b4c2e1.md (hash: 8b4c2e1)
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+  · commit-precheck
+→ Local validation: PASSED (2 local validation step(s) passed against origin/main)
+
+pr-captain-land: rehearsal complete — integrated + validated, nothing published.
 ```
 
-### Dry-run to preview
-
-Captain wants to see the PR body before committing:
+`--dry-run` is the same run plus a printout of what would be published:
 
 ```
 /pr-captain-land jordan-devex-d12-r3 --dry-run
 ```
 
-Expected: walks Steps 1-4 (precondition check + receipt verify + version-bump preview + PR body compose) and stops before mutation. Prints the proposed PR title, body, and version bump target. Exit 0.
-
-### Custom title override
-
 ```
-/pr-captain-land jordan-devex-d12-r3 --title "[devex] Critical: fix worktree-sync for all fleet agents"
-```
-
-Uses the override instead of the agent's scope.
-
-### Land without release
-
-Rare — a PR that shouldn't cut a release (e.g., a doc-only amendment to a prior release):
-
-```
-/pr-captain-land jordan-captain-d41-r22-doc-fix --no-release
+…
+[DRY-RUN] Would publish:
+    PR title:    jordan-devex-d12-r3
+    Head branch: _land-jordan-devex-d12-r3 (pushed from the scratch worktree)
+    Base branch: main
+    Agent to notify: jordan
+    Release:     yes, v<bumped version>
 ```
 
-Steps 1–7 run; Step 8 skips release creation; Step 9 dispatches agent without a release URL.
+---
 
-## Failure-mode examples
+## Happy path — full land
 
-### Not in main checkout
-
-Captain accidentally invokes from a worktree:
+Captain on `main` in the main checkout. Agent dispatched `/pr-submit` for
+`jordan-devex-d12-r3`.
 
 ```
 /pr-captain-land jordan-devex-d12-r3
 ```
 
 ```
-[pr-captain-land] ERROR: Preflight failed — not in main checkout.
-  Current: /Users/{principal}/code/{repo}/.claude/worktrees/devex
-  Expected: main checkout (first entry of `git worktree list`)
-  Fix: cd to main checkout and re-run, OR use /pr-submit if you're an agent.
+→ Fetching origin...
+→ Branch origin/jordan-devex-d12-r3 is current with origin/main
+→ Creating scratch worktree _land-jordan-devex-d12-r3 at origin/jordan-devex-d12-r3...
+→ Agent receipt verified: agency/workstreams/devex/qgr/…-8b4c2e1.md (hash: 8b4c2e1)
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+  · commit-precheck
+→ Local validation: PASSED (2 local validation step(s) passed against origin/main)
+→ Bumping agency_version 46.25 → 46.26 (in scratch)
+→ Signing captain landing receipt (hash_e: 3f19ad0)...
+→ Pushing _land-jordan-devex-d12-r3...
+→ Creating PR...
+→ PR created: https://github.com/the-agency-ai/the-agency/pull/470 (#470)
+→ Waiting for CI on PR #470 (aggregate status check rollup)...
+→ CI green: bash 3.2 probe,manifest version,smoke
+→ Merging PR #470 (true merge commit)...
+→ Creating release v46.26...
+→ Cleaning up scratch worktree and land branch...
+→ Dispatching devex with merge outcome...
+→ Reconciling local main with origin...
+
+pr-captain-land: complete
+  Branch:  jordan-devex-d12-r3 (via _land-jordan-devex-d12-r3)
+  PR:      https://github.com/the-agency-ai/the-agency/pull/470
+  Release: v46.26
+  Gate:    local (2 local validation step(s) passed against origin/main), CI confirmed
 ```
 
-Exit 1. Zero mutation. (Runtime precondition — Layer 4 of the captain-only defense.)
+Note what did **not** happen: the main checkout never switched branches, the
+agent's branch was never modified, and local `main` moved only at the very end,
+by a plain fast-forward from origin.
 
-### Agent branch name fails validation
-
-Rare — adversarial branch name or typo:
-
-```
-/pr-captain-land "evil; rm -rf /"
-```
+### Custom title
 
 ```
-[pr-captain-land] ERROR: Invalid branch name.
-  Provided: "evil; rm -rf /"
-  Required: regex ^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$, no '..', no leading '-'
+/pr-captain-land jordan-devex-d12-r3 --title "[devex] Fix worktree-sync for all fleet agents"
 ```
 
-Exit 1. (Branch-name validation from ccf054ad / MAR finding F-SEC-2.)
+### Explicit agent to notify
 
-### Receipt mismatch (most common legit failure)
-
-Captain's coord commits landed on master between agent's `/pr-prep` and captain's `/pr-captain-land`. Agent's receipt hash no longer matches:
+The dispatch target defaults to the branch-name prefix, which is a guess. Override it:
 
 ```
-[pr-captain-land] Preflight OK
-[pr-captain-land] Switched to jordan-devex-d12-r3
-[pr-captain-land] ERROR: No receipt matches current diff-hash (c1d2e3f).
-  Searched: agency/workstreams/**/qgr/*qgr-pr-prep-*-c1d2e3f.md (0 matches)
-  The agent's receipt was signed against an older origin/master baseline.
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Dispatching agent: "Receipt stale — re-run /pr-prep + /pr-submit."
+/pr-captain-land fix/pr-submit-org-resolution --agent devex
 ```
 
-Exit 1. Captain is back on master, agent is notified, no partial state.
+(That branch would land via scratch worktree `_land-fix-pr-submit-org-resolution` —
+slashes collapse to dashes.)
 
-### CI failure
-
-```
-[pr-captain-land] ... (steps 1-6 succeed)
-[pr-captain-land] CI check (lint-and-test): PENDING... FAILURE (attempt 2 of 30, 40s)
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Dispatching agent: "CI failed — fix and re-submit. Version bump commit (abc1234) stays on your branch."
-```
-
-Exit 1. Version-bump commit is on the agent's branch; they can push more fixes on top. On re-submit, `pr-captain-land` detects current version == target and skips re-bump.
-
-### CI timeout
-
-10-minute wait elapsed with no resolution:
+### Land without cutting a release
 
 ```
-[pr-captain-land] CI check (lint-and-test): still PENDING after 30 attempts (10min)
-[pr-captain-land] Switching back to master.
-[pr-captain-land] Timeout — captain investigate manually. PR #118 open at https://github.com/...
+/pr-captain-land jordan-captain-d41-r22-doc-fix --no-release
 ```
 
-Exit 1. Captain uses `gh pr checks 118` + whatever manual resolution.
+Steps 0-8 run; the release is skipped; the agent dispatch omits the release URL.
 
-### Merge fails after green CI
+---
 
-Unusual — likely branch-protection edge:
+## Failure modes
 
-```
-[pr-captain-land] CI green. Merging via pr-merge --principal-approved.
-[pr-captain-land] ERROR: pr-merge exit 3 (branch protection blocked).
-  Fallback: run /pr-captain-merge 118 --principal-approved manually.
-```
-
-Exit 1. Release is skipped. Captain resolves via the companion skill.
-
-### Release creation fails but merge succeeded
-
-Most common: GitHub release API hiccup:
+### Stale base — the most common block
 
 ```
-[pr-captain-land] Merged PR #118 successfully.
-[pr-captain-land] gh-release create v1.10 FAILED: ...
-[pr-captain-land] WARN: merge is the primary outcome (success). Release creation deferred.
-  Captain: run `gh release create v1.10 --target main --notes-file ...` manually.
-[pr-captain-land] Dispatched agent with merge confirmation (no release URL).
+/pr-captain-land jordan-mdpal-app-phase3
 ```
 
-Exit 0 because merge is authoritative. (MAR follow-up H13 proposes stricter semantics — track there.)
+```
+→ Fetching origin...
 
-### Dispatch emission fails at the end
+BLOCKED: 'jordan-mdpal-app-phase3' does not contain origin/main (4 commit(s) behind).
+
+  Its QGR receipt was signed against an older base, so it can never
+  verify against the current one. This is not a receipt bug.
+
+  Agent action: merge main into jordan-mdpal-app-phase3, re-run /pr-prep,
+                push, then re-run /pr-submit.
+```
+
+Nothing was created. This is the message you want instead of a bare hash
+mismatch — it names the cause and the fix.
+
+### Local validation fails — the whole point of v2
 
 ```
-[pr-captain-land] Merged + released successfully.
-[pr-captain-land] WARN: dispatch emission failed (ISCP tool error).
-  Agent will see the PR landed on next /sync, even without the dispatch.
+→ Validating locally in _land-jordan-devex-d12-r3 (this is the gate)...
+  · tests (<pm> run bats:all)
+
+── local validation output (tail) ──
+not ok 41 worktree-sync: resolves MAIN_BRANCH from origin/HEAD
+…
+────────────────────────────────────
+
+pr-captain-land: local validation failed at step 'tests' — see output above.
+  Rolled back: scratch worktree _land-jordan-devex-d12-r3 deleted. Nothing was published.
 ```
 
-Exit 0. Merge + release are the authoritative record.
+No PR was opened. No version was bumped. No release exists. The agent gets a
+dispatch naming the failing step and re-preps. In v1 this failure would have
+surfaced on GitHub *after* a version bump had already been pushed to the
+agent's branch.
 
-## Four-layer defense in action
+### Receipt does not match the branch
 
-Each of the four defense layers has caught a different incident in development:
+```
+pr-captain-land: no QGR receipt matching hash 8b4c2e1 on branch jordan-devex-d12-r3.
+  The branch content and the newest receipt disagree.
+  Agent action: re-run /pr-prep, push, re-run /pr-submit.
+```
 
-1. **`disable-model-invocation: true`** — prevented an auto-tool-use accidentally firing during a multi-turn coord dialog
-2. **`paths: []`** — prevented the skill from auto-surfacing when captain opened a file under `.claude/worktrees/*/` (which is where this skill definitely should not fire)
-3. **`captain-` name qualifier** — a new agent browsing the skill list asked "wait, is this captain-only?" → answered by the name before even reading SKILL.md
-4. **Runtime precondition** — caught a case where the first three layers were all bypassed (captain copied the script to a worktree sandbox to test) and the script refused to run because `pwd` wasn't the main checkout
+Scratch deleted. Nothing published.
 
-Defense in depth works.
+### Leftover scratch from a crashed run
 
-## Concurrency note
+```
+pr-captain-land: scratch worktree _land-jordan-devex-d12-r3 already exists at
+  /Users/jdm/code/the-agency/.claude/worktrees/_land-jordan-devex-d12-r3
+  A previous land is still running, or crashed. Inspect it, then:
+    ./agency/tools/worktree-delete _land-jordan-devex-d12-r3 --force
+```
 
-**Never run two `/pr-captain-land` simultaneously.** Phase 1 pilot enforces this by captain discipline (one captain, one sequential skill). Phase 2 adds a lockfile at `$HOME/.agency/{repo}/pr-captain-land.lock`.
+The script never auto-deletes a pre-existing scratch — it could be another land
+in flight.
 
-Captain CAN run other non-land work concurrently (dispatch reads, flag triage, reviewer-agent launches). Just not two lands.
+### CI red after a green local gate
+
+```
+pr-captain-land: CI FAILED on PR #470 — failing checks: smoke
+  The local gate passed but the server disagreed. Investigate before re-landing.
+  Agent must fix, push, and re-submit via /pr-submit.
+```
+
+Worth reading carefully: local and server disagreeing is a signal about the
+validation ladder, not just about the branch.
+
+### No status checks at all
+
+```
+pr-captain-land: no status checks found on PR #470.
+  This is NOT a pass. Either CI is not configured for this repo,
+  or the required-contexts filter matched nothing.
+  Merge manually with /pr-captain-merge if that is expected.
+```
+
+An empty rollup is never treated as green.
+
+### No local validation command resolved
+
+```
+WARNING: no local validation command resolved for this repo.
+  Set PR_LAND_VALIDATE_CMD, or declare a build/test script.
+  Landing continues, but local-first validation did NOT happen.
+```
+
+The landing proceeds, but the warning is also written into the landing
+receipt's summary so the audit trail records that the local gate was empty.
+
+Fix it for the repo:
+
+```
+PR_LAND_VALIDATE_CMD='make ci' /pr-captain-land some-branch --rehearse
+```
+
+### Running from the wrong place
+
+```
+pr-captain-land: must run from main checkout (you're in a worktree).
+  Main checkout: /Users/jdm/code/the-agency
+  Current:       /Users/jdm/code/the-agency/.claude/worktrees/devex
+```
+
+### A dirty main checkout is fine now
+
+```
+note: main checkout is dirty — harmless here (the land runs in a scratch worktree).
+→ Fetching origin...
+```
+
+In v1 this was a hard stop (#393). The land no longer touches local main, so
+uncommitted captain work is simply irrelevant to it.

--- a/src/claude/skills/pr-captain-land/reference.md
+++ b/src/claude/skills/pr-captain-land/reference.md
@@ -1,158 +1,245 @@
-# pr-captain-land Protocol
+# pr-captain-land Protocol (v2 — local-first)
 
 Full step-by-step execution flow for `/pr-captain-land`, with failure modes and recovery paths. This document is the contract; the script at `scripts/pr-captain-land` implements it.
 
-## Preconditions checklist
+**Protocol version 2.0.** v1 was PR-first: switch the main checkout to the agent's branch, push, open a PR, let GitHub CI gate. v2 inverts that — integrate and validate locally in a scratch worktree, then publish already-validated work.
 
-Before any mutation, the script must verify ALL of these:
+---
+
+## The core idea
+
+Everything happens in a **scratch worktree** at `.claude/worktrees/_land-<branch>`, cut from `origin/<agent-branch>`.
+
+```
+origin/<default> ──ancestor-of──▶ origin/<agent-branch>
+                                        │
+                                        │ worktree-create --from
+                                        ▼
+                         .claude/worktrees/_land-<branch>   ← all work happens here
+                                        │
+                        validate → bump → sign → push → PR
+```
+
+The main checkout stays on the default branch, untouched, for the whole run. **Rollback at any pre-publish failure is `worktree-delete _land-<branch> --force`** — there is no `git reset --hard`, no `merge --abort`, no stash, and nothing that can strand the captain.
+
+Slashes in the agent branch name collapse to dashes in the scratch name (`fix/foo` → `_land-fix-foo`): a worktree directory must not nest under `.claude/worktrees/`, and `_land-fix/foo` as a ref would collide with an existing `_land-fix` ref.
+
+## Preconditions checklist
 
 | # | Check | Failure action |
 |---|---|---|
-| 1 | `pwd` equals main checkout (first `git worktree list` entry) | exit 1, point at /pr-captain-land help |
-| 2 | Current branch is `master` or `main` | exit 1, ask captain to switch |
-| 3 | `git status --porcelain` empty | exit 1, list dirty files |
-| 4 | `<agent-branch>` exists on origin | exit 1, list suggestion |
-| 5 | Diff-hash of `<agent-branch>` matches a QGR receipt at `agency/workstreams/**/qgr/*qgr-pr-prep-*-{hash}.md` | exit 1, tell agent to re-prep |
+| 1 | `pwd` is the main checkout (first `git worktree list` entry) | exit 1 naming both paths |
+| 2 | Current branch is the resolved default branch | exit 1, ask captain to switch |
+| 3 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the `worktree-delete` fix |
+| 4 | `<agent-branch>` exists on origin | exit 1 |
+| 5 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
+| 6 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
 
-Any failure => zero mutation, clean error message.
+**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues.
 
-## The 9 steps
+The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode.
 
-### Step 1 — Switch to agent branch
+---
 
-```
-./agency/tools/git-captain switch-branch <agent-branch>
-```
+## The 10 steps
 
-Current working branch becomes the agent's. Main checkout is now sitting on agent's branch.
+### Step 0 — Preflight
 
-**Failure:** switch fails (dirty tree, branch doesn't exist locally). Script exits; captain resolves.
+Precondition checks 1-3, then `git-captain fetch`. No read or write of local main's content.
 
-### Step 2 — Verify receipt
-
-Compute current diff-hash against `origin/<default-branch>` (resolved via `resolve_default_branch`, not hardcoded). Find receipt matching that hash.
+### Step 1 — Verify the branch and its base
 
 ```
-./agency/tools/diff-hash --base "origin/$DEFAULT_BRANCH" --json   # default branch resolved, not hardcoded
-# extract hash
+git show-ref --verify refs/remotes/origin/<agent-branch>
+git merge-base --is-ancestor origin/<default> origin/<agent-branch>
+```
+
+**Stale base is the important case.** If `origin/<default>` moved after the agent branched, the agent's QGR receipt was signed against an older base and can *never* verify. Reporting that as a hash mismatch sends the captain hunting the wrong problem. The script BLOCKS with the count of commits behind and the actual fix:
+
+> merge `<default>` into `<agent-branch>`, re-run `/pr-prep`, push, re-run `/pr-submit`
+
+### Step 2 — Cut the scratch worktree
+
+```
+./agency/tools/worktree-create _land-<branch> --from origin/<agent-branch>
+```
+
+This **is** the local integration. Step 1 proved `origin/<default>` is an ancestor, so the scratch tree already represents the agent's work on top of the default branch — no merge needed, no merge conflict possible.
+
+`--from` was added to `worktree-create` for this (v2.2.0), along with allowing a leading underscore in worktree names so machine-created scratch worktrees are visually distinct from agent worktrees.
+
+**Note:** `git-captain merge-to-master` is deliberately NOT used. It requires a *local* branch ref and merges into local main — both of which v2 avoids by construction.
+
+### Step 2b — Verify the agent's QGR receipt
+
+```
+(cd _land-<branch> && diff-hash --base origin/<default> --json)
 find agency/workstreams -name "*qgr-pr-prep-*-{hash}.md"
+receipt-verify --file <receipt>
 ```
 
-**Failure:** no matching receipt. Branch state doesn't match what /pr-submit claimed. Switch back to master, exit 1. Agent must re-prep.
+**Ordering is load-bearing.** The version bump in Step 4 edits `agency/config/manifest.json`, which is inside `diff-hash`'s file set. Verifying *after* the bump would invalidate the very receipt being checked and ask the agent to re-prep for a change the captain made — the #463 trap.
 
-### Step 3 — Bump `agency_version`
+The receipt's `hash_e` is captured here; it becomes `hash_a` of the landing receipt.
 
-Read current version from `agency/config/manifest.json`. Bump minor (e.g., 1.8 → 1.9). Write back with `updated_at` refreshed to current UTC timestamp.
+**Failure:** delete the scratch, exit 1, tell the agent to re-run `/pr-prep`.
 
-Commit via `git-safe-commit` with message:
-```
-chore(manifest): bump agency_version {old} → {new} for PR landing (captain)
-```
+### Step 3 — VALIDATE LOCALLY
 
-Push to origin.
+This is the gate. GitHub is not the gate.
 
-**Failure:** push fails (concurrent captain activity, branch protection edge case). Switch back to master, exit 1.
+Resolution ladder, all run inside the scratch:
 
-### Step 4 — Create PR
+1. `PR_LAND_VALIDATE_CMD` if set — replaces everything below.
+2. `<pm> run build`, if `package.json` declares a `build` script.
+3. `<pm> run bats:all`, else `<pm> run test` — the widest declared suite.
+4. `agency/tools/commit-precheck`.
 
-```
-./agency/tools/pr-create --title "{title}" --body "{body}"
-```
+The package manager is resolved by `agency/tools/pkg-manager`, which picks one from the lockfile and only returns it if that manager is installed. Skills never name a package manager inline — adopter repos differ.
 
-Title: `--title` flag value, or `<agent-branch>` as fallback. Body: captain-authored fleet-aware description that wraps the agent's scope with:
-- "Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot)"
-- Branch, receipt path, hash, version bump
-- Release v{new} will follow on merge
+Every step's output is appended to a validation log; the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
 
-**Failure:** pr-create blocks on receipt mismatch (race with a concurrent captain coord commit on master). Re-verify hash, retry once; on second failure, exit 1 and ask captain to investigate.
-
-### Step 5 — Switch back to master
-
-```
-./agency/tools/git-captain switch-branch "$DEFAULT_BRANCH"
-```
-
-Captain should sit on master for the wait-and-merge phase. Avoids any accidental commit landing on the PR branch.
-
-### Step 6 — Watch CI
-
-Poll `gh pr view {num} --json statusCheckRollup` every 20 seconds. Look at the `lint-and-test` check.
-
-| State | Action |
+| Outcome | Action |
 |---|---|
-| SUCCESS | proceed to Step 7 |
-| FAILURE | exit 1 — agent must fix + push + resubmit |
-| PENDING / IN_PROGRESS | wait 20s, poll again |
+| All steps pass | proceed |
+| Any step fails | tail the log, **dispatch the agent** naming the failing step, delete the scratch, exit 1 |
+| No step resolved | loud WARNING, recorded in the receipt summary — never a silent pass |
 
-Max 30 attempts = 10 minutes. On timeout, exit 1.
+`--rehearse` and `--dry-run` stop here, delete the scratch, and exit 0.
 
-**Note on `deploy-preview-backend`**: this check is environmental flake (ordinaryfolk org lookup issue). IGNORED by /pr-captain-land. Only `lint-and-test` is the gate.
+### Step 4 — Bump `agency_version` in the scratch
 
-### Step 7 — Merge
+Read `agency/config/manifest.json`, bump the minor component, refresh `updated_at`, `git-safe add`, `git-safe-commit`.
 
-```
-./agency/tools/pr-merge {pr-num} --principal-approved
-```
+**Security:** the bump uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable.
 
-Uses admin merge (principal-approved flag gated). True merge commit — never squash, never rebase per framework discipline.
+### Step 5 — Sign the captain LANDING receipt
 
-**Failure:** merge conflicts (agent's branch drifted from master during the CI wait). Exit 1; captain resolves.
-
-### Step 8 — Sync master + create release
+`pr-create` is not bypassed and not weakened. The captain signs a receipt for the state it validated:
 
 ```
-./agency/tools/git-captain fetch
-./agency/tools/git-captain merge-from-origin
-./agency/tools/gh-release create v{new-version} --target "$DEFAULT_BRANCH" --title "..." --notes "..."
+receipt-sign --type qgr --boundary pr-captain-land \
+  --agent captain --workstream agency --project <branch-slug> \
+  --hash-a <agent receipt hash_e> \
+  --hash-b <sha256 of the validation log> \
+  --hash-c <= B>  --hash-d <= C>  \
+  --hash-e <diff hash of the bumped tree vs origin/<default>> \
+  --diff-base origin/<default>
 ```
 
-Release notes: captain-authored, references the PR number and agent.
+A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C (auto-approved, no principal 1B1). E = what is being published.
 
-**Failure (release only):** release creation fails but merge succeeded → warn captain, suggest manual `gh release create`. Skill returns success (merge is the primary outcome).
+The receipt is then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
-### Step 9 — Dispatch agent
+### Step 6 — Publish
 
-Dispatch type: `master-updated`
-Subject: `PR #{num} landed — v{new} released (pr-captain-land)`
-Body: PR URL, release URL, version bump, Phase 1 pilot feedback request
+```
+(cd _land-<branch> && git-push _land-<branch>)
+(cd _land-<branch> && pr-create --title ... --body ... --base <default>)
+```
 
-Agent receives on their next /session-resume.
+`pr-create` re-derives the newest receipt (the landing receipt) and re-verifies it, and independently confirms `manifest.json` differs from `origin/<default>`. Both gates pass on their own terms.
+
+**This is the first irreversible action.** Past this point `abort_land` is no longer correct — work exists on origin. Failures report, name the pushed branch, and leave the scratch in place for inspection.
+
+### Step 7 — CI confirmation on the aggregate rollup
+
+```
+gh pr view <num> --json statusCheckRollup
+```
+
+Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Otherwise every check in the rollup is treated as required.
+
+State normalization handles both node shapes: `CheckRun` (`status` + `conclusion`) and `StatusContext` (`state`).
+
+| Verdict | Action |
+|---|---|
+| every check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
+| any check in {FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE, STALE} | exit 1 immediately, naming the checks |
+| any check pending | wait 20s, poll again |
+| rollup empty after filtering | exit 1 with a **distinct** error |
+| gh output unreadable | treat as transient, retry |
+
+Max 45 attempts × 20s = 15 minutes.
+
+**Why the empty-rollup case is its own error:** "no checks configured" and "all checks green" must never be indistinguishable. A rollup gate that silently passes an unchecked PR is worse than the hardcode it replaced.
+
+**Why the hardcode was wrong:** v1 gated on a check literally named `lint-and-test`. This repo's checks are `bash 3.2 probe`, `manifest version`, and `smoke`. The loop could only ever time out — and a genuinely failing check could never fail fast. `src/tests/skills/pr-captain-land-localfirst.bats` asserts that literal never comes back.
+
+### Step 8 — Merge + release
+
+```
+./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
+```
+
+True merge commit — never squash, never rebase.
+
+### Step 9 — Cleanup, notify, reconcile
+
+1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
+2. `dispatch create --type master-updated` to the agent.
+3. `post-merge-state clear <num>`.
+4. `git-captain merge-from-origin` — reconcile local main with the server merge.
+
+Step 4 is deliberately separate and idempotent: it is exactly what `/captain-sync-all` does, so running either afterwards is a no-op rather than a double-integration.
+
+---
 
 ## Recovery flows
 
-### Version-bump landed but CI failed
+### Local validation failed
 
-The version-bump commit is on agent's branch. Two paths:
+Nothing was published. The scratch is gone. The agent has a dispatch naming the failing step. Agent fixes, re-preps, pushes, re-submits. The captain does nothing else.
 
-- **Agent fixes + pushes** — version bump stays, new fixes layer on top. /pr-captain-land can be re-run after agent re-submits via /pr-submit. Version doesn't bump again (current → same).
-- **Agent wants fresh state** — captain reverts the version-bump commit on agent's branch (separate cleanup).
+This replaces v1's "version-bump landed but CI failed" recovery entirely — there is no orphan bump commit on the agent's branch to clean up, because the bump never touched the agent's branch.
 
-Recommend the first path; simpler.
+### Receipt invalidated between `/pr-submit` and `/pr-captain-land`
 
-### Receipt invalidated mid-flow (Step 4 retry)
+A captain coord commit lands on the default branch, moving `origin/<default>`. Detected at **Step 1** as a stale base — with the correct message — rather than surfacing later as a bare hash mismatch. Agent merges the default branch, re-runs `/pr-prep`, re-submits.
 
-Between /pr-submit and /pr-captain-land, a captain coord commit may land on the default branch, changing `origin/<default-branch>` and thus the diff-hash. Agent's receipt no longer matches.
+### Leftover `_land-` worktree from a crashed run
 
-Detected at Step 2 or Step 4 (pr-create). Script exits; agent re-runs /pr-prep (re-signs receipt) + /pr-submit.
+Step 0 refuses to start and names the path. Inspect it (it may contain a useful validation log or an unpushed bump), then:
 
-### CI green but merge fails
+```
+./agency/tools/worktree-delete _land-<branch> --force
+./agency/tools/git-captain branch-delete _land-<branch> --force
+```
 
-Likely branch-protection edge case. Script exits; captain uses `/pr-captain-merge <num> --principal-approved` manually to resolve.
+The script never auto-deletes a pre-existing scratch — that could be another land in flight.
 
-### Dispatch monitor doesn't pick up /pr-submit
+### `pr-create` returned no URL
 
-Captain manually runs `/pr-captain-land <branch>`. Dispatch integration is auto-convenience, not required for correctness.
+The land branch **is** pushed. The scratch is kept. Either finish manually (`pr-create` from the scratch, then `/pr-captain-merge`), or abandon: delete the remote branch, then the scratch.
+
+### CI red after a green local gate
+
+Genuinely interesting — the local gate and the server disagree. Do not re-land until you know why. Usual causes: a check that only exists on the server (secrets, permissions, matrix OS), or a local validation ladder that resolved nothing (check for the WARNING in the run output and in the landing receipt summary).
+
+### Merge fails after green CI
+
+Branch-protection edge case. `/pr-captain-merge <num> --principal-approved`.
+
+## Rehearsal
+
+```
+/pr-captain-land <agent-branch> --rehearse
+```
+
+Runs steps 0-3 and deletes the scratch. No push, no PR, no bump, no receipt, no release, no dispatch. This is the cheap way to answer "would this branch actually land?" and the recommended first action on any branch class you have not landed before.
+
+`--dry-run` is `--rehearse` plus a printout of what would have been published.
 
 ## Concurrency
 
-**One /pr-captain-land at a time.** Running two simultaneously would race on the version bump. No tool-level lock today; captain discipline enforces. Phase 2 adds a lockfile.
+**One `/pr-captain-land` at a time.** Two concurrent runs would race on the version bump. Two runs *for the same branch* are now blocked mechanically by the leftover-scratch precondition; two runs for *different* branches are still captain discipline. No lockfile yet.
 
-Captain can run other non-land work (dispatch reads, flag triage, reviewer agent launches) concurrently with /pr-captain-land. Just not two /pr-captain-land.
+Concurrency against the captain's own work is much safer than in v1: the land no longer requires a clean main checkout and never moves local main, so captain coord work can proceed alongside it.
 
 ## Protocol versioning
 
-v1.0 — this document. Phase 1 pilot.
-
-v1.1 (planned): parse full dispatch payload instead of just branch name; agent's scope text becomes the PR body core.
-
-v2.0 (planned): dispatch-monitor auto-invocation (captain doesn't type /pr-captain-land; monitor picks up /pr-submit dispatch and fires /pr-captain-land).
+- **v1.0** — Phase 1 pilot (the-agency#296). PR-first; switch-checkout; hardcoded `lint-and-test` CI gate.
+- **v2.0** — local-first. Scratch-worktree integration, local validation gate, captain landing receipt, aggregate CI rollup gate, `--rehearse`, shared `resolve-default-branch` primitive. Per `usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md`, MAR-reviewed.
+- **v2.1 (planned)** — parse the full `/pr-submit` dispatch payload so the agent's scope text becomes the PR body core.
+- **v2.2 (planned)** — dispatch-monitor auto-invocation.

--- a/src/claude/skills/pr-captain-land/reference.md
+++ b/src/claude/skills/pr-captain-land/reference.md
@@ -28,16 +28,20 @@ Slashes in the agent branch name collapse to dashes in the scratch name (`fix/fo
 
 | # | Check | Failure action |
 |---|---|---|
-| 1 | `pwd` is the main checkout (first `git worktree list` entry) | exit 1 naming both paths |
-| 2 | Current branch is the resolved default branch | exit 1, ask captain to switch |
-| 3 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the `worktree-delete` fix |
-| 4 | `<agent-branch>` exists on origin | exit 1 |
-| 5 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
-| 6 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
+| 1 | `pwd` is the main checkout (first `git worktree list --porcelain` entry) | exit 1 naming both paths |
+| 2 | No existing `.claude/worktrees/_land-<branch>` | exit 1 naming the path + the cleanup commands |
+| 3 | No existing `refs/heads/_land-<branch>` | exit 1 — a crash between `worktree add -b` and `worktree remove` leaves only the branch, and `worktree-create` then refuses on every retry with no visible reason |
+| 4 | `post-merge-state check` is clean (C#372 Fix B) | exit 1 — finish the prior release first |
+| 5 | `git-captain fetch` succeeds | exit 1 — **fatal, not best-effort** |
+| 6 | `<agent-branch>` exists on origin | exit 1 |
+| 7 | Branch name matches `^[a-zA-Z0-9][a-zA-Z0-9/_.-]*$`, no `..`, no leading `-` | exit 2 |
+| 8 | `origin/<default>` is an ancestor of `origin/<agent-branch>` | BLOCK — see Step 1 |
 
-**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues.
+**A dirty main checkout is NOT a precondition failure (#393).** The land never reads, commits to, or moves local main. The script notes the dirt and continues. The Step-9 reconcile does need a clean tree, so on a dirty checkout that last fast-forward is skipped with a note and `/captain-sync-all` picks it up.
 
-The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode.
+**Which branch the main checkout is on is also not a precondition.** v1 required the default branch; v2 does not read it, so requiring it only blocked lands while the captain was mid-`/captain-release` on a `captain-*` branch.
+
+The default branch is resolved by `agency/tools/resolve-default-branch` — one shared primitive, never a hardcode. Its probe order is **remote-authoritative**: `origin/HEAD` → `refs/remotes/origin/{main,master}` → local `refs/heads/{main,master}`. Local branches are the offline fallback only. Probing them first (git-captain's historical order) reintroduces issue #107 — a stale local `main` in a `master`-default clone would make every consumer build `origin/main`, a ref that does not exist.
 
 ---
 
@@ -68,6 +72,10 @@ This **is** the local integration. Step 1 proved `origin/<default>` is an ancest
 
 `--from` was added to `worktree-create` for this (v2.2.0), along with allowing a leading underscore in worktree names so machine-created scratch worktrees are visually distinct from agent worktrees.
 
+The slug collapses **both** slashes and dots (`fix/v1.2` → `_land-fix-v1-2`): `worktree-create` validates against `^[a-zA-Z_][a-zA-Z0-9_-]*$`, while the branch-name gate deliberately permits dots. Slugging only slashes made every dotted branch unlandable.
+
+`worktree-create`'s stderr is **not** discarded on the failure path. Swallowing it turned every distinct cause — invalid name, existing branch, disk full — into one opaque "could not create scratch worktree".
+
 **Note:** `git-captain merge-to-master` is deliberately NOT used. It requires a *local* branch ref and merges into local main — both of which v2 avoids by construction.
 
 ### Step 2b — Verify the agent's QGR receipt
@@ -93,17 +101,20 @@ Resolution ladder, all run inside the scratch:
 1. `PR_LAND_VALIDATE_CMD` if set — replaces everything below.
 2. `<pm> run build`, if `package.json` declares a `build` script.
 3. `<pm> run bats:all`, else `<pm> run test` — the widest declared suite.
-4. `agency/tools/commit-precheck`.
 
-The package manager is resolved by `agency/tools/pkg-manager`, which picks one from the lockfile and only returns it if that manager is installed. Skills never name a package manager inline — adopter repos differ.
+The package manager is resolved by `agency/tools/pkg-manager` — `packageManager` field, else lockfile, else npm — and it fails rather than substituting npm for a declared-but-uninstalled manager. Skills never name a package manager inline; adopter repos differ.
 
-Every step's output is appended to a validation log; the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
+**`commit-precheck` is deliberately not in this ladder.** It gates on *staged* files and the scratch tree is clean here, so it exits 0 having inspected nothing — while still counting as a step. That inflated the step count, suppressed the no-validation abort below, and wrote "N local validation step(s) passed" into a signed receipt on the strength of a no-op. It still runs where it means something: `git-safe-commit` invokes it on the Step-4 and Step-5 commits.
+
+Each step runs with the captain's credentials removed from the environment (`GH_TOKEN`, `GITHUB_TOKEN`, `GH_ENTERPRISE_TOKEN`, `GIT_ASKPASS`, `SSH_AUTH_SOCK`; `GIT_TERMINAL_PROMPT=0`). The command comes from the branch under review, and on failure its output is tailed to stderr — i.e. into the session transcript. Defence in depth, not a sandbox: validating a branch locally means executing its code as the captain's user, which is inherent to the design.
+
+Every step's output is appended to a validation log (mode 0600, removed by the EXIT trap); the log's SHA-256 becomes `hash_b` of the landing receipt, so the receipt binds to *what was actually run*.
 
 | Outcome | Action |
 |---|---|
 | All steps pass | proceed |
 | Any step fails | tail the log, **dispatch the agent** naming the failing step, delete the scratch, exit 1 |
-| No step resolved | loud WARNING, recorded in the receipt summary — never a silent pass |
+| No step resolved | **ABORT.** Signing a five-hash receipt for a gate that never ran would make the receipt a lie. `--allow-unvalidated` overrides, and is recorded verbatim in the receipt summary. |
 
 `--rehearse` and `--dry-run` stop here, delete the scratch, and exit 0.
 
@@ -111,7 +122,9 @@ Every step's output is appended to a validation log; the log's SHA-256 becomes `
 
 Read `agency/config/manifest.json`, bump the minor component, refresh `updated_at`, `git-safe add`, `git-safe-commit`.
 
-**Security:** the bump uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable.
+The bump policy itself lives in `agency/tools/agency-version-next` (`46.25 → 46.26`; three-component semver is refused, not guessed). Inline, it was `NEW_VER=$(python3 -c '... sys.exit(1)')`, which under `set -euo pipefail` killed the *caller* before its own error could run — so the friendly "could not bump version" message was unreachable for exactly the input it was written for, and the scratch worktree was stranded.
+
+**Security:** the manifest write uses Python **env-var** substitution, never f-string interpolation into python source (MAR F-SEC-1 / CRITICAL-3). Prevents code injection if the manifest were ever attacker-controllable. It also writes a trailing newline (`json.dump` does not), so a land no longer adds a spurious "\ No newline at end of file" hunk, and refreshes both the nested and top-level `updated_at`.
 
 ### Step 5 — Sign the captain LANDING receipt
 
@@ -123,11 +136,12 @@ receipt-sign --type qgr --boundary pr-captain-land \
   --hash-a <agent receipt hash_e> \
   --hash-b <sha256 of the validation log> \
   --hash-c <= B>  --hash-d <= C>  \
+  --hash-d-source <"auto-approved — no principal 1B1" | the --principal-approved attestation> \
   --hash-e <diff hash of the bumped tree vs origin/<default>> \
   --diff-base origin/<default>
 ```
 
-A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C (auto-approved, no principal 1B1). E = what is being published.
+A = what was reviewed (chains to the agent's receipt). B = what was validated. C = B (nothing to triage — validation was green). D = C, with `hash_d_source` recording whether a principal actually approved — the receipt must not attest to an approval that did not happen. E = what is being published.
 
 The receipt is then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
 
@@ -148,38 +162,49 @@ The receipt is then committed. Receipts are excluded from `diff-hash`, so commit
 gh pr view <num> --json statusCheckRollup
 ```
 
-Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Otherwise every check in the rollup is treated as required.
+Classification is **not** inline. It lives in `agency/tools/ci-rollup-verdict`, a pure function of (rollup JSON, required contexts) that prints one verdict token — table-tested in `src/tests/tools/ci-rollup-verdict.bats`. Inline it was a python heredoc inside a command substitution inside the polling loop, which no test could reach: every guard written for it was a `grep` for a string, and all of them still passed with the PASS and FAIL state sets swapped.
 
-State normalization handles both node shapes: `CheckRun` (`status` + `conclusion`) and `StatusContext` (`state`).
+Where branch protection exposes `/repos/{org}/{repo}/branches/{default}/protection/required_status_checks/contexts`, the rollup is narrowed to those contexts. Anything that is not a non-empty JSON array (the endpoint returns an error *object* on unprotected repos and without admin scope) means no narrowing.
+
+State normalization handles both node shapes: `CheckRun` (`status` + `conclusion` — the conclusion is meaningless until the status is COMPLETED) and `StatusContext` (`state`).
 
 | Verdict | Action |
 |---|---|
-| every check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
+| every gated check terminal in {SUCCESS, NEUTRAL, SKIPPED} | proceed |
 | any check in {FAILURE, ERROR, TIMED_OUT, CANCELLED, ACTION_REQUIRED, STARTUP_FAILURE, STALE} | exit 1 immediately, naming the checks |
-| any check pending | wait 20s, poll again |
-| rollup empty after filtering | exit 1 with a **distinct** error |
+| any gated check pending | wait 20s, poll again |
+| a **required** context absent from the rollup | PENDING, not absent |
+| rollup empty, past the 3-minute grace window | exit 1 with a **distinct** error |
 | gh output unreadable | treat as transient, retry |
 
 Max 45 attempts × 20s = 15 minutes.
 
-**Why the empty-rollup case is its own error:** "no checks configured" and "all checks green" must never be indistinguishable. A rollup gate that silently passes an unchecked PR is worse than the hardcode it replaced.
+**Why a required context that has not reported is PENDING:** narrowing to "required contexts that happen to be present" means 1-of-3 required checks reporting green reads as PASSED, and the PR merges on partial evidence.
+
+**Why the empty-rollup case has a grace window:** GitHub has usually registered no check runs in the first seconds after a PR opens. Treating that as immediately fatal would abort nearly every real land. Past the window it is a hard error — "no checks configured" and "all checks green" must never be indistinguishable.
+
+**Name-mismatch caveat:** branch-protection contexts are often `"workflow / job"` while check runs are named just `job`. When they do not match, the gate reports PENDING and eventually times out rather than merging — the safe direction, but worth knowing when a green PR appears to hang.
 
 **Why the hardcode was wrong:** v1 gated on a check literally named `lint-and-test`. This repo's checks are `bash 3.2 probe`, `manifest version`, and `smoke`. The loop could only ever time out — and a genuinely failing check could never fail fast. `src/tests/skills/pr-captain-land-localfirst.bats` asserts that literal never comes back.
 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> --principal-approved --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
 ./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
 ```
 
 True merge commit — never squash, never rebase.
 
+`--principal-approved` is forwarded **only** when the captain passed it to `/pr-captain-land`. `pr-merge` treats that flag as the captain's attestation that the principal verbally approved, and it is the only route to `gh pr merge --admin`; asserting it unconditionally in a non-interactive script would make branch-protection bypass the fleet's default merge mode. Default behaviour is to defer to GitHub's gates, and the failure message says to re-run with the flag if protection is the blocker.
+
+Both calls capture their output and print the tail on failure. Silencing them at the two most consequential steps left "pr-merge failed — check manually" with nothing to check.
+
 ### Step 9 — Cleanup, notify, reconcile
 
 1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
-2. `dispatch create --type master-updated` to the agent.
-3. `post-merge-state clear <num>`.
+2. `dispatch create --type master-updated` to the agent. The recipient is resolved against the agent registry, not guessed from the branch prefix — `pr-lifecycle-v2` would otherwise yield `pr`, and the dispatch (best-effort by design) would vanish. An unresolvable name routes to captain with a note.
+3. `post-merge-state clear <num>` — **only if a release was actually cut.** Clearing it after `--no-release` or a failed `gh-release` discards exactly the "merged but release not cut" signal the guard exists to carry.
 4. `git-captain merge-from-origin` — reconcile local main with the server merge.
 
 Step 4 is deliberately separate and idempotent: it is exactly what `/captain-sync-all` does, so running either afterwards is a no-op rather than a double-integration.

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -1,30 +1,74 @@
 #!/usr/bin/env bash
 #
-# pr-captain-land — Captain lands an agent's prepared branch as a PR + release
+# pr-captain-land — Captain lands an agent's prepared branch, LOCAL-FIRST
 #
 # WHAT: Captain runs this in the main checkout to own the full PR lifecycle
-# for a branch prepared by an agent via /pr-submit. Switches to the
-# branch, verifies the QGR receipt, bumps the version, creates the PR with
-# a captain-authored description, watches CI, merges, cuts the release, and
-# dispatches the agent with the outcome.
+# for a branch prepared by an agent via /pr-submit. The branch is integrated
+# and validated LOCALLY first; only already-validated work is published.
 #
-# WHY: Addresses the-agency#296 — single serialization point for version
-# bumps + PR creation + release creation. Eliminates version-bump races,
-# QGR hash races, and split responsibility.
+# WHY (the v2 inversion): the previous flow was PR-first — switch the main
+# checkout to the agent's branch, bump, push, open a PR, and let GitHub CI be
+# the gate. That had three structural problems:
 #
-# SCOPE: Phase 1 pilot — sandbox tool in usr/{principal}/captain/tools/. Tested
-# by dogfooding on one captain-driven PR before promotion to .claude/skills/.
+#   1. Switching the main checkout to a branch that is already checked out in
+#      the agent's worktree fails outright (worktree collision), and switching
+#      at all makes the captain's checkout a moving target mid-land.
+#   2. GitHub CI was the FIRST gate. TheAgency's model is local review and
+#      validation; the server is the publish step, not the reviewer.
+#   3. Any mid-flight abort left the main checkout on someone else's branch.
+#
+# The fix is not a better rollback — it is having nothing to roll back. The
+# whole landing runs in a DEDICATED SCRATCH WORKTREE cut from `origin/<agent
+# branch>` (which, per the step-1 receipt gate, already contains the default
+# branch). Local `main` is never read for content, never merged into, never
+# reset, and never pushed. Rollback at any pre-publish failure is one action:
+# delete the scratch worktree.
+#
+# Validating against pristine `origin/<default>` rather than the captain's
+# local main is also STRICTLY more correct: local main routinely carries
+# unpushed coordination commits and other worktrees' merges, none of which
+# belong in the PR under test.
+#
+# FLOW (plan-pr-captain-land-localfirst-20260809 v2, steps 0-9):
+#   0  Preflight — main checkout, fetch, resolve default branch
+#   1  Verify agent branch on origin + base freshness (stale base BLOCKS with
+#      "merge main + re-run /pr-prep", never a bare hash error)
+#   2  Cut scratch worktree `_land-<branch>` at `origin/<agent-branch>`
+#   2b Verify the agent's QGR receipt against the scratch — BEFORE any bump
+#      (the bump touches manifest.json, which is inside the hashed file set;
+#      verifying after would churn the receipt — the #463 trap)
+#   3  VALIDATE LOCALLY in the scratch (build + tests + commit-precheck).
+#      Failure → delete scratch, dispatch the agent, abort.
+#   4  Bump agency_version in the scratch, commit
+#   5  Sign a captain LANDING receipt binding the bumped tree to
+#      origin/<default> (hash_a = the agent receipt's hash_e). This is what
+#      lets pr-create pass — pr-create is NOT weakened.
+#   6  Publish from the scratch: push `_land-<branch>` → pr-create
+#   7  Wait on the AGGREGATE statusCheckRollup (every required context green;
+#      fail-fast on failure; empty rollup is its own distinct error). No
+#      hardcoded check name.
+#   8  pr-merge (true merge commit) → gh-release
+#   9  Cleanup: delete scratch + local/remote land branch, dispatch the agent,
+#      clear post-merge state, reconcile local main via merge-from-origin
+#
+# INVARIANTS this script must never violate:
+#   - The agent's branch is NEVER checked out in the main checkout.
+#   - `main`/`master` is NEVER pushed.
+#   - Local `main` is never reset, force-moved, or committed onto.
 #
 # USAGE:
-#   pr-captain-land <agent-branch> [--dry-run] [--title "..."] [--no-release]
+#   pr-captain-land <agent-branch> [--rehearse] [--dry-run]
+#                                  [--title "..."] [--agent <name>]
+#                                  [--no-release]
 #
-# PRECONDITIONS (tool enforces):
-#   - Running in main checkout on master
-#   - Tree is clean
-#   - <agent-branch> exists on origin
-#   - <agent-branch> has a valid QGR receipt
+#   --rehearse   Run steps 0-3 only (integrate + validate), then delete the
+#                scratch. Nothing is pushed, no PR, no receipt, no bump.
+#                De-risks the first land of any given branch.
+#   --dry-run    --rehearse plus a printout of exactly what would be published.
 #
 # WRITTEN: 2026-04-19 (Phase 1 pilot, the-agency#296)
+# REWRITTEN: 2026-08-09 (devex) — local-first v2 per
+#            usr/{principal}/captain/plans/plan-pr-captain-land-localfirst-20260809.md
 
 set -euo pipefail
 
@@ -40,6 +84,8 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
 # script behind its PR_SUBMIT_LIB_ONLY guard and unit-tested in
 # src/tests/skills/pr-submit-helpers.bats. Sourcing loads the functions only;
 # the guard returns before any pr-submit precondition runs.
+# resolve_default_branch is itself now a thin wrapper over the shared
+# agency/tools/resolve-default-branch primitive.
 PR_SUBMIT_LIB_ONLY=1 source "$REPO_ROOT/.claude/skills/pr-submit/scripts/pr-submit"
 
 # ── Resolve ORG, REPO, PRINCIPAL ─────────────────────────────────────────────
@@ -53,11 +99,7 @@ if ! ORG="$(parse_org_from_remote "$REMOTE_URL")" || ! REPO="$(parse_repo_from_r
 fi
 PRINCIPAL="jordan"  # TODO: resolve via agency whoami in v2 (matches pr-submit)
 
-# ── Resolve the repo's default branch — never assume master ──────────────────
-# The PR lifecycle hardcoded origin/master. In a repo whose default branch is
-# main (this one), the receipt-verify diff-hash resolved nothing, switch-back
-# targeted a nonexistent branch, and the release targeted master. Resolve it
-# once here and use it everywhere below.
+# ── Resolve the repo's default branch — never assume ─────────────────────────
 DEFAULT_BRANCH="$(resolve_default_branch)"
 BASE_REF="origin/${DEFAULT_BRANCH}"
 
@@ -65,18 +107,38 @@ BASE_REF="origin/${DEFAULT_BRANCH}"
 
 AGENT_BRANCH=""
 DRY_RUN=false
+REHEARSE=false
 CUSTOM_TITLE=""
+AGENT_OVERRIDE=""
 SKIP_RELEASE=false
+
+usage() {
+    cat <<'HELP'
+Usage: pr-captain-land <agent-branch> [options]
+
+Local-first landing: the branch is integrated and validated in a scratch
+worktree cut from origin/<default>, and only then published. The main
+checkout is never switched and local main is never touched.
+
+Options:
+  --rehearse        Steps 0-3 only (integrate + validate). No push, no PR,
+                    no version bump, no receipt. Scratch is deleted after.
+  --dry-run         --rehearse plus a printout of what would be published.
+  --title "..."     PR title (default: the agent branch name)
+  --agent <name>    Agent to dispatch (default: inferred from branch prefix)
+  --no-release      Skip the GitHub release after merge
+  --help, -h        Show this help
+HELP
+}
 
 while [[ $# -gt 0 ]]; do
     case $1 in
-        --dry-run) DRY_RUN=true; shift ;;
+        --dry-run) DRY_RUN=true; REHEARSE=true; shift ;;
+        --rehearse) REHEARSE=true; shift ;;
         --title) CUSTOM_TITLE="$2"; shift 2 ;;
+        --agent) AGENT_OVERRIDE="$2"; shift 2 ;;
         --no-release) SKIP_RELEASE=true; shift ;;
-        --help|-h)
-            echo "Usage: $0 <agent-branch> [--dry-run] [--title \"...\"] [--no-release]"
-            exit 0
-            ;;
+        --help|-h) usage; exit 0 ;;
         -*) echo "pr-captain-land: unknown flag: $1" >&2; exit 2 ;;
         *) AGENT_BRANCH="$1"; shift ;;
     esac
@@ -100,7 +162,40 @@ if [[ "$AGENT_BRANCH" == *..* ]] || [[ "$AGENT_BRANCH" == -* ]]; then
     exit 2
 fi
 
-# ── Precondition: in main checkout on master ────────────────────────────────
+# Scratch identity. Slashes collapse to dashes: a worktree directory must not
+# nest under .claude/worktrees/, and `_land-fix/x` as a ref would collide with
+# an existing `_land-fix` ref (git stores refs as directories).
+LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/' '-')"
+SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Rollback — the entire pre-publish rollback story
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Nothing outside the scratch worktree has been modified before step 6, so
+# "undo" is "delete the scratch". No git reset, no merge --abort, no stashing,
+# and crucially nothing that could strand the captain's main checkout.
+destroy_scratch() {
+    [[ -d "$SCRATCH_DIR" ]] || return 0
+    bash "$REPO_ROOT/agency/tools/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    # worktree-delete deliberately leaves the branch behind (it prints advice
+    # instead). For a machine-created scratch branch there is nothing to
+    # preserve, so remove it too.
+    bash "$REPO_ROOT/agency/tools/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
+}
+
+# abort_land <message...> — roll back and exit non-zero.
+abort_land() {
+    echo "" >&2
+    echo "pr-captain-land: $*" >&2
+    destroy_scratch
+    echo "  Rolled back: scratch worktree $LAND_SLUG deleted. Nothing was published." >&2
+    exit 1
+}
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 0 — Preflight
+# ═════════════════════════════════════════════════════════════════════════════
 
 MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
 if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
@@ -116,51 +211,264 @@ if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
     exit 1
 fi
 
-# ── Precondition: clean tree ─────────────────────────────────────────────────
-
-DIRTY=$(git status --porcelain 2>/dev/null)
+# NOTE (#393): a dirty main checkout no longer blocks a land. The landing never
+# reads, commits to, or moves local main — everything happens in the scratch
+# worktree. Uncommitted captain work is simply irrelevant here. It is still
+# worth surfacing, because a dirty tree usually means an unfinished handoff.
+DIRTY=$(git status --porcelain 2>/dev/null || true)
 if [[ -n "$DIRTY" ]]; then
-    echo "pr-captain-land: $DEFAULT_BRANCH tree dirty — commit or stash first." >&2
-    echo "$DIRTY" | head -5 | sed 's/^/  /' >&2
+    echo "note: $DEFAULT_BRANCH checkout is dirty — harmless here (the land runs in a scratch worktree)."
+fi
+
+if [[ -d "$SCRATCH_DIR" ]]; then
+    echo "pr-captain-land: scratch worktree $LAND_SLUG already exists at" >&2
+    echo "  $SCRATCH_DIR" >&2
+    echo "  A previous land is still running, or crashed. Inspect it, then:" >&2
+    echo "    ./agency/tools/worktree-delete $LAND_SLUG --force" >&2
     exit 1
 fi
 
-# ── Precondition: agent branch exists on origin ─────────────────────────────
-
+echo "→ Fetching origin..."
 bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 1 — Verify the agent branch on origin, and that its base is current
+# ═════════════════════════════════════════════════════════════════════════════
 
 if ! git show-ref --verify --quiet "refs/remotes/origin/$AGENT_BRANCH"; then
     echo "pr-captain-land: branch '$AGENT_BRANCH' not found on origin." >&2
+    echo "  The agent must push before /pr-submit." >&2
     exit 1
 fi
 
-# ── Switch to agent branch ───────────────────────────────────────────────────
+# Base freshness. If origin/<default> has moved ahead of what the agent
+# branched from, the agent's QGR receipt describes a diff against an older
+# base — the hash CANNOT match, and reporting that as a bare hash mismatch
+# sends the captain hunting for the wrong problem. Name the real cause.
+if ! git merge-base --is-ancestor "$BASE_REF" "origin/$AGENT_BRANCH" 2>/dev/null; then
+    BEHIND=$(git rev-list --count "origin/$AGENT_BRANCH..$BASE_REF" 2>/dev/null || echo "?")
+    echo "" >&2
+    echo "BLOCKED: '$AGENT_BRANCH' does not contain $BASE_REF ($BEHIND commit(s) behind)." >&2
+    echo "" >&2
+    echo "  Its QGR receipt was signed against an older base, so it can never" >&2
+    echo "  verify against the current one. This is not a receipt bug." >&2
+    echo "" >&2
+    echo "  Agent action: merge $DEFAULT_BRANCH into $AGENT_BRANCH, re-run /pr-prep," >&2
+    echo "                push, then re-run /pr-submit." >&2
+    exit 1
+fi
 
-echo "→ Switching to $AGENT_BRANCH..."
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$AGENT_BRANCH" >/dev/null
+echo "→ Branch origin/$AGENT_BRANCH is current with $BASE_REF"
 
-# ── Verify QGR receipt ───────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 2 — Cut the scratch worktree at origin/<agent-branch>
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# This IS the local integration. The branch is not checked out in the main
+# checkout (invariant), and because the step-1 gate proved origin/<default> is
+# an ancestor, the scratch tree already represents "the agent's work merged
+# into the default branch".
 
-DIFF_HASH_FULL=$(bash "$REPO_ROOT/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null | \
+echo "→ Creating scratch worktree $LAND_SLUG at origin/$AGENT_BRANCH..."
+if ! bash "$REPO_ROOT/agency/tools/worktree-create" "$LAND_SLUG" \
+        --from "origin/$AGENT_BRANCH" >/dev/null 2>&1; then
+    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG" >&2
+    destroy_scratch
+    exit 1
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 2b — Verify the agent's QGR receipt, BEFORE any mutation
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Ordering is load-bearing (#463): the version bump edits manifest.json, which
+# is inside the hashed file set. Verify first, mutate second — otherwise every
+# land invalidates the receipt it is checking and the agent is asked to re-prep
+# for a change the captain made.
+
+DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
 
-RECEIPT=$(find "$REPO_ROOT/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
-if [[ -z "$RECEIPT" ]]; then
+if [[ -z "$DIFF_HASH_SHORT" ]]; then
+    abort_land "could not compute a diff hash for origin/$AGENT_BRANCH against $BASE_REF."
+fi
+
+AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+if [[ -z "$AGENT_RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
-    echo "  Agent must run /pr-prep to produce a receipt before submitting." >&2
-    # Switch back to master before exit
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+    echo "  The branch content and the newest receipt disagree." >&2
+    echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
+    destroy_scratch
     exit 1
 fi
 
-RECEIPT_REL="${RECEIPT#$REPO_ROOT/}"
-echo "→ Receipt: $RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
+if ! (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
+    echo "pr-captain-land: receipt $AGENT_RECEIPT does not verify against the branch." >&2
+    echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
+    destroy_scratch
+    exit 1
+fi
 
-# ── Bump agency_version on the branch ─────────────────────────────────────
+AGENT_RECEIPT_REL="${AGENT_RECEIPT#$SCRATCH_DIR/}"
+# hash_a of the landing receipt chains to hash_e of the agent's receipt — the
+# captain's gate extends the agent's chain rather than starting a new one.
+AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"')
 
-MANIFEST="$REPO_ROOT/agency/config/manifest.json"
+echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 3 — VALIDATE LOCALLY. This is the gate. GitHub is not the gate.
+# ═════════════════════════════════════════════════════════════════════════════
+
+VALIDATION_LOG="$(mktemp -t pr-captain-land-validate)"
+VALIDATION_SUMMARY=""
+
+# run_validation_step <label> <command...>
+# Appends to the validation log and returns THE COMMAND'S status.
+#
+# The status must be captured explicitly: wrapping the command in a brace group
+# that ends with an `echo` would make the group's status that of the echo, i.e.
+# always 0 — a validation gate that can never fail is worse than no gate.
+run_validation_step() {
+    local label="$1"; shift
+    local st=0
+    echo "  · $label"
+    echo "=== $label ===" >> "$VALIDATION_LOG"
+    "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
+    echo "=== exit: $st ===" >> "$VALIDATION_LOG"
+    return "$st"
+}
+
+# Resolve the package manager via the shared primitive — a skill must never
+# name one inline (it ships to adopter repos that use a different one; see
+# src/tests/skills/skill-validation.bats). Absent one, the JS steps do not run.
+detect_pm() {
+    bash "$SCRATCH_DIR/agency/tools/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
+}
+
+has_pkg_script() {
+    [[ -f "$SCRATCH_DIR/package.json" ]] || return 1
+    SCRIPT_NAME="$1" python3 -c '
+import json, os, sys
+p = json.load(open(os.path.join(os.environ["SCRATCH"], "package.json")))
+sys.exit(0 if os.environ["SCRIPT_NAME"] in (p.get("scripts") or {}) else 1)
+' 2>/dev/null
+}
+
+echo "→ Validating locally in $LAND_SLUG (this is the gate)..."
+
+VALIDATION_STEPS=0
+VALIDATION_FAILED=""
+
+# The validation command can be overridden wholesale for repos whose gate is
+# not expressible as "package script + commit-precheck".
+if [[ -n "${PR_LAND_VALIDATE_CMD:-}" ]]; then
+    VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+    if ! (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD"); then
+        VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
+    fi
+else
+    PM="$(detect_pm)"
+    export SCRATCH="$SCRATCH_DIR"
+
+    if [[ -n "$PM" ]] && has_pkg_script build; then
+        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+        (cd "$SCRATCH_DIR" && run_validation_step "build ($PM run build)" "$PM" run build) \
+            || VALIDATION_FAILED="build"
+    fi
+
+    # Prefer the widest test script the repo declares. bats:all covers the
+    # framework's own suites; `test` is the conventional fallback.
+    if [[ -z "$VALIDATION_FAILED" && -n "$PM" ]]; then
+        for script in bats:all test; do
+            if has_pkg_script "$script"; then
+                VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+                (cd "$SCRATCH_DIR" && run_validation_step "tests ($PM run $script)" "$PM" run "$script") \
+                    || VALIDATION_FAILED="tests"
+                break
+            fi
+        done
+    fi
+
+    # commit-precheck is the same pre-commit gate every agent commit passes
+    # through — cheap, and it catches provenance/format regressions the test
+    # suites do not.
+    if [[ -z "$VALIDATION_FAILED" && -x "$SCRATCH_DIR/agency/tools/commit-precheck" ]]; then
+        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
+        (cd "$SCRATCH_DIR" && run_validation_step "commit-precheck" bash "$SCRATCH_DIR/agency/tools/commit-precheck") \
+            || VALIDATION_FAILED="commit-precheck"
+    fi
+fi
+
+if [[ "$VALIDATION_STEPS" -eq 0 ]]; then
+    # Distinct, loud, and NOT a silent pass: a repo with no resolvable local
+    # gate has opted out of the whole point of this flow.
+    echo "WARNING: no local validation command resolved for this repo." >&2
+    echo "  Set PR_LAND_VALIDATE_CMD, or declare a build/test script." >&2
+    echo "  Landing continues, but local-first validation did NOT happen." >&2
+    VALIDATION_SUMMARY="no local validation command resolved (see warning)"
+else
+    VALIDATION_SUMMARY="$VALIDATION_STEPS local validation step(s) passed against $BASE_REF"
+fi
+
+if [[ -n "$VALIDATION_FAILED" ]]; then
+    echo "" >&2
+    echo "── local validation output (tail) ──" >&2
+    tail -40 "$VALIDATION_LOG" >&2
+    echo "────────────────────────────────────" >&2
+
+    # Tell the agent before rolling back — the scratch is about to vanish.
+    AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+    bash "$REPO_ROOT/agency/tools/dispatch" create \
+        --type dispatch \
+        --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
+        --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
+        --body "Captain ran /pr-captain-land on \`$AGENT_BRANCH\` and it failed the LOCAL validation gate before anything was published.
+
+- Failed step: \`$VALIDATION_FAILED\`
+- Validated against: \`$BASE_REF\`
+- Nothing was pushed. No PR. No version bump. No release.
+
+Fix locally, re-run /pr-prep, push, then re-run /pr-submit.
+
+-- $ORG/$PRINCIPAL/captain" \
+        >/dev/null 2>&1 || true
+
+    abort_land "local validation failed at step '$VALIDATION_FAILED' — see output above."
+fi
+
+echo "→ Local validation: PASSED ($VALIDATION_SUMMARY)"
+
+# ── Rehearsal stops here ─────────────────────────────────────────────────────
+
+if [[ "$REHEARSE" == true ]]; then
+    if [[ "$DRY_RUN" == true ]]; then
+        echo ""
+        echo "[DRY-RUN] Would publish:"
+        echo "    PR title:    ${CUSTOM_TITLE:-$AGENT_BRANCH}"
+        echo "    Head branch: $LAND_SLUG (pushed from the scratch worktree)"
+        echo "    Base branch: $DEFAULT_BRANCH"
+        echo "    Agent to notify: ${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+        echo "    Release:     $([[ "$SKIP_RELEASE" == true ]] && echo "skipped" || echo "yes, v<bumped version>")"
+    fi
+    destroy_scratch
+    rm -f "$VALIDATION_LOG"
+    echo ""
+    echo "pr-captain-land: rehearsal complete — integrated + validated, nothing published."
+    exit 0
+fi
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 4 — Bump agency_version in the scratch
+# ═════════════════════════════════════════════════════════════════════════════
+
+MANIFEST="$SCRATCH_DIR/agency/config/manifest.json"
+if [[ ! -f "$MANIFEST" ]]; then
+    abort_land "manifest.json not found in scratch at $MANIFEST"
+fi
+
 # Security: pass values via env, never string-interpolate into python source
 # (F-SEC-1 / CRITICAL-3 from MAR 2026-04-19). Prevents RCE if manifest is
 # ever attacker-controllable.
@@ -169,7 +477,6 @@ import json, os
 print(json.load(open(os.environ["MANIFEST"]))["agency_version"])
 ')
 
-# Parse and bump — value via env, not f-string
 NEW_VER=$(CURRENT_VER="$CURRENT_VER" python3 -c '
 import os, sys
 v = os.environ["CURRENT_VER"]
@@ -185,16 +492,12 @@ else:
 ')
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
-    echo "pr-captain-land: could not bump version from $CURRENT_VER" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
-    exit 1
+    abort_land "could not bump version from $CURRENT_VER"
 fi
 
-echo "→ Bumping agency_version $CURRENT_VER → $NEW_VER"
+echo "→ Bumping agency_version $CURRENT_VER → $NEW_VER (in scratch)"
 
-if [[ "$DRY_RUN" == false ]]; then
-    # Security: env vars, not string interpolation (F-SEC-1)
-    MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
+MANIFEST="$MANIFEST" NEW_VER="$NEW_VER" python3 -c '
 import json, os
 from datetime import datetime, timezone
 path = os.environ["MANIFEST"]
@@ -203,141 +506,304 @@ m["agency_version"] = os.environ["NEW_VER"]
 m["project"]["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 json.dump(m, open(path, "w"), indent=2)
 '
-    bash "$REPO_ROOT/agency/tools/git-safe" add agency/config/manifest.json
-    bash "$REPO_ROOT/agency/tools/git-safe-commit" \
-        "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
-        --no-work-item >/dev/null
 
-    bash "$REPO_ROOT/agency/tools/git-push" "$AGENT_BRANCH" >/dev/null
-    echo "→ Version bumped + pushed"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add agency/config/manifest.json) \
+    || abort_land "could not stage the version bump"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+    "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
+    --no-work-item >/dev/null) \
+    || abort_land "could not commit the version bump"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 5 — Sign the captain LANDING receipt
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# pr-create is NOT weakened to let a captain-bumped branch through. Instead the
+# captain signs a receipt for the state it actually validated. The five-hash
+# chain stays intact and extends the agent's:
+#   A = the agent receipt's hash_e   (what was reviewed)
+#   B = hash of the local validation log
+#   C = B                            (nothing to triage — validation was green)
+#   D = C                            (auto-approved; no principal 1B1)
+#   E = diff hash of the bumped tree against origin/<default>
+#
+# Receipts live outside diff-hash's file set, so committing this receipt does
+# not invalidate the hash it carries.
+
+LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+                 python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
+                 echo "")
+if [[ -z "$LAND_HASH_FULL" ]]; then
+    abort_land "could not compute the post-bump diff hash for the landing receipt"
 fi
 
-# ── Create PR ────────────────────────────────────────────────────────────────
+VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" | cut -d' ' -f1)
+# project must be filename-safe: it becomes part of the receipt name.
+LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
+
+echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-sign" \
+    --type qgr \
+    --boundary pr-captain-land \
+    --org "$ORG" \
+    --principal "$PRINCIPAL" \
+    --agent captain \
+    --workstream agency \
+    --project "$LAND_PROJECT" \
+    --hash-a "${AGENT_HASH_E:-$DIFF_HASH_FULL}" \
+    --hash-b "$VALIDATION_HASH" \
+    --hash-c "$VALIDATION_HASH" \
+    --hash-d "$VALIDATION_HASH" \
+    --hash-e "$LAND_HASH_FULL" \
+    --diff-base "$BASE_REF" \
+    --summary "Local-first landing of $AGENT_BRANCH. Integrated in scratch worktree $LAND_SLUG cut from origin/$AGENT_BRANCH; $VALIDATION_SUMMARY; agency_version $CURRENT_VER → $NEW_VER. Chains to agent receipt $AGENT_RECEIPT_REL." \
+    >/dev/null) || abort_land "could not sign the landing receipt"
+
+LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | head -1 || echo "")
+if [[ -z "$LANDING_RECEIPT" ]]; then
+    abort_land "landing receipt was signed but could not be located"
+fi
+LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
+
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add "$LANDING_RECEIPT_REL") \
+    || abort_land "could not stage the landing receipt"
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+    "misc(pr-captain-land): landing receipt for $AGENT_BRANCH (${LAND_HASH_FULL:0:7})" \
+    --no-work-item >/dev/null) \
+    || abort_land "could not commit the landing receipt"
+
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 6 — Publish (first irreversible action)
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# Past this point `abort_land` is no longer correct: work exists on origin.
+# Failures below report and leave the scratch in place for inspection.
+
+echo "→ Pushing $LAND_SLUG..."
+(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-push" "$LAND_SLUG" >/dev/null) \
+    || abort_land "could not push $LAND_SLUG"
 
 PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
-Captain-landed PR via pr-captain-land (the-agency#296 Phase 1 pilot).
+Captain-landed via \`/pr-captain-land\` — **local-first** flow.
 
-Branch prepared by agent via /pr-submit. Captain owns the landing lifecycle:
-- Switched to \`$AGENT_BRANCH\`
-- Verified QGR receipt \`$RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`)
-- Bumped \`agency_version\` $CURRENT_VER → $NEW_VER
-- Will merge when CI is green
-- Will create release v$NEW_VER
+The work was integrated and validated locally BEFORE this PR existed. CI here
+is confirmation, not the gate.
+
+- Source branch: \`$AGENT_BRANCH\` (untouched; this PR rides \`$LAND_SLUG\`)
+- Integrated in a scratch worktree cut from \`origin/$AGENT_BRANCH\`, verified to contain \`$BASE_REF\`
+- Agent QGR receipt: \`$AGENT_RECEIPT_REL\` (hash \`$DIFF_HASH_SHORT\`) — verified before any mutation
+- Local validation: $VALIDATION_SUMMARY
+- Captain landing receipt: \`$LANDING_RECEIPT_REL\` (hash \`${LAND_HASH_FULL:0:7}\`)
+- \`agency_version\`: $CURRENT_VER → $NEW_VER
+- Release v$NEW_VER cut on merge
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)
 EOF
 )
 
-if [[ "$DRY_RUN" == true ]]; then
-    echo "→ [DRY-RUN] Would create PR:"
-    echo "    Title: $PR_TITLE"
-    echo "    Body:  (see stdout)"
-    # Switch back to master
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
-    echo "pr-captain-land: dry-run complete"
-    exit 0
-fi
-
 echo "→ Creating PR..."
-PR_URL=$(bash "$REPO_ROOT/agency/tools/pr-create" --title "$PR_TITLE" --body "$PR_BODY" 2>&1 | \
+PR_URL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/pr-create" \
+            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) | \
          tail -1 | grep -oE 'https://github.com/[^ ]+' || echo "")
 
 if [[ -z "$PR_URL" ]]; then
-    echo "pr-captain-land: pr-create did not return a URL — check output above" >&2
-    bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null 2>&1 || true
+    echo "pr-captain-land: pr-create did not return a URL — check output above." >&2
+    echo "  Scratch worktree kept for inspection: $SCRATCH_DIR" >&2
+    echo "  Branch $LAND_SLUG is pushed; delete it if you abandon this land." >&2
     exit 1
 fi
 
 PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
 echo "→ PR created: $PR_URL (#$PR_NUM)"
 
-# ── Back to master for merge ────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 7 — CI wait on the AGGREGATE status check rollup
+# ═════════════════════════════════════════════════════════════════════════════
+#
+# The old implementation waited on a single hardcoded check name
+# ("lint-and-test") that does not exist in this repo — so the loop always timed
+# out at 10 minutes regardless of CI's actual verdict, and a genuinely failing
+# check could never fail fast. Gate on the whole rollup instead:
+#
+#   - every check must reach a terminal SUCCESS-like state
+#   - any terminal failure state aborts immediately
+#   - an EMPTY rollup is its own distinct error, not a silent pass — "no checks
+#     configured" and "all checks green" must never look alike
+#
+# Where branch protection exposes a required-contexts list, narrow to it.
 
-bash "$REPO_ROOT/agency/tools/git-captain" switch-branch "$DEFAULT_BRANCH" >/dev/null
-echo "→ Back on $DEFAULT_BRANCH"
+REQUIRED_CONTEXTS=$(bash "$REPO_ROOT/agency/tools/gh-api" \
+    "/repos/$ORG/$REPO/branches/$DEFAULT_BRANCH/protection/required_status_checks/contexts" \
+    2>/dev/null || echo "")
 
-# ── Wait for CI ──────────────────────────────────────────────────────────────
-
-echo "→ Waiting for CI..."
+echo "→ Waiting for CI on PR #$PR_NUM (aggregate status check rollup)..."
 ATTEMPTS=0
-MAX_ATTEMPTS=30  # 30 × 20s = 10 minutes
+MAX_ATTEMPTS=45  # 45 × 20s = 15 minutes
+CI_VERDICT=""
+
 while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
-    STATE=$(gh pr view "$PR_NUM" --json statusCheckRollup --jq '.statusCheckRollup[] | select(.name=="lint-and-test") | .conclusion' 2>/dev/null || echo "")
-    if [[ "$STATE" == "SUCCESS" ]]; then
-        echo "→ lint-and-test: PASSED"
-        break
-    fi
-    if [[ "$STATE" == "FAILURE" ]]; then
-        echo "pr-captain-land: lint-and-test FAILED on PR #$PR_NUM" >&2
-        echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
-        exit 1
-    fi
+    ROLLUP=$(bash "$REPO_ROOT/agency/tools/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
+
+    CI_VERDICT=$(ROLLUP_JSON="$ROLLUP" REQUIRED="$REQUIRED_CONTEXTS" python3 <<'PY'
+import json, os, sys
+
+raw = os.environ.get("ROLLUP_JSON") or ""
+try:
+    checks = (json.loads(raw) or {}).get("statusCheckRollup") or []
+except (ValueError, AttributeError):
+    print("UNREADABLE")
+    sys.exit(0)
+
+# Narrow to branch-protection required contexts when we could read them.
+try:
+    required = json.loads(os.environ.get("REQUIRED") or "[]")
+    required = set(required) if isinstance(required, list) else set()
+except ValueError:
+    required = set()
+
+
+def name_of(c):
+    return c.get("name") or c.get("context") or "(unnamed)"
+
+
+def state_of(c):
+    # CheckRun: status + conclusion. StatusContext: state.
+    if c.get("status") is not None or c.get("conclusion") is not None:
+        if (c.get("status") or "").upper() != "COMPLETED":
+            return "PENDING"
+        return (c.get("conclusion") or "PENDING").upper()
+    return (c.get("state") or "PENDING").upper()
+
+
+if required:
+    checks = [c for c in checks if name_of(c) in required]
+
+if not checks:
+    print("NO_CHECKS")
+    sys.exit(0)
+
+PASS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
+FAIL = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"}
+
+failed = [name_of(c) for c in checks if state_of(c) in FAIL]
+if failed:
+    print("FAILED " + ",".join(failed))
+    sys.exit(0)
+
+pending = [name_of(c) for c in checks if state_of(c) not in PASS]
+if pending:
+    print("PENDING " + ",".join(pending))
+    sys.exit(0)
+
+print("PASSED " + ",".join(name_of(c) for c in checks))
+PY
+)
+
+    case "$CI_VERDICT" in
+        PASSED*)
+            echo "→ CI green: ${CI_VERDICT#PASSED }"
+            break
+            ;;
+        FAILED*)
+            echo "pr-captain-land: CI FAILED on PR #$PR_NUM — failing checks: ${CI_VERDICT#FAILED }" >&2
+            echo "  The local gate passed but the server disagreed. Investigate before re-landing." >&2
+            echo "  Agent must fix, push, and re-submit via /pr-submit." >&2
+            exit 1
+            ;;
+        NO_CHECKS)
+            echo "pr-captain-land: no status checks found on PR #$PR_NUM." >&2
+            echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
+            echo "  or the required-contexts filter matched nothing." >&2
+            echo "  Merge manually with /pr-captain-merge if that is expected." >&2
+            exit 1
+            ;;
+        UNREADABLE)
+            : # transient gh/network hiccup — retry
+            ;;
+    esac
+
     sleep 20
     ATTEMPTS=$((ATTEMPTS + 1))
 done
 
-if [[ $ATTEMPTS -eq $MAX_ATTEMPTS ]]; then
-    echo "pr-captain-land: CI timeout on PR #$PR_NUM — check manually" >&2
+if [[ "$CI_VERDICT" != PASSED* ]]; then
+    echo "pr-captain-land: CI timeout on PR #$PR_NUM after $((MAX_ATTEMPTS * 20))s — check manually." >&2
+    echo "  Last verdict: ${CI_VERDICT:-none}" >&2
     exit 1
 fi
 
-# ── Merge ────────────────────────────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 8 — Merge + release
+# ═════════════════════════════════════════════════════════════════════════════
 
-echo "→ Merging PR #$PR_NUM..."
-bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved >/dev/null 2>&1 || {
+echo "→ Merging PR #$PR_NUM (true merge commit)..."
+bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved --delete-branch >/dev/null 2>&1 || {
     echo "pr-captain-land: pr-merge failed — check manually" >&2
     exit 1
 }
 
-# ── Sync master ──────────────────────────────────────────────────────────────
-
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1
-bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1
-
-# ── Create release ───────────────────────────────────────────────────────────
+bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
 
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
     bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
         --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
-        --notes "Captain-landed via pr-captain-land (the-agency#296 Phase 1 pilot). See PR #$PR_NUM." \
+        --notes "Captain-landed via /pr-captain-land (local-first). See PR #$PR_NUM." \
         >/dev/null 2>&1 || {
-        echo "pr-captain-land: gh-release failed — create manually" >&2
+        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER" >&2
     }
 fi
 
-# ── Dispatch agent with outcome ─────────────────────────────────────────────
+# ═════════════════════════════════════════════════════════════════════════════
+# Step 9 — Cleanup + notify + reconcile
+# ═════════════════════════════════════════════════════════════════════════════
 
-# Agent is encoded in the branch name or retrievable from the branch's commits
-# For Phase 1 pilot: assume branch name hints at agent (e.g., captain-X, devex-Y)
-# Full lookup happens when promoted to .claude/skills/
+echo "→ Cleaning up scratch worktree and land branch..."
+destroy_scratch
+rm -f "$VALIDATION_LOG"
+# The REMOTE copy of the land branch is deleted by `pr-merge --delete-branch`
+# above. It is deliberately NOT retried here: git-push takes a branch name
+# positionally and has no delete mode, so a "belt and braces" call would
+# re-PUSH the branch rather than remove it.
 
-AGENT_HINT="${AGENT_BRANCH%%-*}"  # naive parse: prefix before first dash
-echo "→ Dispatching $AGENT_HINT agent with merge outcome..."
-
+AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+echo "→ Dispatching $AGENT_NAME with merge outcome..."
 bash "$REPO_ROOT/agency/tools/dispatch" create \
     --type master-updated \
-    --to "$ORG/$PRINCIPAL/$AGENT_HINT" \
+    --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \
-    --body "Captain-landed your branch \`$AGENT_BRANCH\` via the-agency#296 Phase 1 pilot flow.
+    --body "Captain landed your branch \`$AGENT_BRANCH\` via the local-first flow.
 
-- PR: $PR_URL
+- PR: $PR_URL (head branch \`$LAND_SLUG\`, now deleted)
 - Release: https://github.com/$ORG/$REPO/releases/tag/v$NEW_VER
 - Version: $CURRENT_VER → $NEW_VER
+- Local validation before publish: $VALIDATION_SUMMARY
+- Captain landing receipt: \`$LANDING_RECEIPT_REL\`
 
-Your branch is merged to $DEFAULT_BRANCH. Run /session-resume to pick up on your next cycle.
-
-Phase 1 pilot feedback: did anything feel off about the handoff? Reply dispatch.
+Your branch \`$AGENT_BRANCH\` was never checked out or modified by the landing —
+it is merged into $DEFAULT_BRANCH through the land branch. Run /session-resume to
+sync and pick up your next cycle.
 
 -- $ORG/$PRINCIPAL/captain" \
     >/dev/null 2>&1 || true
 
-# ── Done ─────────────────────────────────────────────────────────────────────
+bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+
+# Reconcile local main with the server merge. This is a separate, idempotent
+# step ON PURPOSE: it is a normal merge-from-origin, identical to what
+# /captain-sync-all does, so running either afterwards is a no-op rather than a
+# double-integration. Local main is only ever moved by this reconciliation —
+# never by the landing itself.
+echo "→ Reconciling local $DEFAULT_BRANCH with origin..."
+bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1 || {
+    echo "note: could not fast-forward local $DEFAULT_BRANCH — run /captain-sync-all." >&2
+}
 
 echo ""
 echo "pr-captain-land: complete"
+echo "  Branch:  $AGENT_BRANCH (via $LAND_SLUG)"
 echo "  PR:      $PR_URL"
 echo "  Release: v$NEW_VER"
-echo "  Merged:  ✓"
+echo "  Gate:    local ($VALIDATION_SUMMARY), CI confirmed"

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -111,6 +111,8 @@ REHEARSE=false
 CUSTOM_TITLE=""
 AGENT_OVERRIDE=""
 SKIP_RELEASE=false
+ALLOW_UNVALIDATED=false
+PRINCIPAL_APPROVED=false
 
 usage() {
     cat <<'HELP'
@@ -127,7 +129,20 @@ Options:
   --title "..."     PR title (default: the agent branch name)
   --agent <name>    Agent to dispatch (default: inferred from branch prefix)
   --no-release      Skip the GitHub release after merge
+  --principal-approved
+                    Forward --admin to pr-merge, bypassing branch protection.
+                    Pass ONLY when the principal actually said so. Without it
+                    the merge defers to GitHub's own gates.
+  --allow-unvalidated
+                    Land even when no local validation command resolves.
+                    Recorded verbatim in the landing receipt.
   --help, -h        Show this help
+
+Environment:
+  PR_LAND_VALIDATE_CMD   Replaces the whole local validation ladder with this
+                         command, run with `bash -c` inside the scratch
+                         worktree. Use for repos whose gate is not a package
+                         build/test script.
 HELP
 }
 
@@ -135,9 +150,15 @@ while [[ $# -gt 0 ]]; do
     case $1 in
         --dry-run) DRY_RUN=true; REHEARSE=true; shift ;;
         --rehearse) REHEARSE=true; shift ;;
-        --title) CUSTOM_TITLE="$2"; shift 2 ;;
-        --agent) AGENT_OVERRIDE="$2"; shift 2 ;;
+        --title)
+            [[ -n "${2:-}" ]] || { echo "pr-captain-land: --title needs a value" >&2; exit 2; }
+            CUSTOM_TITLE="$2"; shift 2 ;;
+        --agent)
+            [[ -n "${2:-}" ]] || { echo "pr-captain-land: --agent needs a value" >&2; exit 2; }
+            AGENT_OVERRIDE="$2"; shift 2 ;;
         --no-release) SKIP_RELEASE=true; shift ;;
+        --allow-unvalidated) ALLOW_UNVALIDATED=true; shift ;;
+        --principal-approved) PRINCIPAL_APPROVED=true; shift ;;
         --help|-h) usage; exit 0 ;;
         -*) echo "pr-captain-land: unknown flag: $1" >&2; exit 2 ;;
         *) AGENT_BRANCH="$1"; shift ;;
@@ -162,11 +183,37 @@ if [[ "$AGENT_BRANCH" == *..* ]] || [[ "$AGENT_BRANCH" == -* ]]; then
     exit 2
 fi
 
-# Scratch identity. Slashes collapse to dashes: a worktree directory must not
-# nest under .claude/worktrees/, and `_land-fix/x` as a ref would collide with
-# an existing `_land-fix` ref (git stores refs as directories).
-LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/' '-')"
+# --agent lands in the same dispatch --to routing as the branch-derived name,
+# so it gets the same character class. It had none.
+if [[ -n "$AGENT_OVERRIDE" ]] && ! [[ "$AGENT_OVERRIDE" =~ ^[a-zA-Z0-9][a-zA-Z0-9_.-]*$ ]]; then
+    echo "pr-captain-land: invalid --agent '$AGENT_OVERRIDE' — must be [a-zA-Z0-9][a-zA-Z0-9_.-]*" >&2
+    exit 2
+fi
+
+# Scratch identity.
+#
+# BOTH slashes and dots collapse to dashes. Slashes because a worktree
+# directory must not nest under .claude/worktrees/, and `_land-fix/x` as a ref
+# would collide with an existing `_land-fix` ref (git stores refs as
+# directories). Dots because `worktree-create` validates its name against
+# ^[a-zA-Z_][a-zA-Z0-9_-]*$ — the branch-name gate above deliberately PERMITS
+# dots, so slugging only slashes made every dotted branch (v1.2, 46.20)
+# unlandable, and the failure surfaced as an opaque "could not create scratch
+# worktree". Keep this in sync with LAND_PROJECT below, which uses the same
+# translation for the receipt filename.
+LAND_SLUG="_land-$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
+
+# Trusted tool root.
+#
+# Every tool that VERIFIES or PUBLISHES must come from the captain's own
+# checkout, never from the tree under review. A branch that edits
+# receipt-verify to `exit 0`, or diff-hash to return a constant, would
+# otherwise pass its own gate — and pr-create, the tool that enforces
+# "valid receipt + version bumped", would be supplied by the very branch it
+# is meant to police. Tools are invoked as "$TOOLS/<name>" with the cwd set
+# to the scratch, so they operate ON the branch without being FROM it.
+TOOLS="$REPO_ROOT/agency/tools"
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Rollback — the entire pre-publish rollback story
@@ -175,14 +222,44 @@ SCRATCH_DIR="$REPO_ROOT/.claude/worktrees/$LAND_SLUG"
 # Nothing outside the scratch worktree has been modified before step 6, so
 # "undo" is "delete the scratch". No git reset, no merge --abort, no stashing,
 # and crucially nothing that could strand the captain's main checkout.
+#
+# Set once this invocation actually created the scratch. Until then
+# destroy_scratch must not touch anything: the most likely reason step 2 fails
+# is that a PREVIOUS run's `_land-<x>` branch still exists, and force-deleting
+# that on the way out would destroy the state step 0 just told the captain to
+# go inspect.
+SCRATCH_IS_OURS=false
+
 destroy_scratch() {
-    [[ -d "$SCRATCH_DIR" ]] || return 0
-    bash "$REPO_ROOT/agency/tools/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    [[ "$SCRATCH_IS_OURS" == true ]] || return 0
+    if [[ -d "$SCRATCH_DIR" ]]; then
+        bash "$TOOLS/worktree-delete" "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    fi
     # worktree-delete deliberately leaves the branch behind (it prints advice
     # instead). For a machine-created scratch branch there is nothing to
-    # preserve, so remove it too.
-    bash "$REPO_ROOT/agency/tools/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
+    # preserve, so remove it too — and do it even when the directory is
+    # already gone, otherwise a half-cleaned run leaves a branch that wedges
+    # every future land of this branch at worktree-create.
+    bash "$TOOLS/git-captain" branch-delete "$LAND_SLUG" --force >/dev/null 2>&1 || true
 }
+
+# ── Unconditional cleanup ────────────────────────────────────────────────────
+#
+# `set -euo pipefail` means any unhandled non-zero status exits immediately,
+# skipping the explicit abort_land calls. Without a trap, every such abort
+# between step 2 and step 6 — and every Ctrl-C — strands the scratch worktree,
+# and step 0 then refuses all future lands of that branch. The trap is
+# disarmed at the publish boundary, where deleting the scratch stops being the
+# right answer.
+PUBLISHED=false
+on_exit() {
+    local st=$?
+    rm -f "${VALIDATION_LOG:-}" 2>/dev/null || true
+    if [[ "$PUBLISHED" == false && $st -ne 0 ]]; then
+        destroy_scratch
+    fi
+}
+trap on_exit EXIT INT TERM
 
 # abort_land <message...> — roll back and exit non-zero.
 abort_land() {
@@ -197,7 +274,9 @@ abort_land() {
 # Step 0 — Preflight
 # ═════════════════════════════════════════════════════════════════════════════
 
-MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+# --porcelain, not the columnar form: `awk '{print $1}'` truncates any repo
+# path containing a space, and the guard then misfires.
+MAIN_CHECKOUT=$(git worktree list --porcelain 2>/dev/null | head -1 | sed 's/^worktree //')
 if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
     echo "pr-captain-land: must run from main checkout (you're in a worktree)." >&2
     echo "  Main checkout: $MAIN_CHECKOUT" >&2
@@ -205,10 +284,13 @@ if [[ "$REPO_ROOT" != "$MAIN_CHECKOUT" ]]; then
     exit 1
 fi
 
-CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+# Which branch the main checkout happens to be on is NOT load-bearing in v2 —
+# the land never reads, commits to, or moves it. Requiring the default branch
+# here is leftover v1 coupling that would refuse a land while the captain is
+# mid-/captain-release on a captain-* branch. Note it, do not block on it.
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "")
 if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
-    echo "pr-captain-land: captain must be on $DEFAULT_BRANCH (you're on $CURRENT_BRANCH)." >&2
-    exit 1
+    echo "note: main checkout is on '$CURRENT_BRANCH', not '$DEFAULT_BRANCH' — harmless (the land runs in a scratch worktree)."
 fi
 
 # NOTE (#393): a dirty main checkout no longer blocks a land. The landing never
@@ -220,16 +302,70 @@ if [[ -n "$DIRTY" ]]; then
     echo "note: $DEFAULT_BRANCH checkout is dirty — harmless here (the land runs in a scratch worktree)."
 fi
 
+# Leftover scratch state from a crashed run. BOTH the directory and the branch
+# are checked: a run that died between `worktree add -b` and `worktree remove`
+# leaves only the branch, and worktree-create then refuses ("--from given but
+# branch already exists") on every retry with no way to see why.
 if [[ -d "$SCRATCH_DIR" ]]; then
     echo "pr-captain-land: scratch worktree $LAND_SLUG already exists at" >&2
     echo "  $SCRATCH_DIR" >&2
     echo "  A previous land is still running, or crashed. Inspect it, then:" >&2
     echo "    ./agency/tools/worktree-delete $LAND_SLUG --force" >&2
+    echo "    ./agency/tools/git-captain branch-delete $LAND_SLUG --force" >&2
+    exit 1
+fi
+if git show-ref --verify --quiet "refs/heads/$LAND_SLUG"; then
+    echo "pr-captain-land: land branch $LAND_SLUG already exists (no worktree)." >&2
+    echo "  A previous land crashed mid-cleanup. Inspect it, then:" >&2
+    echo "    ./agency/tools/git-captain branch-delete $LAND_SLUG --force" >&2
     exit 1
 fi
 
+# C#372 Fix B: a previously merged PR whose release was never cut leaves
+# pending state. Landing another PR on top of it loses the trail, and main
+# CI's release-tag-check stays red with nothing tracking why.
+if [[ -x "$TOOLS/post-merge-state" ]] && ! bash "$TOOLS/post-merge-state" check >/dev/null 2>&1; then
+    echo "pr-captain-land: a previous PR merge has no release yet." >&2
+    bash "$TOOLS/post-merge-state" get 2>/dev/null | sed 's/^/  /' >&2 || true
+    echo "  Run /pr-captain-post-merge <that-PR> first, then re-run this land." >&2
+    exit 1
+fi
+
+# Fetch is FATAL, not best-effort. Every guarantee below — base freshness, the
+# receipt's diff_base, "validated against pristine origin/<default>" — assumes
+# the origin refs are current. Swallowing the failure means an offline or
+# auth-expired captain validates against stale refs and still publishes.
 echo "→ Fetching origin..."
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+if ! bash "$TOOLS/git-captain" fetch >/dev/null 2>&1; then
+    echo "pr-captain-land: could not fetch origin." >&2
+    echo "  The land validates against origin/<default>; stale refs would make" >&2
+    echo "  every downstream check meaningless. Fix connectivity/auth and retry." >&2
+    exit 1
+fi
+
+# Who to notify. The branch-name prefix is a GUESS — `pr-lifecycle-v2` yields
+# `pr`, `feature/x-y` yields `feature/x`. Both dispatch calls are best-effort
+# (`|| true`), so a wrong name means the agent is silently never told their
+# work landed. Resolve against the actual agent registry and say so when the
+# guess does not land.
+resolve_agent_name() {
+    local candidate="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+    if [[ -f "$REPO_ROOT/.claude/agents/$PRINCIPAL/$candidate.md" ]] || \
+       [[ -f "$REPO_ROOT/.claude/agents/$candidate.md" ]]; then
+        printf '%s' "$candidate"
+        return 0
+    fi
+    if [[ -n "$AGENT_OVERRIDE" ]]; then
+        echo "note: --agent '$AGENT_OVERRIDE' has no registration; dispatching to it anyway." >&2
+        printf '%s' "$AGENT_OVERRIDE"
+        return 0
+    fi
+    # Unregistered guess: route to captain rather than into the void, and be
+    # explicit that the notification did not reach the author.
+    echo "note: could not resolve an agent from branch '$AGENT_BRANCH' (guessed '$candidate')." >&2
+    echo "  Dispatching to captain instead. Pass --agent <name> to route correctly." >&2
+    printf '%s' "captain"
+}
 
 # ═════════════════════════════════════════════════════════════════════════════
 # Step 1 — Verify the agent branch on origin, and that its base is current
@@ -270,10 +406,12 @@ echo "→ Branch origin/$AGENT_BRANCH is current with $BASE_REF"
 # into the default branch".
 
 echo "→ Creating scratch worktree $LAND_SLUG at origin/$AGENT_BRANCH..."
-if ! bash "$REPO_ROOT/agency/tools/worktree-create" "$LAND_SLUG" \
-        --from "origin/$AGENT_BRANCH" >/dev/null 2>&1; then
-    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG" >&2
-    destroy_scratch
+# stdout is noise; stderr is the diagnosis. Discarding both turned every
+# distinct failure (invalid name, existing branch, disk full) into one opaque
+# "could not create scratch worktree".
+SCRATCH_IS_OURS=true
+if ! bash "$TOOLS/worktree-create" "$LAND_SLUG" --from "origin/$AGENT_BRANCH" >/dev/null; then
+    echo "pr-captain-land: could not create scratch worktree $LAND_SLUG (see above)" >&2
     exit 1
 fi
 
@@ -286,7 +424,7 @@ fi
 # land invalidates the receipt it is checking and the agent is asked to re-prep
 # for a change the captain made.
 
-DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+DIFF_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 DIFF_HASH_SHORT="${DIFF_HASH_FULL:0:7}"
@@ -295,7 +433,10 @@ if [[ -z "$DIFF_HASH_SHORT" ]]; then
     abort_land "could not compute a diff hash for origin/$AGENT_BRANCH against $BASE_REF."
 fi
 
-AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | head -1 || echo "")
+# `sort` before `head` so two receipts sharing a 7-char short hash resolve
+# deterministically rather than by filesystem order. The name carries a
+# timestamp, so the last one sorts newest.
+AGENT_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams" -name "*qgr-pr-prep-*-$DIFF_HASH_SHORT.md" 2>/dev/null | sort | tail -1 || echo "")
 if [[ -z "$AGENT_RECEIPT" ]]; then
     echo "pr-captain-land: no QGR receipt matching hash $DIFF_HASH_SHORT on branch $AGENT_BRANCH." >&2
     echo "  The branch content and the newest receipt disagree." >&2
@@ -304,17 +445,23 @@ if [[ -z "$AGENT_RECEIPT" ]]; then
     exit 1
 fi
 
-if ! (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
+# receipt-verify comes from the CAPTAIN'S checkout, not the branch's. A branch
+# that edits its own copy to `exit 0` would otherwise pass its own gate.
+if ! (cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-verify" --file "$AGENT_RECEIPT" >/dev/null 2>&1); then
     echo "pr-captain-land: receipt $AGENT_RECEIPT does not verify against the branch." >&2
     echo "  Agent action: re-run /pr-prep, push, re-run /pr-submit." >&2
     destroy_scratch
     exit 1
 fi
 
-AGENT_RECEIPT_REL="${AGENT_RECEIPT#$SCRATCH_DIR/}"
+AGENT_RECEIPT_REL="${AGENT_RECEIPT#"$SCRATCH_DIR"/}"
 # hash_a of the landing receipt chains to hash_e of the agent's receipt — the
 # captain's gate extends the agent's chain rather than starting a new one.
-AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"')
+#
+# `|| true` is load-bearing: under `set -euo pipefail` a receipt with no
+# hash_e line makes grep exit 1, the assignment fails, and the script dies
+# SILENTLY — which also made the ${AGENT_HASH_E:-...} fallback below dead code.
+AGENT_HASH_E=$(grep '^hash_e:' "$AGENT_RECEIPT" 2>/dev/null | head -1 | sed 's/^hash_e:[[:space:]]*//' | tr -d '"' || true)
 
 echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
 
@@ -322,7 +469,11 @@ echo "→ Agent receipt verified: $AGENT_RECEIPT_REL (hash: $DIFF_HASH_SHORT)"
 # Step 3 — VALIDATE LOCALLY. This is the gate. GitHub is not the gate.
 # ═════════════════════════════════════════════════════════════════════════════
 
-VALIDATION_LOG="$(mktemp -t pr-captain-land-validate)"
+# `mktemp -t <prefix>` is a BSD-ism: GNU coreutils requires a template with at
+# least three X's and errors out. The framework ships to Linux adopters, and a
+# failure here happens AFTER the scratch worktree exists.
+VALIDATION_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-validate.XXXXXX")"
+chmod 600 "$VALIDATION_LOG" 2>/dev/null || true
 VALIDATION_SUMMARY=""
 
 # run_validation_step <label> <command...>
@@ -331,12 +482,21 @@ VALIDATION_SUMMARY=""
 # The status must be captured explicitly: wrapping the command in a brace group
 # that ends with an `echo` would make the group's status that of the echo, i.e.
 # always 0 — a validation gate that can never fail is worse than no gate.
+#
+# The command comes from the branch under review, so it runs with the
+# captain's credentials scrubbed out of the environment. A `build` script of
+# `gh auth token` would otherwise write the captain's PAT into this log — and
+# the log is tailed to stderr on failure, i.e. into the session transcript.
+# This is defence in depth, not a sandbox: the branch still executes code as
+# the captain's user, which is inherent to validating it locally at all.
 run_validation_step() {
     local label="$1"; shift
     local st=0
     echo "  · $label"
     echo "=== $label ===" >> "$VALIDATION_LOG"
-    "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
+    env -u GH_TOKEN -u GITHUB_TOKEN -u GH_ENTERPRISE_TOKEN -u GIT_ASKPASS \
+        -u SSH_AUTH_SOCK GIT_TERMINAL_PROMPT=0 \
+        "$@" >> "$VALIDATION_LOG" 2>&1 || st=$?
     echo "=== exit: $st ===" >> "$VALIDATION_LOG"
     return "$st"
 }
@@ -345,12 +505,12 @@ run_validation_step() {
 # name one inline (it ships to adopter repos that use a different one; see
 # src/tests/skills/skill-validation.bats). Absent one, the JS steps do not run.
 detect_pm() {
-    bash "$SCRATCH_DIR/agency/tools/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
+    bash "$TOOLS/pkg-manager" -C "$SCRATCH_DIR" 2>/dev/null || echo ""
 }
 
 has_pkg_script() {
     [[ -f "$SCRATCH_DIR/package.json" ]] || return 1
-    SCRIPT_NAME="$1" python3 -c '
+    SCRIPT_NAME="$1" SCRATCH="$SCRATCH_DIR" python3 -c '
 import json, os, sys
 p = json.load(open(os.path.join(os.environ["SCRATCH"], "package.json")))
 sys.exit(0 if os.environ["SCRIPT_NAME"] in (p.get("scripts") or {}) else 1)
@@ -363,15 +523,13 @@ VALIDATION_STEPS=0
 VALIDATION_FAILED=""
 
 # The validation command can be overridden wholesale for repos whose gate is
-# not expressible as "package script + commit-precheck".
+# not expressible as "package build + test script". See --help.
 if [[ -n "${PR_LAND_VALIDATE_CMD:-}" ]]; then
     VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
-    if ! (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD"); then
-        VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
-    fi
+    (cd "$SCRATCH_DIR" && run_validation_step "PR_LAND_VALIDATE_CMD" bash -c "$PR_LAND_VALIDATE_CMD") \
+        || VALIDATION_FAILED="PR_LAND_VALIDATE_CMD"
 else
     PM="$(detect_pm)"
-    export SCRATCH="$SCRATCH_DIR"
 
     if [[ -n "$PM" ]] && has_pkg_script build; then
         VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
@@ -391,24 +549,33 @@ else
             fi
         done
     fi
-
-    # commit-precheck is the same pre-commit gate every agent commit passes
-    # through — cheap, and it catches provenance/format regressions the test
-    # suites do not.
-    if [[ -z "$VALIDATION_FAILED" && -x "$SCRATCH_DIR/agency/tools/commit-precheck" ]]; then
-        VALIDATION_STEPS=$((VALIDATION_STEPS + 1))
-        (cd "$SCRATCH_DIR" && run_validation_step "commit-precheck" bash "$SCRATCH_DIR/agency/tools/commit-precheck") \
-            || VALIDATION_FAILED="commit-precheck"
-    fi
 fi
 
+# NOTE on commit-precheck: it is deliberately NOT part of this ladder. It gates
+# on STAGED files, and the scratch tree is clean here — so it would exit 0
+# having inspected nothing, while still counting as a step. That inflated the
+# step count, suppressed the "no validation resolved" abort below, and wrote
+# "N local validation step(s) passed" into a signed receipt on the strength of
+# a no-op. It still runs, where it means something: git-safe-commit invokes it
+# on the version-bump and landing-receipt commits in steps 4 and 5.
+
 if [[ "$VALIDATION_STEPS" -eq 0 ]]; then
-    # Distinct, loud, and NOT a silent pass: a repo with no resolvable local
-    # gate has opted out of the whole point of this flow.
-    echo "WARNING: no local validation command resolved for this repo." >&2
-    echo "  Set PR_LAND_VALIDATE_CMD, or declare a build/test script." >&2
-    echo "  Landing continues, but local-first validation did NOT happen." >&2
-    VALIDATION_SUMMARY="no local validation command resolved (see warning)"
+    # FAIL CLOSED. A landing with no local gate is not a local-first landing —
+    # it is the old PR-first flow with extra steps, and it would go on to sign
+    # a five-hash receipt attesting to a validation that never ran.
+    if [[ "$ALLOW_UNVALIDATED" != true ]]; then
+        abort_land "no local validation command resolved for this repo — refusing to land.
+  The local gate is the whole point of this flow; signing a landing receipt
+  for a validation that did not happen would make the receipt a lie.
+
+  Fix one of these:
+    - declare a build/test script in package.json, or
+    - set PR_LAND_VALIDATE_CMD='<your gate>', or
+    - pass --allow-unvalidated to land anyway (recorded in the receipt)."
+    fi
+    echo "WARNING: no local validation command resolved; --allow-unvalidated given." >&2
+    echo "  Local-first validation did NOT happen. This is recorded in the receipt." >&2
+    VALIDATION_SUMMARY="NO LOCAL VALIDATION RAN (--allow-unvalidated)"
 else
     VALIDATION_SUMMARY="$VALIDATION_STEPS local validation step(s) passed against $BASE_REF"
 fi
@@ -420,8 +587,8 @@ if [[ -n "$VALIDATION_FAILED" ]]; then
     echo "────────────────────────────────────" >&2
 
     # Tell the agent before rolling back — the scratch is about to vanish.
-    AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
-    bash "$REPO_ROOT/agency/tools/dispatch" create \
+    AGENT_NAME="$(resolve_agent_name)"
+    bash "$TOOLS/dispatch" create \
         --type dispatch \
         --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
         --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
@@ -450,7 +617,7 @@ if [[ "$REHEARSE" == true ]]; then
         echo "    PR title:    ${CUSTOM_TITLE:-$AGENT_BRANCH}"
         echo "    Head branch: $LAND_SLUG (pushed from the scratch worktree)"
         echo "    Base branch: $DEFAULT_BRANCH"
-        echo "    Agent to notify: ${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+        echo "    Agent to notify: $(resolve_agent_name)"
         echo "    Release:     $([[ "$SKIP_RELEASE" == true ]] && echo "skipped" || echo "yes, v<bumped version>")"
     fi
     destroy_scratch
@@ -473,23 +640,25 @@ fi
 # (F-SEC-1 / CRITICAL-3 from MAR 2026-04-19). Prevents RCE if manifest is
 # ever attacker-controllable.
 CURRENT_VER=$(MANIFEST="$MANIFEST" python3 -c '
-import json, os
-print(json.load(open(os.environ["MANIFEST"]))["agency_version"])
-')
-
-NEW_VER=$(CURRENT_VER="$CURRENT_VER" python3 -c '
-import os, sys
-v = os.environ["CURRENT_VER"]
-parts = v.split(".")
-if len(parts) == 2:
-    major, minor = int(parts[0]), int(parts[1])
-    print(f"{major}.{minor+1}")
-elif len(parts) == 1:
-    print(f"{int(parts[0])+1}")
-else:
-    print(v)
+import json, os, sys
+m = json.load(open(os.environ["MANIFEST"]))
+v = m.get("agency_version")
+if not v:
     sys.exit(1)
-')
+print(v)
+' || true)
+
+if [[ -z "$CURRENT_VER" ]]; then
+    abort_land "manifest.json has no agency_version — cannot bump."
+fi
+
+# The bump policy lives in agency/tools/agency-version-next. Inline, it was
+# `NEW_VER=$(python3 -c '... sys.exit(1)')`, which under `set -euo pipefail`
+# killed THIS script before the friendly error below could run — so the abort
+# was unreachable for exactly the input it was written for, and the scratch
+# worktree was left stranded.
+NEW_VER=$(bash "$TOOLS/agency-version-next" "$CURRENT_VER") || \
+    abort_land "could not bump agency_version from '$CURRENT_VER' (see above)."
 
 if [[ -z "$NEW_VER" || "$NEW_VER" == "$CURRENT_VER" ]]; then
     abort_land "could not bump version from $CURRENT_VER"
@@ -502,14 +671,24 @@ import json, os
 from datetime import datetime, timezone
 path = os.environ["MANIFEST"]
 m = json.load(open(path))
+stamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 m["agency_version"] = os.environ["NEW_VER"]
-m["project"]["updated_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-json.dump(m, open(path, "w"), indent=2)
-'
+# Both timestamps: the nested one was already maintained, the top-level one
+# exists and was being left stale by every land.
+if isinstance(m.get("project"), dict):
+    m["project"]["updated_at"] = stamp
+if "updated_at" in m:
+    m["updated_at"] = stamp
+with open(path, "w") as fh:
+    json.dump(m, fh, indent=2)
+    # The file on disk ends with a newline; json.dump does not write one, so
+    # without this every land adds a spurious "\ No newline at end of file".
+    fh.write("\n")
+' || abort_land "could not write the version bump into manifest.json"
 
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add agency/config/manifest.json) \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe" add agency/config/manifest.json) \
     || abort_land "could not stage the version bump"
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe-commit" \
     "chore(manifest): bump agency_version $CURRENT_VER → $NEW_VER for PR landing (captain)" \
     --no-work-item >/dev/null) \
     || abort_land "could not commit the version bump"
@@ -524,25 +703,37 @@ json.dump(m, open(path, "w"), indent=2)
 #   A = the agent receipt's hash_e   (what was reviewed)
 #   B = hash of the local validation log
 #   C = B                            (nothing to triage — validation was green)
-#   D = C                            (auto-approved; no principal 1B1)
+#   D = C, or the principal-approval marker when --principal-approved is given
 #   E = diff hash of the bumped tree against origin/<default>
 #
 # Receipts live outside diff-hash's file set, so committing this receipt does
 # not invalidate the hash it carries.
 
-LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
+LAND_HASH_FULL=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/diff-hash" --base "$BASE_REF" --json 2>/dev/null) | \
                  python3 -c "import sys, json; d=json.load(sys.stdin); print(d.get('full_hash',''))" 2>/dev/null || \
                  echo "")
 if [[ -z "$LAND_HASH_FULL" ]]; then
     abort_land "could not compute the post-bump diff hash for the landing receipt"
 fi
 
-VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" | cut -d' ' -f1)
+VALIDATION_HASH=$(shasum -a 256 "$VALIDATION_LOG" 2>/dev/null | cut -d' ' -f1 || true)
+if [[ -z "$VALIDATION_HASH" ]]; then
+    abort_land "could not hash the validation log — refusing to sign a receipt with no hash_b"
+fi
+
+# hash_d is the principal-approval link. It must not claim an approval that
+# did not happen: it equals hash_c unless the captain actually passed
+# --principal-approved, in which case the source string records that.
+if [[ "$PRINCIPAL_APPROVED" == true ]]; then
+    HASH_D_SOURCE="principal-approved flag passed by captain at land time"
+else
+    HASH_D_SOURCE="auto-approved — no principal 1B1"
+fi
 # project must be filename-safe: it becomes part of the receipt name.
 LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 
 echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/receipt-sign" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-sign" \
     --type qgr \
     --boundary pr-captain-land \
     --org "$ORG" \
@@ -555,19 +746,20 @@ echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
     --hash-c "$VALIDATION_HASH" \
     --hash-d "$VALIDATION_HASH" \
     --hash-e "$LAND_HASH_FULL" \
+    --hash-d-source "$HASH_D_SOURCE" \
     --diff-base "$BASE_REF" \
     --summary "Local-first landing of $AGENT_BRANCH. Integrated in scratch worktree $LAND_SLUG cut from origin/$AGENT_BRANCH; $VALIDATION_SUMMARY; agency_version $CURRENT_VER → $NEW_VER. Chains to agent receipt $AGENT_RECEIPT_REL." \
     >/dev/null) || abort_land "could not sign the landing receipt"
 
-LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | head -1 || echo "")
+LANDING_RECEIPT=$(find "$SCRATCH_DIR/agency/workstreams/agency/qgr" -name "*-pr-captain-land-*-${LAND_HASH_FULL:0:7}.md" 2>/dev/null | sort | tail -1 || echo "")
 if [[ -z "$LANDING_RECEIPT" ]]; then
     abort_land "landing receipt was signed but could not be located"
 fi
-LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
+LANDING_RECEIPT_REL="${LANDING_RECEIPT#"$SCRATCH_DIR"/}"
 
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe" add "$LANDING_RECEIPT_REL") \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe" add "$LANDING_RECEIPT_REL") \
     || abort_land "could not stage the landing receipt"
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-safe-commit" \
+(cd "$SCRATCH_DIR" && bash "$TOOLS/git-safe-commit" \
     "misc(pr-captain-land): landing receipt for $AGENT_BRANCH (${LAND_HASH_FULL:0:7})" \
     --no-work-item >/dev/null) \
     || abort_land "could not commit the landing receipt"
@@ -580,8 +772,21 @@ LANDING_RECEIPT_REL="${LANDING_RECEIPT#$SCRATCH_DIR/}"
 # Failures below report and leave the scratch in place for inspection.
 
 echo "→ Pushing $LAND_SLUG..."
-(cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/git-push" "$LAND_SLUG" >/dev/null) \
-    || abort_land "could not push $LAND_SLUG"
+if ! (cd "$SCRATCH_DIR" && bash "$TOOLS/git-push" "$LAND_SLUG" >/dev/null); then
+    # The push may have partially succeeded, so say so before rolling back —
+    # otherwise an orphaned remote branch exists with nothing referencing it.
+    echo "pr-captain-land: could not push $LAND_SLUG." >&2
+    echo "  If the remote branch was created anyway, delete it:" >&2
+    echo "    gh api -X DELETE repos/$ORG/$REPO/git/refs/heads/$LAND_SLUG" >&2
+    abort_land "push failed"
+fi
+
+# ── Publish boundary ────────────────────────────────────────────────────────
+# Work now exists on origin. Deleting the scratch stops being "rollback" and
+# starts being "destroy the only local record of what was published", so the
+# EXIT trap's cleanup is disarmed here. Everything below reports and leaves
+# state for inspection.
+PUBLISHED=true
 
 PR_TITLE="${CUSTOM_TITLE:-$AGENT_BRANCH}"
 PR_BODY=$(cat <<EOF
@@ -603,18 +808,34 @@ EOF
 )
 
 echo "→ Creating PR..."
-PR_URL=$( (cd "$SCRATCH_DIR" && bash "$SCRATCH_DIR/agency/tools/pr-create" \
-            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) | \
-         tail -1 | grep -oE 'https://github.com/[^ ]+' || echo "")
+# pr-create runs from the CAPTAIN'S tools with the cwd in the scratch: the
+# branch supplies the content, never the tool that gates it. Otherwise a
+# branch could ship its own pr-create and the "pr-create is not weakened"
+# guarantee would be unenforceable.
+#
+# The URL is matched anywhere in the output, not just on the last line — gh
+# emits warnings on the same stream, and scraping `tail -1` sent a
+# successfully created PR down the "did not return a URL" path, leaving an
+# orphan PR for the operator to find.
+PR_OUT=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/pr-create" \
+            --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) || true)
+PR_URL=$(printf '%s\n' "$PR_OUT" | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1 || true)
 
 if [[ -z "$PR_URL" ]]; then
-    echo "pr-captain-land: pr-create did not return a URL — check output above." >&2
+    echo "$PR_OUT" >&2
+    echo "" >&2
+    echo "pr-captain-land: pr-create did not return a PR URL — see output above." >&2
     echo "  Scratch worktree kept for inspection: $SCRATCH_DIR" >&2
-    echo "  Branch $LAND_SLUG is pushed; delete it if you abandon this land." >&2
+    echo "  Branch $LAND_SLUG IS pushed; delete it if you abandon this land." >&2
     exit 1
 fi
 
-PR_NUM=$(echo "$PR_URL" | grep -oE '[0-9]+$')
+PR_NUM=$(printf '%s' "$PR_URL" | grep -oE '[0-9]+$' || true)
+if [[ -z "$PR_NUM" ]]; then
+    echo "pr-captain-land: could not read a PR number from '$PR_URL'." >&2
+    echo "  The PR exists; finish it manually with /pr-captain-merge." >&2
+    exit 1
+fi
 echo "→ PR created: $PR_URL (#$PR_NUM)"
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -633,72 +854,34 @@ echo "→ PR created: $PR_URL (#$PR_NUM)"
 #
 # Where branch protection exposes a required-contexts list, narrow to it.
 
-REQUIRED_CONTEXTS=$(bash "$REPO_ROOT/agency/tools/gh-api" \
+# The branch-protection required-contexts list, when readable. The endpoint
+# 404s on unprotected repos and without admin scope; ci-rollup-verdict treats
+# anything that is not a non-empty JSON array as "no narrowing".
+REQUIRED_CONTEXTS=$(bash "$TOOLS/gh-api" \
     "/repos/$ORG/$REPO/branches/$DEFAULT_BRANCH/protection/required_status_checks/contexts" \
     2>/dev/null || echo "")
 
 echo "→ Waiting for CI on PR #$PR_NUM (aggregate status check rollup)..."
 ATTEMPTS=0
 MAX_ATTEMPTS=45  # 45 × 20s = 15 minutes
+# GitHub has usually not registered any check runs in the first seconds after
+# a PR is opened, so the rollup is legitimately empty then. Treating that as
+# the fatal NO_CHECKS case would abort almost every real land. NO_CHECKS is
+# only believed once the grace window has passed — at which point "no CI
+# configured" is the honest reading, and it is still never a pass.
+NO_CHECKS_GRACE=9  # 9 × 20s = 3 minutes
 CI_VERDICT=""
 
 while [[ $ATTEMPTS -lt $MAX_ATTEMPTS ]]; do
-    ROLLUP=$(bash "$REPO_ROOT/agency/tools/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
+    ROLLUP=$(bash "$TOOLS/gh" pr view "$PR_NUM" --json statusCheckRollup 2>/dev/null || echo "")
 
-    CI_VERDICT=$(ROLLUP_JSON="$ROLLUP" REQUIRED="$REQUIRED_CONTEXTS" python3 <<'PY'
-import json, os, sys
-
-raw = os.environ.get("ROLLUP_JSON") or ""
-try:
-    checks = (json.loads(raw) or {}).get("statusCheckRollup") or []
-except (ValueError, AttributeError):
-    print("UNREADABLE")
-    sys.exit(0)
-
-# Narrow to branch-protection required contexts when we could read them.
-try:
-    required = json.loads(os.environ.get("REQUIRED") or "[]")
-    required = set(required) if isinstance(required, list) else set()
-except ValueError:
-    required = set()
-
-
-def name_of(c):
-    return c.get("name") or c.get("context") or "(unnamed)"
-
-
-def state_of(c):
-    # CheckRun: status + conclusion. StatusContext: state.
-    if c.get("status") is not None or c.get("conclusion") is not None:
-        if (c.get("status") or "").upper() != "COMPLETED":
-            return "PENDING"
-        return (c.get("conclusion") or "PENDING").upper()
-    return (c.get("state") or "PENDING").upper()
-
-
-if required:
-    checks = [c for c in checks if name_of(c) in required]
-
-if not checks:
-    print("NO_CHECKS")
-    sys.exit(0)
-
-PASS = {"SUCCESS", "NEUTRAL", "SKIPPED"}
-FAIL = {"FAILURE", "ERROR", "TIMED_OUT", "CANCELLED", "ACTION_REQUIRED", "STARTUP_FAILURE", "STALE"}
-
-failed = [name_of(c) for c in checks if state_of(c) in FAIL]
-if failed:
-    print("FAILED " + ",".join(failed))
-    sys.exit(0)
-
-pending = [name_of(c) for c in checks if state_of(c) not in PASS]
-if pending:
-    print("PENDING " + ",".join(pending))
-    sys.exit(0)
-
-print("PASSED " + ",".join(name_of(c) for c in checks))
-PY
-)
+    # Classification lives in agency/tools/ci-rollup-verdict — a pure function
+    # of (rollup, required contexts), table-tested in
+    # src/tests/tools/ci-rollup-verdict.bats. Inline, it was a python heredoc
+    # that no test could reach, and every guard written for it still passed
+    # with the PASS and FAIL sets swapped.
+    CI_VERDICT=$(printf '%s' "$ROLLUP" | \
+        python3 "$TOOLS/ci-rollup-verdict" --required "$REQUIRED_CONTEXTS" 2>/dev/null || echo "UNREADABLE")
 
     case "$CI_VERDICT" in
         PASSED*)
@@ -712,14 +895,16 @@ PY
             exit 1
             ;;
         NO_CHECKS)
-            echo "pr-captain-land: no status checks found on PR #$PR_NUM." >&2
-            echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
-            echo "  or the required-contexts filter matched nothing." >&2
-            echo "  Merge manually with /pr-captain-merge if that is expected." >&2
-            exit 1
+            if [[ $ATTEMPTS -ge $NO_CHECKS_GRACE ]]; then
+                echo "pr-captain-land: no status checks found on PR #$PR_NUM after $((NO_CHECKS_GRACE * 20))s." >&2
+                echo "  This is NOT a pass. Either CI is not configured for this repo," >&2
+                echo "  or the required-contexts filter matched nothing." >&2
+                echo "  Merge manually with /pr-captain-merge if that is expected." >&2
+                exit 1
+            fi
             ;;
-        UNREADABLE)
-            : # transient gh/network hiccup — retry
+        PENDING*|UNREADABLE)
+            : # still running, or a transient gh/network hiccup — retry
             ;;
     esac
 
@@ -737,23 +922,50 @@ fi
 # Step 8 — Merge + release
 # ═════════════════════════════════════════════════════════════════════════════
 
+# --principal-approved is NOT asserted unconditionally. pr-merge treats it as
+# the captain's attestation that the principal verbally approved, and it is
+# the only route to `gh pr merge --admin`. Hardcoding it in a non-interactive
+# script would turn a deliberate human gate into a constant and make branch-
+# protection bypass the fleet's default merge mode. Default: defer to GitHub.
+MERGE_ARGS="--delete-branch"
+if [[ "$PRINCIPAL_APPROVED" == true ]]; then
+    MERGE_ARGS="--principal-approved --delete-branch"
+fi
+
 echo "→ Merging PR #$PR_NUM (true merge commit)..."
-bash "$REPO_ROOT/agency/tools/pr-merge" "$PR_NUM" --principal-approved --delete-branch >/dev/null 2>&1 || {
-    echo "pr-captain-land: pr-merge failed — check manually" >&2
+MERGE_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-merge.XXXXXX")"
+# shellcheck disable=SC2086  # MERGE_ARGS is a controlled, space-separated flag list
+if ! bash "$TOOLS/pr-merge" "$PR_NUM" $MERGE_ARGS >"$MERGE_LOG" 2>&1; then
+    # Silencing this was indefensible at the single most consequential step.
+    echo "pr-captain-land: pr-merge failed on PR #$PR_NUM:" >&2
+    tail -30 "$MERGE_LOG" >&2
+    rm -f "$MERGE_LOG"
+    if [[ "$PRINCIPAL_APPROVED" == false ]]; then
+        echo "" >&2
+        echo "  If branch protection is the blocker and the principal approved," >&2
+        echo "  re-run with --principal-approved, or merge via /pr-captain-merge." >&2
+    fi
     exit 1
-}
+fi
+rm -f "$MERGE_LOG"
 
-bash "$REPO_ROOT/agency/tools/git-captain" fetch >/dev/null 2>&1 || true
+bash "$TOOLS/git-captain" fetch >/dev/null 2>&1 || true
 
+RELEASE_CUT=false
 if [[ "$SKIP_RELEASE" == false ]]; then
     echo "→ Creating release v$NEW_VER..."
-    bash "$REPO_ROOT/agency/tools/gh-release" create "v$NEW_VER" \
+    RELEASE_LOG="$(mktemp "${TMPDIR:-/tmp}/pr-captain-land-release.XXXXXX")"
+    if bash "$TOOLS/gh-release" create "v$NEW_VER" \
         --target "$DEFAULT_BRANCH" \
         --title "v$NEW_VER — $PR_TITLE" \
         --notes "Captain-landed via /pr-captain-land (local-first). See PR #$PR_NUM." \
-        >/dev/null 2>&1 || {
-        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER" >&2
-    }
+        >"$RELEASE_LOG" 2>&1; then
+        RELEASE_CUT=true
+    else
+        echo "pr-captain-land: gh-release failed — verify whether auto-release already cut v$NEW_VER:" >&2
+        tail -20 "$RELEASE_LOG" >&2
+    fi
+    rm -f "$RELEASE_LOG"
 fi
 
 # ═════════════════════════════════════════════════════════════════════════════
@@ -768,9 +980,9 @@ rm -f "$VALIDATION_LOG"
 # positionally and has no delete mode, so a "belt and braces" call would
 # re-PUSH the branch rather than remove it.
 
-AGENT_NAME="${AGENT_OVERRIDE:-${AGENT_BRANCH%%-*}}"
+AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."
-bash "$REPO_ROOT/agency/tools/dispatch" create \
+bash "$TOOLS/dispatch" create \
     --type master-updated \
     --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \
@@ -789,7 +1001,16 @@ sync and pick up your next cycle.
 -- $ORG/$PRINCIPAL/captain" \
     >/dev/null 2>&1 || true
 
-bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+# post-merge-state is the C#372 Fix B guard for "merged but release not cut".
+# Clearing it when the release was skipped or failed discards exactly the
+# signal it exists to carry, and main CI's release-tag-check then goes red
+# with nothing tracking why.
+if [[ "$RELEASE_CUT" == true ]]; then
+    bash "$TOOLS/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 || true
+else
+    echo "note: leaving post-merge state pending for PR #$PR_NUM — no release was cut." >&2
+    echo "  Run /pr-captain-post-merge $PR_NUM once the release exists." >&2
+fi
 
 # Reconcile local main with the server merge. This is a separate, idempotent
 # step ON PURPOSE: it is a normal merge-from-origin, identical to what
@@ -797,7 +1018,7 @@ bash "$REPO_ROOT/agency/tools/post-merge-state" clear "$PR_NUM" >/dev/null 2>&1 
 # double-integration. Local main is only ever moved by this reconciliation —
 # never by the landing itself.
 echo "→ Reconciling local $DEFAULT_BRANCH with origin..."
-bash "$REPO_ROOT/agency/tools/git-captain" merge-from-origin >/dev/null 2>&1 || {
+bash "$TOOLS/git-captain" merge-from-origin >/dev/null 2>&1 || {
     echo "note: could not fast-forward local $DEFAULT_BRANCH — run /captain-sync-all." >&2
 }
 

--- a/src/claude/skills/pr-captain-merge/SKILL.md
+++ b/src/claude/skills/pr-captain-merge/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-captain-merge
 description: Captain-only. Merge a PR safely — true merge commit (never squash, never rebase), branch protection respected, --principal-approved gate for --admin override. Prevents the "accidentally squashed via the wide GitHub UI button" failure mode that has burned the fleet.
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, after PR has passed CI and principal has approved (verbally or via GitHub review). Invoked by captain directly or as a step within /pr-captain-land. NEVER from a worktree. Intended for explicit invocation — runtime precondition in underlying `agency/tools/pr-merge` refuses from wrong context.
+when_to_use: Captain on master in main checkout, after PR has passed CI and principal has approved (verbally or via GitHub review). Invoked by captain directly or as Step 8 within /pr-captain-land (after that skill's local validation gate and CI confirmation). NEVER from a worktree. Intended for explicit invocation — runtime precondition in underlying `agency/tools/pr-merge` refuses from wrong context.
 argument-hint: "<pr-number> [--principal-approved] [--delete-branch] [--dry-run]"
 paths: []
 required_reading:
@@ -156,7 +156,7 @@ Defense in depth against accidental invocation from the wrong context:
 
 ## Related
 
-- `/pr-captain-land` — composite skill that calls this as its merge step
+- `/pr-captain-land` — the local-first landing flow; calls this as its Step 8 merge, on a `_land-<branch>` head
 - `/pr-prep` — the QG-before-PR-create (agent-side)
 - `/pr-submit` — agent hands branch to captain for landing
 - `/pr-captain-post-merge` (TBD refactored to `/pr-captain-post-merge`) — release + fleet-notify after merge

--- a/src/claude/skills/pr-captain-merge/examples.md
+++ b/src/claude/skills/pr-captain-merge/examples.md
@@ -131,7 +131,7 @@ Exit 2.
 
 ## Integration examples
 
-### As Step 7 of `/pr-captain-land`
+### As Step 8 of `/pr-captain-land`
 
 When captain runs the full captain-owned PR lifecycle:
 
@@ -139,14 +139,18 @@ When captain runs the full captain-owned PR lifecycle:
 /pr-captain-land <agent-branch>
 ```
 
-Internally, Step 7 invokes `pr-captain-merge`:
+By the time the merge runs, the work has already passed the **local** validation gate
+(Step 3) and CI has confirmed it (Step 7). The merge is Step 8:
+
 ```
-→ CI green, merging PR #45...
-→ Merged: https://github.com/org/repo/pull/45
-→ Step 8: creating release v1.10...
+→ CI green: bash 3.2 probe,manifest version,smoke
+→ Merging PR #45 (true merge commit)...
+→ Creating release v1.10...
 ```
 
-The `--principal-approved` flag propagates from `pr-captain-land`'s caller.
+The PR head is the captain's short-lived `_land-<branch>`, so `--delete-branch` is
+passed; the agent's own branch is untouched. `--principal-approved` propagates from
+`pr-captain-land`'s caller.
 
 ### Before `/pr-captain-post-merge`
 

--- a/src/claude/skills/pr-captain-merge/reference.md
+++ b/src/claude/skills/pr-captain-merge/reference.md
@@ -26,12 +26,14 @@ This skill's unique protocol is thin — most of the behavior is in `agency/tool
 
 ## Composition with `pr-captain-land`
 
-When captain runs `/pr-captain-land`, this skill is invoked as Step 7 of the 9-step land flow. In that composition:
+When captain runs `/pr-captain-land` (v2, local-first), the merge happens at **Step 8**, after the local validation gate (Step 3) and the aggregate-CI confirmation (Step 7). In that composition:
 
-- `--principal-approved` is passed if captain initiated `/pr-captain-land` with the flag (principal authorized the full lifecycle, not just the merge)
-- Exit codes propagate to `/pr-captain-land`'s step handler — Step 8 (release) does not run if this Step 7 fails
+- The PR being merged rides a captain-created `_land-<branch>` head branch, not the agent's branch. The agent's branch is never checked out or pushed by the landing.
+- `--delete-branch` is passed so the short-lived land branch is removed on merge.
+- `--principal-approved` is passed because the principal authorized the full lifecycle, not just the merge.
+- Exit codes propagate; the release (also Step 8) does not run if the merge fails.
 
-See `pr-captain-land/references/land-protocol.md` for the full integration.
+See `.claude/skills/pr-captain-land/reference.md` for the full integration.
 
 ## Why the tool is separate from the skill
 

--- a/src/claude/skills/pr-captain-post-merge/SKILL.md
+++ b/src/claude/skills/pr-captain-post-merge/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-captain-post-merge
 description: Captain-only. After a PR has merged on GitHub, verify the merge, merge origin/master locally, sync all worktrees, create the GitHub release (every PR is a release), and clean up the PR branch. Formerly `/post-merge` — v2 rename to noun-actor-verb.
 agency-skill-version: 2
-when_to_use: Captain on master in main checkout, immediately after a PR has merged on GitHub. Triggered when principal says "merged" / "done" / indicates a PR landed, or as Step 8 of /pr-captain-land. NEVER from a worktree. NEVER auto-invoked.
+when_to_use: Captain on master in main checkout, immediately after a PR has merged on GitHub. Triggered when principal says "merged" / "done" / indicates a PR landed, or to finish a land that failed after its merge (/pr-captain-land performs this work inline at Steps 8-9). NEVER from a worktree. NEVER auto-invoked.
 argument-hint: "<pr-number>"
 paths: []
 required_reading:
@@ -197,7 +197,7 @@ Post-merge complete:
 ## Related
 
 - `/pr-captain-merge` — the merge itself, runs before this skill
-- `/pr-captain-land` — the full captain-owned PR lifecycle (this skill is Step 8 of that flow)
+- `/pr-captain-land` — the full captain-owned, local-first PR lifecycle; it performs this skill's work inline at Steps 8-9, so use this one only for manual or partially-failed landings
 - `/sync-all` — the fleet-sync sub-skill this calls in Step 5
 - `/release` (TBD refactored to `/captain-release`) — alternate entry point that runs /pr-captain-merge + this skill in one flow
 - `agency/tools/gh-release` — the release-creation tool

--- a/src/claude/skills/pr-captain-post-merge/examples.md
+++ b/src/claude/skills/pr-captain-post-merge/examples.md
@@ -127,19 +127,20 @@ Exit 2.
 
 ## Integration examples
 
-### As Step 8 of `/pr-captain-land`
+### Relationship to `/pr-captain-land`
 
-When captain runs the full captain-owned PR lifecycle:
+`/pr-captain-land` (v2, local-first) does this work inline — Step 8 merges and releases,
+Step 9 cleans up, dispatches the agent, clears post-merge state, and reconciles local
+main. You do not chain this skill after a successful land.
+
+Reach for it when a land was done manually, or when `/pr-captain-land` failed *after*
+the merge and the tail still needs running:
 
 ```
-/pr-captain-land <agent-branch>
+/pr-captain-post-merge <pr-number>
 ```
 
-Internally:
-- Step 7 invokes `/pr-captain-merge`
-- Step 8 invokes `/pr-captain-post-merge`
-
-Output from `/pr-captain-land` includes the combined report.
+It is idempotent with the landing's Step 9 and with `/captain-sync-all`.
 
 ### Chained with `/collaborate` for cross-repo notice
 

--- a/src/claude/skills/pr-captain-post-merge/reference.md
+++ b/src/claude/skills/pr-captain-post-merge/reference.md
@@ -33,14 +33,11 @@ GitHub Actions workflow `release-tag-check` runs on every push to master. If a m
 
 ## Composition with `/pr-captain-land`
 
-When captain runs `/pr-captain-land`, this skill is invoked as Step 8. In that composition:
+`/pr-captain-land` (v2, local-first) performs this skill's work inline rather than delegating: its **Step 8** merges and cuts the release, and its **Step 9** cleans up, dispatches the agent, clears post-merge state, and reconciles local main via `merge-from-origin`.
 
-- The merge (Step 7 of `/pr-captain-land`) has already happened via `/pr-captain-merge`
-- Steps 1-2 of this skill are skipped (parent skill has verified)
-- Steps 3-8 run in sequence
-- Exit code propagates; if Step 6 (release creation) fails, the full land flow fails
+Use this skill directly when a landing was done manually, or when `/pr-captain-land` failed after the merge (release creation is the usual culprit) and the post-merge tail still needs to run. It is idempotent with `/pr-captain-land`'s Step 9 and with `/captain-sync-all`.
 
-See `.claude/skills/pr-captain-land/references/land-protocol.md` for the full integration.
+See `.claude/skills/pr-captain-land/reference.md` for the full landing protocol.
 
 ## Recovery flows
 

--- a/src/claude/skills/pr-submit/scripts/pr-submit
+++ b/src/claude/skills/pr-submit/scripts/pr-submit
@@ -186,6 +186,22 @@ if [[ -z "$SCOPE" ]]; then
     exit 2
 fi
 
+# Validate the priority at parse time.
+#
+# It is expanded below as ${PRIORITY:+--priority "$PRIORITY"} — and the
+# expansion itself is unquoted, so the result undergoes word splitting and the
+# inner quotes are literal characters rather than grouping. A value like
+# 'high --reply-to 5' therefore injects extra flags into `dispatch create`,
+# and 'a b' arrives as two mangled words. Constrain the value instead of
+# relying on the caller.
+case "$PRIORITY" in
+    low|normal|high|urgent) ;;
+    *)
+        echo "submit-for-pr: invalid --priority '$PRIORITY' (expected low|normal|high|urgent)" >&2
+        exit 2
+        ;;
+esac
+
 # ── Precondition: not in main checkout ───────────────────────────────────────
 
 MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
@@ -340,7 +356,7 @@ EOF
     --to "$ORG/$PRINCIPAL/captain" \
     --subject "Ready for PR landing: $BRANCH — $SCOPE" \
     --body "$DISPATCH_BODY" \
-    ${PRIORITY:+--priority "$PRIORITY"} >/dev/null
+    --priority "$PRIORITY" >/dev/null
 
 echo "submit-for-pr: submitted"
 echo "  branch:   $BRANCH"

--- a/src/claude/skills/pr-submit/scripts/pr-submit
+++ b/src/claude/skills/pr-submit/scripts/pr-submit
@@ -114,18 +114,31 @@ parse_repo_from_remote() {
 # empty, and the agent is told "could not compute diff hash" with no hint that
 # the ref name is the problem. That blocks /pr-submit for every agent in such
 # a repo.
+#
+# The resolution ladder itself now lives in `agency/tools/resolve-default-branch`
+# — one tested primitive instead of seven drifting copies. This function stays
+# as a THIN WRAPPER on purpose: it is part of the sourced-lib contract
+# (PR_SUBMIT_LIB_ONLY), and `pr-captain-land` calls it by name. Renaming or
+# deleting it would break that consumer silently.
+#
+# Default (non-strict) mode is deliberate here: pr-submit's historical
+# behaviour was to fall back rather than abort. The fallback is now `main`
+# rather than `master` (#463 QG finding).
 resolve_default_branch() {
-    local branch candidate
-    branch="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')"
-    if [[ -z "$branch" ]]; then
-        for candidate in main master; do
-            if git rev-parse --verify --quiet "origin/$candidate" >/dev/null 2>&1; then
-                branch="$candidate"
-                break
-            fi
-        done
+    local self_dir tool target branch
+    # Locate the primitive relative to THIS FILE, not to the cwd repo — the
+    # function is routinely called with the cwd inside some other repository
+    # (the helper unit tests do exactly that, and so does any adopter checkout
+    # being inspected). Resolving against cwd would look for the tool in the
+    # wrong tree and silently degrade to the fallback.
+    self_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    tool="$self_dir/../../../../agency/tools/resolve-default-branch"
+    # The repo being asked about IS the cwd repo — pass it explicitly.
+    target="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+    if [[ -x "$tool" ]]; then
+        branch="$("$tool" -C "$target" 2>/dev/null || true)"
     fi
-    printf '%s' "${branch:-master}"
+    printf '%s' "${branch:-main}"
 }
 
 # Sourced for tests: stop here, before any precondition touches git or the
@@ -291,16 +304,19 @@ $SCOPE
 
 ## Captain action requested
 
-Run /pr-captain-land on branch \`$BRANCH\`:
+Run /pr-captain-land on branch \`$BRANCH\` (local-first):
 
-1. Switch to \`$BRANCH\`
-2. Verify receipt against current state
-3. Bump \`agency_version\` in manifest (serialized — single writer)
-4. Create PR with captain-authored fleet-aware description
-5. Watch CI (\`lint-and-test\` gate)
-6. Merge when green
-7. Create GitHub release v{agency_version}
-8. Dispatch back with merge confirmation + release tag
+1. Cut a scratch worktree \`_land-$BRANCH\` at \`origin/$BRANCH\` — my branch is never checked out
+2. Verify this QGR receipt against that tree, BEFORE any mutation
+3. Validate locally in the scratch (build + tests + commit-precheck) — this is the gate
+4. Bump \`agency_version\` in the scratch (serialized — single writer)
+5. Sign a captain landing receipt chained to this one
+6. Push the scratch branch and open the PR
+7. Wait on the aggregate status check rollup, merge when green
+8. Create GitHub release v{agency_version}, dispatch back with confirmation
+
+If local validation fails, nothing is published and I get a dispatch naming the
+failing step.
 
 ## What I (agent) will NOT do
 

--- a/src/tests/skills/pr-captain-land-localfirst.bats
+++ b/src/tests/skills/pr-captain-land-localfirst.bats
@@ -1,0 +1,253 @@
+#!/usr/bin/env bats
+#
+# pr-captain-land — local-first (v2) invariant guards.
+#
+# The v2 rewrite inverted the flow: integrate + validate in a scratch worktree
+# cut from origin/<default>, publish only already-validated work. Four
+# properties make that rewrite worth having, and all four are invisible to a
+# passing happy path — they only show up when something goes wrong. So they are
+# pinned structurally here:
+#
+#   1. The agent's branch is never checked out in the main checkout (the
+#      worktree-collision bug the old flow shipped with).
+#   2. main/master is never pushed.
+#   3. Rollback is "delete the scratch worktree" — never `git reset --hard`,
+#      never a merge abort on local main.
+#   4. The local validation gate exists and runs BEFORE anything is published,
+#      and the CI gate reads the aggregate rollup rather than one hardcoded
+#      check name that this repo does not even have.
+#
+# Companion suite: pr-captain-land-helpers.bats (the master-hardcode guards and
+# the shared-helper-lib contract, both still live).
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+LAND="${REPO_ROOT}/.claude/skills/pr-captain-land/scripts/pr-captain-land"
+
+# Body of the script with comment lines stripped — every guard below asserts on
+# LIVE CODE. Grepping the raw file would let a deleted safeguard keep passing
+# because the comment that described it survived.
+live_code() {
+    grep -v '^[[:space:]]*#' "$LAND"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: script is syntactically valid" {
+    bash -n "$LAND"
+}
+
+@test "pr-captain-land v2: --help documents --rehearse and --dry-run" {
+    run bash "$LAND" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--rehearse"* ]]
+    [[ "$output" == *"--dry-run"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invariant 1 — the agent's branch is never checked out in the main checkout
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: never switches the main checkout to any branch" {
+    # The old flow ran `git-captain switch-branch $AGENT_BRANCH`, which fails
+    # outright when the agent still has that branch checked out in its own
+    # worktree — and left the captain stranded there on any mid-flight abort.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'switch-branch'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: never checks out or merges the agent branch locally" {
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'checkout-branch|merge-to-master'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: integrates by cutting a scratch worktree from the origin ref" {
+    live_code | grep -q 'worktree-create'
+    live_code | grep -q -- '--from "origin/\$AGENT_BRANCH"'
+}
+
+@test "pr-captain-land v2: the scratch worktree name is namespaced _land-" {
+    live_code | grep -q 'LAND_SLUG="_land-'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invariant 2 — master is never pushed
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: no push of main/master anywhere" {
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'git-push[[:space:]]+\"?(main|master)\"?|git-push[[:space:]]+\"?\\\$DEFAULT_BRANCH\"?'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: the only branch pushed is the scratch land branch" {
+    # Exactly one git-push call site, and it pushes $LAND_SLUG.
+    count="$(live_code | grep -c 'git-push' || true)"
+    [ "$count" -eq 1 ]
+    live_code | grep -q 'git-push" "\$LAND_SLUG"'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invariant 3 — rollback is "delete the scratch", never a reset of local main
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: rollback deletes the scratch worktree" {
+    live_code | grep -q 'destroy_scratch()'
+    live_code | grep -q 'worktree-delete" "\$LAND_SLUG" --force'
+    # And abort_land — the pre-publish failure path — must call it.
+    run bash -c "sed -n '/^abort_land()/,/^}/p' '$LAND' | grep -q destroy_scratch"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-captain-land v2: never hard-resets, never aborts a merge on local main" {
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'reset --hard|reset-soft|merge-abort|merge --abort'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: local main is only ever moved by merge-from-origin" {
+    # merge-from-origin is a normal, idempotent fast-forward — safe to run
+    # again from /captain-sync-all. Any other mutation of local main would
+    # reintroduce the data-loss hazard the scratch worktree exists to avoid.
+    live_code | grep -q 'merge-from-origin'
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'update-ref|_sync-main-ref'"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invariant 4 — the local gate, and the CI gate that is not hardcoded
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: a local validation gate exists" {
+    live_code | grep -q 'run_validation_step()'
+    live_code | grep -q 'VALIDATION_FAILED'
+    live_code | grep -q 'commit-precheck'
+}
+
+@test "pr-captain-land v2: validation failure aborts before anything is published" {
+    # The abort_land call for a failed validation must appear BEFORE the first
+    # git-push line — otherwise the gate is decorative.
+    fail_line="$(grep -n 'local validation failed at step' "$LAND" | head -1 | cut -d: -f1)"
+    push_line="$(grep -n 'git-push' "$LAND" | head -1 | cut -d: -f1)"
+    [ -n "$fail_line" ]
+    [ -n "$push_line" ]
+    [ "$fail_line" -lt "$push_line" ]
+}
+
+@test "pr-captain-land v2: run_validation_step returns the command's status, not the echo's" {
+    # A brace group ending in `echo` swallows the failure and the gate can
+    # never fail. Assert the explicit capture is present.
+    body="$(sed -n '/^run_validation_step()/,/^}/p' "$LAND")"
+    [[ "$body" == *'|| st=$?'* ]]
+    [[ "$body" == *'return "$st"'* ]]
+}
+
+@test "pr-captain-land v2: the CI gate is NOT hardcoded to lint-and-test" {
+    # This repo's checks are 'bash 3.2 probe' / 'manifest version' / 'smoke'.
+    # The old hardcode meant the wait loop could only ever time out.
+    # Live code only — the header comment names the old hardcode on purpose,
+    # to explain why the rollup gate exists.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'lint-and-test'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: the CI gate reads the aggregate statusCheckRollup" {
+    live_code | grep -q 'statusCheckRollup'
+}
+
+@test "pr-captain-land v2: an empty check rollup is a distinct error, not a pass" {
+    live_code | grep -q 'NO_CHECKS'
+    grep -q 'no status checks found' "$LAND"
+}
+
+@test "pr-captain-land v2: the CI gate fails fast on a failing check" {
+    live_code | grep -q 'FAILED\*)'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Receipt integrity — verify BEFORE the bump (#463 trap), and sign a landing
+# receipt rather than weakening pr-create
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: the agent receipt is verified before the version bump" {
+    verify_line="$(grep -n 'receipt-verify' "$LAND" | head -1 | cut -d: -f1)"
+    bump_line="$(grep -n 'Bumping agency_version' "$LAND" | head -1 | cut -d: -f1)"
+    [ -n "$verify_line" ]
+    [ -n "$bump_line" ]
+    [ "$verify_line" -lt "$bump_line" ]
+}
+
+@test "pr-captain-land v2: captain signs a landing receipt chained to the agent's" {
+    live_code | grep -q 'receipt-sign'
+    live_code | grep -q -- '--boundary pr-captain-land'
+    # hash_a chains to the agent receipt's hash_e.
+    live_code | grep -q 'AGENT_HASH_E'
+}
+
+@test "pr-captain-land v2: pr-create is still the publish gate (not bypassed)" {
+    live_code | grep -q 'agency/tools/pr-create'
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'gh pr create'"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --rehearse — steps 0-3 only
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: --rehearse exits before the version bump" {
+    rehearse_exit="$(grep -n 'rehearsal complete' "$LAND" | head -1 | cut -d: -f1)"
+    bump_line="$(grep -n 'Bumping agency_version' "$LAND" | head -1 | cut -d: -f1)"
+    [ -n "$rehearse_exit" ]
+    [ "$rehearse_exit" -lt "$bump_line" ]
+}
+
+@test "pr-captain-land v2: --rehearse cleans up its scratch worktree" {
+    block="$(sed -n '/if \[\[ "\$REHEARSE" == true \]\]/,/^fi$/p' "$LAND")"
+    [[ "$block" == *"destroy_scratch"* ]]
+    [[ "$block" == *"exit 0"* ]]
+}
+
+@test "pr-captain-land v2: --dry-run implies --rehearse" {
+    grep -q 'dry-run) DRY_RUN=true; REHEARSE=true' "$LAND"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Runtime: argument and precondition handling (no network, no side effects)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: missing branch argument exits 2" {
+    run bash "$LAND"
+    [ "$status" -eq 2 ]
+}
+
+@test "pr-captain-land v2: unknown flag exits 2" {
+    run bash "$LAND" some-branch --bogus
+    [ "$status" -eq 2 ]
+}
+
+@test "pr-captain-land v2: path-traversal branch names are rejected" {
+    run bash "$LAND" "../evil"
+    [ "$status" -eq 2 ]
+    run bash "$LAND" "a/../../evil"
+    [ "$status" -eq 2 ]
+}
+
+@test "pr-captain-land v2: refuses to run from a worktree" {
+    # This suite runs inside a worktree during development; when it runs from
+    # the main checkout the branch precondition catches it instead. Either way
+    # the tool must refuse a bare invocation rather than start a land.
+    run bash "$LAND" definitely-not-a-real-branch --rehearse
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"main checkout"* ]] || [[ "$output" == *"not found on origin"* ]] || [[ "$output" == *"must be on"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shared default-branch primitive
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: default branch comes from the shared resolver" {
+    live_code | grep -qE '\$\(resolve_default_branch\)'
+}
+
+@test "pr-captain-land v2: the shared resolver primitive exists and is executable" {
+    [ -x "${REPO_ROOT}/agency/tools/resolve-default-branch" ]
+}

--- a/src/tests/skills/pr-captain-land-localfirst.bats
+++ b/src/tests/skills/pr-captain-land-localfirst.bats
@@ -53,7 +53,11 @@ live_code() {
     # The old flow ran `git-captain switch-branch $AGENT_BRANCH`, which fails
     # outright when the agent still has that branch checked out in its own
     # worktree — and left the captain stranded there on any mid-flight abort.
-    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'switch-branch'"
+    #
+    # The pattern covers every way to move HEAD, not just the one tool the v1
+    # code happened to use: a guard that only knows `switch-branch` passes
+    # happily the day someone reaches for `git checkout` instead.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'switch-branch|checkout-branch|git(-safe)? +(checkout|switch)'"
     [ "$status" -ne 0 ]
 }
 
@@ -109,7 +113,7 @@ live_code() {
     # again from /captain-sync-all. Any other mutation of local main would
     # reintroduce the data-loss hazard the scratch worktree exists to avoid.
     live_code | grep -q 'merge-from-origin'
-    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'update-ref|_sync-main-ref'"
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'update-ref|_sync-main-ref|branch +-f|sync-main'"
     [ "$status" -ne 0 ]
 }
 
@@ -120,7 +124,10 @@ live_code() {
 @test "pr-captain-land v2: a local validation gate exists" {
     live_code | grep -q 'run_validation_step()'
     live_code | grep -q 'VALIDATION_FAILED'
-    live_code | grep -q 'commit-precheck'
+    live_code | grep -q 'VALIDATION_STEPS'
+    # The ladder resolves a package manager through the shared primitive
+    # rather than naming one inline.
+    live_code | grep -q 'pkg-manager'
 }
 
 @test "pr-captain-land v2: validation failure aborts before anything is published" {
@@ -133,12 +140,45 @@ live_code() {
     [ "$fail_line" -lt "$push_line" ]
 }
 
-@test "pr-captain-land v2: run_validation_step returns the command's status, not the echo's" {
-    # A brace group ending in `echo` swallows the failure and the gate can
-    # never fail. Assert the explicit capture is present.
+@test "pr-captain-land v2: run_validation_step actually returns the command's status" {
+    # A real unit test, not a grep: the function is self-contained (its only
+    # dependency is $VALIDATION_LOG), so extract and run it. A brace group
+    # ending in `echo` would swallow the failure and the gate could never
+    # fail — and a source-grep for the fix cannot tell you the fix works.
+    run bash -c "
+        set -uo pipefail
+        VALIDATION_LOG='$BATS_TEST_TMPDIR/vlog'
+        eval \"\$(sed -n '/^run_validation_step()/,/^}/p' '$LAND')\"
+        run_validation_step failing false >/dev/null 2>&1 && echo 'BUG: false reported success'
+        run_validation_step passing true  >/dev/null 2>&1 || echo 'BUG: true reported failure'
+        echo OK
+    "
+    [ "$status" -eq 0 ]
+    [[ "$output" != *BUG* ]]
+    [[ "$output" == *OK* ]]
+}
+
+@test "pr-captain-land v2: run_validation_step records both label and exit code in the log" {
+    # The log's SHA-256 becomes hash_b of the landing receipt, so it has to
+    # actually contain what ran and how it went.
+    run bash -c "
+        set -uo pipefail
+        VALIDATION_LOG='$BATS_TEST_TMPDIR/vlog2'
+        eval \"\$(sed -n '/^run_validation_step()/,/^}/p' '$LAND')\"
+        run_validation_step 'my-step' sh -c 'exit 3' >/dev/null 2>&1 || true
+        cat \"\$VALIDATION_LOG\"
+    "
+    [[ "$output" == *"my-step"* ]]
+    [[ "$output" == *"exit: 3"* ]]
+}
+
+@test "pr-captain-land v2: validation runs with the captain's credentials scrubbed" {
+    # The command comes from the branch under review and its output is tailed
+    # to stderr on failure. A `build` script of `gh auth token` must not be
+    # able to put the captain's PAT into the transcript.
     body="$(sed -n '/^run_validation_step()/,/^}/p' "$LAND")"
-    [[ "$body" == *'|| st=$?'* ]]
-    [[ "$body" == *'return "$st"'* ]]
+    [[ "$body" == *"-u GH_TOKEN"* ]]
+    [[ "$body" == *"-u GITHUB_TOKEN"* ]]
 }
 
 @test "pr-captain-land v2: the CI gate is NOT hardcoded to lint-and-test" {
@@ -163,6 +203,110 @@ live_code() {
     live_code | grep -q 'FAILED\*)'
 }
 
+@test "pr-captain-land v2: a repo with no resolvable local gate FAILS CLOSED" {
+    # A landing with no local validation is the old PR-first flow with extra
+    # steps — and it would sign a five-hash receipt attesting to a gate that
+    # never ran. It must abort unless the captain explicitly opts out.
+    live_code | grep -q 'ALLOW_UNVALIDATED'
+    run bash -c "sed -n '/VALIDATION_STEPS.*-eq 0/,/^fi$/p' '$LAND' | grep -q abort_land"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-captain-land v2: commit-precheck is not counted as a validation step" {
+    # It gates on STAGED files and the scratch tree is clean, so it exits 0
+    # having inspected nothing. Counting it suppressed the fail-closed check
+    # above and inflated the receipt summary.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'commit-precheck'"
+    [ "$status" -ne 0 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Trust boundary — the branch under review must not supply its own verifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: no tool is executed from the scratch worktree" {
+    # A branch that ships its own receipt-verify (or diff-hash, or pr-create)
+    # would otherwise pass its own gate, and the "pr-create is not weakened"
+    # guarantee would be unenforceable.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'SCRATCH_DIR/agency/tools'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: tools resolve from the captain's checkout" {
+    live_code | grep -q 'TOOLS="\$REPO_ROOT/agency/tools"'
+    live_code | grep -q 'TOOLS/receipt-verify'
+    live_code | grep -q 'TOOLS/pr-create'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Cleanup is unconditional, and branch protection is not bypassed by default
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pr-captain-land v2: an EXIT trap cleans up, so a set -e abort cannot strand the scratch" {
+    live_code | grep -qE 'trap .*EXIT'
+    live_code | grep -q 'PUBLISHED=false'
+    live_code | grep -q 'PUBLISHED=true'
+}
+
+@test "pr-captain-land v2: cleanup only touches a scratch THIS run created" {
+    # Step 2 most often fails because a previous run's branch survives. Force-
+    # deleting it on the way out would destroy the state step 0 just told the
+    # captain to inspect.
+    live_code | grep -q 'SCRATCH_IS_OURS'
+    run bash -c "sed -n '/^destroy_scratch()/,/^}/p' '$LAND' | grep -q 'SCRATCH_IS_OURS'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-captain-land v2: step 0 refuses a leftover land BRANCH, not just a leftover directory" {
+    live_code | grep -q 'refs/heads/\$LAND_SLUG'
+}
+
+@test "pr-captain-land v2: --principal-approved is a flag, never hardcoded on pr-merge" {
+    # pr-merge treats it as the captain's attestation that the principal
+    # approved, and it is the only route to `gh pr merge --admin`. Asserting
+    # it unconditionally makes branch-protection bypass the default.
+    live_code | grep -q 'PRINCIPAL_APPROVED'
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'pr-merge.*--principal-approved'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: the preflight fetch failure is fatal, not swallowed" {
+    # Every downstream guarantee — base freshness, the receipt's diff_base,
+    # "validated against pristine origin/<default>" — assumes origin refs are
+    # current. `|| true` there means an offline captain validates stale refs
+    # and still publishes.
+    #
+    # Scoped to the preflight: the post-merge fetch in step 8 is legitimately
+    # best-effort, since the merge already happened.
+    live_code | grep -q 'could not fetch origin'
+    fetch_line="$(grep -n 'could not fetch origin' "$LAND" | head -1 | cut -d: -f1)"
+    step1_line="$(grep -n 'Step 1 — Verify the agent branch' "$LAND" | head -1 | cut -d: -f1)"
+    [ -n "$fetch_line" ]
+    [ "$fetch_line" -lt "$step1_line" ]
+}
+
+@test "pr-captain-land v2: the scratch slug collapses dots as well as slashes" {
+    # worktree-create rejects dots; the branch-name gate permits them. Slugging
+    # only slashes made every dotted branch (v1.2, 46.20) unlandable.
+    live_code | grep -q "LAND_SLUG=.*tr '/\.' '--'"
+    # And the slug-only-slashes form must not come back.
+    run grep -c "LAND_SLUG=.*tr '/' '-'" "$LAND"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: mktemp uses a portable template" {
+    # `mktemp -t <prefix>` is a BSD-ism; GNU coreutils needs XXXXXX.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -nE 'mktemp -t'"
+    [ "$status" -ne 0 ]
+    live_code | grep -q 'XXXXXX'
+}
+
+@test "pr-captain-land v2: post-merge state is not cleared when no release was cut" {
+    live_code | grep -q 'RELEASE_CUT'
+    run bash -c "sed -n '/RELEASE_CUT.*==.*true/,/^fi$/p' '$LAND' | grep -q 'post-merge-state\" clear'"
+    [ "$status" -eq 0 ]
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Receipt integrity — verify BEFORE the bump (#463 trap), and sign a landing
 # receipt rather than weakening pr-create
@@ -184,7 +328,7 @@ live_code() {
 }
 
 @test "pr-captain-land v2: pr-create is still the publish gate (not bypassed)" {
-    live_code | grep -q 'agency/tools/pr-create'
+    live_code | grep -q 'TOOLS/pr-create'
     run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n 'gh pr create'"
     [ "$status" -ne 0 ]
 }
@@ -231,13 +375,18 @@ live_code() {
     [ "$status" -eq 2 ]
 }
 
-@test "pr-captain-land v2: refuses to run from a worktree" {
-    # This suite runs inside a worktree during development; when it runs from
-    # the main checkout the branch precondition catches it instead. Either way
-    # the tool must refuse a bare invocation rather than start a land.
-    run bash "$LAND" definitely-not-a-real-branch --rehearse
+@test "pr-captain-land v2: refuses to run outside the repo it belongs to" {
+    # Hermetic: cwd is a throwaway repo, so the refusal is structural rather
+    # than incidental to wherever the suite happens to run. Previously this
+    # test reached `git-captain fetch` against the REAL origin — a network
+    # call and a mutation of real refs from a unit suite.
+    tmp="$BATS_TEST_TMPDIR/elsewhere"
+    mkdir -p "$tmp"
+    git init --quiet "$tmp"
+    run bash -c "cd '$tmp' && bash '$LAND' some-branch --rehearse"
     [ "$status" -ne 0 ]
-    [[ "$output" == *"main checkout"* ]] || [[ "$output" == *"not found on origin"* ]] || [[ "$output" == *"must be on"* ]]
+    # Whichever guard fires first, it must be a refusal — never a started land.
+    [[ "$output" != *"Creating scratch worktree"* ]]
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/tools/agency-version-next.bats
+++ b/src/tests/tools/agency-version-next.bats
@@ -1,0 +1,146 @@
+#!/usr/bin/env bats
+#
+# agency-version-next — the agency_version bump policy, as a pure primitive.
+#
+# Extracted from pr-captain-land, where it was inline Python whose
+# `sys.exit(1)` killed the CALLER under `set -euo pipefail` before the
+# caller's own "could not bump version" error could run — leaving the
+# landing's scratch worktree stranded. The table below is what makes that
+# failure mode a reported error instead of a silent abort.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+TOOL="${REPO_ROOT}/agency/tools/agency-version-next"
+
+@test "agency-version-next: exists and is executable" {
+    [ -x "$TOOL" ]
+}
+
+@test "agency-version-next: is syntactically valid bash" {
+    bash -n "$TOOL"
+}
+
+@test "agency-version-next: --help exits 0" {
+    run bash "$TOOL" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "agency-version-next: no argument is a usage error (exit 2)" {
+    run bash "$TOOL"
+    [ "$status" -eq 2 ]
+}
+
+@test "agency-version-next: two arguments is a usage error (exit 2)" {
+    run bash "$TOOL" 1.2 3.4
+    [ "$status" -eq 2 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The policy
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version-next: 46.25 → 46.26" {
+    run bash "$TOOL" 46.25
+    [ "$status" -eq 0 ]
+    [ "$output" = "46.26" ]
+}
+
+@test "agency-version-next: 46.9 → 46.10 (numeric, not lexical)" {
+    run bash "$TOOL" 46.9
+    [ "$status" -eq 0 ]
+    [ "$output" = "46.10" ]
+}
+
+@test "agency-version-next: 46.99 → 46.100 (no rollover into the first component)" {
+    run bash "$TOOL" 46.99
+    [ "$status" -eq 0 ]
+    [ "$output" = "46.100" ]
+}
+
+@test "agency-version-next: a zero-padded component is base-10, not octal" {
+    # 10# is load-bearing: bash reads a leading-zero literal as octal, so
+    # "08" would be a syntax error and "07" would bump to 8 by luck.
+    run bash "$TOOL" 46.08
+    [ "$status" -eq 0 ]
+    [ "$output" = "46.9" ]
+}
+
+@test "agency-version-next: single component 46 → 47" {
+    run bash "$TOOL" 46
+    [ "$status" -eq 0 ]
+    [ "$output" = "47" ]
+}
+
+@test "agency-version-next: 0.0 → 0.1" {
+    run bash "$TOOL" 0.0
+    [ "$status" -eq 0 ]
+    [ "$output" = "0.1" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Refusals — each must exit 1 with an EMPTY stdout, so
+# `NEW=$(agency-version-next "$CUR") || die` reaches its error path with no value
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version-next: three-component semver is refused, not guessed" {
+    run bash -c "bash '$TOOL' 1.2.3 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agency-version-next: the semver refusal explains itself on stderr" {
+    run bash -c "bash '$TOOL' 1.2.3 2>&1 >/dev/null"
+    [[ "$output" == *"Refusing to guess"* ]]
+}
+
+@test "agency-version-next: non-numeric input is refused" {
+    run bash -c "bash '$TOOL' abc 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agency-version-next: empty string is refused" {
+    run bash -c "bash '$TOOL' '' 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agency-version-next: a v-prefix is refused (callers strip it)" {
+    run bash -c "bash '$TOOL' v46.25 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "agency-version-next: a trailing suffix is refused" {
+    run bash -c "bash '$TOOL' 46.25-rc1 2>/dev/null"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The integration property the extraction exists for
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "agency-version-next: a refusal lets the CALLER report, instead of aborting it" {
+    # This is the whole point. The inline Python form killed the caller
+    # outright under `set -euo pipefail`; the || branch never ran.
+    run bash -c "
+        set -euo pipefail
+        NEW=\$(bash '$TOOL' 1.2.3 2>/dev/null) || { echo 'CALLER HANDLED IT'; exit 7; }
+        echo \"UNEXPECTED: \$NEW\"
+    "
+    [ "$status" -eq 7 ]
+    [ "$output" = "CALLER HANDLED IT" ]
+}
+
+@test "agency-version-next: matches the version currently in the manifest" {
+    # Guards against the manifest drifting into a format the bump refuses —
+    # which would make every land abort at step 4.
+    current="$(python3 -c '
+import json
+print(json.load(open("'"${REPO_ROOT}"'/agency/config/manifest.json"))["agency_version"])
+')"
+    run bash "$TOOL" "$current"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
+    [ "$output" != "$current" ]
+}

--- a/src/tests/tools/ci-rollup-verdict.bats
+++ b/src/tests/tools/ci-rollup-verdict.bats
@@ -1,0 +1,240 @@
+#!/usr/bin/env bats
+#
+# ci-rollup-verdict — the CI gate's classification logic.
+#
+# This logic used to live in a python heredoc inside a command substitution
+# inside pr-captain-land's polling loop, where the only tests possible were
+# `grep` for a string. Every one of those guards still passed if the PASS and
+# FAIL state sets were swapped. Extracted so the real property can be
+# asserted: given this rollup, what does the gate decide?
+#
+# The two rows that matter most are the ones a naive gate gets wrong:
+#   - a required context that has not reported yet is PENDING, not absent
+#   - an empty rollup is NO_CHECKS, never PASSED
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+TOOL="${REPO_ROOT}/agency/tools/ci-rollup-verdict"
+
+# classify <rollup-json> [required-json]
+classify() {
+    if [ -n "${2:-}" ]; then
+        printf '%s' "$1" | python3 "$TOOL" --required "$2"
+    else
+        printf '%s' "$1" | python3 "$TOOL"
+    fi
+}
+
+# Shorthand builders keep the table rows readable.
+check_run() {  # name, status, conclusion
+    printf '{"__typename":"CheckRun","name":"%s","status":"%s","conclusion":%s}' \
+        "$1" "$2" "$3"
+}
+status_ctx() { # context, state
+    printf '{"__typename":"StatusContext","context":"%s","state":"%s"}' "$1" "$2"
+}
+rollup() {     # ...nodes
+    local IFS=,
+    printf '{"statusCheckRollup":[%s]}' "$*"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: exists and is executable" {
+    [ -x "$TOOL" ]
+}
+
+@test "ci-rollup-verdict: --help exits 0" {
+    run python3 "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"NO_CHECKS"* ]]
+}
+
+@test "ci-rollup-verdict: unknown argument is a usage error" {
+    run bash -c "echo '{}' | python3 '$TOOL' --bogus"
+    [ "$status" -eq 2 ]
+}
+
+@test "ci-rollup-verdict: --required with no value is a usage error" {
+    run bash -c "echo '{}' | python3 '$TOOL' --required"
+    [ "$status" -eq 2 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Empty and unreadable — the two "must never look green" cases
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: empty rollup → NO_CHECKS (never PASSED)" {
+    run classify '{"statusCheckRollup":[]}'
+    [ "$output" = "NO_CHECKS" ]
+}
+
+@test "ci-rollup-verdict: null rollup → NO_CHECKS" {
+    run classify '{"statusCheckRollup":null}'
+    [ "$output" = "NO_CHECKS" ]
+}
+
+@test "ci-rollup-verdict: missing key → NO_CHECKS" {
+    run classify '{}'
+    [ "$output" = "NO_CHECKS" ]
+}
+
+@test "ci-rollup-verdict: non-JSON input → UNREADABLE" {
+    run classify 'not json at all'
+    [ "$output" = "UNREADABLE" ]
+}
+
+@test "ci-rollup-verdict: empty input → UNREADABLE" {
+    run classify ''
+    [ "$output" = "UNREADABLE" ]
+}
+
+@test "ci-rollup-verdict: JSON array at top level → UNREADABLE" {
+    run classify '[]'
+    [ "$output" = "UNREADABLE" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# CheckRun nodes — status must gate the conclusion
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: completed SUCCESS → PASSED" {
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")"
+    [[ "$output" == PASSED* ]]
+    [[ "$output" == *build* ]]
+}
+
+@test "ci-rollup-verdict: IN_PROGRESS with a stale SUCCESS conclusion → PENDING" {
+    # Reading `conclusion` before `status` is COMPLETED is exactly how an
+    # in-progress check gets counted green.
+    run classify "$(rollup "$(check_run build IN_PROGRESS '"SUCCESS"')")"
+    [[ "$output" == PENDING* ]]
+}
+
+@test "ci-rollup-verdict: QUEUED with null conclusion → PENDING" {
+    run classify "$(rollup "$(check_run build QUEUED null)")"
+    [[ "$output" == PENDING* ]]
+}
+
+@test "ci-rollup-verdict: completed FAILURE → FAILED, naming the check" {
+    run classify "$(rollup "$(check_run smoke COMPLETED '"FAILURE"')")"
+    [[ "$output" == FAILED* ]]
+    [[ "$output" == *smoke* ]]
+}
+
+@test "ci-rollup-verdict: NEUTRAL and SKIPPED count as pass" {
+    run classify "$(rollup "$(check_run a COMPLETED '"NEUTRAL"')" "$(check_run b COMPLETED '"SKIPPED"')")"
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: TIMED_OUT and CANCELLED count as failure" {
+    run classify "$(rollup "$(check_run a COMPLETED '"TIMED_OUT"')")"
+    [[ "$output" == FAILED* ]]
+    run classify "$(rollup "$(check_run a COMPLETED '"CANCELLED"')")"
+    [[ "$output" == FAILED* ]]
+}
+
+@test "ci-rollup-verdict: failure wins over pending (fail fast)" {
+    run classify "$(rollup "$(check_run a IN_PROGRESS null)" "$(check_run b COMPLETED '"FAILURE"')")"
+    [[ "$output" == FAILED* ]]
+}
+
+@test "ci-rollup-verdict: mixed pass + pending → PENDING, naming only the pending one" {
+    run classify "$(rollup "$(check_run a COMPLETED '"SUCCESS"')" "$(check_run b IN_PROGRESS null)")"
+    [ "$output" = "PENDING b" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# StatusContext nodes (the other rollup shape)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: StatusContext success → PASSED" {
+    run classify "$(rollup "$(status_ctx legacy-ci SUCCESS)")"
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: lowercase StatusContext state is normalized" {
+    run classify "$(rollup "$(status_ctx legacy-ci failure)")"
+    [[ "$output" == FAILED* ]]
+}
+
+@test "ci-rollup-verdict: StatusContext pending → PENDING" {
+    run classify "$(rollup "$(status_ctx legacy-ci pending)")"
+    [[ "$output" == PENDING* ]]
+}
+
+@test "ci-rollup-verdict: both node shapes in one rollup" {
+    run classify "$(rollup "$(check_run a COMPLETED '"SUCCESS"')" "$(status_ctx b failure)")"
+    [[ "$output" == FAILED* ]]
+    [[ "$output" == *b* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Required-contexts narrowing — the partial-evidence trap
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: a required context that has not reported is PENDING, not absent" {
+    # 1 of 3 required checks green must NOT read as PASSED.
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")" '["build","test","lint"]'
+    [[ "$output" == PENDING* ]]
+    [[ "$output" == *lint* ]]
+    [[ "$output" == *test* ]]
+}
+
+@test "ci-rollup-verdict: all required contexts present and green → PASSED" {
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')" "$(check_run test COMPLETED '"SUCCESS"')")" '["build","test"]'
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: a failing required context fails fast even with others missing" {
+    run classify "$(rollup "$(check_run build COMPLETED '"FAILURE"')")" '["build","test"]'
+    [[ "$output" == FAILED* ]]
+    [[ "$output" == *build* ]]
+}
+
+@test "ci-rollup-verdict: non-required checks are ignored when required is given" {
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')" "$(check_run flaky COMPLETED '"FAILURE"')")" '["build"]'
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: required names matching nothing → PENDING, not a green PASS" {
+    # Branch-protection contexts are often "workflow / job" while check runs
+    # are named just "job". A name mismatch must not resolve to PASSED.
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")" '["ci / build"]'
+    [[ "$output" == PENDING* ]]
+}
+
+@test "ci-rollup-verdict: an error OBJECT from the protection API is ignored, not obeyed" {
+    # /protection/required_status_checks/contexts 404s on unprotected repos
+    # and returns {"message": "..."} — that must mean "no narrowing", not
+    # "no required contexts, therefore vacuously green".
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")" '{"message":"Branch not protected"}'
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: an empty required array means no narrowing" {
+    run classify "$(rollup "$(check_run build COMPLETED '"FAILURE"')")" '[]'
+    [[ "$output" == FAILED* ]]
+}
+
+@test "ci-rollup-verdict: unparseable required value means no narrowing" {
+    run classify "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")" 'gh: command failed'
+    [[ "$output" == PASSED* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --file
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "ci-rollup-verdict: --file reads the rollup from disk" {
+    printf '%s' "$(rollup "$(check_run build COMPLETED '"SUCCESS"')")" > "$BATS_TEST_TMPDIR/r.json"
+    run python3 "$TOOL" --file "$BATS_TEST_TMPDIR/r.json"
+    [ "$status" -eq 0 ]
+    [[ "$output" == PASSED* ]]
+}
+
+@test "ci-rollup-verdict: --file on a missing path is a usage error" {
+    run python3 "$TOOL" --file "$BATS_TEST_TMPDIR/nope.json"
+    [ "$status" -eq 2 ]
+}

--- a/src/tests/tools/git-captain.bats
+++ b/src/tests/tools/git-captain.bats
@@ -22,6 +22,12 @@ setup() {
     mkdir -p agency/tools/lib
     cp "${REPO_ROOT}/agency/tools/git-captain" agency/tools/git-captain
     chmod +x agency/tools/git-captain
+    # detect_main_branch delegates to the shared resolve-default-branch
+    # primitive, which must therefore live beside git-captain in the fixture.
+    # Without it every subcommand that resolves the default branch dies with
+    # "Cannot find main or master branch".
+    cp "${REPO_ROOT}/agency/tools/resolve-default-branch" agency/tools/resolve-default-branch
+    chmod +x agency/tools/resolve-default-branch
     cp "${REPO_ROOT}/agency/tools/lib/_log-helper" agency/tools/lib/_log-helper 2>/dev/null || true
     cp "${REPO_ROOT}/agency/tools/lib/_colors" agency/tools/lib/_colors 2>/dev/null || true
 

--- a/src/tests/tools/pkg-manager.bats
+++ b/src/tests/tools/pkg-manager.bats
@@ -6,12 +6,43 @@
 # manager inline; src/tests/skills/skill-validation.bats enforces that rule and
 # pr-captain-land's local validation gate needs the answer.
 #
-# The contract worth pinning: lockfile decides, installation is checked, and a
-# directory with no package.json resolves to nothing (exit 1) rather than a
-# plausible-looking guess.
+# Every test builds its own PATH out of stubs in BATS_TEST_TMPDIR, so the
+# resolution order is exercised deterministically on any machine. An earlier
+# version of this suite `skip`ped whenever the developer happened to have yarn
+# installed — which meant the only interesting test did not run on half the
+# fleet, and pnpm/yarn/bun were never covered at all.
 
 REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
 TOOL="${REPO_ROOT}/agency/tools/pkg-manager"
+
+setup() {
+    PROJ="$BATS_TEST_TMPDIR/proj"
+    STUBS="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$PROJ" "$STUBS"
+}
+
+# stub <name>... — put fake executables on a PATH that contains nothing else
+# except the system dirs python3 needs.
+stub() {
+    local n
+    for n in "$@"; do
+        printf '#!/bin/sh\nexit 0\n' > "$STUBS/$n"
+        chmod +x "$STUBS/$n"
+    done
+}
+
+# resolve — run the tool with ONLY the stubs (plus system bins) on PATH.
+resolve() {
+    PATH="$STUBS:/usr/bin:/bin:/usr/sbin:/sbin" bash "$TOOL" -C "$PROJ"
+}
+
+pkg() {  # pkg [<json body>]
+    printf '%s' "${1:-\{\}}" > "$PROJ/package.json"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shape
+# ─────────────────────────────────────────────────────────────────────────────
 
 @test "pkg-manager: exists and is executable" {
     [ -x "$TOOL" ]
@@ -31,45 +62,145 @@ TOOL="${REPO_ROOT}/agency/tools/pkg-manager"
     [ "$status" -eq 2 ]
 }
 
+@test "pkg-manager: -C with no argument is a usage error, not a silent exit 1" {
+    run bash "$TOOL" -C
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"requires a directory"* ]]
+}
+
 @test "pkg-manager: no package.json → exit 1 and no output" {
-    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    run bash "$TOOL" -C "$PROJ"
     [ "$status" -eq 1 ]
     [ -z "$output" ]
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# Lockfile → manager
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pkg-manager: pnpm-lock.yaml → pnpm" {
+    pkg; touch "$PROJ/pnpm-lock.yaml"; stub pnpm npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "pnpm" ]
+}
+
+@test "pkg-manager: yarn.lock → yarn" {
+    pkg; touch "$PROJ/yarn.lock"; stub yarn npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "yarn" ]
+}
+
+@test "pkg-manager: bun.lockb → bun" {
+    pkg; touch "$PROJ/bun.lockb"; stub bun npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "bun" ]
+}
+
+@test "pkg-manager: bun.lock (text form) → bun" {
+    pkg; touch "$PROJ/bun.lock"; stub bun npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "bun" ]
+}
+
+@test "pkg-manager: package-lock.json → npm" {
+    pkg; touch "$PROJ/package-lock.json"; stub npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "npm" ]
+}
+
 @test "pkg-manager: package.json with no lockfile falls back to npm" {
-    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
-    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
-    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    pkg; stub npm
+    run resolve
     [ "$status" -eq 0 ]
     [ "$output" = "npm" ]
 }
 
-@test "pkg-manager: package-lock.json resolves to npm" {
-    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
-    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
-    echo '{}' > "$BATS_TEST_TMPDIR/package-lock.json"
-    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+@test "pkg-manager: pnpm-lock wins over yarn.lock (precedence, not filesystem order)" {
+    pkg; touch "$PROJ/pnpm-lock.yaml" "$PROJ/yarn.lock"; stub pnpm yarn npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "pnpm" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The packageManager field — an explicit declaration beats lockfile archaeology
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pkg-manager: packageManager field is honoured (this repo has no lockfile)" {
+    pkg '{"packageManager":"pnpm@9.1.0"}'; stub pnpm npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "pnpm" ]
+}
+
+@test "pkg-manager: packageManager field beats a contradicting lockfile" {
+    pkg '{"packageManager":"yarn@4.0.0"}'; touch "$PROJ/pnpm-lock.yaml"; stub pnpm yarn npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "yarn" ]
+}
+
+@test "pkg-manager: an unrecognized packageManager value falls through to lockfiles" {
+    pkg '{"packageManager":"cargo@1"}'; touch "$PROJ/pnpm-lock.yaml"; stub pnpm npm
+    run resolve
+    [ "$status" -eq 0 ]
+    [ "$output" = "pnpm" ]
+}
+
+@test "pkg-manager: malformed package.json does not crash the resolver" {
+    printf 'not json' > "$PROJ/package.json"; stub npm
+    run resolve
     [ "$status" -eq 0 ]
     [ "$output" = "npm" ]
 }
 
-@test "pkg-manager: a lockfile for an uninstalled manager does not win" {
-    # Naming a manager that is not on PATH would just move the failure to a
-    # less legible place, so the resolver skips it and keeps looking.
-    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
-    if command -v yarn >/dev/null 2>&1; then skip "yarn IS installed here"; fi
-    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
-    touch "$BATS_TEST_TMPDIR/yarn.lock"
-    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
-    [ "$status" -eq 0 ]
-    [ "$output" = "npm" ]
+# ─────────────────────────────────────────────────────────────────────────────
+# The declared-but-missing case — must FAIL, not silently substitute npm
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "pkg-manager: a lockfile naming an uninstalled manager fails, not falls back to npm" {
+    # Substituting npm here would run `npm run build` against a pnpm
+    # workspace: a confusing failure attributed to the wrong thing.
+    pkg; touch "$PROJ/pnpm-lock.yaml"; stub npm
+    run resolve
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"declares 'pnpm'"* ]]
 }
+
+@test "pkg-manager: a packageManager field naming an uninstalled manager fails" {
+    pkg '{"packageManager":"bun@1.0.0"}'; stub npm
+    run resolve
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"declares 'bun'"* ]]
+}
+
+@test "pkg-manager: nothing installed at all fails cleanly" {
+    pkg
+    run resolve
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"npm not found"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Output shape
+# ─────────────────────────────────────────────────────────────────────────────
 
 @test "pkg-manager: output is a single bare token" {
-    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
-    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
-    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    pkg; stub npm
+    run resolve
     [ "${#lines[@]}" -eq 1 ]
     [[ "$output" =~ ^[a-z]+$ ]]
+}
+
+@test "pkg-manager: resolves this repo without erroring" {
+    # Integration smoke against the real checkout — whatever it answers, it
+    # must answer something, because pr-captain-land's gate depends on it.
+    run bash "$TOOL" -C "$REPO_ROOT"
+    [ "$status" -eq 0 ]
+    [ -n "$output" ]
 }

--- a/src/tests/tools/pkg-manager.bats
+++ b/src/tests/tools/pkg-manager.bats
@@ -1,0 +1,75 @@
+#!/usr/bin/env bats
+#
+# pkg-manager — the shared JS package-manager resolver.
+#
+# Extracted so that skills (which ship to adopter repos) never name a package
+# manager inline; src/tests/skills/skill-validation.bats enforces that rule and
+# pr-captain-land's local validation gate needs the answer.
+#
+# The contract worth pinning: lockfile decides, installation is checked, and a
+# directory with no package.json resolves to nothing (exit 1) rather than a
+# plausible-looking guess.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+TOOL="${REPO_ROOT}/agency/tools/pkg-manager"
+
+@test "pkg-manager: exists and is executable" {
+    [ -x "$TOOL" ]
+}
+
+@test "pkg-manager: is syntactically valid bash" {
+    bash -n "$TOOL"
+}
+
+@test "pkg-manager: --help exits 0" {
+    run bash "$TOOL" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "pkg-manager: unknown flag is a usage error (exit 2)" {
+    run bash "$TOOL" --nope
+    [ "$status" -eq 2 ]
+}
+
+@test "pkg-manager: no package.json → exit 1 and no output" {
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "pkg-manager: package.json with no lockfile falls back to npm" {
+    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
+    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "npm" ]
+}
+
+@test "pkg-manager: package-lock.json resolves to npm" {
+    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
+    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+    echo '{}' > "$BATS_TEST_TMPDIR/package-lock.json"
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "npm" ]
+}
+
+@test "pkg-manager: a lockfile for an uninstalled manager does not win" {
+    # Naming a manager that is not on PATH would just move the failure to a
+    # less legible place, so the resolver skips it and keeps looking.
+    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
+    if command -v yarn >/dev/null 2>&1; then skip "yarn IS installed here"; fi
+    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+    touch "$BATS_TEST_TMPDIR/yarn.lock"
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "$status" -eq 0 ]
+    [ "$output" = "npm" ]
+}
+
+@test "pkg-manager: output is a single bare token" {
+    if ! command -v npm >/dev/null 2>&1; then skip "npm not installed"; fi
+    echo '{}' > "$BATS_TEST_TMPDIR/package.json"
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "${#lines[@]}" -eq 1 ]
+    [[ "$output" =~ ^[a-z]+$ ]]
+}

--- a/src/tests/tools/resolve-default-branch.bats
+++ b/src/tests/tools/resolve-default-branch.bats
@@ -79,19 +79,26 @@ strip_local_branches() {
     [ "$status" -eq 1 ]
 }
 
+@test "resolve-default-branch: -C with no argument is a usage error, not a silent exit 1" {
+    # `shift 2` on a missing operand fails under set -e and kills the script
+    # with no message — indistinguishable from "not a git repository".
+    run bash "$TOOL" -C
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"requires a directory"* ]]
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
-# Probe 1/2 — local branch refs win (git-captain's recovery case: origin
-# unreachable, local main still present)
+# Ordinary repos — both probe families agree
 # ─────────────────────────────────────────────────────────────────────────────
 
-@test "resolve-default-branch: local refs/heads/main resolves to main" {
+@test "resolve-default-branch: main-default repo resolves to main" {
     setup_repo_pair main
     run bash "$TOOL" -C "$CLONE"
     [ "$status" -eq 0 ]
     [ "$output" = "main" ]
 }
 
-@test "resolve-default-branch: local refs/heads/master resolves to master" {
+@test "resolve-default-branch: master-default repo resolves to master" {
     setup_repo_pair master
     run bash "$TOOL" -C "$CLONE"
     [ "$status" -eq 0 ]
@@ -99,7 +106,72 @@ strip_local_branches() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Probe 3 — origin/HEAD
+# PROBE-ORDER CONFLICTS — the only cases where the order actually decides
+# something, and therefore the only cases that pin the contract.
+#
+# Every consumer turns this answer into a REMOTE ref ("origin/<name>"), so a
+# stale local branch must never outvote the remote's own answer. Probing
+# local refs first (git-captain's historical order) reintroduces issue #107:
+# pr-create would diff against a nonexistent origin/main and emit a false
+# "agency_version not bumped".
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: origin/HEAD beats a stale local main" {
+    setup_repo_pair trunk
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    # A leftover local `main` that is NOT the default — the poison case.
+    git -C "$CLONE" branch main
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "trunk" ]
+}
+
+@test "resolve-default-branch: origin/HEAD -> master beats a stale local main" {
+    setup_repo_pair master
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    git -C "$CLONE" branch main
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "master" ]
+}
+
+@test "resolve-default-branch: origin/main beats a stale local master" {
+    setup_repo_pair main
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    git -C "$CLONE" branch master
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "resolve-default-branch: origin/HEAD beats refs/remotes/origin/main" {
+    # Probe 1 must precede probes 2-3, not merely coexist with them.
+    setup_repo_pair trunk
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    # Give the clone an origin/main remote-tracking ref that is NOT the default.
+    git -C "$CLONE" update-ref refs/remotes/origin/main "$(git -C "$CLONE" rev-parse HEAD)"
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "trunk" ]
+}
+
+@test "resolve-default-branch: local refs are the OFFLINE fallback (no remote refs at all)" {
+    # git-captain's issue-#268 recovery case must still work: remote refs
+    # pruned, local branch intact.
+    setup_repo_pair master
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    local r
+    for r in $(git -C "$CLONE" for-each-ref --format='%(refname)' refs/remotes); do
+        git -C "$CLONE" update-ref -d "$r"
+    done
+    run bash "$TOOL" -C "$CLONE" --strict
+    [ "$status" -eq 0 ]
+    [ "$output" = "master" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probe 1 — origin/HEAD
 # ─────────────────────────────────────────────────────────────────────────────
 
 @test "resolve-default-branch: origin/HEAD present (no local branches) resolves via symbolic ref" {

--- a/src/tests/tools/resolve-default-branch.bats
+++ b/src/tests/tools/resolve-default-branch.bats
@@ -1,0 +1,200 @@
+#!/usr/bin/env bats
+#
+# resolve-default-branch — the shared default-branch primitive.
+#
+# Seven copies of this logic had drifted across the tool tree, each with a
+# different probe order, a different fallback, and a different failure mode.
+# This suite pins the UNION contract the consumers were converged onto:
+#
+#   - the probe order (local refs → origin/HEAD → origin/{main,master})
+#   - the `main` fallback in default mode (NOT `master` — #463 QG finding)
+#   - `--strict` exits nonzero and prints NOTHING, so the fail-closed
+#     consumers (git-captain, pr-create) keep failing loud
+#   - slash-bearing default branch names survive the prefix strip
+#
+# Each test builds a throwaway repo pair (origin + clone) in BATS_TEST_TMPDIR
+# so no probe can reach the real repo.
+
+REPO_ROOT="$(cd "$(dirname "${BATS_TEST_DIRNAME}")/../.." && pwd)"
+TOOL="${REPO_ROOT}/agency/tools/resolve-default-branch"
+
+# Build an origin repo whose default branch is $1, cloned to $CLONE.
+# Leaves: $ORIGIN (bare-ish source repo), $CLONE (the repo under test).
+setup_repo_pair() {
+    local default_branch="$1"
+
+    ORIGIN="$BATS_TEST_TMPDIR/origin"
+    CLONE="$BATS_TEST_TMPDIR/clone"
+
+    git init --quiet --initial-branch="$default_branch" "$ORIGIN"
+    git -C "$ORIGIN" config user.email "t@example.com"
+    git -C "$ORIGIN" config user.name "t"
+    echo seed > "$ORIGIN/seed.txt"
+    git -C "$ORIGIN" add seed.txt
+    git -C "$ORIGIN" commit --quiet -m seed
+
+    git clone --quiet "$ORIGIN" "$CLONE"
+    git -C "$CLONE" config user.email "t@example.com"
+    git -C "$CLONE" config user.name "t"
+}
+
+# Detach the clone from any local branch and delete every local branch ref,
+# so only remote-tracking refs remain. This is what isolates probes 3-5 from
+# probes 1-2.
+strip_local_branches() {
+    local sha
+    sha="$(git -C "$CLONE" rev-parse HEAD)"
+    git -C "$CLONE" checkout --quiet --detach "$sha"
+    local b
+    for b in $(git -C "$CLONE" for-each-ref --format='%(refname:short)' refs/heads); do
+        git -C "$CLONE" branch --quiet -D "$b"
+    done
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Shape
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: exists and is executable" {
+    [ -x "$TOOL" ]
+}
+
+@test "resolve-default-branch: is syntactically valid bash" {
+    bash -n "$TOOL"
+}
+
+@test "resolve-default-branch: --help exits 0 and documents --strict" {
+    run bash "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--strict"* ]]
+}
+
+@test "resolve-default-branch: unknown flag is a usage error (exit 2)" {
+    run bash "$TOOL" --nope
+    [ "$status" -eq 2 ]
+}
+
+@test "resolve-default-branch: outside a git repo exits 1" {
+    run bash "$TOOL" -C "$BATS_TEST_TMPDIR"
+    [ "$status" -eq 1 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probe 1/2 — local branch refs win (git-captain's recovery case: origin
+# unreachable, local main still present)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: local refs/heads/main resolves to main" {
+    setup_repo_pair main
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "resolve-default-branch: local refs/heads/master resolves to master" {
+    setup_repo_pair master
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "master" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probe 3 — origin/HEAD
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: origin/HEAD present (no local branches) resolves via symbolic ref" {
+    setup_repo_pair trunk
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "trunk" ]
+}
+
+@test "resolve-default-branch: slash-bearing default branch survives the prefix strip" {
+    setup_repo_pair release/stable
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "release/stable" ]
+}
+
+@test "resolve-default-branch: slash-bearing name also resolves in --strict mode" {
+    setup_repo_pair release/stable
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE" --strict
+    [ "$status" -eq 0 ]
+    [ "$output" = "release/stable" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probe 4/5 — remote-tracking refs when origin/HEAD is absent
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: origin/HEAD absent + origin/main present → main" {
+    setup_repo_pair main
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "resolve-default-branch: origin/HEAD absent + origin/master present → master" {
+    setup_repo_pair master
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    strip_local_branches
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "master" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Probe 6 — the fallback, and the --strict policy split
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "resolve-default-branch: nothing resolvable → falls back to main (not master)" {
+    setup_repo_pair trunk
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    strip_local_branches
+    # Remove every remote-tracking ref too — now no probe can succeed.
+    local r
+    for r in $(git -C "$CLONE" for-each-ref --format='%(refname)' refs/remotes); do
+        git -C "$CLONE" update-ref -d "$r"
+    done
+    run bash "$TOOL" -C "$CLONE"
+    [ "$status" -eq 0 ]
+    [ "$output" = "main" ]
+}
+
+@test "resolve-default-branch: nothing resolvable + --strict → nonzero and no name on stdout" {
+    setup_repo_pair trunk
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    strip_local_branches
+    local r
+    for r in $(git -C "$CLONE" for-each-ref --format='%(refname)' refs/remotes); do
+        git -C "$CLONE" update-ref -d "$r"
+    done
+
+    # stdout captured separately: --strict must print NOTHING there, so a
+    # caller doing BRANCH=$(resolve-default-branch --strict) cannot end up
+    # with a plausible-looking wrong value.
+    run bash -c "bash '$TOOL' -C '$CLONE' --strict 2>/dev/null"
+    [ "$status" -ne 0 ]
+    [ -z "$output" ]
+}
+
+@test "resolve-default-branch: --strict failure explains the fix on stderr" {
+    setup_repo_pair trunk
+    git -C "$CLONE" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+    strip_local_branches
+    local r
+    for r in $(git -C "$CLONE" for-each-ref --format='%(refname)' refs/remotes); do
+        git -C "$CLONE" update-ref -d "$r"
+    done
+    run bash -c "bash '$TOOL' -C '$CLONE' --strict 2>&1 >/dev/null"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"remote set-head"* ]]
+}

--- a/src/tests/tools/scaffolding.bats
+++ b/src/tests/tools/scaffolding.bats
@@ -148,6 +148,30 @@ load 'test_helper'
     [[ ! "$output" =~ "syntax error" ]]
 }
 
+@test "workstream-create: REJECTS a shell-metacharacter name (no directory created)" {
+    # Not merely "does not execute the injection" — it must not create the
+    # directory either. Unvalidated, this call left a literal
+    # `agency/workstreams/test; rm -rf ` behind in the REAL repo on every full
+    # test run, which then failed purge-pollution-guard.bats.
+    run_tool workstream-create 'test; rm -rf /'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid workstream name"* ]]
+    run bash -c "ls -d '${REPO_ROOT}/agency/workstreams/'test* 2>/dev/null"
+    [ "$status" -ne 0 ]
+}
+
+@test "workstream-create: rejects a name starting with a digit" {
+    run_tool workstream-create '9lives'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid workstream name"* ]]
+}
+
+@test "workstream-create: rejects a name containing a slash" {
+    run_tool workstream-create 'a/b'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid workstream name"* ]]
+}
+
 @test "workstream-create: handles path traversal in name" {
     run_tool workstream-create '../../../tmp/hack' || true
     # Should not create files outside expected directory

--- a/src/tests/tools/scaffolding.bats
+++ b/src/tests/tools/scaffolding.bats
@@ -7,6 +7,27 @@
 
 load 'test_helper'
 
+# These suites exercise the REAL scaffolding tools against the REAL repo:
+# `agent-create` and `workstream-create` derive their project root from their
+# own location, so there is no way to point them at a fixture. The artifacts
+# they leave behind are not harmless — a stray `agency/agents/testname/`
+# makes src/tests/tools/triage-batch-E.bats ("#275: no test-fixture agents
+# shipped") and src/tests/tools/purge-pollution-guard.bats go red on the NEXT
+# run, which is how a passing suite poisons its own repo.
+#
+# Until the tools honour AGENCY_PROJECT_ROOT (worktree-create already does),
+# clean up after every test. Overriding teardown() means calling
+# test_isolation_teardown here explicitly — see test_helper.bash.
+teardown() {
+    rm -rf "${REPO_ROOT}/agency/agents/testname"
+    rm -rf "${REPO_ROOT}/agency/agents/unknown"
+    find "${REPO_ROOT}/agency/workstreams" -maxdepth 1 -name 'test*' -exec rm -rf {} + 2>/dev/null || true
+    test_isolation_teardown
+    if [[ -d "${BATS_TEST_TMPDIR}" ]]; then
+        rm -rf "${BATS_TEST_TMPDIR}"
+    fi
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # agent-create - Version and Help
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/tools/triage-wave-I.bats
+++ b/src/tests/tools/triage-wave-I.bats
@@ -121,7 +121,14 @@ setup() {
 @test "issue #343: no skills default project=captain via legacy pattern" {
     # Negative test: no SKILL.md should contain the legacy
     # "default to captain" pattern.
-    run grep -rlE "default.*to.*captain|project=captain" "$REPO_ROOT/.claude/skills/"
+    #
+    # The pattern is anchored on the actual PHRASE. The original
+    # "default.*to.*captain" was a wildcard across the whole line and fired on
+    # any prose that happened to mention a default branch and the captain in
+    # the same sentence — e.g. pr-captain-land's "the main checkout stays on
+    # the default branch … nothing that can strand the captain". A guard that
+    # cannot be satisfied by correct prose gets deleted, not obeyed.
+    run grep -rliE "default(s|ing|ed)?[[:space:]]+to[[:space:]]+captain|project=captain" "$REPO_ROOT/.claude/skills/"
     # grep -l returns 1 when no matches — that's the pass condition.
     [ "$status" -ne 0 ]
 }

--- a/src/tests/tools/worktree-create.bats
+++ b/src/tests/tools/worktree-create.bats
@@ -141,7 +141,45 @@ teardown() {
 @test "positional mode: --version shows new version" {
     run "$TOOL" --version
     [ "$status" -eq 0 ]
-    [[ "$output" == *"2.1"* ]]
+    # Pin the tool name + a 2.x line, not an exact patch level — the exact
+    # string churns on every feature bump (2.1 → 2.2 added --from).
+    [[ "$output" == *"worktree-create 2."* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --from <ref> — explicit start point (local-first landing cuts its scratch
+# worktree from a pristine origin ref, never from whatever HEAD happens to be)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "help: documents --from" {
+    run "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--from"* ]]
+}
+
+@test "--from: rejects a ref that does not resolve to a commit" {
+    run "$TOOL" _scratch-nope --from no/such/ref
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not resolve"* ]]
+}
+
+@test "name validation: a leading underscore is allowed (machine scratch worktrees)" {
+    # The name must survive validation; the run may still fail later for
+    # unrelated environment reasons, so assert on the validation message only.
+    run "$TOOL" _land-example --from no/such/ref
+    [[ "$output" != *"name must start with"* ]]
+}
+
+@test "name validation: a leading digit is still rejected" {
+    run "$TOOL" 9bad
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"name must start with"* ]]
+}
+
+@test "name validation: a slash in the name is still rejected" {
+    run "$TOOL" bad/name
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"name must start with"* ]]
 }
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/tools/worktree-cwd-check.bats
+++ b/src/tests/tools/worktree-cwd-check.bats
@@ -23,7 +23,10 @@ setup() {
     git commit --quiet --no-verify -m "init"
 
     # Copy the tool
-    mkdir -p "$TEST_REPO/claude/tools"
+    # Pre-v46 this said `claude/tools` — a rename miss. Every test in the file
+    # then failed in setup with "No such file or directory", so the suite had
+    # been dark since the great rename.
+    mkdir -p "$TEST_REPO/agency/tools"
     cp "$REPO_ROOT/agency/tools/worktree-cwd-check" "$TEST_REPO/agency/tools/"
     chmod +x "$TEST_REPO/agency/tools/worktree-cwd-check"
 }

--- a/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-58936fce-on-pr-lifecycle-v2-devex-pr-lif-20260810-0029.md
+++ b/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-58936fce-on-pr-lifecycle-v2-devex-pr-lif-20260810-0029.md
@@ -1,0 +1,236 @@
+---
+type: commit
+from: the-agency/jordan/pr-lifecycle-v2
+to: the-agency/jordan/captain
+date: 2026-08-09T16:29
+status: created
+priority: normal
+subject: "Committed 58936fce on pr-lifecycle-v2: devex/pr-lifecycle-v2: fix(pr-captain-land): QG fix cycle — 4-agent review findings
+
+Fixes from the pre-PR quality gate (4 parallel reviewers on the local-first
+rewrite). The reviewers found real defects, not nits.
+
+CORRECTNESS
+- LAND_SLUG collapsed only slashes while worktree-create rejects dots, so
+  every dotted branch (v1.2, 46.20) was unlandable behind an opaque error.
+- No EXIT trap: any set -e abort between steps 2 and 6 stranded the scratch
+  worktree and wedged all future lands of that branch. Trap added, disarmed
+  at the publish boundary.
+- Step 0 checked only for a leftover scratch DIRECTORY; a crash leaving only
+  the branch made worktree-create refuse forever with no visible cause.
+- AGENT_HASH_E extraction had no '|| true' — a receipt lacking hash_e killed
+  the script silently and made its own fallback dead code.
+- Version bump: inline python sys.exit(1) killed the caller before its error
+  could run. Extracted to agency/tools/agency-version-next (NOT version-next,
+  which already exists for the VERSION file's build identifier).
+- NO_CHECKS was fatal on the first poll — i.e. on almost every real land.
+  3-minute grace window added.
+- mktemp -t is a BSD-ism; PR_NUM/PR_URL scraping could kill the script after
+  publishing. Both fixed.
+
+TRUST / SECURITY
+- Every verifying and publishing tool (receipt-verify, diff-hash, pr-create,
+  git-safe-commit, ...) was executed FROM the branch under review. A branch
+  shipping its own receipt-verify passed its own gate. All now resolve from
+  $TOOLS = the captain's checkout, with cwd in the scratch.
+- --principal-approved was hardcoded on pr-merge, making branch-protection
+  bypass the default merge mode. Now an explicit flag, also recorded in the
+  receipt's hash_d_source.
+- Validation steps run with GH_TOKEN/GITHUB_TOKEN/SSH_AUTH_SOCK scrubbed;
+  their output is tailed to the transcript on failure.
+- pr-submit's ${PRIORITY:+--priority "$PRIORITY"} word-split, allowing flag
+  injection into dispatch create. Priority is validated at parse time.
+
+DESIGN
+- resolve-default-branch probed LOCAL refs first, so a stale local 'main' in
+  a master-default clone made every consumer build a nonexistent origin/main
+  — issue #107 through the local-refs door. Order is now remote-authoritative;
+  local refs are the offline fallback. Conflict cases now tested.
+- commit-precheck counted as a validation step while inspecting nothing (the
+  scratch tree is clean), which suppressed the no-validation path and put a
+  false step count into a signed receipt. Removed from the ladder.
+- Zero validation steps now ABORTS (--allow-unvalidated to override) instead
+  of signing a receipt for a gate that never ran.
+- Fetch failure is fatal. post-merge-state is checked at preflight and no
+  longer cleared when no release was cut.
+- Dispatch recipient resolved against the agent registry, not guessed.
+
+TESTS
+- New: ci-rollup-verdict.bats (32) — the CI classifier extracted from a
+  heredoc where every guard passed with PASS/FAIL swapped.
+- New: agency-version-next.bats (19). pkg-manager.bats rewritten with PATH
+  stubs (22, was skip-dependent). resolve-default-branch.bats +6 conflict
+  cases. pr-captain-land-localfirst.bats 30 → 44, tautological guards
+  replaced with real unit tests.
+- scaffolding.bats now cleans up after itself: it was leaving
+  agency/agents/testname in the real repo, reddening two other suites.
+
+Full suite: 1398 pass / 323 fail — zero new failures vs main's baseline
+(333), and 10 pre-existing failures fixed. All 25 agency/ <-> src/ mirror
+pairs byte-identical."
+in_reply_to: null
+---
+
+# Committed 58936fce on pr-lifecycle-v2: devex/pr-lifecycle-v2: fix(pr-captain-land): QG fix cycle — 4-agent review findings
+
+Fixes from the pre-PR quality gate (4 parallel reviewers on the local-first
+rewrite). The reviewers found real defects, not nits.
+
+CORRECTNESS
+- LAND_SLUG collapsed only slashes while worktree-create rejects dots, so
+  every dotted branch (v1.2, 46.20) was unlandable behind an opaque error.
+- No EXIT trap: any set -e abort between steps 2 and 6 stranded the scratch
+  worktree and wedged all future lands of that branch. Trap added, disarmed
+  at the publish boundary.
+- Step 0 checked only for a leftover scratch DIRECTORY; a crash leaving only
+  the branch made worktree-create refuse forever with no visible cause.
+- AGENT_HASH_E extraction had no '|| true' — a receipt lacking hash_e killed
+  the script silently and made its own fallback dead code.
+- Version bump: inline python sys.exit(1) killed the caller before its error
+  could run. Extracted to agency/tools/agency-version-next (NOT version-next,
+  which already exists for the VERSION file's build identifier).
+- NO_CHECKS was fatal on the first poll — i.e. on almost every real land.
+  3-minute grace window added.
+- mktemp -t is a BSD-ism; PR_NUM/PR_URL scraping could kill the script after
+  publishing. Both fixed.
+
+TRUST / SECURITY
+- Every verifying and publishing tool (receipt-verify, diff-hash, pr-create,
+  git-safe-commit, ...) was executed FROM the branch under review. A branch
+  shipping its own receipt-verify passed its own gate. All now resolve from
+  $TOOLS = the captain's checkout, with cwd in the scratch.
+- --principal-approved was hardcoded on pr-merge, making branch-protection
+  bypass the default merge mode. Now an explicit flag, also recorded in the
+  receipt's hash_d_source.
+- Validation steps run with GH_TOKEN/GITHUB_TOKEN/SSH_AUTH_SOCK scrubbed;
+  their output is tailed to the transcript on failure.
+- pr-submit's ${PRIORITY:+--priority "$PRIORITY"} word-split, allowing flag
+  injection into dispatch create. Priority is validated at parse time.
+
+DESIGN
+- resolve-default-branch probed LOCAL refs first, so a stale local 'main' in
+  a master-default clone made every consumer build a nonexistent origin/main
+  — issue #107 through the local-refs door. Order is now remote-authoritative;
+  local refs are the offline fallback. Conflict cases now tested.
+- commit-precheck counted as a validation step while inspecting nothing (the
+  scratch tree is clean), which suppressed the no-validation path and put a
+  false step count into a signed receipt. Removed from the ladder.
+- Zero validation steps now ABORTS (--allow-unvalidated to override) instead
+  of signing a receipt for a gate that never ran.
+- Fetch failure is fatal. post-merge-state is checked at preflight and no
+  longer cleared when no release was cut.
+- Dispatch recipient resolved against the agent registry, not guessed.
+
+TESTS
+- New: ci-rollup-verdict.bats (32) — the CI classifier extracted from a
+  heredoc where every guard passed with PASS/FAIL swapped.
+- New: agency-version-next.bats (19). pkg-manager.bats rewritten with PATH
+  stubs (22, was skip-dependent). resolve-default-branch.bats +6 conflict
+  cases. pr-captain-land-localfirst.bats 30 → 44, tautological guards
+  replaced with real unit tests.
+- scaffolding.bats now cleans up after itself: it was leaving
+  agency/agents/testname in the real repo, reddening two other suites.
+
+Full suite: 1398 pass / 323 fail — zero new failures vs main's baseline
+(333), and 10 pre-existing failures fixed. All 25 agency/ <-> src/ mirror
+pairs byte-identical.
+
+## Commit: 58936fce
+
+**Branch:** pr-lifecycle-v2
+**Agent:** the-agency/jordan/pr-lifecycle-v2
+**Message:** housekeeping/captain: devex/pr-lifecycle-v2: fix(pr-captain-land): QG fix cycle — 4-agent review findings
+
+Fixes from the pre-PR quality gate (4 parallel reviewers on the local-first
+rewrite). The reviewers found real defects, not nits.
+
+CORRECTNESS
+- LAND_SLUG collapsed only slashes while worktree-create rejects dots, so
+  every dotted branch (v1.2, 46.20) was unlandable behind an opaque error.
+- No EXIT trap: any set -e abort between steps 2 and 6 stranded the scratch
+  worktree and wedged all future lands of that branch. Trap added, disarmed
+  at the publish boundary.
+- Step 0 checked only for a leftover scratch DIRECTORY; a crash leaving only
+  the branch made worktree-create refuse forever with no visible cause.
+- AGENT_HASH_E extraction had no '|| true' — a receipt lacking hash_e killed
+  the script silently and made its own fallback dead code.
+- Version bump: inline python sys.exit(1) killed the caller before its error
+  could run. Extracted to agency/tools/agency-version-next (NOT version-next,
+  which already exists for the VERSION file's build identifier).
+- NO_CHECKS was fatal on the first poll — i.e. on almost every real land.
+  3-minute grace window added.
+- mktemp -t is a BSD-ism; PR_NUM/PR_URL scraping could kill the script after
+  publishing. Both fixed.
+
+TRUST / SECURITY
+- Every verifying and publishing tool (receipt-verify, diff-hash, pr-create,
+  git-safe-commit, ...) was executed FROM the branch under review. A branch
+  shipping its own receipt-verify passed its own gate. All now resolve from
+  $TOOLS = the captain's checkout, with cwd in the scratch.
+- --principal-approved was hardcoded on pr-merge, making branch-protection
+  bypass the default merge mode. Now an explicit flag, also recorded in the
+  receipt's hash_d_source.
+- Validation steps run with GH_TOKEN/GITHUB_TOKEN/SSH_AUTH_SOCK scrubbed;
+  their output is tailed to the transcript on failure.
+- pr-submit's ${PRIORITY:+--priority "$PRIORITY"} word-split, allowing flag
+  injection into dispatch create. Priority is validated at parse time.
+
+DESIGN
+- resolve-default-branch probed LOCAL refs first, so a stale local 'main' in
+  a master-default clone made every consumer build a nonexistent origin/main
+  — issue #107 through the local-refs door. Order is now remote-authoritative;
+  local refs are the offline fallback. Conflict cases now tested.
+- commit-precheck counted as a validation step while inspecting nothing (the
+  scratch tree is clean), which suppressed the no-validation path and put a
+  false step count into a signed receipt. Removed from the ladder.
+- Zero validation steps now ABORTS (--allow-unvalidated to override) instead
+  of signing a receipt for a gate that never ran.
+- Fetch failure is fatal. post-merge-state is checked at preflight and no
+  longer cleared when no release was cut.
+- Dispatch recipient resolved against the agent registry, not guessed.
+
+TESTS
+- New: ci-rollup-verdict.bats (32) — the CI classifier extracted from a
+  heredoc where every guard passed with PASS/FAIL swapped.
+- New: agency-version-next.bats (19). pkg-manager.bats rewritten with PATH
+  stubs (22, was skip-dependent). resolve-default-branch.bats +6 conflict
+  cases. pr-captain-land-localfirst.bats 30 → 44, tautological guards
+  replaced with real unit tests.
+- scaffolding.bats now cleans up after itself: it was leaving
+  agency/agents/testname in the real repo, reddening two other suites.
+
+Full suite: 1398 pass / 323 fail — zero new failures vs main's baseline
+(333), and 10 pre-existing failures fixed. All 25 agency/ <-> src/ mirror
+pairs byte-identical.
+
+### Metadata
+- commit_hash: 58936fce
+- branch: pr-lifecycle-v2
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/captain-release/reference.md
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-land/examples.md
+.claude/skills/pr-captain-land/reference.md
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+.claude/skills/pr-submit/scripts/pr-submit
+agency/tools/agency-version-next
+agency/tools/ci-rollup-verdict
+agency/tools/pkg-manager
+agency/tools/resolve-default-branch
+agency/tools/worktree-create
+src/agency/tools/agency-version-next
+src/agency/tools/ci-rollup-verdict
+src/agency/tools/pkg-manager
+src/agency/tools/resolve-default-branch
+src/agency/tools/worktree-create
+src/claude/skills/captain-release/reference.md
+src/claude/skills/pr-captain-land/SKILL.md
+src/claude/skills/pr-captain-land/examples.md
+src/claude/skills/pr-captain-land/reference.md
+```

--- a/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-9786aac1-on-pr-lifecycle-v2-devex-pr-lif-20260809-2335.md
+++ b/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-9786aac1-on-pr-lifecycle-v2-devex-pr-lif-20260809-2335.md
@@ -1,0 +1,143 @@
+---
+type: commit
+from: the-agency/jordan/pr-lifecycle-v2
+to: the-agency/jordan/captain
+date: 2026-08-09T15:35
+status: created
+priority: normal
+subject: "Committed 9786aac1 on pr-lifecycle-v2: devex/pr-lifecycle-v2: feat(pr-captain-land): local-first landing via scratch worktree + shared default-branch primitive
+
+Re-orients the captain PR-landing lifecycle to LOCAL-FIRST per
+plan-pr-captain-land-localfirst-20260809 v2 (MAR-reviewed).
+
+The whole landing now runs in a dedicated scratch worktree cut from
+origin/<agent-branch>. The main checkout is never switched, local main is
+never merged into or reset, and rollback at any pre-publish failure is
+'delete the scratch worktree'. Validation happens LOCALLY before a PR
+exists; GitHub confirms rather than gates.
+
+New primitives:
+- agency/tools/resolve-default-branch — union of the 7 drifted resolvers,
+  with --strict so fail-closed consumers keep failing loud
+- agency/tools/pkg-manager — lockfile-based package-manager resolver, so
+  skills never name one inline
+
+Converged onto resolve-default-branch: git-captain (--strict), pr-create
+(--strict), pr-submit (thin wrapper, name preserved for pr-captain-land),
+_sync-main-ref (was hardcoded origin/main). dispatch/pr-build/worktree-sync
+are explicitly deferred.
+
+Also: worktree-create gains --from <ref> and allows a leading underscore;
+workstream-create validates its name (it was creating a literal
+'test; rm -rf ' directory in the real repo on every full test run).
+
+Tests: resolve-default-branch (15), pkg-manager (9),
+pr-captain-land-localfirst (30), plus fixture fixes to git-captain,
+worktree-create, worktree-cwd-check (dark since the great rename),
+scaffolding, triage-wave-I.
+
+All 21 agency/ <-> src/ mirror pairs byte-identical."
+in_reply_to: null
+---
+
+# Committed 9786aac1 on pr-lifecycle-v2: devex/pr-lifecycle-v2: feat(pr-captain-land): local-first landing via scratch worktree + shared default-branch primitive
+
+Re-orients the captain PR-landing lifecycle to LOCAL-FIRST per
+plan-pr-captain-land-localfirst-20260809 v2 (MAR-reviewed).
+
+The whole landing now runs in a dedicated scratch worktree cut from
+origin/<agent-branch>. The main checkout is never switched, local main is
+never merged into or reset, and rollback at any pre-publish failure is
+'delete the scratch worktree'. Validation happens LOCALLY before a PR
+exists; GitHub confirms rather than gates.
+
+New primitives:
+- agency/tools/resolve-default-branch — union of the 7 drifted resolvers,
+  with --strict so fail-closed consumers keep failing loud
+- agency/tools/pkg-manager — lockfile-based package-manager resolver, so
+  skills never name one inline
+
+Converged onto resolve-default-branch: git-captain (--strict), pr-create
+(--strict), pr-submit (thin wrapper, name preserved for pr-captain-land),
+_sync-main-ref (was hardcoded origin/main). dispatch/pr-build/worktree-sync
+are explicitly deferred.
+
+Also: worktree-create gains --from <ref> and allows a leading underscore;
+workstream-create validates its name (it was creating a literal
+'test; rm -rf ' directory in the real repo on every full test run).
+
+Tests: resolve-default-branch (15), pkg-manager (9),
+pr-captain-land-localfirst (30), plus fixture fixes to git-captain,
+worktree-create, worktree-cwd-check (dark since the great rename),
+scaffolding, triage-wave-I.
+
+All 21 agency/ <-> src/ mirror pairs byte-identical.
+
+## Commit: 9786aac1
+
+**Branch:** pr-lifecycle-v2
+**Agent:** the-agency/jordan/pr-lifecycle-v2
+**Message:** housekeeping/captain: devex/pr-lifecycle-v2: feat(pr-captain-land): local-first landing via scratch worktree + shared default-branch primitive
+
+Re-orients the captain PR-landing lifecycle to LOCAL-FIRST per
+plan-pr-captain-land-localfirst-20260809 v2 (MAR-reviewed).
+
+The whole landing now runs in a dedicated scratch worktree cut from
+origin/<agent-branch>. The main checkout is never switched, local main is
+never merged into or reset, and rollback at any pre-publish failure is
+'delete the scratch worktree'. Validation happens LOCALLY before a PR
+exists; GitHub confirms rather than gates.
+
+New primitives:
+- agency/tools/resolve-default-branch — union of the 7 drifted resolvers,
+  with --strict so fail-closed consumers keep failing loud
+- agency/tools/pkg-manager — lockfile-based package-manager resolver, so
+  skills never name one inline
+
+Converged onto resolve-default-branch: git-captain (--strict), pr-create
+(--strict), pr-submit (thin wrapper, name preserved for pr-captain-land),
+_sync-main-ref (was hardcoded origin/main). dispatch/pr-build/worktree-sync
+are explicitly deferred.
+
+Also: worktree-create gains --from <ref> and allows a leading underscore;
+workstream-create validates its name (it was creating a literal
+'test; rm -rf ' directory in the real repo on every full test run).
+
+Tests: resolve-default-branch (15), pkg-manager (9),
+pr-captain-land-localfirst (30), plus fixture fixes to git-captain,
+worktree-create, worktree-cwd-check (dark since the great rename),
+scaffolding, triage-wave-I.
+
+All 21 agency/ <-> src/ mirror pairs byte-identical.
+
+### Metadata
+- commit_hash: 9786aac1
+- branch: pr-lifecycle-v2
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/captain-sync-all/reference.md
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-land/examples.md
+.claude/skills/pr-captain-land/reference.md
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+.claude/skills/pr-captain-merge/SKILL.md
+.claude/skills/pr-captain-merge/examples.md
+.claude/skills/pr-captain-merge/reference.md
+.claude/skills/pr-captain-post-merge/SKILL.md
+.claude/skills/pr-captain-post-merge/examples.md
+.claude/skills/pr-captain-post-merge/reference.md
+.claude/skills/pr-submit/scripts/pr-submit
+agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
+agency/tools/_sync-main-ref
+agency/tools/git-captain
+agency/tools/pkg-manager
+agency/tools/pr-create
+agency/tools/resolve-default-branch
+agency/tools/workstream-create
+```

--- a/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-9a09b58a-on-pr-lifecycle-v2-chore-manife-20260810-0036.md
+++ b/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-9a09b58a-on-pr-lifecycle-v2-chore-manife-20260810-0036.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/pr-lifecycle-v2
+to: the-agency/jordan/captain
+date: 2026-08-09T16:36
+status: created
+priority: normal
+subject: "Committed 9a09b58a on pr-lifecycle-v2: chore(manifest): bump agency_version 46.27 → 46.28 for PR landing"
+in_reply_to: null
+---
+
+# Committed 9a09b58a on pr-lifecycle-v2: chore(manifest): bump agency_version 46.27 → 46.28 for PR landing
+
+## Commit: 9a09b58a
+
+**Branch:** pr-lifecycle-v2
+**Agent:** the-agency/jordan/pr-lifecycle-v2
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.27 → 46.28 for PR landing
+
+### Metadata
+- commit_hash: 9a09b58a
+- branch: pr-lifecycle-v2
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-e53fe2c3-on-pr-lifecycle-v2-devex-pr-lif-20260810-0030.md
+++ b/usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-e53fe2c3-on-pr-lifecycle-v2-devex-pr-lif-20260810-0030.md
@@ -1,0 +1,32 @@
+---
+type: commit
+from: the-agency/jordan/pr-lifecycle-v2
+to: the-agency/jordan/captain
+date: 2026-08-09T16:30
+status: created
+priority: normal
+subject: "Committed e53fe2c3 on pr-lifecycle-v2: devex/pr-lifecycle-v2: misc(qgr): pr-prep receipt 2de6ec5 for local-first pr-captain-land v2"
+in_reply_to: null
+---
+
+# Committed e53fe2c3 on pr-lifecycle-v2: devex/pr-lifecycle-v2: misc(qgr): pr-prep receipt 2de6ec5 for local-first pr-captain-land v2
+
+## Commit: e53fe2c3
+
+**Branch:** pr-lifecycle-v2
+**Agent:** the-agency/jordan/pr-lifecycle-v2
+**Message:** housekeeping/captain: devex/pr-lifecycle-v2: misc(qgr): pr-prep receipt 2de6ec5 for local-first pr-captain-land v2
+
+### Metadata
+- commit_hash: e53fe2c3
+- branch: pr-lifecycle-v2
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-pr-lifecycle-v2-qgr-pr-prep-20260810-0030-2de6ec5.md
+usr/jordan/pr-lifecycle-v2/dispatches/commit-to-captain-committed-58936fce-on-pr-lifecycle-v2-devex-pr-lif-20260810-0029.md
+```


### PR DESCRIPTION
Re-orients the captain PR-landing lifecycle to LOCAL-FIRST per principal directive ("TheAgency model is about local review and validation"), plan-reviewed via MAR (4 reviewers, 32 defects found+fixed).

## The inversion
pr-captain-land no longer trusts GitHub CI as the gate. The whole land runs in a **throwaway scratch worktree** cut from origin/<agent-branch>: integrate → validate LOCALLY (build+tests) → bump → sign a captain landing receipt → publish → CI-confirm → merge → release. Local main is never read, merged into, reset, or pushed. Rollback = delete the scratch. The agent branch is never checked out (kills the worktree-collision bug).

## Shared primitive
New agency/tools/resolve-default-branch (superset of the 3 divergent resolvers, --strict mode preserves fail-closed). Converged: git-captain, pr-create, pr-submit, _sync-main-ref. (dispatch/pr-build/worktree-sync deferred — seed filed.)

## Also
- diff-hash already excludes handoffs (receipt-churn fix, #463).
- New primitives: ci-rollup-verdict (aggregate CI gate — replaces the hardcoded 'lint-and-test' that never existed here), agency-version-next, pkg-manager.
- Fixes surfaced by the QG: verifying tools ran from the branch-under-review; missing EXIT trap; NO_CHECKS fatal on first poll; --principal-approved hardcoded; commit-precheck false step count; dotted branch names unlandable.

## Gate
377 touched tests pass / 0 fail; full suite zero new failures, 10 pre-existing fixed. QGR receipt a516c7e. All 25 agency/↔src/ pairs byte-identical.

Bootstrap-landed via primitives (the new tool can't land itself). First real use will --rehearse the two pending app PRs before landing them.