### PR TITLE
delivery-path hardening: pr-captain-land publish-path -C repo-root targeting (steps 4-9) + git-sync default-branch guard

### DIFF
--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -172,11 +172,13 @@ Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via
 | D | C. `hash_d_source` records the truth: `auto-approved — no principal 1B1`, or the `--principal-approved` attestation when that flag was passed |
 | E | diff hash of the bumped tree vs `origin/<default>` |
 
-Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
+Written to **the scratch's** `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
+
+The `-C <scratch>` on that `receipt-sign` call is load-bearing: the tool resolves its target repo from its own install location, so `cd`-ing into the scratch does not redirect it. Without `-C` the receipt is signed into the captain's main checkout and the land aborts, unable to find it. See "Repo-root targeting" in `reference.md`.
 
 ### Step 6 — Publish
 
-Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms.
+Push `_land-<branch>` from the scratch, then `pr-create -C <scratch> --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms. `-C` points the gates at the scratch while the gate sub-tools still run from the captain's `$SCRIPT_DIR` — data from the scratch, code from the captain.
 
 **This is the first irreversible action.** Past here, failures report and leave the scratch in place for inspection rather than rolling back.
 

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -131,7 +131,7 @@ The bump policy itself lives in `agency/tools/agency-version-next` (`46.25 → 4
 `pr-create` is not bypassed and not weakened. The captain signs a receipt for the state it validated:
 
 ```
-receipt-sign --type qgr --boundary pr-captain-land \
+receipt-sign -C <scratch> --type qgr --boundary pr-captain-land \
   --agent captain --workstream agency --project <branch-slug> \
   --hash-a <agent receipt hash_e> \
   --hash-b <sha256 of the validation log> \
@@ -149,10 +149,26 @@ The receipt is then committed. Receipts are excluded from `diff-hash`, so commit
 
 ```
 (cd _land-<branch> && git-push _land-<branch>)
-(cd _land-<branch> && pr-create --title ... --body ... --base <default>)
+(cd _land-<branch> && pr-create -C _land-<branch> --title ... --body ... --base <default>)
 ```
 
 `pr-create` re-derives the newest receipt (the landing receipt) and re-verifies it, and independently confirms `manifest.json` differs from `origin/<default>`. Both gates pass on their own terms.
+
+### Repo-root targeting — why `-C` appears in steps 5 and 6
+
+Every tool above runs from the **captain's** `agency/tools/`, never the scratch's: the branch under review must not supply the code that gates it. The cwd is set to the scratch so those tools read the scratch's *data*. Captain's code, scratch's data.
+
+That works only for tools that actually consult the cwd. `receipt-sign`, `pr-create`, and `dispatch` resolved their target repo from `SCRIPT_DIR/../..` — their own install location — and ignored the cwd entirely, so `cd`-ing into the scratch did nothing:
+
+- **Step 5** wrote the landing receipt into the captain's main checkout. The find-in-scratch that follows returned nothing and the land aborted with "landing receipt was signed but could not be located" (clean rollback — origin untouched).
+- **Step 4**'s commit-announce dispatch landed in the main checkout, describing a commit that repo does not contain.
+- **Step 6**'s `pr-create` would have read `BRANCH` from the main checkout (`main`) and blocked, had step 5 not failed first.
+
+`-C <repo-root>` (first argument, git-style) states the target repo explicitly. It retargets **data only** — `pr-create` still invokes `receipt-verify` and `resolve-default-branch` from its own `$SCRIPT_DIR`, so the trust boundary is unchanged. Absent the flag, every tool behaves exactly as before, so no other caller was affected.
+
+Tools invoked here that do *not* take `-C`: `git-safe`, `git-safe-commit`, `git-push`, and `diff-hash` already resolve from the cwd; `pr-merge`, `gh-release`, `gh`, and `gh-api` are repo-agnostic (they key off a PR number or an explicit `org/repo`). `git-safe-commit` forwards its own cwd-derived root to `dispatch` via `-C`.
+
+Coverage: `src/tests/skills/pr-captain-land-publish-locality.bats` runs steps 4-5 for real against a two-repo fixture and asserts the artifacts land in the scratch and *not* in the captain checkout; `src/tests/tools/repo-root-targeting.bats` pins the `-C` contract per tool.
 
 **This is the first irreversible action.** Past this point `abort_land` is no longer correct — work exists on origin. Failures report, name the pushed branch, and leave the scratch in place for inspection.
 

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -588,7 +588,12 @@ if [[ -n "$VALIDATION_FAILED" ]]; then
 
     # Tell the agent before rolling back — the scratch is about to vanish.
     AGENT_NAME="$(resolve_agent_name)"
-    bash "$TOOLS/dispatch" create \
+    # -C "$REPO_ROOT": the captain's main checkout, explicitly. This dispatch is
+    # written moments before destroy_scratch runs, so it must NOT land in the
+    # scratch — and dispatch would otherwise honour a CLAUDE_PROJECT_DIR
+    # inherited from the captain's environment, silently filing the "your land
+    # was blocked" notice into a directory that is about to be deleted.
+    bash "$TOOLS/dispatch" -C "$REPO_ROOT" create \
         --type dispatch \
         --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
         --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
@@ -733,7 +738,14 @@ fi
 LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 
 echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
+# -C "$SCRATCH_DIR" is load-bearing, not decoration. receipt-sign resolves its
+# target repo from its own INSTALL location, so the cd alone did nothing: on a
+# real land the receipt was written into the CAPTAIN'S main checkout, the
+# find-in-scratch below came up empty, and the land aborted with "landing
+# receipt was signed but could not be located". The cd is kept because the tool
+# is still the captain's — captain's code, scratch's data.
 (cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-sign" \
+    -C "$SCRATCH_DIR" \
     --type qgr \
     --boundary pr-captain-land \
     --org "$ORG" \
@@ -817,7 +829,16 @@ echo "→ Creating PR..."
 # emits warnings on the same stream, and scraping `tail -1` sent a
 # successfully created PR down the "did not return a URL" path, leaving an
 # orphan PR for the operator to find.
+#
+# -C "$SCRATCH_DIR" names the repo pr-create GATES — branch, receipt, manifest —
+# and the directory `gh pr create` runs in. Without it every gate read the
+# captain's main checkout instead: the branch check would have seen `main` and
+# blocked the land outright. It does NOT retarget pr-create's sub-tools
+# (receipt-verify, resolve-default-branch); those still resolve from pr-create's
+# own $SCRIPT_DIR, which is what keeps the branch from shipping its own
+# verifier.
 PR_OUT=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/pr-create" \
+            -C "$SCRATCH_DIR" \
             --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) || true)
 PR_URL=$(printf '%s\n' "$PR_OUT" | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1 || true)
 
@@ -982,7 +1003,10 @@ rm -f "$VALIDATION_LOG"
 
 AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."
-bash "$TOOLS/dispatch" create \
+# -C "$REPO_ROOT": destroy_scratch has already run, so the only repo that can
+# hold this payload is the captain's main checkout. Stated explicitly rather
+# than relying on the tool's install-location default.
+bash "$TOOLS/dispatch" -C "$REPO_ROOT" create \
     --type master-updated \
     --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \

--- a/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+++ b/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
@@ -178,6 +178,16 @@ Required flags:
 | `--hash-d-source` | `transcript` or `auto-approved — no principal 1B1` |
 | `--hash-d-transcript` | Path to transcript file (omit if auto-approved) |
 
+Optional, and it must come **first** if used:
+
+| Flag | Description |
+|------|-------------|
+| `-C <repo-root>` | Write the receipt into `<repo-root>` instead of the tool's own checkout |
+
+Without `-C`, the receipt is written relative to the tool's **install location** (`SCRIPT_DIR/../..`) — *not* the cwd. That default is correct for every ordinary caller, which runs the tool out of the repo it is signing for.
+
+It is wrong in exactly one situation, and `-C` exists for it: when a tool from one checkout is run against another. `/pr-captain-land` does this deliberately — captain's trusted tools, scratch worktree's data — and before `-C` existed the landing receipt was signed into the captain's main checkout, where the flow could not find it, aborting the land. If you are invoking `receipt-sign` from outside the repo the receipt belongs to, pass `-C`; `cd` alone will not do it.
+
 ### `receipt-verify`
 
 Find and verify receipts for the current PR content.

--- a/agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+++ b/agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
@@ -221,6 +221,8 @@ Checks (each exits 1 on failure):
 
 QG-aware commit wrapper. Enforces work item tracking, builds structured commit messages, adds per-agent attribution, and dispatches a commit notification to captain.
 
+This tool resolves its repo from the **cwd** (`git rev-parse --show-toplevel`), so it commits to whichever worktree you run it in, and it forwards that root to the `dispatch` tool as `-C` so the commit-announce payload lands in the same repo as the commit it announces. Before that forwarding existed, committing in one worktree with a `git-safe-commit` from another wrote the announce into the *tool's* checkout — a dispatch describing a commit that repo did not contain.
+
 **Usage:** `./agency/tools/git-safe-commit "<message>" --work-item <ID> --stage <stage>`
 
 **Escape hatch:** `./agency/tools/git-safe-commit "<message>" --no-work-item`
@@ -386,9 +388,17 @@ For cross-worktree sync, use `/worktree-sync`.
 
 QG-gated PR creation. Wraps `gh pr create` with three mandatory checks. Hookify blocks raw `gh pr create`.
 
-**Usage:** `./agency/tools/pr-create --title "title" --body "body" [gh pr create flags...]`
+**Usage:** `./agency/tools/pr-create [-C <repo-root>] --title "title" --body "body" [gh pr create flags...]`
 
 All flags after validation are passed through to `gh pr create`.
+
+### `-C <repo-root>` — which repo gets gated
+
+By default the checks below read the tool's own checkout (`SCRIPT_DIR/../..`), while `gh pr create` reads the cwd. Those are the same directory for every ordinary caller, so the split is invisible — until they are not, at which point the tool gates one tree and opens a PR from another.
+
+`-C` closes that: it names one repo for **both** the checks and `gh`. It must be the **first** argument, because everything after it is forwarded verbatim to `gh pr create`.
+
+`-C` retargets **data, never code**. The sub-tools this script runs — `receipt-verify`, `resolve-default-branch` — are still invoked from `$SCRIPT_DIR`. A branch cannot ship its own `receipt-verify` and thereby pass its own gate; that guarantee is what lets `/pr-captain-land` run the captain's `pr-create` against an unreviewed scratch worktree at all.
 
 ### Pre-flight checks
 

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.28",
+  "agency_version": "46.29",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-10T00:45:00Z"
+    "updated_at": "2026-08-12T01:52:42Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-05-09T14:30:00Z"
+  "updated_at": "2026-08-12T01:52:42Z"
 }

--- a/agency/tools/dispatch
+++ b/agency/tools/dispatch
@@ -88,6 +88,23 @@ source "$SCRIPT_DIR/lib/_iscp-db"
 # checkout: retargeting the root moves the payload file without splitting the
 # dispatch index into a second database.
 if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    # Pin the DB *before* moving the root. iscp_db_path derives the database
+    # name from the repo name in agency/config/agency.yaml under
+    # AGENCY_PROJECT_ROOT — which, once retargeted, is a file supplied by the
+    # branch under review. A branch that edited repo.name would send its
+    # dispatches to a different ~/.agency/<name>/iscp.db: the index splits and
+    # the captain never sees the notice. Resolving it here, while the root is
+    # still this tool's own install location, keeps the identity of the DB a
+    # property of the INSTALL and lets -C move only the payload file — which is
+    # what -C is for and what the comment above claims it does.
+    #
+    # ISCP_DB_PATH is the documented override iscp_db_path honours first, so an
+    # explicit one from the caller (or a test harness) still wins.
+    if [[ -z "${ISCP_DB_PATH:-}" ]]; then
+        ISCP_DB_PATH="$(iscp_db_path 2>/dev/null || true)"
+        [[ -n "$ISCP_DB_PATH" ]] && export ISCP_DB_PATH
+    fi
+
     AGENCY_PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
     AGENCY_PRINCIPAL_DIR="$AGENCY_PROJECT_ROOT/usr/${AGENCY_PRINCIPAL:-}"
     AGENCY_REFS_DIR="$AGENCY_PRINCIPAL_DIR/refs"

--- a/agency/tools/dispatch
+++ b/agency/tools/dispatch
@@ -18,6 +18,7 @@
 # Written: 2026-04-05 during ISCP Iteration 1.4
 #
 # Usage:
+#   dispatch [-C <repo-root>] <subcommand> ...
 #   dispatch create --to <addr> --subject <text> --body <text> [--type <type>] [--priority <p>]
 #   dispatch create --to <addr> --subject <text> --template [--type <type>] [--priority <p>]
 #   dispatch list [--all] [--status <s>] [--type <t>]
@@ -36,10 +37,38 @@ set -euo pipefail
 TOOL_VERSION="2.0.1"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: the payload file a dispatch writes lands under
+# $PROJECT_ROOT/usr/<principal>/<project>/dispatches/, and PROJECT_ROOT came
+# only from CLAUDE_PROJECT_DIR or the tool's own INSTALL location. When
+# pr-captain-land commits inside its scratch worktree, git-safe-commit's
+# commit-announce reached this tool and the payload was written into the
+# CAPTAIN'S MAIN CHECKOUT — a stray untracked file in the wrong repo, for a
+# commit that does not exist there. git-safe-commit had already resolved the
+# right root from cwd; it just had no way to say so.
+#
+# How & Why: `-C` is that way to say so, and it outranks CLAUDE_PROJECT_DIR —
+# an explicit argument must beat an inherited environment variable, or a
+# captain-side env var would keep overriding the caller. First argument only,
+# git-style: `reply` and `create --body` take free text, so a scan-anywhere
+# parse could swallow a legitimate "-C" payload. Absent the flag, resolution is
+# exactly as before.
+REPO_ROOT_OVERRIDE=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "dispatch: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "dispatch: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT_OVERRIDE="$(cd "$2" && pwd)"
+    shift 2
+fi
+
 # CLAUDE_PROJECT_DIR is authoritative — worktree agents may cd to main but
 # their identity is rooted in the worktree, not where the tool binary lives.
 # See escalation #90: agent-identity and dispatch both must use this.
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
+elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
 else
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -50,6 +79,20 @@ source "$SCRIPT_DIR/lib/_log-helper"
 source "$SCRIPT_DIR/lib/_path-resolve"
 source "$SCRIPT_DIR/lib/_address-parse"
 source "$SCRIPT_DIR/lib/_iscp-db"
+
+# _path-resolve derives AGENCY_PROJECT_ROOT from SCRIPT_DIR on source, and
+# _address-parse / _iscp-db read it — so setting PROJECT_ROOT above is not
+# enough on its own, and the override has to be re-applied AFTER the sourcing
+# that would otherwise clobber it. The ISCP DB is keyed by the repo NAME out of
+# agency/config/agency.yaml, which is identical in a worktree and its main
+# checkout: retargeting the root moves the payload file without splitting the
+# dispatch index into a second database.
+if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    AGENCY_PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
+    AGENCY_PRINCIPAL_DIR="$AGENCY_PROJECT_ROOT/usr/${AGENCY_PRINCIPAL:-}"
+    AGENCY_REFS_DIR="$AGENCY_PRINCIPAL_DIR/refs"
+    export AGENCY_PROJECT_ROOT AGENCY_PRINCIPAL_DIR AGENCY_REFS_DIR
+fi
 
 # Valid dispatch types (must match _iscp-db CHECK constraint)
 VALID_TYPES="directive seed review review-response commit master-updated escalation dispatch"
@@ -956,6 +999,7 @@ cmd_help() {
 dispatch — ISCP dispatch lifecycle tool (v2)
 
 Usage:
+  dispatch [-C <repo-root>] <subcommand> ...
   dispatch create --to <addr> --subject <text> [--body <text>] [--type <type>] [--priority <p>]
   dispatch list [--all] [--status <s>] [--type <t>]
   dispatch read <id>
@@ -969,6 +1013,11 @@ Usage:
 
 Dispatch types: directive, seed, review, review-response, commit,
   master-updated, escalation, dispatch
+
+-C <repo-root>  Write payload files into <repo-root> instead of this tool's own
+                checkout. Must be the FIRST argument, before the subcommand.
+                Outranks CLAUDE_PROJECT_DIR. Used when a tool runs against a
+                worktree other than the one it was installed in.
 
 Dispatches are indexed in the ISCP SQLite DB. Payload files live in git.
 Arguments take integer dispatch IDs, not file paths.

--- a/agency/tools/git-safe-commit
+++ b/agency/tools/git-safe-commit
@@ -660,7 +660,16 @@ main() {
 ${files_changed}
 \`\`\`"
 
-                    "$DISPATCH_TOOL" create \
+                    # -C "$PROJECT_ROOT": this tool already resolved the repo
+                    # correctly from cwd (git rev-parse --show-toplevel), but
+                    # the dispatch tool resolved its own root from its INSTALL
+                    # location. Committing inside a worktree therefore wrote the
+                    # commit-announce payload into whichever checkout the tool
+                    # binary happened to live in — observed during a real
+                    # pr-captain-land, where a scratch-worktree commit littered
+                    # the captain's main checkout with a dispatch for a commit
+                    # that was not in it. Pass the root we already know.
+                    "$DISPATCH_TOOL" -C "$PROJECT_ROOT" create \
                         --type commit \
                         --to "$CAPTAIN_ADDR" \
                         --subject "Committed ${COMMIT_HASH} on ${CURRENT_BRANCH}: ${MESSAGE}" \

--- a/agency/tools/git-safe-commit
+++ b/agency/tools/git-safe-commit
@@ -60,6 +60,21 @@ elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
 else
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 fi
+
+# The repo this commit is actually going INTO — strictly the cwd's worktree,
+# with no CLAUDE_PROJECT_DIR consultation.
+#
+# PROJECT_ROOT above deliberately prefers CLAUDE_PROJECT_DIR because it is used
+# for the per-agent ATTRIBUTION lookup, which is a property of the session. That
+# is the wrong answer for "where does this commit live": Claude Code sets
+# CLAUDE_PROJECT_DIR to the main checkout, so in any real session PROJECT_ROOT
+# points at the main checkout even while we are committing inside a worktree.
+# Using it for the dispatch target sent commit-announce payloads to a repo that
+# does not contain the commit — the bug -C was added to fix, which the first
+# version of that fix reproduced exactly by passing PROJECT_ROOT.
+if ! COMMIT_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    COMMIT_REPO_ROOT="$PROJECT_ROOT"
+fi
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
     source "$SCRIPT_DIR/lib/_log-helper"
 fi
@@ -660,16 +675,16 @@ main() {
 ${files_changed}
 \`\`\`"
 
-                    # -C "$PROJECT_ROOT": this tool already resolved the repo
-                    # correctly from cwd (git rev-parse --show-toplevel), but
-                    # the dispatch tool resolved its own root from its INSTALL
-                    # location. Committing inside a worktree therefore wrote the
-                    # commit-announce payload into whichever checkout the tool
-                    # binary happened to live in — observed during a real
-                    # pr-captain-land, where a scratch-worktree commit littered
-                    # the captain's main checkout with a dispatch for a commit
-                    # that was not in it. Pass the root we already know.
-                    "$DISPATCH_TOOL" -C "$PROJECT_ROOT" create \
+                    # -C "$COMMIT_REPO_ROOT" — the cwd's worktree, NOT
+                    # PROJECT_ROOT (which follows CLAUDE_PROJECT_DIR to the main
+                    # checkout; see the derivation above). dispatch resolves its
+                    # own root from its INSTALL location, so committing inside a
+                    # worktree otherwise wrote the commit-announce into whichever
+                    # checkout the tool binary lived in — observed during a real
+                    # pr-captain-land, where a scratch commit littered the
+                    # captain's main checkout with a dispatch for a commit that
+                    # was not in it. The payload must land with its commit.
+                    "$DISPATCH_TOOL" -C "$COMMIT_REPO_ROOT" create \
                         --type commit \
                         --to "$CAPTAIN_ADDR" \
                         --subject "Committed ${COMMIT_HASH} on ${CURRENT_BRANCH}: ${MESSAGE}" \

--- a/agency/tools/git-sync
+++ b/agency/tools/git-sync
@@ -1,6 +1,25 @@
 #!/bin/bash
-# Sync local commits with remote (pull --rebase + push)
-# This is the ONLY approved way to push to remote
+# Sync local commits with remote (pull --no-rebase + push)
+#
+# What Problem: this tool contradicted two of the framework's sacred invariants
+# and nothing stopped it. It ran `git pull --rebase` (merge, never rebase) and
+# `git push -u origin "$BRANCH"` with NO main/master guard (never push master).
+# Invoked on main it did both at once: rewrote main's history and pushed main
+# straight past the PR flow. That happened. The content was benign captain
+# coordination, so the damage was recoverable, but the tool was a landmine —
+# `git-push` right next to it has blocked main since Day 40.
+#
+# How & Why: three changes.
+#   1. Refuse outright on the default branch, mirroring git-push's block. The
+#      branch name is resolved via resolve-default-branch rather than hardcoded,
+#      so this holds on master-default repos too — and main/master are BOTH
+#      always refused regardless of which one this repo uses, because a tool
+#      whose safety depends on remote resolution succeeding is not safe.
+#   2. Merge, not rebase. The "pull before push so the push is not rejected"
+#      intent is preserved; the history rewrite is not.
+#   3. The push log recorded every agent as "unknown" (it read $AGENTNAME, which
+#      Claude Code does not set), making the accountability log useless. Resolve
+#      the real identity via agent-identity, best-effort.
 #
 # Usage: ./agency/tools/git-sync [options]
 #   --check    Show what would be pushed without pushing
@@ -8,10 +27,13 @@
 #   --verbose  Show detailed output instead of logging
 #
 # Features:
-# - Pulls with rebase first (keeps history clean)
-# - Logs all pushes for accountability
+# - Refuses on main/master — those reach the remote through PRs only
+# - Pulls with MERGE first (never rebase — no history rewrite)
+# - Logs all pushes for accountability, with the real agent identity
 # - Shows commit summary before pushing
 # - Context-efficient: 1-line output, details in log-service
+#
+# Updated: 2026-08-11 (devex) — main/master guard + merge-not-rebase + identity
 
 set -euo pipefail
 
@@ -55,6 +77,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --verbose, -v       Show detailed output instead of logging"
             echo "  --version           Show version"
             echo "  --help, -h          Show this help"
+            echo ""
+            echo "Refuses to run on main/master (or the resolved default branch)."
+            echo "Those reach origin only through PRs: /pr-submit, /pr-captain-land."
+            echo "Pulls with MERGE, never rebase."
             exit 0
             ;;
         *)
@@ -164,11 +190,47 @@ main() {
 
     REPO_ROOT="$(git rev-parse --show-toplevel)"
     PUSH_LOG="$REPO_ROOT/history/push-log.md"
-    AGENT="${AGENTNAME:-unknown}"
     TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S %Z')
 
     # Get current branch
     BRANCH=$(git branch --show-current)
+
+    # ── BLOCK: never sync the default branch ─────────────────────────────────
+    #
+    # This runs BEFORE the pull, the push, and the push-log append, so a refused
+    # invocation mutates nothing at all — not even the log.
+    #
+    # main and master are refused unconditionally, and the resolved default
+    # branch on top of that. Belt and braces on purpose: resolve-default-branch
+    # falls back to "main" when it cannot reach the remote, and a guard that
+    # goes quiet the moment the network does is not a guard. Checking the two
+    # literals as well means an offline sync on a master-default repo is still
+    # refused.
+    DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" 2>/dev/null || echo "")"
+    if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || \
+          ( -n "$DEFAULT_BRANCH" && "$BRANCH" == "$DEFAULT_BRANCH" ) ]]; then
+        end_run "failure" "Refused: $BRANCH is the default branch"
+        echo "BLOCKED: Cannot sync $BRANCH — the default branch never goes to origin directly." >&2
+        echo "" >&2
+        echo "  All changes reach $BRANCH through PRs:" >&2
+        echo "    agent   → /pr-prep, then /pr-submit" >&2
+        echo "    captain → /pr-captain-land <branch>" >&2
+        echo "" >&2
+        echo "  To bring origin's $BRANCH into your local one, merge — never rebase:" >&2
+        echo "    ./agency/tools/git-captain merge-from-origin" >&2
+        exit 1
+    fi
+
+    # Resolve the acting agent for the push log. The log read \$AGENTNAME, which
+    # Claude Code does not set, so every historical row says "unknown" and the
+    # accountability log accounts for nobody. Best-effort by design: a failure
+    # to resolve identity must never block a legitimate push.
+    AGENT="${AGENTNAME:-}"
+    if [[ -z "$AGENT" && -x "$SCRIPT_DIR/agent-identity" ]]; then
+        AGENT="$("$SCRIPT_DIR/agent-identity" 2>/dev/null || echo "")"
+    fi
+    AGENT="${AGENT:-unknown}"
+
     log_info "Starting sync on branch: $BRANCH"
 
     # Check if we have commits to push
@@ -224,10 +286,14 @@ EOF
     fi
     echo "| $TIMESTAMP | $AGENT | $AHEAD | $SKIP_CI_COUNT skip-ci | $BRANCH |" >> "$PUSH_LOG"
 
-    # Pull with rebase
-    log_info "Pulling with rebase"
-    if ! git pull --rebase origin "$BRANCH" 2>/dev/null; then
-        log_info "No remote branch yet, skipping pull"
+    # Pull with MERGE — never rebase.
+    #
+    # --no-rebase is explicit rather than relying on git's default, because
+    # pull.rebase=true in a user's global config would silently restore the
+    # rewrite this tool exists to have stopped doing.
+    log_info "Pulling with merge (never rebase)"
+    if ! git pull --no-rebase origin "$BRANCH" 2>/dev/null; then
+        log_info "No remote branch yet, or merge needs attention; skipping pull"
     fi
 
     # Push

--- a/agency/tools/git-sync
+++ b/agency/tools/git-sync
@@ -178,16 +178,6 @@ output_failure() {
 main() {
     start_run
 
-    # Check for uncommitted changes
-    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-        log_warn "Uncommitted changes detected"
-        if [[ "$CHECK_ONLY" == "true" ]]; then
-            end_run "failure" "Uncommitted changes"
-            output_failure "Uncommitted changes in working tree"
-            exit 1
-        fi
-    fi
-
     REPO_ROOT="$(git rev-parse --show-toplevel)"
     PUSH_LOG="$REPO_ROOT/history/push-log.md"
     TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S %Z')
@@ -197,8 +187,10 @@ main() {
 
     # ── BLOCK: never sync the default branch ─────────────────────────────────
     #
-    # This runs BEFORE the pull, the push, and the push-log append, so a refused
-    # invocation mutates nothing at all — not even the log.
+    # This runs BEFORE the pull, the push, the push-log append, and even the
+    # uncommitted-changes check, so a refused invocation mutates nothing and
+    # always reports the reason that actually matters. (`--check` on a dirty
+    # main used to answer "uncommitted changes" — true, but not the point.)
     #
     # main and master are refused unconditionally, and the resolved default
     # branch on top of that. Belt and braces on purpose: resolve-default-branch
@@ -206,11 +198,26 @@ main() {
     # goes quiet the moment the network does is not a guard. Checking the two
     # literals as well means an offline sync on a master-default repo is still
     # refused.
+    #
+    # An EMPTY branch is refused too: `git branch --show-current` prints nothing
+    # on a detached HEAD, which matched none of the clauses. The tool then ran
+    # `git push -u origin ""` — fatal, so nothing reached origin, but only after
+    # appending a push-log row with an empty branch column and reporting "push
+    # failed" instead of "you are not on a branch".
     DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" 2>/dev/null || echo "")"
+    if [[ -z "$BRANCH" ]]; then
+        end_run "failure" "Refused: detached HEAD"
+        output_failure "BLOCKED: not on a branch (detached HEAD) — nothing to sync."
+        echo "  Check out a branch first: ./agency/tools/git-safe switch <branch>" >&2
+        exit 1
+    fi
     if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || \
           ( -n "$DEFAULT_BRANCH" && "$BRANCH" == "$DEFAULT_BRANCH" ) ]]; then
         end_run "failure" "Refused: $BRANCH is the default branch"
-        echo "BLOCKED: Cannot sync $BRANCH — the default branch never goes to origin directly." >&2
+        # output_failure, not a bare echo: every other failure path in this tool
+        # emits a "FAILURE: ..." line on stdout and callers grep for it. A guard
+        # that only spoke on stderr was invisible to them.
+        output_failure "BLOCKED: cannot sync $BRANCH — the default branch never goes to origin directly."
         echo "" >&2
         echo "  All changes reach $BRANCH through PRs:" >&2
         echo "    agent   → /pr-prep, then /pr-submit" >&2
@@ -219,6 +226,16 @@ main() {
         echo "  To bring origin's $BRANCH into your local one, merge — never rebase:" >&2
         echo "    ./agency/tools/git-captain merge-from-origin" >&2
         exit 1
+    fi
+
+    # Check for uncommitted changes
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        log_warn "Uncommitted changes detected"
+        if [[ "$CHECK_ONLY" == "true" ]]; then
+            end_run "failure" "Uncommitted changes"
+            output_failure "Uncommitted changes in working tree"
+            exit 1
+        fi
     fi
 
     # Resolve the acting agent for the push log. The log read \$AGENTNAME, which
@@ -282,7 +299,13 @@ EOF
 
     SKIP_CI_COUNT=0
     if git rev-parse "$UPSTREAM" >/dev/null 2>&1; then
-        SKIP_CI_COUNT=$(git log --oneline "$UPSTREAM..HEAD" | grep -c '\[skip ci\]' || echo "0")
+        # `|| true`, NOT `|| echo "0"`. grep -c already prints 0 when it matches
+        # nothing and THEN exits 1, so the echo appended a second zero and every
+        # row after the first sync was written as "0\n0", splitting the markdown
+        # table row across two lines. The log this change exists to make usable
+        # was corrupting itself on every run.
+        SKIP_CI_COUNT=$(git log --oneline "$UPSTREAM..HEAD" | grep -c '\[skip ci\]' || true)
+        SKIP_CI_COUNT="${SKIP_CI_COUNT:-0}"
     fi
     echo "| $TIMESTAMP | $AGENT | $AHEAD | $SKIP_CI_COUNT skip-ci | $BRANCH |" >> "$PUSH_LOG"
 
@@ -291,9 +314,28 @@ EOF
     # --no-rebase is explicit rather than relying on git's default, because
     # pull.rebase=true in a user's global config would silently restore the
     # rewrite this tool exists to have stopped doing.
+    #
+    # A failed pull is NOT uniformly benign, and treating it as such was its own
+    # bug: a conflicted merge left MERGE_HEAD and conflict markers in the working
+    # tree, the tool logged "skipping pull", pushed anyway, and reported "push
+    # failed" — never once mentioning the conflict the operator now had to find.
+    # Distinguish the two cases: no upstream branch is fine, a conflict stops the
+    # run with the tree left intact for the human to resolve.
     log_info "Pulling with merge (never rebase)"
-    if ! git pull --no-rebase origin "$BRANCH" 2>/dev/null; then
-        log_info "No remote branch yet, or merge needs attention; skipping pull"
+    if ! git pull --no-rebase origin "$BRANCH" >/dev/null 2>&1; then
+        if [[ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]]; then
+            log_error "Merge conflict during pull"
+            end_run "failure" "Merge conflict on $BRANCH"
+            output_failure "Merge conflict pulling origin/$BRANCH — nothing pushed."
+            echo "" >&2
+            echo "  The merge is in progress and left in place deliberately." >&2
+            echo "  Resolve the conflicts, commit, then re-run git-sync:" >&2
+            echo "    ./agency/tools/git-safe status" >&2
+            echo "  Or abandon it:" >&2
+            echo "    ./agency/tools/git-safe merge-abort" >&2
+            exit 1
+        fi
+        log_info "No remote branch yet; skipping pull"
     fi
 
     # Push

--- a/agency/tools/pr-create
+++ b/agency/tools/pr-create
@@ -90,7 +90,15 @@ if [[ -z "$NEWEST_RECEIPT" ]]; then
     exit 1
 fi
 
-if ! "$SCRIPT_DIR/receipt-verify" --file "$NEWEST_RECEIPT" 2>&1; then
+# Run the verifier FROM the captain's $SCRIPT_DIR but WITH the cwd in the repo
+# being gated. receipt-verify compares the receipt's hash against a freshly
+# computed one, and that computation goes through diff-hash, which is purely
+# cwd-based (`git diff <base>..HEAD -- .`). Without the cd, -C would retarget
+# receipt DISCOVERY but not hash VERIFICATION: a receipt found in tree A would
+# be graded against whatever tree the caller happened to be standing in. Today
+# pr-captain-land also wraps this call in a cd to the scratch, so the two agree
+# by luck; this makes them agree by construction.
+if ! (cd "$REPO_ROOT" && "$SCRIPT_DIR/receipt-verify" --file "$NEWEST_RECEIPT") 2>&1; then
     echo "" >&2
     echo "Every PR requires a valid receipt. Run /pr-prep again." >&2
     exit 1

--- a/agency/tools/pr-create
+++ b/agency/tools/pr-create
@@ -8,16 +8,47 @@
 # 3. agency_version must be bumped
 # Hookify blocks raw gh pr create.
 #
-# Usage: ./agency/tools/pr-create --title "title" --body "body"
+# Usage: ./agency/tools/pr-create [-C <repo-root>] --title "title" --body "body"
 #        All gh pr create flags are passed through after validation.
 #
 # Written: 2026-04-14 during captain session (PR discipline enforcement)
 # Updated: iteration 1.4 — replaced inline hash logic with receipt-verify
+# Updated: v46.29 — added `-C <repo-root>` (see the block below for why)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: pr-captain-land runs THIS tool from the captain's checkout with
+# the cwd set to a scratch worktree — captain's code gating the scratch's data.
+# But every gate below read REPO_ROOT = SCRIPT_DIR/../.., the tool's own INSTALL
+# location. So the BRANCH check inspected the captain's main checkout (always
+# `main`) and blocked the land outright, and the receipt/version gates likewise
+# graded the wrong tree. cwd only ever reached `gh pr create` at the very end,
+# which is how the mismatch went unnoticed.
+#
+# How & Why: `-C` retargets the DATA this tool reads — branch, receipt,
+# manifest — and the directory `gh pr create` runs in. It deliberately does NOT
+# retarget the CODE: receipt-verify and resolve-default-branch below are still
+# invoked from "$SCRIPT_DIR", so a branch cannot ship its own verifier and pass
+# its own gate. Captain's code, scratch's data — that is the whole security
+# model, and `-C` must not be a hole in it.
+#
+# First argument only: everything after this point is passed through verbatim to
+# `gh pr create`, so a scan-anywhere parse would eat a `--body` whose value was
+# literally "-C". Absent the flag, behaviour is unchanged for every caller.
+REPO_ROOT=""
+GH_RUN_DIR=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "BLOCKED: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "BLOCKED: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT="$(cd "$2" && pwd)"
+    GH_RUN_DIR="$REPO_ROOT"
+    shift 2
+fi
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # ── Step 1: Verify on a branch, not main ─────────────────────────────────
 
@@ -114,4 +145,12 @@ echo "✓ Version bumped: $CURRENT_VERSION"
 # ── Step 4: Create the PR ────────────────────────────────────────────────
 
 echo "Creating PR..."
+
+# `gh pr create` infers both the branch and the target repo from its cwd, so it
+# has to run where the gates just looked. Without -C that is the caller's cwd
+# (unchanged behaviour); with -C it is the repo the caller named, so the PR
+# cannot be opened against a different tree than the one that was gated.
+if [[ -n "$GH_RUN_DIR" ]]; then
+    cd "$GH_RUN_DIR"
+fi
 gh pr create "$@"

--- a/agency/tools/pr-merge
+++ b/agency/tools/pr-merge
@@ -45,7 +45,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Deliberately NO PROJECT_ROOT here. This tool is repo-agnostic: it operates on
+# a PR NUMBER and lets `gh` infer the repository from the cwd. It previously
+# carried an unused `PROJECT_ROOT="$SCRIPT_DIR/../.."`, which is the exact
+# install-location pattern that broke receipt-sign and pr-create when
+# pr-captain-land ran them against a scratch worktree. Leaving a dead one here
+# is an invitation for someone to "start using it" and reintroduce the bug. If
+# this tool ever does need a repo root, take it as an explicit `-C` flag.
 
 # Source helpers
 [[ -f "$SCRIPT_DIR/lib/_log-helper" ]] && source "$SCRIPT_DIR/lib/_log-helper"

--- a/agency/tools/receipt-sign
+++ b/agency/tools/receipt-sign
@@ -138,11 +138,28 @@ if [[ "$TYPE" != "qgr" && "$TYPE" != "rgr" ]]; then
     exit 1
 fi
 
-# D42-R3: path traversal check on workstream (QG finding)
-if [[ "$WORKSTREAM" == *".."* || "$WORKSTREAM" == *"/"* ]]; then
-    echo "Error: --workstream contains invalid characters (.. or /)" >&2
-    exit 1
-fi
+# D42-R3: path traversal check. Originally --workstream only, because that was
+# the one component interpolated into a DIRECTORY. But ORG/PRINCIPAL/AGENT/
+# PROJECT/BOUNDARY are all interpolated into FILENAME below, and a `/` or `..`
+# in any of them escapes RECEIPTS_DIR just as effectively — the mkdir -p that
+# follows is unconditional. That asymmetry became load-bearing once -C made the
+# write root caller-chosen too, so every component that reaches a path is
+# checked. (The land flow already sanitizes its --project via `tr '/.' '--'`;
+# this makes the tool safe rather than relying on each caller to be.)
+for _component_name in workstream org principal agent project boundary; do
+    case "$_component_name" in
+        workstream) _component_value="$WORKSTREAM" ;;
+        org)        _component_value="$ORG" ;;
+        principal)  _component_value="$PRINCIPAL" ;;
+        agent)      _component_value="$AGENT" ;;
+        project)    _component_value="$PROJECT" ;;
+        boundary)   _component_value="$BOUNDARY" ;;
+    esac
+    if [[ "$_component_value" == *".."* || "$_component_value" == *"/"* ]]; then
+        echo "Error: --$_component_name contains invalid characters (.. or /)" >&2
+        exit 1
+    fi
+done
 
 # Default hash-d-source
 if [[ -z "$HASH_D_SOURCE" ]]; then

--- a/agency/tools/receipt-sign
+++ b/agency/tools/receipt-sign
@@ -9,7 +9,7 @@
 # tool — never write receipts manually.
 #
 # Usage:
-#   ./agency/tools/receipt-sign \
+#   ./agency/tools/receipt-sign [-C <repo-root>] \
 #     --type qgr \
 #     --boundary iteration-complete \
 #     --org the-agency \
@@ -28,11 +28,39 @@
 #     --summary "Review summary text"
 #
 # Written: 2026-04-14 during captain session (receipt infrastructure Phase 1)
+# Updated: v46.29 — added `-C <repo-root>` so a caller can retarget the repo
+#   this tool writes into (see the block below for why).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: pr-captain-land runs the CAPTAIN'S trusted tools against a
+# scratch worktree by setting the cwd — captain's code, scratch's data. That
+# works for cwd-aware tools (diff-hash, git-safe, git-safe-commit), but
+# receipt-sign resolved its target from SCRIPT_DIR/../.. — its own INSTALL
+# location — and ignored cwd entirely. On a real land the landing receipt was
+# therefore written into the captain's main checkout, the find-in-scratch that
+# follows came up empty, and the land aborted with "landing receipt was signed
+# but could not be located".
+#
+# How & Why: an explicit git-style `-C` flag, accepted only as the FIRST
+# argument (unambiguous, and it cannot collide with a `--summary` value that
+# happens to be the string "-C"). When absent the root stays SCRIPT_DIR/../..,
+# byte-for-byte the previous behaviour, so no existing caller changes. cwd is
+# deliberately NOT consulted as a fallback: a tool that silently follows cwd is
+# how this class of bug hides. The caller must say what it means.
+REPO_ROOT=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "Error: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "Error: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT="$(cd "$2" && pwd)"
+    shift 2
+fi
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
 # D42-R3: receipts write to per-workstream paths.
 # RECEIPTS_DIR is set after --workstream is parsed (see below).
 
@@ -73,7 +101,11 @@ while [[ $# -gt 0 ]]; do
         --diff-base) DIFF_BASE="$2"; shift 2 ;;
         --summary) SUMMARY="$2"; shift 2 ;;
         --help)
-            echo "Usage: receipt-sign --type qgr|rgr --boundary <boundary> --org <org> --principal <principal> --agent <agent> --workstream <ws> --project <proj> --hash-a <h> --hash-b <h> --hash-c <h> --hash-d <h> --hash-e <h> [--hash-d-source <src>] [--hash-d-transcript <path>] [--diff-base <ref>] [--summary <text>]"
+            echo "Usage: receipt-sign [-C <repo-root>] --type qgr|rgr --boundary <boundary> --org <org> --principal <principal> --agent <agent> --workstream <ws> --project <proj> --hash-a <h> --hash-b <h> --hash-c <h> --hash-d <h> --hash-e <h> [--hash-d-source <src>] [--hash-d-transcript <path>] [--diff-base <ref>] [--summary <text>]"
+            echo ""
+            echo "  -C <repo-root>  Write the receipt into <repo-root> instead of this tool's"
+            echo "                  own checkout. Must be the FIRST argument. Used by"
+            echo "                  pr-captain-land to sign into its scratch worktree."
             exit 0
             ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-devex-publish-path-repo-root-qgr-pr-captain-land-20260812-0953-b21fea5.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-devex-publish-path-repo-root-qgr-pr-captain-land-20260812-0953-b21fea5.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: devex-publish-path-repo-root
+diff_base: origin/main
+hash_a: 607a479f313d68cff606344e8a7bbf7d413804c4a1a99025c2d480b20126aa05
+hash_b: b209fa455af1e45562ae8a819cffb9c0cfed7a7d062a9b7853135089e8ac7c97
+hash_c: 8d8a07cc3e7c3ff2155aebe408bfd007258431a989f8fa257a6e9e834421b410
+hash_d: 8d8a07cc3e7c3ff2155aebe408bfd007258431a989f8fa257a6e9e834421b410
+hash_d_source: "auto-approved — no principal 1B1 (agent QG); captain landing per principal in-session directive"
+hash_e: b21fea5f5a8dbe38d60a49acdb5ec6a5c9577d7b5e15dae71b16edde86c02bd1
+date: 2026-08-12T09:53
+---
+
+# Receipt: pr-captain-land — devex-publish-path-repo-root
+
+## Chain of Trust
+- A (original): 607a479
+- B (findings): b209fa4
+- C (triage): 8d8a07c
+- D (principal): 8d8a07c — auto-approved — no principal 1B1 (agent QG); captain landing per principal in-session directive
+- E (final): b21fea5
+
+## Review Summary
+Bootstrap-land of devex-publish-path-repo-root: -C repo-root targeting for pr-captain-land publish path (steps 4-9) + git-sync default-branch guard/merge-not-rebase. Chains to agent receipt d60f4bd; agency_version 46.28 → 46.29.

--- a/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260811-1704-8f81cef.md
+++ b/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260811-1704-8f81cef.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: devex
+workstream: devex
+project: publish-path-repo-root
+diff_base: origin/main
+hash_a: 281c0abae0f08bf7cb48426a14c10058783c86cb506910ebd918d5a45822d2a6
+hash_b: 87ed7bb29a18965eebff00ee66844c57accd7c534ec733633351e2e611ddd568
+hash_c: 079771bf28973854f10e16bb4b93e1bd28c1b6bc1c7f3a5bd0daab030b1970e3
+hash_d: 079771bf28973854f10e16bb4b93e1bd28c1b6bc1c7f3a5bd0daab030b1970e3
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 8f81cefa31586a2c7ee16fbfcbca069c588720ad11520de2dc3ad4c4e8b158fe
+date: 2026-08-11T17:04
+---
+
+# Receipt: pr-prep — publish-path-repo-root
+
+## Chain of Trust
+- A (original): 281c0ab
+- B (findings): 87ed7bb
+- C (triage): 079771b
+- D (principal): 079771b — auto-approved — no principal 1B1
+- E (final): 8f81cef
+
+## Review Summary
+pr-prep for -C repo-root targeting on the pr-captain-land publish path (steps 4-9). 14 findings scored, 10 accepted and fixed, 4 deferred with rationale. Critical: the first cut of the fix was inert in a real captain session because git-safe-commit's PROJECT_ROOT prefers CLAUDE_PROJECT_DIR, and both new suites ran with that variable unset so they passed against broken code. Fixed via COMMIT_REPO_ROOT + a test that runs with the variable set. Also fixed pr-create's cwd/-C hash-verification split, dispatch's branch-supplied ISCP DB name, receipt-sign's partial traversal check, and two portability/assertion defects in the new suites. 368 passing / 2 failing on the changed-tool suites; both failures pre-existing hookify-rule tests present in the baseline.

--- a/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260812-0858-d60f4bd.md
+++ b/agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260812-0858-d60f4bd.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: devex
+workstream: devex
+project: publish-path-repo-root
+diff_base: origin/main
+hash_a: 607a479f313d68cff606344e8a7bbf7d413804c4a1a99025c2d480b20126aa05
+hash_b: b209fa455af1e45562ae8a819cffb9c0cfed7a7d062a9b7853135089e8ac7c97
+hash_c: 8d8a07cc3e7c3ff2155aebe408bfd007258431a989f8fa257a6e9e834421b410
+hash_d: 8d8a07cc3e7c3ff2155aebe408bfd007258431a989f8fa257a6e9e834421b410
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: d60f4bd1c40d9b34fdfe070ecc254588f031e6e5a26c4d46ace3489794d82df9
+date: 2026-08-12T08:58
+---
+
+# Receipt: pr-prep — publish-path-repo-root
+
+## Chain of Trust
+- A (original): 607a479
+- B (findings): b209fa4
+- C (triage): 8d8a07c
+- D (principal): 8d8a07c — auto-approved — no principal 1B1
+- E (final): d60f4bd
+
+## Review Summary
+Combined pr-prep: -C repo-root targeting for the pr-captain-land publish path (steps 4-9) plus the git-sync default-branch guard and merge-not-rebase fix. Round 2 reviewed the git-sync delta: 13 findings, 12 fixed, 1 noted. The gate mutation-tested the new guard and found its resolved-default-branch clause was entirely uncovered (deleting it left 16/16 green) and that three tests passed for reasons other than their stated ones; both guard clauses are now independently mutation-verified. Also fixed in git-sync: unguarded detached HEAD, a swallowed merge conflict that pushed anyway, and a push-log that split every row across two lines. 444 passing / 4 failing across the changed-tool suites; all 4 failures pre-existing and present in the baseline.

--- a/history/push-log.md
+++ b/history/push-log.md
@@ -1,0 +1,7 @@
+# Push Log
+
+Accountability log for all remote pushes. All agents must use `./agency/tools/git-sync`.
+
+| Timestamp | Agent | Commits | Skip CI | Branch |
+|-----------|-------|---------|---------|--------|
+| 2026-08-12 08:55:23 +08 | the-agency/jordan/devex-publish-path-repo-root | 1 | 0 skip-ci | devex-publish-path-repo-root |

--- a/src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+++ b/src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
@@ -93,10 +93,12 @@ For RGR methodology artifacts, hash the file content directly:
 
 **Hash match only. No time window.**
 
-Hash E in the receipt matches the current artifact on disk → valid.
+Hash E in the receipt matches the current artifact in the **committed state** (`git diff` against `diff_base`) → valid.
 Hash E does not match → stale, blocked.
 
 Time is irrelevant. The hash is the validity check.
+
+**Important:** "Committed state" means what `diff-hash` computes against `diff_base` — i.e., what is *committed* to the branch, not what is in the working tree. Unstaged or uncommitted changes in the working tree do NOT invalidate a receipt. The receipt tracks what has been reviewed + committed; dirty working tree is transient. DevEx Phase 2 verification (#331) confirmed this: `receipt-verify` runs `diff-hash` with the same `diff_base` recorded in the receipt and compares Hash E against the resulting diff hash of the committed content.
 
 ---
 
@@ -175,6 +177,16 @@ Required flags:
 | `--hash-a` through `--hash-e` | Full SHA-256 for each chain position |
 | `--hash-d-source` | `transcript` or `auto-approved — no principal 1B1` |
 | `--hash-d-transcript` | Path to transcript file (omit if auto-approved) |
+
+Optional, and it must come **first** if used:
+
+| Flag | Description |
+|------|-------------|
+| `-C <repo-root>` | Write the receipt into `<repo-root>` instead of the tool's own checkout |
+
+Without `-C`, the receipt is written relative to the tool's **install location** (`SCRIPT_DIR/../..`) — *not* the cwd. That default is correct for every ordinary caller, which runs the tool out of the repo it is signing for.
+
+It is wrong in exactly one situation, and `-C` exists for it: when a tool from one checkout is run against another. `/pr-captain-land` does this deliberately — captain's trusted tools, scratch worktree's data — and before `-C` existed the landing receipt was signed into the captain's main checkout, where the flow could not find it, aborting the land. If you are invoking `receipt-sign` from outside the repo the receipt belongs to, pass `-C`; `cd` alone will not do it.
 
 ### `receipt-verify`
 

--- a/src/agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+++ b/src/agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
@@ -4,6 +4,44 @@ Tool path root: `./agency/tools/`
 
 ---
 
+## Hooks and Hookify — Locations
+
+Two related but distinct directories:
+
+| Directory | Purpose | Referenced by |
+|---|---|---|
+| `agency/hooks/*.sh` | Executable hook scripts. Block, warn, or inform at agent tool-use boundaries. | `.claude/settings.json` `PreToolUse` / `PostToolUse` / `Stop` etc. (by absolute path via `$CLAUDE_PROJECT_DIR`) |
+| `agency/hookify/*.md` | Enforcement-rule definitions (block / warn / inform rules — the docs the hook scripts enforce). | Referenced from hook scripts; also loaded by ref-injector when triggered. |
+
+**`.claude/hooks/` does NOT exist and does NOT need to.** Claude Code reads hooks from `.claude/settings.json`, not from a conventional directory. The settings file references hook scripts by absolute path; that path is `agency/hooks/` in this framework.
+
+Both `agency/hooks/` and `agency/hookify/` are framework source — they ship with the framework and are versioned with it. Putting them under `.claude/` would mix framework code with Claude Code's private state.
+
+Post-Great-Rename, the canonical paths are `agency/hooks/` and `agency/hookify/` (formerly `claude/hooks/` and `claude/hookify/`). `.claude/settings.json` was updated accordingly.
+
+---
+
+## Tool-tier Carve-out (Agent Boundary vs. Tool Boundary)
+
+The `git-safe` / `git-captain` / `cp-safe` / `pr-create` wrappers enforce discipline on **agent invocations** (Bash tool calls). The hookify layer blocks raw `git`, `gh pr create`, `cp`, etc. at the **agent boundary**.
+
+Framework tools (`agency/tools/*`) are the **implementation layer** — they call `git`, `gh`, `cp` directly because they *are* what the wrappers wrap. Hookify does not block tool-internal subshells; tools are trusted code.
+
+### Rules for tool authors
+
+1. **You may call `git` directly** inside an `agency/tools/*` script. Tools are trusted; the hookify layer is scoped to the agent boundary, not the tool boundary.
+2. **If a tool emits a command for an agent to run** (e.g., prints `"git push origin main"` for the user to execute), route the *printed* command through the safe form (`./agency/tools/git-push origin main`).
+3. **`git-safe` must not call `git-safe`** — that creates a cycle. The wrapper calls raw `git` internally. Same for `git-captain`, `cp-safe`, `pr-create`.
+4. **Tool-tier code is reviewed at author time** — not enforced at invocation. Review for correctness, injection-safety, and error handling the way you would any shell script.
+
+### Why this matters
+
+- Without the explicit carve-out, new reviewers ask "why doesn't this tool use `git-safe`?" and well-intentioned sweeps introduce cycles.
+- The framework has >50 direct `git` calls across `agency/tools/*` — they are all intentional.
+- Session-lifecycle primitives (`session-pause`, `session-pickup`, etc.) follow this pattern: direct `git` calls for internal state, safe-tool wrappers when the tool prints a command for the agent to run.
+
+---
+
 ## `git-safe`
 
 Safe git operations for all agents. Hookify blocks raw `git add -A`, `git add .`, and `git rebase`; this tool provides the approved read and limited-write path.
@@ -183,6 +221,8 @@ Checks (each exits 1 on failure):
 
 QG-aware commit wrapper. Enforces work item tracking, builds structured commit messages, adds per-agent attribution, and dispatches a commit notification to captain.
 
+This tool resolves its repo from the **cwd** (`git rev-parse --show-toplevel`), so it commits to whichever worktree you run it in, and it forwards that root to the `dispatch` tool as `-C` so the commit-announce payload lands in the same repo as the commit it announces. Before that forwarding existed, committing in one worktree with a `git-safe-commit` from another wrote the announce into the *tool's* checkout — a dispatch describing a commit that repo did not contain.
+
 **Usage:** `./agency/tools/git-safe-commit "<message>" --work-item <ID> --stage <stage>`
 
 **Escape hatch:** `./agency/tools/git-safe-commit "<message>" --no-work-item`
@@ -195,6 +235,7 @@ QG-aware commit wrapper. Enforces work item tracking, builds structured commit m
 | `--work-item <ID>` | `-w` | Yes* | Work item ID: `REQUEST-jordan-0065`, `SPRINT-web-2026w03`, etc. |
 | `--stage <stage>` | `-s` | When work-item given | One of: `impl`, `review`, `tests` |
 | `--no-work-item` | — | Alternative to `--work-item` | Explicit escape hatch |
+| `--coord` | — | Alternative to `--work-item` | Coord-artifact alias — same semantics as `--no-work-item`; matches `/coord-commit` skill naming (#395) |
 | `--allow-large` | — | No | Bypass commit-precheck large-file block for this commit (sets `ALLOW_LARGE_COMMIT=1`) |
 | `--body <text>` | `-b` | No | Detailed commit body |
 | `--principal <name>` | `-p` | No | Override principal (default: from work item or env) |
@@ -347,9 +388,17 @@ For cross-worktree sync, use `/worktree-sync`.
 
 QG-gated PR creation. Wraps `gh pr create` with three mandatory checks. Hookify blocks raw `gh pr create`.
 
-**Usage:** `./agency/tools/pr-create --title "title" --body "body" [gh pr create flags...]`
+**Usage:** `./agency/tools/pr-create [-C <repo-root>] --title "title" --body "body" [gh pr create flags...]`
 
 All flags after validation are passed through to `gh pr create`.
+
+### `-C <repo-root>` — which repo gets gated
+
+By default the checks below read the tool's own checkout (`SCRIPT_DIR/../..`), while `gh pr create` reads the cwd. Those are the same directory for every ordinary caller, so the split is invisible — until they are not, at which point the tool gates one tree and opens a PR from another.
+
+`-C` closes that: it names one repo for **both** the checks and `gh`. It must be the **first** argument, because everything after it is forwarded verbatim to `gh pr create`.
+
+`-C` retargets **data, never code**. The sub-tools this script runs — `receipt-verify`, `resolve-default-branch` — are still invoked from `$SCRIPT_DIR`. A branch cannot ship its own `receipt-verify` and thereby pass its own gate; that guarantee is what lets `/pr-captain-land` run the captain's `pr-create` against an unreviewed scratch worktree at all.
 
 ### Pre-flight checks
 

--- a/src/agency/tools/dispatch
+++ b/src/agency/tools/dispatch
@@ -88,6 +88,23 @@ source "$SCRIPT_DIR/lib/_iscp-db"
 # checkout: retargeting the root moves the payload file without splitting the
 # dispatch index into a second database.
 if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    # Pin the DB *before* moving the root. iscp_db_path derives the database
+    # name from the repo name in agency/config/agency.yaml under
+    # AGENCY_PROJECT_ROOT — which, once retargeted, is a file supplied by the
+    # branch under review. A branch that edited repo.name would send its
+    # dispatches to a different ~/.agency/<name>/iscp.db: the index splits and
+    # the captain never sees the notice. Resolving it here, while the root is
+    # still this tool's own install location, keeps the identity of the DB a
+    # property of the INSTALL and lets -C move only the payload file — which is
+    # what -C is for and what the comment above claims it does.
+    #
+    # ISCP_DB_PATH is the documented override iscp_db_path honours first, so an
+    # explicit one from the caller (or a test harness) still wins.
+    if [[ -z "${ISCP_DB_PATH:-}" ]]; then
+        ISCP_DB_PATH="$(iscp_db_path 2>/dev/null || true)"
+        [[ -n "$ISCP_DB_PATH" ]] && export ISCP_DB_PATH
+    fi
+
     AGENCY_PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
     AGENCY_PRINCIPAL_DIR="$AGENCY_PROJECT_ROOT/usr/${AGENCY_PRINCIPAL:-}"
     AGENCY_REFS_DIR="$AGENCY_PRINCIPAL_DIR/refs"

--- a/src/agency/tools/dispatch
+++ b/src/agency/tools/dispatch
@@ -18,6 +18,7 @@
 # Written: 2026-04-05 during ISCP Iteration 1.4
 #
 # Usage:
+#   dispatch [-C <repo-root>] <subcommand> ...
 #   dispatch create --to <addr> --subject <text> --body <text> [--type <type>] [--priority <p>]
 #   dispatch create --to <addr> --subject <text> --template [--type <type>] [--priority <p>]
 #   dispatch list [--all] [--status <s>] [--type <t>]
@@ -36,10 +37,38 @@ set -euo pipefail
 TOOL_VERSION="2.0.1"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: the payload file a dispatch writes lands under
+# $PROJECT_ROOT/usr/<principal>/<project>/dispatches/, and PROJECT_ROOT came
+# only from CLAUDE_PROJECT_DIR or the tool's own INSTALL location. When
+# pr-captain-land commits inside its scratch worktree, git-safe-commit's
+# commit-announce reached this tool and the payload was written into the
+# CAPTAIN'S MAIN CHECKOUT — a stray untracked file in the wrong repo, for a
+# commit that does not exist there. git-safe-commit had already resolved the
+# right root from cwd; it just had no way to say so.
+#
+# How & Why: `-C` is that way to say so, and it outranks CLAUDE_PROJECT_DIR —
+# an explicit argument must beat an inherited environment variable, or a
+# captain-side env var would keep overriding the caller. First argument only,
+# git-style: `reply` and `create --body` take free text, so a scan-anywhere
+# parse could swallow a legitimate "-C" payload. Absent the flag, resolution is
+# exactly as before.
+REPO_ROOT_OVERRIDE=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "dispatch: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "dispatch: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT_OVERRIDE="$(cd "$2" && pwd)"
+    shift 2
+fi
+
 # CLAUDE_PROJECT_DIR is authoritative — worktree agents may cd to main but
 # their identity is rooted in the worktree, not where the tool binary lives.
 # See escalation #90: agent-identity and dispatch both must use this.
-if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
+if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
+elif [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     PROJECT_ROOT="$CLAUDE_PROJECT_DIR"
 else
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
@@ -51,8 +80,33 @@ source "$SCRIPT_DIR/lib/_path-resolve"
 source "$SCRIPT_DIR/lib/_address-parse"
 source "$SCRIPT_DIR/lib/_iscp-db"
 
+# _path-resolve derives AGENCY_PROJECT_ROOT from SCRIPT_DIR on source, and
+# _address-parse / _iscp-db read it — so setting PROJECT_ROOT above is not
+# enough on its own, and the override has to be re-applied AFTER the sourcing
+# that would otherwise clobber it. The ISCP DB is keyed by the repo NAME out of
+# agency/config/agency.yaml, which is identical in a worktree and its main
+# checkout: retargeting the root moves the payload file without splitting the
+# dispatch index into a second database.
+if [[ -n "$REPO_ROOT_OVERRIDE" ]]; then
+    AGENCY_PROJECT_ROOT="$REPO_ROOT_OVERRIDE"
+    AGENCY_PRINCIPAL_DIR="$AGENCY_PROJECT_ROOT/usr/${AGENCY_PRINCIPAL:-}"
+    AGENCY_REFS_DIR="$AGENCY_PRINCIPAL_DIR/refs"
+    export AGENCY_PROJECT_ROOT AGENCY_PRINCIPAL_DIR AGENCY_REFS_DIR
+fi
+
 # Valid dispatch types (must match _iscp-db CHECK constraint)
 VALID_TYPES="directive seed review review-response commit master-updated escalation dispatch"
+
+# Alias map — human-friendly aliases that resolve to canonical types.
+# Used to heal doc drift (e.g. legacy docs say "main-updated").
+# Issue #167 — unify main-updated vs master-updated vocabulary.
+_canonicalize_type() {
+    local dtype="$1"
+    case "$dtype" in
+        main-updated) echo "master-updated" ;;
+        *) echo "$dtype" ;;
+    esac
+}
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Helpers
@@ -214,7 +268,7 @@ _validate_type() {
 # create — Create dispatch (DB record + git payload file)
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_create() {
-    local to_addr="" subject="" reply_to="" priority="normal" dtype="dispatch" project="" body="" use_template=false
+    local to_addr="" subject="" reply_to="" priority="normal" dtype="dispatch" project="" body="" body_file="" use_template=false
 
     while [[ $# -gt 0 ]]; do
         case "$1" in
@@ -227,6 +281,9 @@ cmd_create() {
             --body)
                 [[ -n "${2:-}" ]] || { echo "Error: --body requires text" >&2; return 1; }
                 body="$2"; shift 2 ;;
+            --body-file)
+                [[ -n "${2:-}" ]] || { echo "Error: --body-file requires a path" >&2; return 1; }
+                body_file="$2"; shift 2 ;;
             --template)
                 use_template=true; shift ;;
             --type)
@@ -243,7 +300,11 @@ cmd_create() {
                 project="$2"; shift 2 ;;
             --help|-h)
                 echo "Usage: dispatch create --to <addr> --subject <text> --body <text> [--type <type>] [--priority <p>] [--reply-to <id>] [--project <name>]"
+                echo "       dispatch create --to <addr> --subject <text> --body-file <path> [--type <type>]"
                 echo "       dispatch create --to <addr> --subject <text> --template [--type <type>]"
+                echo ""
+                echo "  --body and --body-file are mutually exclusive."
+                echo "  --body-file must point to a non-empty file."
                 return 0 ;;
             *)
                 echo "Error: unknown option for create: $1" >&2; return 1 ;;
@@ -264,12 +325,36 @@ cmd_create() {
     # How & Why: Require --body (content) or --template (explicit opt-in).
     # No content = no dispatch. Fail loud.
     # Written: 2026-04-06 — escalation #53
+
+    # Mutex: --body and --body-file cannot be combined (issue #251)
+    if [[ -n "$body" ]] && [[ -n "$body_file" ]]; then
+        echo "Error: --body and --body-file are mutually exclusive" >&2
+        return 1
+    fi
+
+    # Resolve --body-file → body string (issue #251)
+    if [[ -n "$body_file" ]]; then
+        if [[ ! -f "$body_file" ]]; then
+            echo "Error: --body-file not found: $body_file" >&2
+            return 1
+        fi
+        body="$(cat "$body_file")"
+        if [[ -z "$body" ]] || [[ -z "${body//[[:space:]]/}" ]]; then
+            echo "Error: --body-file is empty (or whitespace-only): $body_file" >&2
+            return 1
+        fi
+    fi
+
     if [[ -z "$body" ]] && [[ "$use_template" != "true" ]]; then
-        echo "Error: --body <text> is required (or use --template for placeholder file)" >&2
+        echo "Error: --body <text> or --body-file <path> is required (or use --template for placeholder file)" >&2
         echo "  dispatch create --to <addr> --subject <text> --body \"your content here\"" >&2
+        echo "  dispatch create --to <addr> --subject <text> --body-file path/to/body.md" >&2
         echo "  dispatch create --to <addr> --subject <text> --template" >&2
         return 1
     fi
+
+    # Canonicalize type aliases (e.g. main-updated → master-updated, issue #167)
+    dtype="$(_canonicalize_type "$dtype")"
 
     # Validate type
     _validate_type "$dtype" || return 1
@@ -914,6 +999,7 @@ cmd_help() {
 dispatch — ISCP dispatch lifecycle tool (v2)
 
 Usage:
+  dispatch [-C <repo-root>] <subcommand> ...
   dispatch create --to <addr> --subject <text> [--body <text>] [--type <type>] [--priority <p>]
   dispatch list [--all] [--status <s>] [--type <t>]
   dispatch read <id>
@@ -927,6 +1013,11 @@ Usage:
 
 Dispatch types: directive, seed, review, review-response, commit,
   master-updated, escalation, dispatch
+
+-C <repo-root>  Write payload files into <repo-root> instead of this tool's own
+                checkout. Must be the FIRST argument, before the subcommand.
+                Outranks CLAUDE_PROJECT_DIR. Used when a tool runs against a
+                worktree other than the one it was installed in.
 
 Dispatches are indexed in the ISCP SQLite DB. Payload files live in git.
 Arguments take integer dispatch IDs, not file paths.

--- a/src/agency/tools/git-safe-commit
+++ b/src/agency/tools/git-safe-commit
@@ -29,6 +29,7 @@
 #   --work-item, -w   Work item ID (REQUEST-jordan-0065, SPRINT-web-2026w03, etc.)
 #   --stage, -s       Stage: impl, review, tests (required if work-item provided)
 #   --no-work-item    Escape hatch when no work item applies (skip work-item requirement)
+#   --coord           Alias for --no-work-item (coord-artifact commits; see /coord-commit)
 #   --allow-large     Bypass commit-precheck large-file block (single-commit override)
 #   --body, -b        Detailed commit body
 #   --principal, -p   Override principal (default: from config or work item)
@@ -162,7 +163,19 @@ while [[ $# -gt 0 ]]; do
             STAGED_ONLY=true
             shift
             ;;
-        --no-work-item)
+        --no-work-item|--force|-f)
+            # --force / -f are documented aliases for --no-work-item (issue #283)
+            # Skill docs historically showed --force; keep the alias to match.
+            NO_WORK_ITEM=true
+            shift
+            ;;
+        --coord)
+            # --coord is a convenience alias for --no-work-item (issue #395).
+            # Semantics match /coord-commit skill's happy path: commit coord
+            # artifacts (handoffs, dispatches, seeds, config) without QG.
+            # NOTE: This is the minimal happy-path alias. Full validation of
+            # "staged files are coord artifacts" and automatic `misc:` prefix
+            # injection are follow-ups tracked in #395 (acceptance criteria).
             NO_WORK_ITEM=true
             shift
             ;;
@@ -285,6 +298,28 @@ main() {
         trap - EXIT
         log_end "$RUN_ID" "failure" 1 0 "Missing commit message"
         exit 1
+    fi
+
+    # Issue #204: first-launch UX. Git itself errors "Please tell me who you
+    # are" with exit 128 when user.name/user.email are unconfigured, but that
+    # message often gets swallowed by the pre-commit hook chain and surfaces
+    # as a silent exit 128. Check up front with an actionable remediation.
+    local git_user_name git_user_email
+    git_user_name=$(git config --get user.name 2>/dev/null || true)
+    git_user_email=$(git config --get user.email 2>/dev/null || true)
+    if [ -z "$git_user_name" ] || [ -z "$git_user_email" ]; then
+        log_error "Git identity not configured — cannot commit."
+        echo ""
+        echo "Git requires user.name and user.email to record a commit. Configure them via git-safe:"
+        echo "  ./agency/tools/git-safe config --global user.name  \"Your Name\""
+        echo "  ./agency/tools/git-safe config --global user.email \"you@example.com\""
+        echo ""
+        echo "Current values:"
+        echo "  user.name  = ${git_user_name:-<unset>}"
+        echo "  user.email = ${git_user_email:-<unset>}"
+        trap - EXIT
+        log_end "$RUN_ID" "failure" 128 0 "Git identity not configured"
+        exit 128
     fi
 
     # ENFORCEMENT: Require work item OR --no-work-item
@@ -625,7 +660,16 @@ main() {
 ${files_changed}
 \`\`\`"
 
-                    "$DISPATCH_TOOL" create \
+                    # -C "$PROJECT_ROOT": this tool already resolved the repo
+                    # correctly from cwd (git rev-parse --show-toplevel), but
+                    # the dispatch tool resolved its own root from its INSTALL
+                    # location. Committing inside a worktree therefore wrote the
+                    # commit-announce payload into whichever checkout the tool
+                    # binary happened to live in — observed during a real
+                    # pr-captain-land, where a scratch-worktree commit littered
+                    # the captain's main checkout with a dispatch for a commit
+                    # that was not in it. Pass the root we already know.
+                    "$DISPATCH_TOOL" -C "$PROJECT_ROOT" create \
                         --type commit \
                         --to "$CAPTAIN_ADDR" \
                         --subject "Committed ${COMMIT_HASH} on ${CURRENT_BRANCH}: ${MESSAGE}" \

--- a/src/agency/tools/git-safe-commit
+++ b/src/agency/tools/git-safe-commit
@@ -60,6 +60,21 @@ elif PROJECT_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
 else
     PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 fi
+
+# The repo this commit is actually going INTO — strictly the cwd's worktree,
+# with no CLAUDE_PROJECT_DIR consultation.
+#
+# PROJECT_ROOT above deliberately prefers CLAUDE_PROJECT_DIR because it is used
+# for the per-agent ATTRIBUTION lookup, which is a property of the session. That
+# is the wrong answer for "where does this commit live": Claude Code sets
+# CLAUDE_PROJECT_DIR to the main checkout, so in any real session PROJECT_ROOT
+# points at the main checkout even while we are committing inside a worktree.
+# Using it for the dispatch target sent commit-announce payloads to a repo that
+# does not contain the commit — the bug -C was added to fix, which the first
+# version of that fix reproduced exactly by passing PROJECT_ROOT.
+if ! COMMIT_REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+    COMMIT_REPO_ROOT="$PROJECT_ROOT"
+fi
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
     source "$SCRIPT_DIR/lib/_log-helper"
 fi
@@ -660,16 +675,16 @@ main() {
 ${files_changed}
 \`\`\`"
 
-                    # -C "$PROJECT_ROOT": this tool already resolved the repo
-                    # correctly from cwd (git rev-parse --show-toplevel), but
-                    # the dispatch tool resolved its own root from its INSTALL
-                    # location. Committing inside a worktree therefore wrote the
-                    # commit-announce payload into whichever checkout the tool
-                    # binary happened to live in — observed during a real
-                    # pr-captain-land, where a scratch-worktree commit littered
-                    # the captain's main checkout with a dispatch for a commit
-                    # that was not in it. Pass the root we already know.
-                    "$DISPATCH_TOOL" -C "$PROJECT_ROOT" create \
+                    # -C "$COMMIT_REPO_ROOT" — the cwd's worktree, NOT
+                    # PROJECT_ROOT (which follows CLAUDE_PROJECT_DIR to the main
+                    # checkout; see the derivation above). dispatch resolves its
+                    # own root from its INSTALL location, so committing inside a
+                    # worktree otherwise wrote the commit-announce into whichever
+                    # checkout the tool binary lived in — observed during a real
+                    # pr-captain-land, where a scratch commit littered the
+                    # captain's main checkout with a dispatch for a commit that
+                    # was not in it. The payload must land with its commit.
+                    "$DISPATCH_TOOL" -C "$COMMIT_REPO_ROOT" create \
                         --type commit \
                         --to "$CAPTAIN_ADDR" \
                         --subject "Committed ${COMMIT_HASH} on ${CURRENT_BRANCH}: ${MESSAGE}" \

--- a/src/agency/tools/git-sync
+++ b/src/agency/tools/git-sync
@@ -1,6 +1,25 @@
 #!/bin/bash
-# Sync local commits with remote (pull --rebase + push)
-# This is the ONLY approved way to push to remote
+# Sync local commits with remote (pull --no-rebase + push)
+#
+# What Problem: this tool contradicted two of the framework's sacred invariants
+# and nothing stopped it. It ran `git pull --rebase` (merge, never rebase) and
+# `git push -u origin "$BRANCH"` with NO main/master guard (never push master).
+# Invoked on main it did both at once: rewrote main's history and pushed main
+# straight past the PR flow. That happened. The content was benign captain
+# coordination, so the damage was recoverable, but the tool was a landmine —
+# `git-push` right next to it has blocked main since Day 40.
+#
+# How & Why: three changes.
+#   1. Refuse outright on the default branch, mirroring git-push's block. The
+#      branch name is resolved via resolve-default-branch rather than hardcoded,
+#      so this holds on master-default repos too — and main/master are BOTH
+#      always refused regardless of which one this repo uses, because a tool
+#      whose safety depends on remote resolution succeeding is not safe.
+#   2. Merge, not rebase. The "pull before push so the push is not rejected"
+#      intent is preserved; the history rewrite is not.
+#   3. The push log recorded every agent as "unknown" (it read $AGENTNAME, which
+#      Claude Code does not set), making the accountability log useless. Resolve
+#      the real identity via agent-identity, best-effort.
 #
 # Usage: ./agency/tools/git-sync [options]
 #   --check    Show what would be pushed without pushing
@@ -8,10 +27,13 @@
 #   --verbose  Show detailed output instead of logging
 #
 # Features:
-# - Pulls with rebase first (keeps history clean)
-# - Logs all pushes for accountability
+# - Refuses on main/master — those reach the remote through PRs only
+# - Pulls with MERGE first (never rebase — no history rewrite)
+# - Logs all pushes for accountability, with the real agent identity
 # - Shows commit summary before pushing
 # - Context-efficient: 1-line output, details in log-service
+#
+# Updated: 2026-08-11 (devex) — main/master guard + merge-not-rebase + identity
 
 set -euo pipefail
 
@@ -55,6 +77,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --verbose, -v       Show detailed output instead of logging"
             echo "  --version           Show version"
             echo "  --help, -h          Show this help"
+            echo ""
+            echo "Refuses to run on main/master (or the resolved default branch)."
+            echo "Those reach origin only through PRs: /pr-submit, /pr-captain-land."
+            echo "Pulls with MERGE, never rebase."
             exit 0
             ;;
         *)
@@ -164,11 +190,47 @@ main() {
 
     REPO_ROOT="$(git rev-parse --show-toplevel)"
     PUSH_LOG="$REPO_ROOT/history/push-log.md"
-    AGENT="${AGENTNAME:-unknown}"
     TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S %Z')
 
     # Get current branch
     BRANCH=$(git branch --show-current)
+
+    # ── BLOCK: never sync the default branch ─────────────────────────────────
+    #
+    # This runs BEFORE the pull, the push, and the push-log append, so a refused
+    # invocation mutates nothing at all — not even the log.
+    #
+    # main and master are refused unconditionally, and the resolved default
+    # branch on top of that. Belt and braces on purpose: resolve-default-branch
+    # falls back to "main" when it cannot reach the remote, and a guard that
+    # goes quiet the moment the network does is not a guard. Checking the two
+    # literals as well means an offline sync on a master-default repo is still
+    # refused.
+    DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" 2>/dev/null || echo "")"
+    if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || \
+          ( -n "$DEFAULT_BRANCH" && "$BRANCH" == "$DEFAULT_BRANCH" ) ]]; then
+        end_run "failure" "Refused: $BRANCH is the default branch"
+        echo "BLOCKED: Cannot sync $BRANCH — the default branch never goes to origin directly." >&2
+        echo "" >&2
+        echo "  All changes reach $BRANCH through PRs:" >&2
+        echo "    agent   → /pr-prep, then /pr-submit" >&2
+        echo "    captain → /pr-captain-land <branch>" >&2
+        echo "" >&2
+        echo "  To bring origin's $BRANCH into your local one, merge — never rebase:" >&2
+        echo "    ./agency/tools/git-captain merge-from-origin" >&2
+        exit 1
+    fi
+
+    # Resolve the acting agent for the push log. The log read \$AGENTNAME, which
+    # Claude Code does not set, so every historical row says "unknown" and the
+    # accountability log accounts for nobody. Best-effort by design: a failure
+    # to resolve identity must never block a legitimate push.
+    AGENT="${AGENTNAME:-}"
+    if [[ -z "$AGENT" && -x "$SCRIPT_DIR/agent-identity" ]]; then
+        AGENT="$("$SCRIPT_DIR/agent-identity" 2>/dev/null || echo "")"
+    fi
+    AGENT="${AGENT:-unknown}"
+
     log_info "Starting sync on branch: $BRANCH"
 
     # Check if we have commits to push
@@ -224,10 +286,14 @@ EOF
     fi
     echo "| $TIMESTAMP | $AGENT | $AHEAD | $SKIP_CI_COUNT skip-ci | $BRANCH |" >> "$PUSH_LOG"
 
-    # Pull with rebase
-    log_info "Pulling with rebase"
-    if ! git pull --rebase origin "$BRANCH" 2>/dev/null; then
-        log_info "No remote branch yet, skipping pull"
+    # Pull with MERGE — never rebase.
+    #
+    # --no-rebase is explicit rather than relying on git's default, because
+    # pull.rebase=true in a user's global config would silently restore the
+    # rewrite this tool exists to have stopped doing.
+    log_info "Pulling with merge (never rebase)"
+    if ! git pull --no-rebase origin "$BRANCH" 2>/dev/null; then
+        log_info "No remote branch yet, or merge needs attention; skipping pull"
     fi
 
     # Push

--- a/src/agency/tools/git-sync
+++ b/src/agency/tools/git-sync
@@ -178,16 +178,6 @@ output_failure() {
 main() {
     start_run
 
-    # Check for uncommitted changes
-    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
-        log_warn "Uncommitted changes detected"
-        if [[ "$CHECK_ONLY" == "true" ]]; then
-            end_run "failure" "Uncommitted changes"
-            output_failure "Uncommitted changes in working tree"
-            exit 1
-        fi
-    fi
-
     REPO_ROOT="$(git rev-parse --show-toplevel)"
     PUSH_LOG="$REPO_ROOT/history/push-log.md"
     TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S %Z')
@@ -197,8 +187,10 @@ main() {
 
     # ── BLOCK: never sync the default branch ─────────────────────────────────
     #
-    # This runs BEFORE the pull, the push, and the push-log append, so a refused
-    # invocation mutates nothing at all — not even the log.
+    # This runs BEFORE the pull, the push, the push-log append, and even the
+    # uncommitted-changes check, so a refused invocation mutates nothing and
+    # always reports the reason that actually matters. (`--check` on a dirty
+    # main used to answer "uncommitted changes" — true, but not the point.)
     #
     # main and master are refused unconditionally, and the resolved default
     # branch on top of that. Belt and braces on purpose: resolve-default-branch
@@ -206,11 +198,26 @@ main() {
     # goes quiet the moment the network does is not a guard. Checking the two
     # literals as well means an offline sync on a master-default repo is still
     # refused.
+    #
+    # An EMPTY branch is refused too: `git branch --show-current` prints nothing
+    # on a detached HEAD, which matched none of the clauses. The tool then ran
+    # `git push -u origin ""` — fatal, so nothing reached origin, but only after
+    # appending a push-log row with an empty branch column and reporting "push
+    # failed" instead of "you are not on a branch".
     DEFAULT_BRANCH="$("$SCRIPT_DIR/resolve-default-branch" 2>/dev/null || echo "")"
+    if [[ -z "$BRANCH" ]]; then
+        end_run "failure" "Refused: detached HEAD"
+        output_failure "BLOCKED: not on a branch (detached HEAD) — nothing to sync."
+        echo "  Check out a branch first: ./agency/tools/git-safe switch <branch>" >&2
+        exit 1
+    fi
     if [[ "$BRANCH" == "main" || "$BRANCH" == "master" || \
           ( -n "$DEFAULT_BRANCH" && "$BRANCH" == "$DEFAULT_BRANCH" ) ]]; then
         end_run "failure" "Refused: $BRANCH is the default branch"
-        echo "BLOCKED: Cannot sync $BRANCH — the default branch never goes to origin directly." >&2
+        # output_failure, not a bare echo: every other failure path in this tool
+        # emits a "FAILURE: ..." line on stdout and callers grep for it. A guard
+        # that only spoke on stderr was invisible to them.
+        output_failure "BLOCKED: cannot sync $BRANCH — the default branch never goes to origin directly."
         echo "" >&2
         echo "  All changes reach $BRANCH through PRs:" >&2
         echo "    agent   → /pr-prep, then /pr-submit" >&2
@@ -219,6 +226,16 @@ main() {
         echo "  To bring origin's $BRANCH into your local one, merge — never rebase:" >&2
         echo "    ./agency/tools/git-captain merge-from-origin" >&2
         exit 1
+    fi
+
+    # Check for uncommitted changes
+    if ! git diff --quiet 2>/dev/null || ! git diff --cached --quiet 2>/dev/null; then
+        log_warn "Uncommitted changes detected"
+        if [[ "$CHECK_ONLY" == "true" ]]; then
+            end_run "failure" "Uncommitted changes"
+            output_failure "Uncommitted changes in working tree"
+            exit 1
+        fi
     fi
 
     # Resolve the acting agent for the push log. The log read \$AGENTNAME, which
@@ -282,7 +299,13 @@ EOF
 
     SKIP_CI_COUNT=0
     if git rev-parse "$UPSTREAM" >/dev/null 2>&1; then
-        SKIP_CI_COUNT=$(git log --oneline "$UPSTREAM..HEAD" | grep -c '\[skip ci\]' || echo "0")
+        # `|| true`, NOT `|| echo "0"`. grep -c already prints 0 when it matches
+        # nothing and THEN exits 1, so the echo appended a second zero and every
+        # row after the first sync was written as "0\n0", splitting the markdown
+        # table row across two lines. The log this change exists to make usable
+        # was corrupting itself on every run.
+        SKIP_CI_COUNT=$(git log --oneline "$UPSTREAM..HEAD" | grep -c '\[skip ci\]' || true)
+        SKIP_CI_COUNT="${SKIP_CI_COUNT:-0}"
     fi
     echo "| $TIMESTAMP | $AGENT | $AHEAD | $SKIP_CI_COUNT skip-ci | $BRANCH |" >> "$PUSH_LOG"
 
@@ -291,9 +314,28 @@ EOF
     # --no-rebase is explicit rather than relying on git's default, because
     # pull.rebase=true in a user's global config would silently restore the
     # rewrite this tool exists to have stopped doing.
+    #
+    # A failed pull is NOT uniformly benign, and treating it as such was its own
+    # bug: a conflicted merge left MERGE_HEAD and conflict markers in the working
+    # tree, the tool logged "skipping pull", pushed anyway, and reported "push
+    # failed" — never once mentioning the conflict the operator now had to find.
+    # Distinguish the two cases: no upstream branch is fine, a conflict stops the
+    # run with the tree left intact for the human to resolve.
     log_info "Pulling with merge (never rebase)"
-    if ! git pull --no-rebase origin "$BRANCH" 2>/dev/null; then
-        log_info "No remote branch yet, or merge needs attention; skipping pull"
+    if ! git pull --no-rebase origin "$BRANCH" >/dev/null 2>&1; then
+        if [[ -f "$(git rev-parse --git-dir)/MERGE_HEAD" ]]; then
+            log_error "Merge conflict during pull"
+            end_run "failure" "Merge conflict on $BRANCH"
+            output_failure "Merge conflict pulling origin/$BRANCH — nothing pushed."
+            echo "" >&2
+            echo "  The merge is in progress and left in place deliberately." >&2
+            echo "  Resolve the conflicts, commit, then re-run git-sync:" >&2
+            echo "    ./agency/tools/git-safe status" >&2
+            echo "  Or abandon it:" >&2
+            echo "    ./agency/tools/git-safe merge-abort" >&2
+            exit 1
+        fi
+        log_info "No remote branch yet; skipping pull"
     fi
 
     # Push

--- a/src/agency/tools/pr-create
+++ b/src/agency/tools/pr-create
@@ -90,7 +90,15 @@ if [[ -z "$NEWEST_RECEIPT" ]]; then
     exit 1
 fi
 
-if ! "$SCRIPT_DIR/receipt-verify" --file "$NEWEST_RECEIPT" 2>&1; then
+# Run the verifier FROM the captain's $SCRIPT_DIR but WITH the cwd in the repo
+# being gated. receipt-verify compares the receipt's hash against a freshly
+# computed one, and that computation goes through diff-hash, which is purely
+# cwd-based (`git diff <base>..HEAD -- .`). Without the cd, -C would retarget
+# receipt DISCOVERY but not hash VERIFICATION: a receipt found in tree A would
+# be graded against whatever tree the caller happened to be standing in. Today
+# pr-captain-land also wraps this call in a cd to the scratch, so the two agree
+# by luck; this makes them agree by construction.
+if ! (cd "$REPO_ROOT" && "$SCRIPT_DIR/receipt-verify" --file "$NEWEST_RECEIPT") 2>&1; then
     echo "" >&2
     echo "Every PR requires a valid receipt. Run /pr-prep again." >&2
     exit 1

--- a/src/agency/tools/pr-create
+++ b/src/agency/tools/pr-create
@@ -8,16 +8,47 @@
 # 3. agency_version must be bumped
 # Hookify blocks raw gh pr create.
 #
-# Usage: ./agency/tools/pr-create --title "title" --body "body"
+# Usage: ./agency/tools/pr-create [-C <repo-root>] --title "title" --body "body"
 #        All gh pr create flags are passed through after validation.
 #
 # Written: 2026-04-14 during captain session (PR discipline enforcement)
 # Updated: iteration 1.4 — replaced inline hash logic with receipt-verify
+# Updated: v46.29 — added `-C <repo-root>` (see the block below for why)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: pr-captain-land runs THIS tool from the captain's checkout with
+# the cwd set to a scratch worktree — captain's code gating the scratch's data.
+# But every gate below read REPO_ROOT = SCRIPT_DIR/../.., the tool's own INSTALL
+# location. So the BRANCH check inspected the captain's main checkout (always
+# `main`) and blocked the land outright, and the receipt/version gates likewise
+# graded the wrong tree. cwd only ever reached `gh pr create` at the very end,
+# which is how the mismatch went unnoticed.
+#
+# How & Why: `-C` retargets the DATA this tool reads — branch, receipt,
+# manifest — and the directory `gh pr create` runs in. It deliberately does NOT
+# retarget the CODE: receipt-verify and resolve-default-branch below are still
+# invoked from "$SCRIPT_DIR", so a branch cannot ship its own verifier and pass
+# its own gate. Captain's code, scratch's data — that is the whole security
+# model, and `-C` must not be a hole in it.
+#
+# First argument only: everything after this point is passed through verbatim to
+# `gh pr create`, so a scan-anywhere parse would eat a `--body` whose value was
+# literally "-C". Absent the flag, behaviour is unchanged for every caller.
+REPO_ROOT=""
+GH_RUN_DIR=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "BLOCKED: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "BLOCKED: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT="$(cd "$2" && pwd)"
+    GH_RUN_DIR="$REPO_ROOT"
+    shift 2
+fi
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 
 # ── Step 1: Verify on a branch, not main ─────────────────────────────────
 
@@ -114,4 +145,12 @@ echo "✓ Version bumped: $CURRENT_VERSION"
 # ── Step 4: Create the PR ────────────────────────────────────────────────
 
 echo "Creating PR..."
+
+# `gh pr create` infers both the branch and the target repo from its cwd, so it
+# has to run where the gates just looked. Without -C that is the caller's cwd
+# (unchanged behaviour); with -C it is the repo the caller named, so the PR
+# cannot be opened against a different tree than the one that was gated.
+if [[ -n "$GH_RUN_DIR" ]]; then
+    cd "$GH_RUN_DIR"
+fi
 gh pr create "$@"

--- a/src/agency/tools/pr-merge
+++ b/src/agency/tools/pr-merge
@@ -45,7 +45,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+# Deliberately NO PROJECT_ROOT here. This tool is repo-agnostic: it operates on
+# a PR NUMBER and lets `gh` infer the repository from the cwd. It previously
+# carried an unused `PROJECT_ROOT="$SCRIPT_DIR/../.."`, which is the exact
+# install-location pattern that broke receipt-sign and pr-create when
+# pr-captain-land ran them against a scratch worktree. Leaving a dead one here
+# is an invitation for someone to "start using it" and reintroduce the bug. If
+# this tool ever does need a repo root, take it as an explicit `-C` flag.
 
 # Source helpers
 [[ -f "$SCRIPT_DIR/lib/_log-helper" ]] && source "$SCRIPT_DIR/lib/_log-helper"

--- a/src/agency/tools/receipt-sign
+++ b/src/agency/tools/receipt-sign
@@ -138,11 +138,28 @@ if [[ "$TYPE" != "qgr" && "$TYPE" != "rgr" ]]; then
     exit 1
 fi
 
-# D42-R3: path traversal check on workstream (QG finding)
-if [[ "$WORKSTREAM" == *".."* || "$WORKSTREAM" == *"/"* ]]; then
-    echo "Error: --workstream contains invalid characters (.. or /)" >&2
-    exit 1
-fi
+# D42-R3: path traversal check. Originally --workstream only, because that was
+# the one component interpolated into a DIRECTORY. But ORG/PRINCIPAL/AGENT/
+# PROJECT/BOUNDARY are all interpolated into FILENAME below, and a `/` or `..`
+# in any of them escapes RECEIPTS_DIR just as effectively — the mkdir -p that
+# follows is unconditional. That asymmetry became load-bearing once -C made the
+# write root caller-chosen too, so every component that reaches a path is
+# checked. (The land flow already sanitizes its --project via `tr '/.' '--'`;
+# this makes the tool safe rather than relying on each caller to be.)
+for _component_name in workstream org principal agent project boundary; do
+    case "$_component_name" in
+        workstream) _component_value="$WORKSTREAM" ;;
+        org)        _component_value="$ORG" ;;
+        principal)  _component_value="$PRINCIPAL" ;;
+        agent)      _component_value="$AGENT" ;;
+        project)    _component_value="$PROJECT" ;;
+        boundary)   _component_value="$BOUNDARY" ;;
+    esac
+    if [[ "$_component_value" == *".."* || "$_component_value" == *"/"* ]]; then
+        echo "Error: --$_component_name contains invalid characters (.. or /)" >&2
+        exit 1
+    fi
+done
 
 # Default hash-d-source
 if [[ -z "$HASH_D_SOURCE" ]]; then

--- a/src/agency/tools/receipt-sign
+++ b/src/agency/tools/receipt-sign
@@ -9,7 +9,7 @@
 # tool — never write receipts manually.
 #
 # Usage:
-#   ./agency/tools/receipt-sign \
+#   ./agency/tools/receipt-sign [-C <repo-root>] \
 #     --type qgr \
 #     --boundary iteration-complete \
 #     --org the-agency \
@@ -28,11 +28,39 @@
 #     --summary "Review summary text"
 #
 # Written: 2026-04-14 during captain session (receipt infrastructure Phase 1)
+# Updated: v46.29 — added `-C <repo-root>` so a caller can retarget the repo
+#   this tool writes into (see the block below for why).
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+# ── Repo-root targeting: `-C <repo-root>`, first argument only ───────────────
+#
+# What Problem: pr-captain-land runs the CAPTAIN'S trusted tools against a
+# scratch worktree by setting the cwd — captain's code, scratch's data. That
+# works for cwd-aware tools (diff-hash, git-safe, git-safe-commit), but
+# receipt-sign resolved its target from SCRIPT_DIR/../.. — its own INSTALL
+# location — and ignored cwd entirely. On a real land the landing receipt was
+# therefore written into the captain's main checkout, the find-in-scratch that
+# follows came up empty, and the land aborted with "landing receipt was signed
+# but could not be located".
+#
+# How & Why: an explicit git-style `-C` flag, accepted only as the FIRST
+# argument (unambiguous, and it cannot collide with a `--summary` value that
+# happens to be the string "-C"). When absent the root stays SCRIPT_DIR/../..,
+# byte-for-byte the previous behaviour, so no existing caller changes. cwd is
+# deliberately NOT consulted as a fallback: a tool that silently follows cwd is
+# how this class of bug hides. The caller must say what it means.
+REPO_ROOT=""
+if [[ "${1:-}" == "-C" ]]; then
+    [[ -n "${2:-}" ]] || { echo "Error: -C requires a directory argument" >&2; exit 1; }
+    [[ -d "$2" ]] || { echo "Error: -C directory does not exist: $2" >&2; exit 1; }
+    REPO_ROOT="$(cd "$2" && pwd)"
+    shift 2
+fi
+[[ -n "$REPO_ROOT" ]] || REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
 # D42-R3: receipts write to per-workstream paths.
 # RECEIPTS_DIR is set after --workstream is parsed (see below).
 
@@ -73,7 +101,11 @@ while [[ $# -gt 0 ]]; do
         --diff-base) DIFF_BASE="$2"; shift 2 ;;
         --summary) SUMMARY="$2"; shift 2 ;;
         --help)
-            echo "Usage: receipt-sign --type qgr|rgr --boundary <boundary> --org <org> --principal <principal> --agent <agent> --workstream <ws> --project <proj> --hash-a <h> --hash-b <h> --hash-c <h> --hash-d <h> --hash-e <h> [--hash-d-source <src>] [--hash-d-transcript <path>] [--diff-base <ref>] [--summary <text>]"
+            echo "Usage: receipt-sign [-C <repo-root>] --type qgr|rgr --boundary <boundary> --org <org> --principal <principal> --agent <agent> --workstream <ws> --project <proj> --hash-a <h> --hash-b <h> --hash-c <h> --hash-d <h> --hash-e <h> [--hash-d-source <src>] [--hash-d-transcript <path>] [--diff-base <ref>] [--summary <text>]"
+            echo ""
+            echo "  -C <repo-root>  Write the receipt into <repo-root> instead of this tool's"
+            echo "                  own checkout. Must be the FIRST argument. Used by"
+            echo "                  pr-captain-land to sign into its scratch worktree."
             exit 0
             ;;
         *) echo "Unknown argument: $1" >&2; exit 1 ;;

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -172,11 +172,13 @@ Read `agency/config/manifest.json`, bump minor, refresh `updated_at`, commit via
 | D | C. `hash_d_source` records the truth: `auto-approved — no principal 1B1`, or the `--principal-approved` attestation when that flag was passed |
 | E | diff hash of the bumped tree vs `origin/<default>` |
 
-Written to `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
+Written to **the scratch's** `agency/workstreams/agency/qgr/` with boundary `pr-captain-land`, then committed. Receipts are excluded from `diff-hash`, so committing one does not invalidate the hash it carries.
+
+The `-C <scratch>` on that `receipt-sign` call is load-bearing: the tool resolves its target repo from its own install location, so `cd`-ing into the scratch does not redirect it. Without `-C` the receipt is signed into the captain's main checkout and the land aborts, unable to find it. See "Repo-root targeting" in `reference.md`.
 
 ### Step 6 — Publish
 
-Push `_land-<branch>` from the scratch, then `pr-create --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms.
+Push `_land-<branch>` from the scratch, then `pr-create -C <scratch> --base <default>`. The landing receipt is the newest receipt, so `pr-create`'s receipt gate and version-bump gate both pass on their own terms. `-C` points the gates at the scratch while the gate sub-tools still run from the captain's `$SCRIPT_DIR` — data from the scratch, code from the captain.
 
 **This is the first irreversible action.** Past here, failures report and leave the scratch in place for inspection rather than rolling back.
 

--- a/src/claude/skills/pr-captain-land/reference.md
+++ b/src/claude/skills/pr-captain-land/reference.md
@@ -131,7 +131,7 @@ The bump policy itself lives in `agency/tools/agency-version-next` (`46.25 → 4
 `pr-create` is not bypassed and not weakened. The captain signs a receipt for the state it validated:
 
 ```
-receipt-sign --type qgr --boundary pr-captain-land \
+receipt-sign -C <scratch> --type qgr --boundary pr-captain-land \
   --agent captain --workstream agency --project <branch-slug> \
   --hash-a <agent receipt hash_e> \
   --hash-b <sha256 of the validation log> \
@@ -149,10 +149,26 @@ The receipt is then committed. Receipts are excluded from `diff-hash`, so commit
 
 ```
 (cd _land-<branch> && git-push _land-<branch>)
-(cd _land-<branch> && pr-create --title ... --body ... --base <default>)
+(cd _land-<branch> && pr-create -C _land-<branch> --title ... --body ... --base <default>)
 ```
 
 `pr-create` re-derives the newest receipt (the landing receipt) and re-verifies it, and independently confirms `manifest.json` differs from `origin/<default>`. Both gates pass on their own terms.
+
+### Repo-root targeting — why `-C` appears in steps 5 and 6
+
+Every tool above runs from the **captain's** `agency/tools/`, never the scratch's: the branch under review must not supply the code that gates it. The cwd is set to the scratch so those tools read the scratch's *data*. Captain's code, scratch's data.
+
+That works only for tools that actually consult the cwd. `receipt-sign`, `pr-create`, and `dispatch` resolved their target repo from `SCRIPT_DIR/../..` — their own install location — and ignored the cwd entirely, so `cd`-ing into the scratch did nothing:
+
+- **Step 5** wrote the landing receipt into the captain's main checkout. The find-in-scratch that follows returned nothing and the land aborted with "landing receipt was signed but could not be located" (clean rollback — origin untouched).
+- **Step 4**'s commit-announce dispatch landed in the main checkout, describing a commit that repo does not contain.
+- **Step 6**'s `pr-create` would have read `BRANCH` from the main checkout (`main`) and blocked, had step 5 not failed first.
+
+`-C <repo-root>` (first argument, git-style) states the target repo explicitly. It retargets **data only** — `pr-create` still invokes `receipt-verify` and `resolve-default-branch` from its own `$SCRIPT_DIR`, so the trust boundary is unchanged. Absent the flag, every tool behaves exactly as before, so no other caller was affected.
+
+Tools invoked here that do *not* take `-C`: `git-safe`, `git-safe-commit`, `git-push`, and `diff-hash` already resolve from the cwd; `pr-merge`, `gh-release`, `gh`, and `gh-api` are repo-agnostic (they key off a PR number or an explicit `org/repo`). `git-safe-commit` forwards its own cwd-derived root to `dispatch` via `-C`.
+
+Coverage: `src/tests/skills/pr-captain-land-publish-locality.bats` runs steps 4-5 for real against a two-repo fixture and asserts the artifacts land in the scratch and *not* in the captain checkout; `src/tests/tools/repo-root-targeting.bats` pins the `-C` contract per tool.
 
 **This is the first irreversible action.** Past this point `abort_land` is no longer correct — work exists on origin. Failures report, name the pushed branch, and leave the scratch in place for inspection.
 

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -588,7 +588,12 @@ if [[ -n "$VALIDATION_FAILED" ]]; then
 
     # Tell the agent before rolling back — the scratch is about to vanish.
     AGENT_NAME="$(resolve_agent_name)"
-    bash "$TOOLS/dispatch" create \
+    # -C "$REPO_ROOT": the captain's main checkout, explicitly. This dispatch is
+    # written moments before destroy_scratch runs, so it must NOT land in the
+    # scratch — and dispatch would otherwise honour a CLAUDE_PROJECT_DIR
+    # inherited from the captain's environment, silently filing the "your land
+    # was blocked" notice into a directory that is about to be deleted.
+    bash "$TOOLS/dispatch" -C "$REPO_ROOT" create \
         --type dispatch \
         --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
         --subject "PR landing BLOCKED: $AGENT_BRANCH failed local validation ($VALIDATION_FAILED)" \
@@ -733,7 +738,14 @@ fi
 LAND_PROJECT="$(printf '%s' "$AGENT_BRANCH" | tr '/.' '--')"
 
 echo "→ Signing captain landing receipt (hash_e: ${LAND_HASH_FULL:0:7})..."
+# -C "$SCRATCH_DIR" is load-bearing, not decoration. receipt-sign resolves its
+# target repo from its own INSTALL location, so the cd alone did nothing: on a
+# real land the receipt was written into the CAPTAIN'S main checkout, the
+# find-in-scratch below came up empty, and the land aborted with "landing
+# receipt was signed but could not be located". The cd is kept because the tool
+# is still the captain's — captain's code, scratch's data.
 (cd "$SCRATCH_DIR" && bash "$TOOLS/receipt-sign" \
+    -C "$SCRATCH_DIR" \
     --type qgr \
     --boundary pr-captain-land \
     --org "$ORG" \
@@ -817,7 +829,16 @@ echo "→ Creating PR..."
 # emits warnings on the same stream, and scraping `tail -1` sent a
 # successfully created PR down the "did not return a URL" path, leaving an
 # orphan PR for the operator to find.
+#
+# -C "$SCRATCH_DIR" names the repo pr-create GATES — branch, receipt, manifest —
+# and the directory `gh pr create` runs in. Without it every gate read the
+# captain's main checkout instead: the branch check would have seen `main` and
+# blocked the land outright. It does NOT retarget pr-create's sub-tools
+# (receipt-verify, resolve-default-branch); those still resolve from pr-create's
+# own $SCRIPT_DIR, which is what keeps the branch from shipping its own
+# verifier.
 PR_OUT=$( (cd "$SCRATCH_DIR" && bash "$TOOLS/pr-create" \
+            -C "$SCRATCH_DIR" \
             --title "$PR_TITLE" --body "$PR_BODY" --base "$DEFAULT_BRANCH" 2>&1) || true)
 PR_URL=$(printf '%s\n' "$PR_OUT" | grep -oE 'https://github\.com/[^ ]+/pull/[0-9]+' | tail -1 || true)
 
@@ -982,7 +1003,10 @@ rm -f "$VALIDATION_LOG"
 
 AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."
-bash "$TOOLS/dispatch" create \
+# -C "$REPO_ROOT": destroy_scratch has already run, so the only repo that can
+# hold this payload is the captain's main checkout. Stated explicitly rather
+# than relying on the tool's install-location default.
+bash "$TOOLS/dispatch" -C "$REPO_ROOT" create \
     --type master-updated \
     --to "$ORG/$PRINCIPAL/$AGENT_NAME" \
     --subject "PR #$PR_NUM landed — v$NEW_VER released (pr-captain-land)" \

--- a/src/tests/skills/pr-captain-land-publish-locality.bats
+++ b/src/tests/skills/pr-captain-land-publish-locality.bats
@@ -73,7 +73,9 @@ principals:
   testuser: testprincipal
   default: testprincipal
 YAML
-        git init --quiet "$root"
+        # -b main explicitly — see the note in repo-root-targeting.bats: with
+        # GIT_CONFIG_GLOBAL nulled, the default branch name is the git build's.
+        git init --quiet -b main "$root"
         git -C "$root" config user.email "test@example.com"
         git -C "$root" config user.name "Test User"
         git -C "$root" remote add origin https://github.com/test-org/test-repo.git
@@ -81,7 +83,10 @@ YAML
 
     # The scratch identifies as the land agent, exactly as worktree-create
     # leaves it — this is what put payloads under usr/<principal>/_land-*/.
-    echo "captain" > "$CAPTAIN_REPO/.agency-agent"
+    # NOT literally "captain": git-safe-commit refuses to dispatch to itself, so
+    # an identity of exactly "captain" suppresses the commit-announce entirely
+    # and every locality assertion below would pass vacuously.
+    echo "captainmain" > "$CAPTAIN_REPO/.agency-agent"
     echo "landagent" > "$SCRATCH_REPO/.agency-agent"
     printf '{"agency_version": "46.28"}\n' > "$SCRATCH_REPO/agency/config/manifest.json"
     printf '{"agency_version": "46.28"}\n' > "$CAPTAIN_REPO/agency/config/manifest.json"
@@ -158,6 +163,21 @@ _run_step_5_sign() {
     [ "$(_captain_payloads)" -eq 0 ]
 }
 
+@test "step 4: locality holds with CLAUDE_PROJECT_DIR set — the captain's REAL environment" {
+    # The two tests above run with CLAUDE_PROJECT_DIR unset, which is NOT what a
+    # captain session looks like: Claude Code sets it to the main checkout, and
+    # so does every hook. git-safe-commit's PROJECT_ROOT prefers that env var
+    # over `git rev-parse --show-toplevel`, so the first version of this fix
+    # forwarded the CAPTAIN root to dispatch -C and changed nothing at all in
+    # the one environment it was written for — while these tests passed.
+    #
+    # An env var that inverts the result is not incidental setup; it is the
+    # condition under test. Pinned explicitly.
+    CLAUDE_PROJECT_DIR="$CAPTAIN_REPO" _run_step_4
+    [ "$(_scratch_payloads)" -ge 1 ]
+    [ "$(_captain_payloads)" -eq 0 ]
+}
+
 @test "step 4: the captain's working tree is left clean by a scratch commit" {
     _run_step_4
     run bash -c "git -C '$CAPTAIN_REPO' status --porcelain"
@@ -230,8 +250,11 @@ _run_step_5_sign() {
 # ─────────────────────────────────────────────────────────────────────────────
 
 @test "step 5 call site: receipt-sign is invoked with -C \$SCRATCH_DIR" {
+    # grep -A2 rather than a sed range: the range's end pattern can never match
+    # after its start line, so sed printed to EOF and only the head -3 kept the
+    # assertion honest. Say what is meant — the flag is on the invocation.
     live_code | grep -q 'TOOLS/receipt-sign"'
-    run bash -c "sed -n '/TOOLS\/receipt-sign\"/,/receipt-sign\"\$/p' '$LAND' | head -3 | grep -q -- '-C \"\$SCRATCH_DIR\"'"
+    run bash -c "grep -A2 'TOOLS/receipt-sign\"' '$LAND' | grep -q -- '-C \"\$SCRATCH_DIR\"'"
     assert_success
 }
 
@@ -264,11 +287,17 @@ _run_step_5_sign() {
     #   post-merge-state — captain-side state by design; the scratch is gone by
     #                      the time it is cleared.
     #   dispatch         — checked above; passes -C "$REPO_ROOT" deliberately.
-    #   git-safe-commit  — resolves PROJECT_ROOT from `git rev-parse
-    #                      --show-toplevel` FIRST and only falls back to its
-    #                      install dir; run with the cwd in the scratch it is
-    #                      already correct, and it forwards that root to
-    #                      dispatch via -C.
+    #   git-safe-commit  — commits through plain git, so the commit itself
+    #                      always lands in the cwd's worktree regardless of any
+    #                      root variable. Its one install-rooted read is a
+    #                      LAST-resort fallback. The part that did mis-target —
+    #                      the dispatch it spawns — is covered by its own
+    #                      COMMIT_REPO_ROOT tests in repo-root-targeting.bats
+    #                      and by the CLAUDE_PROJECT_DIR test above.
+    #                      (An earlier version of this note claimed
+    #                      git-safe-commit resolves PROJECT_ROOT from cwd first.
+    #                      It does not — CLAUDE_PROJECT_DIR wins — and that
+    #                      wrong rationale is what let a broken -C through.)
     allow=" receipt-verify post-merge-state dispatch git-safe-commit "
     offenders=""
 

--- a/src/tests/skills/pr-captain-land-publish-locality.bats
+++ b/src/tests/skills/pr-captain-land-publish-locality.bats
@@ -1,0 +1,313 @@
+#!/usr/bin/env bats
+#
+# pr-captain-land — publish path (steps 4-9) SCRATCH-LOCALITY.
+#
+# What Problem: the v2 rewrite validates in a scratch worktree and publishes
+# only validated work. It does that by running the CAPTAIN'S trusted tools with
+# the cwd set to the scratch — captain's code, scratch's data. Three of those
+# tools (receipt-sign, pr-create, dispatch) resolved their target repo from
+# their own INSTALL location and never looked at cwd, so on a real land:
+#
+#   - step 5's landing receipt was written into the captain's MAIN CHECKOUT,
+#     the find-in-scratch that follows returned nothing, and the land aborted
+#     with "landing receipt was signed but could not be located";
+#   - step 4's version-bump commit announced itself into the main checkout,
+#     leaving a dispatch for a commit that repo does not contain;
+#   - step 6's pr-create would have read BRANCH from the main checkout (=main)
+#     and blocked, had step 5 not failed first.
+#
+# The rollback was clean and origin was untouched — the safety design held. Only
+# the targeting was wrong.
+#
+# How & Why: this slipped through because --rehearse stops at step 3 and NOTHING
+# exercised 4-9. So this suite runs the step-4 and step-5 composition for real
+# — real git-safe-commit, real receipt-sign, installed in one repo and pointed
+# at another — and asserts on BOTH repos: the artifact appears in the scratch
+# AND the captain's checkout is untouched. A single-repo fixture cannot tell
+# those apart, which is precisely how the bug survived.
+#
+# Step 5's locate step is not re-implemented here: the `find` expression is
+# EXTRACTED FROM pr-captain-land ITSELF and evaluated against the fixture. The
+# original failure was the sign call and the locate call disagreeing about which
+# repo they meant, so a test that hardcodes its own pattern would have passed
+# through the whole outage. Steps 6-9 are network-bound (gh, origin), so they
+# are pinned structurally, at the specific call sites that carry the defect.
+#
+# Companions: pr-captain-land-localfirst.bats (flow invariants),
+# src/tests/tools/repo-root-targeting.bats (the -C contract, per tool).
+#
+# Written: 2026-08-11 (devex) — publish-path repo-root targeting
+
+load '../tools/test_helper'
+
+LAND="${REPO_ROOT}/.claude/skills/pr-captain-land/scripts/pr-captain-land"
+
+live_code() {
+    grep -v '^[[:space:]]*#' "$LAND"
+}
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    iscp_test_isolation_setup
+
+    # CAPTAIN_REPO: the main checkout. The tools are installed HERE, so anything
+    # resolving SCRIPT_DIR/../.. lands here — that is the trap being tested.
+    # SCRATCH_REPO: stands in for .claude/worktrees/_land-<branch>/.
+    export CAPTAIN_REPO="$BATS_TEST_TMPDIR/captain"
+    export SCRATCH_REPO="$BATS_TEST_TMPDIR/scratch"
+
+    mkdir -p "$CAPTAIN_REPO/agency/tools/lib" "$CAPTAIN_REPO/agency/config"
+    mkdir -p "$SCRATCH_REPO/agency/config"
+
+    for tool in dispatch agent-identity receipt-sign git-safe git-safe-commit \
+                stage-hash commit-precheck; do
+        [[ -f "$REPO_ROOT/agency/tools/$tool" ]] || continue
+        cp "$REPO_ROOT/agency/tools/$tool" "$CAPTAIN_REPO/agency/tools/"
+        chmod +x "$CAPTAIN_REPO/agency/tools/$tool"
+    done
+    cp "$REPO_ROOT"/agency/tools/lib/* "$CAPTAIN_REPO/agency/tools/lib/" 2>/dev/null || true
+
+    for root in "$CAPTAIN_REPO" "$SCRATCH_REPO"; do
+        cat > "$root/agency/config/agency.yaml" <<YAML
+principals:
+  testuser: testprincipal
+  default: testprincipal
+YAML
+        git init --quiet "$root"
+        git -C "$root" config user.email "test@example.com"
+        git -C "$root" config user.name "Test User"
+        git -C "$root" remote add origin https://github.com/test-org/test-repo.git
+    done
+
+    # The scratch identifies as the land agent, exactly as worktree-create
+    # leaves it — this is what put payloads under usr/<principal>/_land-*/.
+    echo "captain" > "$CAPTAIN_REPO/.agency-agent"
+    echo "landagent" > "$SCRATCH_REPO/.agency-agent"
+    printf '{"agency_version": "46.28"}\n' > "$SCRATCH_REPO/agency/config/manifest.json"
+    printf '{"agency_version": "46.28"}\n' > "$CAPTAIN_REPO/agency/config/manifest.json"
+
+    git -C "$CAPTAIN_REPO" add -A && git -C "$CAPTAIN_REPO" commit -qm init
+    git -C "$SCRATCH_REPO" add -A && git -C "$SCRATCH_REPO" commit -qm init
+    git -C "$SCRATCH_REPO" branch -m "_land-devex-fix"
+
+    export USER="testuser"
+    unset CLAUDE_PROJECT_DIR AGENCY_PROJECT_ROOT AGENCY_PRINCIPAL CLAUDE_AGENT_NAME
+
+    TOOLS="$CAPTAIN_REPO/agency/tools"
+    LAND_HASH_FULL="abc1234deadbeefcafe0000111122223333444455556666777788889999aaaa"
+}
+
+teardown() {
+    iscp_test_isolation_teardown
+    [[ -d "${BATS_TEST_TMPDIR}" ]] && rm -rf "${BATS_TEST_TMPDIR}"
+}
+
+_captain_receipts()  { find "$CAPTAIN_REPO/agency/workstreams" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+_captain_payloads()  { find "$CAPTAIN_REPO/usr" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+_scratch_payloads()  { find "$SCRATCH_REPO/usr" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+
+# Step 4, as pr-captain-land performs it: edit the SCRATCH manifest, stage it
+# with the captain's git-safe, commit it with the captain's git-safe-commit,
+# cwd in the scratch throughout.
+_run_step_4() {
+    printf '{"agency_version": "46.29"}\n' > "$SCRATCH_REPO/agency/config/manifest.json"
+    (cd "$SCRATCH_REPO" && bash "$TOOLS/git-safe" add agency/config/manifest.json) >/dev/null
+    (cd "$SCRATCH_REPO" && bash "$TOOLS/git-safe-commit" \
+        "chore(manifest): bump agency_version 46.28 → 46.29 for PR landing (captain)" \
+        --no-work-item) >/dev/null 2>&1
+}
+
+# Step 5's signing call, with the same -C the real script passes.
+_run_step_5_sign() {
+    (cd "$SCRATCH_REPO" && bash "$TOOLS/receipt-sign" \
+        -C "$SCRATCH_REPO" \
+        --type qgr --boundary pr-captain-land \
+        --org testorg --principal testprincipal --agent captain \
+        --workstream agency --project "devex-fix" \
+        --hash-a aaaa --hash-b bbbb --hash-c cccc --hash-d dddd \
+        --hash-e "$LAND_HASH_FULL") >/dev/null
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 4 — the version bump and its commit stay in the scratch
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "step 4: the version bump is committed in the scratch, not the captain checkout" {
+    _run_step_4
+    run git -C "$SCRATCH_REPO" log -1 --pretty=%s
+    assert_output_contains "bump agency_version"
+    # The captain checkout still has exactly its init commit.
+    run bash -c "git -C '$CAPTAIN_REPO' rev-list --count HEAD"
+    [ "$output" -eq 1 ]
+    run bash -c "grep -o '46\\.[0-9]*' '$CAPTAIN_REPO/agency/config/manifest.json'"
+    assert_output_contains "46.28"
+}
+
+@test "step 4: the commit-announce dispatch lands in the scratch" {
+    _run_step_4
+    [ "$(_scratch_payloads)" -ge 1 ]
+    run find "$SCRATCH_REPO/usr" -name 'commit-to-captain-committed-*.md'
+    assert_success
+    [ -n "$output" ]
+}
+
+@test "step 4: the commit-announce does NOT leak into the captain's main checkout" {
+    # The observed symptom: a stray usr/<principal>/_land-<branch>/dispatches/
+    # file in the main checkout, announcing a commit that repo does not contain.
+    _run_step_4
+    [ "$(_captain_payloads)" -eq 0 ]
+}
+
+@test "step 4: the captain's working tree is left clean by a scratch commit" {
+    _run_step_4
+    run bash -c "git -C '$CAPTAIN_REPO' status --porcelain"
+    assert_success
+    [ -z "$output" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Step 5 — the landing receipt is signed into, and findable in, the scratch
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "step 5: the landing receipt is written into the scratch worktree" {
+    _run_step_5_sign
+    run find "$SCRATCH_REPO/agency/workstreams/agency/qgr" -name '*-pr-captain-land-*.md'
+    assert_success
+    [ -n "$output" ]
+}
+
+@test "step 5: the landing receipt does NOT land in the captain's main checkout" {
+    # This exact leak aborted a real land: signed successfully, into the wrong
+    # repo, so the locate step below found nothing and rolled everything back.
+    _run_step_5_sign
+    [ "$(_captain_receipts)" -eq 0 ]
+}
+
+@test "step 5: pr-captain-land's OWN locate expression finds the signed receipt" {
+    # The heart of the regression. The `find` is lifted verbatim out of the
+    # script rather than restated, so if the sign call and the locate call ever
+    # disagree about which repo they mean — the original bug — this fails.
+    _run_step_5_sign
+
+    locate_line="$(grep -n 'LANDING_RECEIPT=\$(find' "$LAND" | head -1 | cut -d: -f2-)"
+    [ -n "$locate_line" ]
+
+    run bash -c "
+        set -uo pipefail
+        SCRATCH_DIR='$SCRATCH_REPO'
+        LAND_HASH_FULL='$LAND_HASH_FULL'
+        $locate_line
+        echo \"\$LANDING_RECEIPT\"
+    "
+    assert_success
+    [ -n "$output" ]
+    [[ "$output" == "$SCRATCH_REPO"* ]]
+    [[ "$output" == *"pr-captain-land"* ]]
+}
+
+@test "step 5: the located receipt relativizes to a path inside the scratch" {
+    # LANDING_RECEIPT_REL is what gets staged and what the PR body advertises.
+    # An absolute captain-checkout path here is what produced the abort.
+    _run_step_5_sign
+    receipt="$(find "$SCRATCH_REPO/agency/workstreams/agency/qgr" -name '*-pr-captain-land-*.md' | head -1)"
+    rel="${receipt#"$SCRATCH_REPO"/}"
+    [ "$rel" != "$receipt" ]
+    [ -f "$SCRATCH_REPO/$rel" ]
+    [[ "$rel" == agency/workstreams/agency/qgr/* ]]
+}
+
+@test "steps 4+5 together: the captain checkout gains nothing at all" {
+    # The composite property the whole scratch-worktree design rests on.
+    before="$(cd "$CAPTAIN_REPO" && find . -path ./.git -prune -o -type f -print | sort)"
+    _run_step_4
+    _run_step_5_sign
+    after="$(cd "$CAPTAIN_REPO" && find . -path ./.git -prune -o -type f -print | sort)"
+    [ "$before" == "$after" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Steps 4-9 call sites — the -C wiring, and the class of bug behind it
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "step 5 call site: receipt-sign is invoked with -C \$SCRATCH_DIR" {
+    live_code | grep -q 'TOOLS/receipt-sign"'
+    run bash -c "sed -n '/TOOLS\/receipt-sign\"/,/receipt-sign\"\$/p' '$LAND' | head -3 | grep -q -- '-C \"\$SCRATCH_DIR\"'"
+    assert_success
+}
+
+@test "step 6 call site: pr-create is invoked with -C \$SCRATCH_DIR" {
+    run bash -c "sed -n '/TOOLS\/pr-create\"/,+3p' '$LAND' | grep -q -- '-C \"\$SCRATCH_DIR\"'"
+    assert_success
+}
+
+@test "steps 4-9: every dispatch call names its repo root explicitly" {
+    # Both dispatch call sites belong to the CAPTAIN's checkout: the failure
+    # notice is written moments before destroy_scratch, and the success notice
+    # after it. Neither may inherit a root from CLAUDE_PROJECT_DIR — a captain
+    # whose env points at a worktree would file both into a directory that is
+    # deleted or wrong.
+    total="$(live_code | grep -c 'TOOLS/dispatch"' || true)"
+    with_c="$(live_code | grep -c 'TOOLS/dispatch" -C "\$REPO_ROOT"' || true)"
+    [ "$total" -ge 2 ]
+    [ "$total" -eq "$with_c" ]
+}
+
+@test "steps 4-9: no install-rooted tool is run against the scratch without -C" {
+    # The class guard, not just the two known instances. Any tool that resolves
+    # its repo from SCRIPT_DIR/../.. is mis-targeted the moment pr-captain-land
+    # runs it with the cwd in the scratch. Enumerate them from the SOURCE rather
+    # than from a list someone has to remember to update.
+    #
+    # Allowlist, each with a reason that must still hold if you extend it:
+    #   receipt-verify   — always called with an ABSOLUTE --file path, so its
+    #                      REPO_ROOT is never consulted on that code path.
+    #   post-merge-state — captain-side state by design; the scratch is gone by
+    #                      the time it is cleared.
+    #   dispatch         — checked above; passes -C "$REPO_ROOT" deliberately.
+    #   git-safe-commit  — resolves PROJECT_ROOT from `git rev-parse
+    #                      --show-toplevel` FIRST and only falls back to its
+    #                      install dir; run with the cwd in the scratch it is
+    #                      already correct, and it forwards that root to
+    #                      dispatch via -C.
+    allow=" receipt-verify post-merge-state dispatch git-safe-commit "
+    offenders=""
+
+    for tool in $(live_code | grep -oE 'TOOLS/[a-z0-9-]+' | cut -d/ -f2 | sort -u); do
+        src="$REPO_ROOT/agency/tools/$tool"
+        [[ -f "$src" ]] || continue
+        # LIVE CODE only. A comment that merely NAMES the bad pattern — such as
+        # the one in pr-merge explaining why it has no repo root — is not the
+        # bug, and flagging it teaches authors to stop documenting the trap.
+        grep -v '^[[:space:]]*#' "$src" | grep -q 'SCRIPT_DIR/\.\./\.\.' || continue
+        [[ "$allow" == *" $tool "* ]] && continue
+        # Install-rooted and used here: every invocation must carry -C.
+        if ! live_code | grep -A3 "TOOLS/$tool\"" | grep -q -- '-C '; then
+            offenders="$offenders $tool"
+        fi
+    done
+
+    [ -z "$offenders" ] || {
+        echo "Install-rooted tools invoked without -C: $offenders" >&2
+        echo "Each resolves its repo from its own install dir and will target" >&2
+        echo "the captain's main checkout, not the scratch. Pass -C, or add to" >&2
+        echo "the allowlist above WITH a reason." >&2
+        false
+    }
+}
+
+@test "steps 4-9: pr-merge carries no install-rooted repo root to be misused" {
+    # It is repo-agnostic (operates on a PR number, lets gh infer the repo). It
+    # used to carry a dead PROJECT_ROOT="$SCRIPT_DIR/../.." — the exact pattern
+    # that broke the other three, sitting there waiting to be "used".
+    run bash -c "grep -v '^[[:space:]]*#' '$REPO_ROOT/agency/tools/pr-merge' | grep -q 'PROJECT_ROOT='"
+    assert_failure
+}
+
+@test "the publish path is no longer wholly untested" {
+    # Meta-guard on the gap itself. --rehearse stops at step 3, so for as long
+    # as this file is the only runtime coverage of steps 4-5, deleting it must
+    # be a deliberate act rather than a quiet one.
+    [ -f "$BATS_TEST_FILENAME" ]
+    run bash -c "grep -c '^@test' '$BATS_TEST_FILENAME'"
+    [ "$output" -ge 10 ]
+}

--- a/src/tests/tools/address-parse.bats
+++ b/src/tests/tools/address-parse.bats
@@ -350,7 +350,7 @@ LIB_DIR="${REPO_ROOT}/agency/tools/lib"
 @test "principal detection: YAML with colon in display_name does not break parsing" {
     # Create a test agency.yaml with colon-containing display_name
     local yaml="${BATS_TEST_TMPDIR}/agency.yaml"
-    mkdir -p "${BATS_TEST_TMPDIR}/claude/config"
+    mkdir -p "${BATS_TEST_TMPDIR}/agency/config"
     cp "$yaml" "${BATS_TEST_TMPDIR}/agency/config/agency.yaml" 2>/dev/null || true
     cat > "${BATS_TEST_TMPDIR}/agency/config/agency.yaml" << 'YAML'
 principals:

--- a/src/tests/tools/dispatch-create.bats
+++ b/src/tests/tools/dispatch-create.bats
@@ -21,7 +21,7 @@ setup() {
     # Create a mock git repo with agency.yaml and all required tool files
     export MOCK_REPO="$BATS_TEST_TMPDIR/mock-repo"
     mkdir -p "$MOCK_REPO/agency/tools/lib"
-    mkdir -p "$MOCK_REPO/claude/config"
+    mkdir -p "$MOCK_REPO/agency/config"
 
     # Copy tools and libs
     for tool in dispatch dispatch-create agent-identity; do

--- a/src/tests/tools/flag.bats
+++ b/src/tests/tools/flag.bats
@@ -18,7 +18,7 @@ setup() {
     iscp_test_isolation_setup
 
     export MOCK_REPO="$BATS_TEST_TMPDIR/mock-repo"
-    mkdir -p "$MOCK_REPO/agency/tools/lib" "$MOCK_REPO/claude/config"
+    mkdir -p "$MOCK_REPO/agency/tools/lib" "$MOCK_REPO/agency/config"
 
     for tool in flag agent-identity; do
         cp "$REPO_ROOT/agency/tools/$tool" "$MOCK_REPO/agency/tools/"

--- a/src/tests/tools/git-sync-guard.bats
+++ b/src/tests/tools/git-sync-guard.bats
@@ -57,6 +57,24 @@ teardown() {
 _origin_main_sha() { git -C "$ORIGIN" rev-parse main; }
 _log_rows() { [[ -f "$PUSH_LOG" ]] && grep -c '^| 2' "$PUSH_LOG" || echo 0; }
 
+# Rebuild ORIGIN + CLONE with an arbitrary default branch name. Needed because
+# renaming only the local branch leaves origin/HEAD pointing at the old default,
+# which quietly turns a "resolved default" test into a "hardcoded literal" test.
+_make_repo_with_default() {
+    local name="$1"
+    rm -rf "$ORIGIN" "$CLONE"
+    git init --quiet --bare -b "$name" "$ORIGIN"
+    git init --quiet -b "$name" "$CLONE"
+    git -C "$CLONE" config user.email "test@example.com"
+    git -C "$CLONE" config user.name "Test User"
+    git -C "$CLONE" remote add origin "$ORIGIN"
+    echo "seed" > "$CLONE/file.txt"
+    git -C "$CLONE" add -A
+    git -C "$CLONE" commit -qm "init"
+    git -C "$CLONE" push -q -u origin "$name"
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1 || true
+}
+
 # Put a local-only commit on the current branch so there is genuinely something
 # to push — otherwise git-sync exits early on "nothing to push" and a guard that
 # does not exist would still look like it worked.
@@ -104,25 +122,84 @@ _add_local_commit() {
     [ "$(_log_rows)" -eq "$before" ]
 }
 
-@test "git-sync: refuses on master too, in a master-default repo" {
-    # Not just the string "main". A repo whose default is master gets the same
-    # protection, which is why the branch name is resolved rather than assumed.
-    git -C "$CLONE" branch -m master
+@test "git-sync: refuses on master in a genuinely master-default repo" {
+    # An earlier version of this test only renamed the LOCAL branch, leaving
+    # origin on main — so it exercised the hardcoded "master" literal, the exact
+    # opposite of what its comment claimed. Build a real master-default repo.
+    _make_repo_with_default master
     _add_local_commit
     run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
     assert_failure
     assert_output_contains "BLOCKED"
 }
 
-@test "git-sync: refuses on main even with the remote unreachable" {
-    # resolve-default-branch falls back to "main" when it cannot reach origin.
-    # A guard that softens the moment the network does is not a guard, so the
-    # literals are checked independently of resolution.
-    git -C "$CLONE" remote set-url origin "$BATS_TEST_TMPDIR/does-not-exist.git"
+@test "git-sync: refuses a default branch that is NEITHER main NOR master" {
+    # The clause the change argues hardest for, and the one nothing covered:
+    # deleting the resolver test from the guard left the old suite 16/16 green,
+    # because every case was reachable through the two literals. A trunk-default
+    # repo can only be caught by resolution.
+    _make_repo_with_default trunk
     _add_local_commit
     run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
     assert_failure
     assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: a feature branch in a trunk-default repo still syncs" {
+    # The other half of the resolver clause — it must block the default branch
+    # without blocking everything else in a repo that does not use main.
+    _make_repo_with_default trunk
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_success
+}
+
+@test "git-sync: refuses main/master even when they are NOT the default branch" {
+    # This is the case that makes the two literals load-bearing, and nothing
+    # else reaches it. Mutation-verified: strip the literals from the guard and
+    # this is the only test that fails — every other "refuses on main" case is
+    # also caught by the resolver clause, because resolve-default-branch falls
+    # back to refs/heads/main whenever a local main exists.
+    #
+    # Scenario: a trunk-default repo carrying a stale local `master`. The
+    # resolver correctly says "trunk", so only the hardcoded literal stops a
+    # direct push of a conventionally protected branch name.
+    _make_repo_with_default trunk
+    git -C "$CLONE" checkout -q -b master
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: refuses on main with the default branch UNRESOLVABLE" {
+    # The literals must stand on their own. Merely repointing the remote URL did
+    # not test this: resolve-default-branch reads refs/remotes/origin/main, which
+    # is local data and still resolved. Delete the remote-tracking refs so
+    # resolution genuinely has nothing to go on.
+    git -C "$CLONE" remote set-url origin "$BATS_TEST_TMPDIR/does-not-exist.git"
+    rm -rf "$CLONE/.git/refs/remotes/origin"
+    git -C "$CLONE" pack-refs --all >/dev/null 2>&1 || true
+    rm -rf "$CLONE/.git/refs/remotes/origin"
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: refuses on a detached HEAD" {
+    # `git branch --show-current` prints nothing when detached, which matched
+    # none of the guard's clauses. The tool went on to run `git push -u origin ""`
+    # — fatal, so origin was safe, but only after writing a push-log row with an
+    # empty branch and reporting "push failed" instead of the real reason.
+    _add_local_commit
+    git -C "$CLONE" checkout -q --detach HEAD
+    before="$(_log_rows)"
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "detached HEAD"
+    [ "$(_log_rows)" -eq "$before" ]
 }
 
 @test "git-sync: the refusal names the PR flow, not just the rule" {
@@ -185,6 +262,12 @@ _add_local_commit() {
     # different local commit, sync, and assert the original local commit is
     # still reachable by its ORIGINAL sha. A rebase would have replayed it under
     # a new sha; a merge preserves it and adds a merge commit.
+    # pull.rebase=true locally: without this the test proves nothing, because
+    # the isolation helper nulls GIT_CONFIG_GLOBAL so git's default is already
+    # merge and the flag could be deleted with the test still green. This is the
+    # exact config the explicit --no-rebase exists to defeat.
+    git -C "$CLONE" config pull.rebase true
+
     git -C "$CLONE" checkout -q -b feature-work
     _add_local_commit
     git -C "$CLONE" push -q -u origin feature-work
@@ -227,7 +310,58 @@ _add_local_commit() {
     bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
     [ -f "$PUSH_LOG" ]
     run bash -c "grep '^| 2' '$PUSH_LOG' | tail -1"
+    # Positively, not just "not unknown" — a negative match passes vacuously
+    # when grep finds nothing at all, which is exactly what happened while the
+    # rows were being split across two lines.
+    [ -n "$output" ]
+    assert_output_contains "feature-work"
     [[ "$output" != *"| unknown |"* ]]
+}
+
+@test "git-sync: each push-log entry is ONE row, not split across lines" {
+    # `grep -c ... || echo "0"` wrote a second zero on top of grep's own, so
+    # every sync after the first produced "0\n0" and broke the markdown table.
+    # Two syncs, so the second one goes through the branch that has an upstream.
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
+    _add_local_commit
+    bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
+
+    # Every non-header table line must be a complete row: starts with '|',
+    # ends with '|', and has the full column count.
+    run bash -c "grep '^| 2' '$PUSH_LOG' | grep -vc '|\$'"
+    [ "$output" -eq 0 ]
+    run bash -c "grep -c '^| 2' '$PUSH_LOG'"
+    [ "$output" -eq 2 ]
+}
+
+@test "git-sync: a degraded identity still pushes, logging 'unknown'" {
+    # Best-effort means best-effort. Shadow agent-identity with a failing stub in
+    # a copied tools dir so resolution genuinely fails, and assert BOTH that the
+    # push succeeded and that the row degraded rather than the run dying.
+    # (Repointing PATH does not do it — the tool is invoked by absolute path.)
+    fake_tools="$BATS_TEST_TMPDIR/faketools/agency/tools"
+    mkdir -p "$fake_tools/lib"
+    cp "$REPO_ROOT/agency/tools/git-sync" "$fake_tools/"
+    cp "$REPO_ROOT/agency/tools/resolve-default-branch" "$fake_tools/"
+    cp "$REPO_ROOT"/agency/tools/lib/* "$fake_tools/lib/" 2>/dev/null || true
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$fake_tools/agent-identity"
+    chmod +x "$fake_tools/agent-identity" "$fake_tools/git-sync"
+
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$fake_tools/git-sync' --verbose"
+    assert_success
+    run bash -c "grep '^| 2' '$PUSH_LOG' | tail -1"
+    assert_output_contains "unknown"
+}
+
+@test "git-sync: the src/ mirror is byte-identical to the shipped tool" {
+    # These tests run the agency/ copy. The self-bootstrapping repo ships both,
+    # and a guard that exists in only one of them is not a guard.
+    run diff -q "$REPO_ROOT/agency/tools/git-sync" "$REPO_ROOT/src/agency/tools/git-sync"
+    assert_success
 }
 
 @test "git-sync: AGENTNAME still wins when it is set" {
@@ -238,11 +372,32 @@ _add_local_commit() {
     assert_output_contains "explicit-agent"
 }
 
-@test "git-sync: identity resolution never blocks the push" {
-    # Best-effort by design. If agent-identity cannot resolve, the row falls back
-    # to "unknown" — a degraded log entry, never a failed push.
+@test "git-sync: a merge conflict stops the run instead of pushing anyway" {
+    # A failed pull was treated as uniformly benign ("no remote branch yet"), so
+    # a conflicted merge left MERGE_HEAD and conflict markers in the tree, then
+    # pushed regardless and reported "push failed" — never naming the conflict
+    # the operator now had to go find.
     git -C "$CLONE" checkout -q -b feature-work
-    _add_local_commit
-    run bash -c "cd '$CLONE' && PATH=/usr/bin:/bin bash '$SYNC' --verbose"
-    assert_success
+    echo "base" > "$CLONE/conflict.txt"
+    git -C "$CLONE" add -A && git -C "$CLONE" commit -qm "base"
+    git -C "$CLONE" push -q -u origin feature-work
+
+    other="$BATS_TEST_TMPDIR/other-conflict"
+    git clone -q "$ORIGIN" "$other"
+    git -C "$other" config user.email "o@example.com"
+    git -C "$other" config user.name "O"
+    git -C "$other" checkout -q feature-work
+    echo "theirs" > "$other/conflict.txt"
+    git -C "$other" add -A && git -C "$other" commit -qm "theirs"
+    git -C "$other" push -q origin feature-work
+
+    echo "ours" > "$CLONE/conflict.txt"
+    git -C "$CLONE" add -A && git -C "$CLONE" commit -qm "ours"
+    origin_before="$(git -C "$ORIGIN" rev-parse feature-work)"
+
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "Merge conflict"
+    # And it pushed nothing.
+    [ "$(git -C "$ORIGIN" rev-parse feature-work)" == "$origin_before" ]
 }

--- a/src/tests/tools/git-sync-guard.bats
+++ b/src/tests/tools/git-sync-guard.bats
@@ -1,0 +1,248 @@
+#!/usr/bin/env bats
+#
+# What Problem: git-sync violated two of the framework's sacred invariants and
+# nothing caught it. It ran `git pull --rebase` (the repo's rule is merge, never
+# rebase) and `git push -u origin "$BRANCH"` with NO main/master guard (the rule
+# is that nothing reaches the default branch except through a PR). Invoked on
+# main it did both in one go — rewrote main's history AND pushed main directly.
+# That is not hypothetical; it happened. `git-push`, sitting in the same
+# directory, has blocked main since Day 40, so the tool contradicted both the
+# methodology and its own neighbour.
+#
+# How & Why: the guard is tested against a REAL local origin, not a mock — a
+# refusal that only holds because the network was absent proves nothing. Each
+# case asserts the refusal AND that nothing moved: no new commit on origin, no
+# rewritten history, and no row appended to the accountability log. "It printed
+# BLOCKED" and "it changed nothing" are separate claims and the second is the
+# one that matters.
+#
+# The rebase ban is asserted on LIVE CODE with comments stripped, because the
+# header comment necessarily names the thing it stopped doing.
+#
+# Written: 2026-08-11 (devex) — git-sync main-guard + merge-not-rebase
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    iscp_test_isolation_setup
+
+    SYNC="$REPO_ROOT/agency/tools/git-sync"
+
+    # A real bare origin + a clone. The guard must hold with a reachable remote,
+    # since resolve-default-branch consults origin/HEAD first.
+    export ORIGIN="$BATS_TEST_TMPDIR/origin.git"
+    export CLONE="$BATS_TEST_TMPDIR/clone"
+
+    git init --quiet --bare -b main "$ORIGIN"
+
+    git init --quiet -b main "$CLONE"
+    git -C "$CLONE" config user.email "test@example.com"
+    git -C "$CLONE" config user.name "Test User"
+    git -C "$CLONE" remote add origin "$ORIGIN"
+    echo "seed" > "$CLONE/file.txt"
+    git -C "$CLONE" add -A
+    git -C "$CLONE" commit -qm "init"
+    git -C "$CLONE" push -q -u origin main
+    git -C "$CLONE" remote set-head origin -a >/dev/null 2>&1 || true
+
+    PUSH_LOG="$CLONE/history/push-log.md"
+}
+
+teardown() {
+    iscp_test_isolation_teardown
+    [[ -d "${BATS_TEST_TMPDIR}" ]] && rm -rf "${BATS_TEST_TMPDIR}"
+}
+
+_origin_main_sha() { git -C "$ORIGIN" rev-parse main; }
+_log_rows() { [[ -f "$PUSH_LOG" ]] && grep -c '^| 2' "$PUSH_LOG" || echo 0; }
+
+# Put a local-only commit on the current branch so there is genuinely something
+# to push — otherwise git-sync exits early on "nothing to push" and a guard that
+# does not exist would still look like it worked.
+_add_local_commit() {
+    echo "local change" >> "$CLONE/file.txt"
+    git -C "$CLONE" add -A
+    git -C "$CLONE" commit -qm "local work"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# The guard
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "git-sync: refuses on main" {
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: refusing on main pushes NOTHING to origin" {
+    before="$(_origin_main_sha)"
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    [ "$(_origin_main_sha)" == "$before" ]
+}
+
+@test "git-sync: refusing on main does not rewrite local history" {
+    _add_local_commit
+    before="$(git -C "$CLONE" rev-parse HEAD)"
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    [ "$(git -C "$CLONE" rev-parse HEAD)" == "$before" ]
+}
+
+@test "git-sync: refusing on main appends no row to the push log" {
+    # The guard sits BEFORE the log append. A refused run must leave no trace —
+    # an accountability log with entries for pushes that never happened is worse
+    # than no log.
+    _add_local_commit
+    before="$(_log_rows)"
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    [ "$(_log_rows)" -eq "$before" ]
+}
+
+@test "git-sync: refuses on master too, in a master-default repo" {
+    # Not just the string "main". A repo whose default is master gets the same
+    # protection, which is why the branch name is resolved rather than assumed.
+    git -C "$CLONE" branch -m master
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: refuses on main even with the remote unreachable" {
+    # resolve-default-branch falls back to "main" when it cannot reach origin.
+    # A guard that softens the moment the network does is not a guard, so the
+    # literals are checked independently of resolution.
+    git -C "$CLONE" remote set-url origin "$BATS_TEST_TMPDIR/does-not-exist.git"
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+@test "git-sync: the refusal names the PR flow, not just the rule" {
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_output_contains "pr-submit"
+    assert_output_contains "pr-captain-land"
+}
+
+@test "git-sync: --check on main is refused as well" {
+    # --check is read-only, but reporting "N commits ready" for a branch that
+    # may never be synced is a false green that invites someone to drop --check.
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --check --verbose"
+    assert_failure
+    assert_output_contains "BLOCKED"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A feature branch still works — the guard must not break the tool
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "git-sync: a feature branch still pushes" {
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_success
+    run git -C "$ORIGIN" rev-parse feature-work
+    assert_success
+}
+
+@test "git-sync: a feature branch sync leaves main on origin untouched" {
+    before="$(_origin_main_sha)"
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
+    [ "$(_origin_main_sha)" == "$before" ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Merge, never rebase
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "git-sync: no --rebase anywhere in live code" {
+    # Comments stripped: the header explains the rebase this tool stopped doing,
+    # and flagging that would teach authors to delete the explanation.
+    run bash -c "grep -v '^[[:space:]]*#' '$SYNC' | grep -n 'pull --rebase'"
+    assert_failure
+}
+
+@test "git-sync: the pull is explicitly --no-rebase" {
+    # Explicit, not merely git's default: a user with pull.rebase=true in global
+    # config would otherwise silently get the rewrite back.
+    run bash -c "grep -v '^[[:space:]]*#' '$SYNC' | grep -q 'git pull --no-rebase'"
+    assert_success
+}
+
+@test "git-sync: a real sync with diverged history produces a MERGE, not a rewrite" {
+    # The behavioural proof. Push a commit to origin from a second clone, make a
+    # different local commit, sync, and assert the original local commit is
+    # still reachable by its ORIGINAL sha. A rebase would have replayed it under
+    # a new sha; a merge preserves it and adds a merge commit.
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    git -C "$CLONE" push -q -u origin feature-work
+
+    other="$BATS_TEST_TMPDIR/other"
+    git clone -q "$ORIGIN" "$other"
+    git -C "$other" config user.email "other@example.com"
+    git -C "$other" config user.name "Other User"
+    git -C "$other" checkout -q feature-work
+    echo "remote change" > "$other/remote.txt"
+    git -C "$other" add -A
+    git -C "$other" commit -qm "remote work"
+    git -C "$other" push -q origin feature-work
+
+    echo "more local" > "$CLONE/local2.txt"
+    git -C "$CLONE" add -A
+    git -C "$CLONE" commit -qm "more local work"
+    local_sha="$(git -C "$CLONE" rev-parse HEAD)"
+
+    run bash -c "cd '$CLONE' && bash '$SYNC' --verbose"
+    assert_success
+
+    # The pre-sync commit survives under its original sha — no history rewrite.
+    run git -C "$CLONE" merge-base --is-ancestor "$local_sha" HEAD
+    assert_success
+    # And a merge commit (two parents) now exists.
+    run bash -c "git -C '$CLONE' rev-list --merges HEAD --count"
+    [ "$output" -ge 1 ]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Accountability
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "git-sync: the push log records a resolved agent, not 'unknown'" {
+    # The log read $AGENTNAME, which Claude Code does not set, so every row said
+    # "unknown" and the accountability log accounted for nobody.
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
+    [ -f "$PUSH_LOG" ]
+    run bash -c "grep '^| 2' '$PUSH_LOG' | tail -1"
+    [[ "$output" != *"| unknown |"* ]]
+}
+
+@test "git-sync: AGENTNAME still wins when it is set" {
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    AGENTNAME="explicit-agent" bash -c "cd '$CLONE' && bash '$SYNC' --verbose" >/dev/null 2>&1
+    run bash -c "grep '^| 2' '$PUSH_LOG' | tail -1"
+    assert_output_contains "explicit-agent"
+}
+
+@test "git-sync: identity resolution never blocks the push" {
+    # Best-effort by design. If agent-identity cannot resolve, the row falls back
+    # to "unknown" — a degraded log entry, never a failed push.
+    git -C "$CLONE" checkout -q -b feature-work
+    _add_local_commit
+    run bash -c "cd '$CLONE' && PATH=/usr/bin:/bin bash '$SYNC' --verbose"
+    assert_success
+}

--- a/src/tests/tools/iscp-check.bats
+++ b/src/tests/tools/iscp-check.bats
@@ -22,7 +22,12 @@ setup() {
     iscp_test_isolation_setup
 
     export MOCK_REPO="$BATS_TEST_TMPDIR/mock-repo"
-    mkdir -p "$MOCK_REPO/agency/tools/lib" "$MOCK_REPO/claude/config"
+    # agency/config, not claude/config: the great-rename moved the config dir
+    # but this setup was not swept, so line 44 below wrote agency.yaml into a
+    # directory that never existed. `cat >` failed in setup, and all 13 tests in
+    # this file have been erroring out rather than running. Found while checking
+    # the ISCP suite for regressions from the -C work.
+    mkdir -p "$MOCK_REPO/agency/tools/lib" "$MOCK_REPO/agency/config"
 
     for tool in iscp-check agent-identity dispatch flag; do
         cp "$REPO_ROOT/agency/tools/$tool" "$MOCK_REPO/agency/tools/"

--- a/src/tests/tools/iscp-db.bats
+++ b/src/tests/tools/iscp-db.bats
@@ -26,7 +26,7 @@ setup() {
 
     # Create a minimal git repo so repo name resolution works
     export MOCK_REPO="$BATS_TEST_TMPDIR/mock-repo"
-    mkdir -p "$MOCK_REPO/claude/config"
+    mkdir -p "$MOCK_REPO/agency/config"
     cd "$MOCK_REPO"
     git init --quiet
     git config user.email "test@example.com"

--- a/src/tests/tools/repo-root-targeting.bats
+++ b/src/tests/tools/repo-root-targeting.bats
@@ -51,7 +51,12 @@ principals:
   testuser: testprincipal
   default: testprincipal
 YAML
-        git init --quiet "$root"
+        # -b main explicitly: the isolation helper points GIT_CONFIG_GLOBAL at
+        # /dev/null, so init.defaultBranch is unset and the default is the git
+        # build's — `main` on Apple git, `master` upstream. The pr-create branch
+        # gate asserts on that name, so leaving it to the platform makes this
+        # suite pass on macOS and fail on Linux CI.
+        git init --quiet -b main "$root"
         git -C "$root" config user.email "test@example.com"
         git -C "$root" config user.name "Test User"
         git -C "$root" remote add origin https://github.com/test-org/test-repo.git
@@ -289,18 +294,27 @@ _count_payloads() { find "$1/usr" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; 
 # git-safe-commit → dispatch
 # ─────────────────────────────────────────────────────────────────────────────
 
-@test "git-safe-commit passes its cwd-resolved root to dispatch via -C" {
-    # git-safe-commit already resolved PROJECT_ROOT correctly from cwd; it just
-    # had no way to tell the dispatch tool. Structural, because reaching the
-    # commit-announce needs a full commit with hooks — the runtime proof that -C
-    # is honoured is the dispatch block above.
-    run grep -q '"\$DISPATCH_TOOL" -C "\$PROJECT_ROOT" create' \
+@test "git-safe-commit forwards the COMMIT repo root to dispatch via -C" {
+    run grep -q '"\$DISPATCH_TOOL" -C "\$COMMIT_REPO_ROOT" create' \
         "$REPO_ROOT/agency/tools/git-safe-commit"
     assert_success
 }
 
-@test "git-safe-commit: PROJECT_ROOT is cwd-derived, so -C carries a real root" {
-    run grep -q 'PROJECT_ROOT="\$(git rev-parse --show-toplevel' \
-        "$REPO_ROOT/agency/tools/git-safe-commit"
-    assert_success
+@test "git-safe-commit: -C must NOT carry PROJECT_ROOT" {
+    # PROJECT_ROOT prefers CLAUDE_PROJECT_DIR (correct for the per-agent
+    # ATTRIBUTION lookup it exists for — that is a property of the session).
+    # Claude Code sets that variable to the MAIN CHECKOUT, so passing
+    # PROJECT_ROOT as -C sends the commit-announce to a repo that does not
+    # contain the commit — the exact bug -C was added to fix. The first cut of
+    # this change did precisely that and every locality test still passed,
+    # because they all ran with the variable unset.
+    run grep -q -- '-C "\$PROJECT_ROOT" create' "$REPO_ROOT/agency/tools/git-safe-commit"
+    assert_failure
+}
+
+@test "git-safe-commit: COMMIT_REPO_ROOT is derived from cwd, never from the env" {
+    body="$(grep -v '^[[:space:]]*#' "$REPO_ROOT/agency/tools/git-safe-commit" \
+            | grep -A1 'COMMIT_REPO_ROOT=')"
+    [[ "$body" == *"git rev-parse --show-toplevel"* ]]
+    [[ "$body" != *"CLAUDE_PROJECT_DIR"* ]]
 }

--- a/src/tests/tools/repo-root-targeting.bats
+++ b/src/tests/tools/repo-root-targeting.bats
@@ -1,0 +1,306 @@
+#!/usr/bin/env bats
+#
+# What Problem: three framework tools — receipt-sign, pr-create, dispatch —
+# resolved the repository they operate on from SCRIPT_DIR/../.., i.e. their own
+# INSTALL location, and ignored the cwd entirely. pr-captain-land runs the
+# CAPTAIN'S trusted tools against a scratch worktree by setting the cwd, so on a
+# real land every one of them silently targeted the captain's main checkout
+# instead of the scratch: the landing receipt was written to the wrong repo (the
+# land then aborted, unable to find it), a commit-announce dispatch was littered
+# into a checkout that did not contain the commit, and pr-create would have read
+# BRANCH=main and blocked outright.
+#
+# How & Why: each tool now takes `-C <repo-root>` as its FIRST argument. These
+# tests are two-repo by construction — the tool is INSTALLED in one repo and
+# pointed at another — because a single-repo fixture cannot tell "honoured -C"
+# apart from "fell back to its install dir", which is the entire bug. Every case
+# asserts BOTH that the write landed in the target AND that the install repo
+# stayed clean; the leak, not just the miss, is what burned a real land.
+#
+# The default (no -C) paths are pinned too. -C exists to fix pr-captain-land
+# without touching the dozens of existing callers, so "unchanged when absent" is
+# a contract, not an implementation detail.
+#
+# Written: 2026-08-11 (devex) — publish-path repo-root targeting
+
+load 'test_helper'
+
+setup() {
+    export BATS_TEST_TMPDIR="$(mktemp -d)"
+    iscp_test_isolation_setup
+
+    # INSTALL_REPO: stands in for the captain's main checkout — the tools live
+    # here, so SCRIPT_DIR/../.. resolves here. TARGET_REPO: stands in for the
+    # scratch worktree. Distinct roots are the whole point of the fixture.
+    export INSTALL_REPO="$BATS_TEST_TMPDIR/install-repo"
+    export TARGET_REPO="$BATS_TEST_TMPDIR/target-repo"
+
+    mkdir -p "$INSTALL_REPO/agency/tools/lib" "$INSTALL_REPO/agency/config"
+    mkdir -p "$TARGET_REPO/agency/config" "$TARGET_REPO/agency/tools"
+
+    for tool in dispatch agent-identity receipt-sign receipt-verify \
+                pr-create resolve-default-branch; do
+        cp "$REPO_ROOT/agency/tools/$tool" "$INSTALL_REPO/agency/tools/"
+        chmod +x "$INSTALL_REPO/agency/tools/$tool"
+    done
+    cp "$REPO_ROOT"/agency/tools/lib/* "$INSTALL_REPO/agency/tools/lib/" 2>/dev/null || true
+
+    for root in "$INSTALL_REPO" "$TARGET_REPO"; do
+        cat > "$root/agency/config/agency.yaml" <<YAML
+principals:
+  testuser: testprincipal
+  default: testprincipal
+YAML
+        git init --quiet "$root"
+        git -C "$root" config user.email "test@example.com"
+        git -C "$root" config user.name "Test User"
+        git -C "$root" remote add origin https://github.com/test-org/test-repo.git
+    done
+
+    echo "captainagent" > "$INSTALL_REPO/.agency-agent"
+    echo "landagent" > "$TARGET_REPO/.agency-agent"
+    echo "seed" > "$TARGET_REPO/file.txt"
+    git -C "$INSTALL_REPO" add -A && git -C "$INSTALL_REPO" commit -qm init
+    git -C "$TARGET_REPO" add -A && git -C "$TARGET_REPO" commit -qm init
+    # The target is on a feature branch and the install repo is on main: that
+    # asymmetry is what makes pr-create's BRANCH gate observable.
+    git -C "$TARGET_REPO" branch -m feature-branch
+
+    export USER="testuser"
+    unset CLAUDE_PROJECT_DIR AGENCY_PROJECT_ROOT AGENCY_PRINCIPAL CLAUDE_AGENT_NAME
+
+    RECEIPT_SIGN="$INSTALL_REPO/agency/tools/receipt-sign"
+    PR_CREATE="$INSTALL_REPO/agency/tools/pr-create"
+    DISPATCH="$INSTALL_REPO/agency/tools/dispatch"
+}
+
+teardown() {
+    iscp_test_isolation_teardown
+    [[ -d "${BATS_TEST_TMPDIR}" ]] && rm -rf "${BATS_TEST_TMPDIR}"
+}
+
+# $1 = repo root to target, or "" to omit -C entirely.
+# No arrays: bash 3.2 is the floor and empty-array expansion is a trap there.
+_sign_into() {
+    local target="$1"
+    if [[ -n "$target" ]]; then
+        "$RECEIPT_SIGN" -C "$target" \
+            --type qgr --boundary test-boundary \
+            --org testorg --principal testprincipal --agent testagent \
+            --workstream testws --project testproj \
+            --hash-a aaaa --hash-b bbbb --hash-c cccc --hash-d dddd \
+            --hash-e eeee1111
+    else
+        "$RECEIPT_SIGN" \
+            --type qgr --boundary test-boundary \
+            --org testorg --principal testprincipal --agent testagent \
+            --workstream testws --project testproj \
+            --hash-a aaaa --hash-b bbbb --hash-c cccc --hash-d dddd \
+            --hash-e eeee1111
+    fi
+}
+
+_count_receipts() { find "$1/agency/workstreams" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+_count_payloads() { find "$1/usr" -name '*.md' 2>/dev/null | wc -l | tr -d ' '; }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# receipt-sign
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "receipt-sign -C: writes the receipt into the named repo" {
+    run _sign_into "$TARGET_REPO"
+    assert_success
+    [ "$(_count_receipts "$TARGET_REPO")" -eq 1 ]
+}
+
+@test "receipt-sign -C: does NOT write into its own install location" {
+    # The leak, stated as its own assertion. This is the failure that aborted a
+    # real land — the receipt existed, just in the wrong repo.
+    _sign_into "$TARGET_REPO"
+    [ "$(_count_receipts "$INSTALL_REPO")" -eq 0 ]
+}
+
+@test "receipt-sign -C: the receipt is findable under the target's workstream path" {
+    _sign_into "$TARGET_REPO"
+    [ -d "$TARGET_REPO/agency/workstreams/testws/qgr" ]
+    run find "$TARGET_REPO/agency/workstreams/testws/qgr" -name '*-qgr-test-boundary-*.md'
+    assert_success
+    [ -n "$output" ]
+}
+
+@test "receipt-sign: WITHOUT -C the install location is still the target (no regression)" {
+    run _sign_into ""
+    assert_success
+    [ "$(_count_receipts "$INSTALL_REPO")" -eq 1 ]
+    [ "$(_count_receipts "$TARGET_REPO")" -eq 0 ]
+}
+
+@test "receipt-sign: cwd is deliberately NOT consulted without -C" {
+    # Pins the root cause as documented behaviour rather than a bug that might
+    # get "fixed" by quietly adding a cwd fallback. A tool that follows cwd
+    # implicitly is how this class of mis-targeting hides; callers must be
+    # explicit. If this ever changes, pr-captain-land's -C wiring must be
+    # revisited at the same time.
+    cd "$TARGET_REPO"
+    _sign_into ""
+    [ "$(_count_receipts "$INSTALL_REPO")" -eq 1 ]
+    [ "$(_count_receipts "$TARGET_REPO")" -eq 0 ]
+}
+
+@test "receipt-sign -C: rejects a nonexistent directory" {
+    run "$RECEIPT_SIGN" -C "$BATS_TEST_TMPDIR/no-such-dir" --type qgr
+    assert_failure
+    assert_output_contains "does not exist"
+}
+
+@test "receipt-sign -C: rejects a missing directory argument" {
+    run "$RECEIPT_SIGN" -C
+    assert_failure
+    assert_output_contains "requires a directory"
+}
+
+@test "receipt-sign: -C is advertised in --help" {
+    run "$RECEIPT_SIGN" --help
+    assert_success
+    assert_output_contains "\-C <repo-root>"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "dispatch -C: writes the payload into the named repo, not the install one" {
+    run "$DISPATCH" -C "$TARGET_REPO" create \
+        --to "test-repo/testprincipal/captain" \
+        --subject "locality probe" --body "body" --type commit
+    assert_success
+    [ "$(_count_payloads "$TARGET_REPO")" -eq 1 ]
+    [ "$(_count_payloads "$INSTALL_REPO")" -eq 0 ]
+}
+
+@test "dispatch -C: outranks CLAUDE_PROJECT_DIR" {
+    # An explicit argument must beat an inherited environment variable. The
+    # captain's own CLAUDE_PROJECT_DIR is set to its main checkout in every real
+    # session, so if the env won, -C would be inert exactly where it is needed.
+    CLAUDE_PROJECT_DIR="$INSTALL_REPO" run "$DISPATCH" -C "$TARGET_REPO" create \
+        --to "test-repo/testprincipal/captain" \
+        --subject "override probe" --body "body" --type commit
+    assert_success
+    [ "$(_count_payloads "$TARGET_REPO")" -eq 1 ]
+    [ "$(_count_payloads "$INSTALL_REPO")" -eq 0 ]
+}
+
+@test "dispatch: WITHOUT -C, CLAUDE_PROJECT_DIR still wins (no regression)" {
+    CLAUDE_PROJECT_DIR="$TARGET_REPO" run "$DISPATCH" create \
+        --to "test-repo/testprincipal/captain" \
+        --subject "env probe" --body "body" --type commit
+    assert_success
+    [ "$(_count_payloads "$TARGET_REPO")" -eq 1 ]
+}
+
+@test "dispatch: WITHOUT -C and without env, cwd is ignored — reproduces the leak" {
+    # The pre-fix behaviour, pinned so the regression is legible: running from
+    # the scratch wrote into the captain's checkout. This test PASSING with the
+    # payload in INSTALL_REPO is correct — it is why -C had to be added rather
+    # than "just make it use cwd", which would have changed every caller.
+    cd "$TARGET_REPO"
+    run "$DISPATCH" create \
+        --to "test-repo/testprincipal/captain" \
+        --subject "cwd probe" --body "body" --type commit
+    assert_success
+    [ "$(_count_payloads "$INSTALL_REPO")" -eq 1 ]
+    [ "$(_count_payloads "$TARGET_REPO")" -eq 0 ]
+}
+
+@test "dispatch -C: rejects a nonexistent directory" {
+    run "$DISPATCH" -C "$BATS_TEST_TMPDIR/no-such-dir" list
+    assert_failure
+    assert_output_contains "does not exist"
+}
+
+@test "dispatch: -C is advertised in --help" {
+    run "$DISPATCH" --help
+    assert_success
+    assert_output_contains "\-C <repo-root>"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# pr-create
+# ─────────────────────────────────────────────────────────────────────────────
+#
+# None of these reach `gh pr create`: every case stops at a gate first, which is
+# exactly the surface under test. No network, no PRs.
+
+@test "pr-create -C: the BRANCH gate reads the named repo" {
+    run "$PR_CREATE" -C "$TARGET_REPO" --title t --body b
+    assert_output_contains "On branch: feature-branch"
+}
+
+@test "pr-create: WITHOUT -C the BRANCH gate reads the install repo — the reported bug" {
+    # cwd is the target's feature branch, yet the gate sees the install repo's
+    # main and blocks. This is what would have killed the land at step 6 had
+    # step 5's receipt failure not aborted it first.
+    cd "$TARGET_REPO"
+    run "$PR_CREATE" --title t --body b
+    assert_failure
+    assert_output_contains "Cannot create PR from main"
+}
+
+@test "pr-create -C: the receipt gate searches the named repo" {
+    run "$PR_CREATE" -C "$TARGET_REPO" --title t --body b
+    assert_failure
+    # Past the branch gate, blocked on the target having no receipt.
+    assert_output_contains "No receipt found"
+}
+
+@test "pr-create -C: does NOT run the TARGET's copy of receipt-verify" {
+    # The trust boundary: captain's code, scratch's data. If -C retargeted the
+    # sub-tools too, a branch could ship a receipt-verify that rubber-stamps
+    # itself and the "pr-create is not weakened" guarantee would be void.
+    printf '#!/usr/bin/env bash\necho POISONED-VERIFIER-RAN\nexit 0\n' \
+        > "$TARGET_REPO/agency/tools/receipt-verify"
+    chmod +x "$TARGET_REPO/agency/tools/receipt-verify"
+    _sign_into "$TARGET_REPO"
+
+    run "$PR_CREATE" -C "$TARGET_REPO" --title t --body b
+    assert_failure
+    [[ "$output" != *POISONED-VERIFIER-RAN* ]]
+}
+
+@test "pr-create -C: rejects a nonexistent directory" {
+    run "$PR_CREATE" -C "$BATS_TEST_TMPDIR/no-such-dir" --title t --body b
+    assert_failure
+    assert_output_contains "does not exist"
+}
+
+@test "pr-create -C: the flag is consumed, never forwarded to gh" {
+    # -C is not a `gh pr create` flag. If the parse ever stopped shifting it
+    # away, gh would reject the invocation at the very last step of a land —
+    # after the push, past the point where rollback is still clean. Asserted on
+    # source because reaching gh needs a receipt that matches a real diff hash;
+    # the parse is one `shift 2` and that is the thing that can rot.
+    run grep -q 'shift 2' "$PR_CREATE"
+    assert_success
+    run grep -q 'gh pr create "\$@"' "$PR_CREATE"
+    assert_success
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# git-safe-commit → dispatch
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "git-safe-commit passes its cwd-resolved root to dispatch via -C" {
+    # git-safe-commit already resolved PROJECT_ROOT correctly from cwd; it just
+    # had no way to tell the dispatch tool. Structural, because reaching the
+    # commit-announce needs a full commit with hooks — the runtime proof that -C
+    # is honoured is the dispatch block above.
+    run grep -q '"\$DISPATCH_TOOL" -C "\$PROJECT_ROOT" create' \
+        "$REPO_ROOT/agency/tools/git-safe-commit"
+    assert_success
+}
+
+@test "git-safe-commit: PROJECT_ROOT is cwd-derived, so -C carries a real root" {
+    run grep -q 'PROJECT_ROOT="\$(git rev-parse --show-toplevel' \
+        "$REPO_ROOT/agency/tools/git-safe-commit"
+    assert_success
+}

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-386fdbf1-on-devex-publish-path-repo-root-20260811-1703.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-386fdbf1-on-devex-publish-path-repo-root-20260811-1703.md
@@ -1,0 +1,164 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-11T09:03
+status: created
+priority: normal
+subject: "Committed 386fdbf1 on devex-publish-path-repo-root: fix(publish-path): QG findings — -C was inert in a real captain session
+
+The quality gate found the first cut of this change did not fix the bug it was
+written for, and that my own tests hid it.
+
+git-safe-commit passed -C "$PROJECT_ROOT", but PROJECT_ROOT prefers
+CLAUDE_PROJECT_DIR and only falls back to the cwd toplevel. Claude Code sets
+that variable to the MAIN CHECKOUT, so in any real captain session -C forwarded
+the main checkout — exactly the leak it was meant to stop. Both new suites ran
+with CLAUDE_PROJECT_DIR unset, so all of them passed, and one asserted the code
+was cwd-derived by grepping a string that lives in the elif branch.
+
+Derives COMMIT_REPO_ROOT strictly from git rev-parse --show-toplevel and passes
+that. PROJECT_ROOT keeps its precedence — it exists for the per-agent
+attribution lookup, which really is a property of the session. Adds a test that
+runs step 4 with CLAUDE_PROJECT_DIR set to the captain root; it fails against
+the old code while the two env-free tests still pass, which is what makes it
+worth having. The captain fixture's .agency-agent also stops being literally
+'captain', since the never-dispatch-to-self guard was silently suppressing the
+announce and letting the locality assertions pass vacuously.
+
+Also from the gate:
+- pr-create ran receipt-verify in the caller's cwd while discovering the receipt
+  under -C. diff-hash is cwd-based, so a receipt found in one tree could be
+  graded against another; the land flow only agreed by luck because it also cd's.
+  Now wrapped in (cd "$REPO_ROOT").
+- dispatch derived the ISCP DB name from agency.yaml under the RETARGETED root —
+  branch-supplied data. A branch editing repo.name would divert its dispatches to
+  a different database. ISCP_DB_PATH is now pinned from the install root before
+  the override, so -C moves the payload and not the index.
+- receipt-sign checked only --workstream for traversal while interpolating five
+  more components into the filename; -C made the write root caller-chosen too.
+  All six are checked now.
+- Both suites git init -b main: with GIT_CONFIG_GLOBAL nulled the default branch
+  is the git build's, so the pr-create branch assertion passed on macOS and would
+  have failed on Linux CI.
+- Replaced an unmatchable sed range with grep -A2, and corrected the allowlist
+  rationale that rested on the false cwd-derived claim.
+
+Deferred with reasons recorded in the QGR: pr-create's relative --body-file under
+-C (latent, no current caller), dispatch's stale AGENCY_PRINCIPAL and cwd-relative
+read strategies (pre-existing, unreachable from the land call sites)."
+in_reply_to: null
+---
+
+# Committed 386fdbf1 on devex-publish-path-repo-root: fix(publish-path): QG findings — -C was inert in a real captain session
+
+The quality gate found the first cut of this change did not fix the bug it was
+written for, and that my own tests hid it.
+
+git-safe-commit passed -C "$PROJECT_ROOT", but PROJECT_ROOT prefers
+CLAUDE_PROJECT_DIR and only falls back to the cwd toplevel. Claude Code sets
+that variable to the MAIN CHECKOUT, so in any real captain session -C forwarded
+the main checkout — exactly the leak it was meant to stop. Both new suites ran
+with CLAUDE_PROJECT_DIR unset, so all of them passed, and one asserted the code
+was cwd-derived by grepping a string that lives in the elif branch.
+
+Derives COMMIT_REPO_ROOT strictly from git rev-parse --show-toplevel and passes
+that. PROJECT_ROOT keeps its precedence — it exists for the per-agent
+attribution lookup, which really is a property of the session. Adds a test that
+runs step 4 with CLAUDE_PROJECT_DIR set to the captain root; it fails against
+the old code while the two env-free tests still pass, which is what makes it
+worth having. The captain fixture's .agency-agent also stops being literally
+'captain', since the never-dispatch-to-self guard was silently suppressing the
+announce and letting the locality assertions pass vacuously.
+
+Also from the gate:
+- pr-create ran receipt-verify in the caller's cwd while discovering the receipt
+  under -C. diff-hash is cwd-based, so a receipt found in one tree could be
+  graded against another; the land flow only agreed by luck because it also cd's.
+  Now wrapped in (cd "$REPO_ROOT").
+- dispatch derived the ISCP DB name from agency.yaml under the RETARGETED root —
+  branch-supplied data. A branch editing repo.name would divert its dispatches to
+  a different database. ISCP_DB_PATH is now pinned from the install root before
+  the override, so -C moves the payload and not the index.
+- receipt-sign checked only --workstream for traversal while interpolating five
+  more components into the filename; -C made the write root caller-chosen too.
+  All six are checked now.
+- Both suites git init -b main: with GIT_CONFIG_GLOBAL nulled the default branch
+  is the git build's, so the pr-create branch assertion passed on macOS and would
+  have failed on Linux CI.
+- Replaced an unmatchable sed range with grep -A2, and corrected the allowlist
+  rationale that rested on the false cwd-derived claim.
+
+Deferred with reasons recorded in the QGR: pr-create's relative --body-file under
+-C (latent, no current caller), dispatch's stale AGENCY_PRINCIPAL and cwd-relative
+read strategies (pre-existing, unreachable from the land call sites).
+
+## Commit: 386fdbf1
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: fix(publish-path): QG findings — -C was inert in a real captain session
+
+The quality gate found the first cut of this change did not fix the bug it was
+written for, and that my own tests hid it.
+
+git-safe-commit passed -C "$PROJECT_ROOT", but PROJECT_ROOT prefers
+CLAUDE_PROJECT_DIR and only falls back to the cwd toplevel. Claude Code sets
+that variable to the MAIN CHECKOUT, so in any real captain session -C forwarded
+the main checkout — exactly the leak it was meant to stop. Both new suites ran
+with CLAUDE_PROJECT_DIR unset, so all of them passed, and one asserted the code
+was cwd-derived by grepping a string that lives in the elif branch.
+
+Derives COMMIT_REPO_ROOT strictly from git rev-parse --show-toplevel and passes
+that. PROJECT_ROOT keeps its precedence — it exists for the per-agent
+attribution lookup, which really is a property of the session. Adds a test that
+runs step 4 with CLAUDE_PROJECT_DIR set to the captain root; it fails against
+the old code while the two env-free tests still pass, which is what makes it
+worth having. The captain fixture's .agency-agent also stops being literally
+'captain', since the never-dispatch-to-self guard was silently suppressing the
+announce and letting the locality assertions pass vacuously.
+
+Also from the gate:
+- pr-create ran receipt-verify in the caller's cwd while discovering the receipt
+  under -C. diff-hash is cwd-based, so a receipt found in one tree could be
+  graded against another; the land flow only agreed by luck because it also cd's.
+  Now wrapped in (cd "$REPO_ROOT").
+- dispatch derived the ISCP DB name from agency.yaml under the RETARGETED root —
+  branch-supplied data. A branch editing repo.name would divert its dispatches to
+  a different database. ISCP_DB_PATH is now pinned from the install root before
+  the override, so -C moves the payload and not the index.
+- receipt-sign checked only --workstream for traversal while interpolating five
+  more components into the filename; -C made the write root caller-chosen too.
+  All six are checked now.
+- Both suites git init -b main: with GIT_CONFIG_GLOBAL nulled the default branch
+  is the git build's, so the pr-create branch assertion passed on macOS and would
+  have failed on Linux CI.
+- Replaced an unmatchable sed range with grep -A2, and corrected the allowlist
+  rationale that rested on the false cwd-derived claim.
+
+Deferred with reasons recorded in the QGR: pr-create's relative --body-file under
+-C (latent, no current caller), dispatch's stale AGENCY_PRINCIPAL and cwd-relative
+read strategies (pre-existing, unreachable from the land call sites).
+
+### Metadata
+- commit_hash: 386fdbf1
+- branch: devex-publish-path-repo-root
+- files_changed: 11
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/dispatch
+agency/tools/git-safe-commit
+agency/tools/pr-create
+agency/tools/receipt-sign
+src/agency/tools/dispatch
+src/agency/tools/git-safe-commit
+src/agency/tools/pr-create
+src/agency/tools/receipt-sign
+src/tests/skills/pr-captain-land-publish-locality.bats
+src/tests/tools/repo-root-targeting.bats
+usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-8a533701-on-devex-publish-path-repo-root-20260811-1642.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-3cbbbd79-on-devex-publish-path-repo-root-20260812-0953.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-3cbbbd79-on-devex-publish-path-repo-root-20260812-0953.md
@@ -1,0 +1,32 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-12T01:53
+status: created
+priority: normal
+subject: "Committed 3cbbbd79 on devex-publish-path-repo-root: chore(manifest): bump agency_version 46.28 → 46.29 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 3cbbbd79 on devex-publish-path-repo-root: chore(manifest): bump agency_version 46.28 → 46.29 for PR landing (captain)
+
+## Commit: 3cbbbd79
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.28 → 46.29 for PR landing (captain)
+
+### Metadata
+- commit_hash: 3cbbbd79
+- branch: devex-publish-path-repo-root
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260812-0858.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-6248d81a-on-devex-publish-path-repo-root-20260812-0858.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-6248d81a-on-devex-publish-path-repo-root-20260812-0858.md
@@ -1,0 +1,32 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-12T00:58
+status: created
+priority: normal
+subject: "Committed 6248d81a on devex-publish-path-repo-root: misc(devex): QGR receipt (d60f4bd) for combined pr-prep — publish-path + git-sync"
+in_reply_to: null
+---
+
+# Committed 6248d81a on devex-publish-path-repo-root: misc(devex): QGR receipt (d60f4bd) for combined pr-prep — publish-path + git-sync
+
+## Commit: 6248d81a
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: misc(devex): QGR receipt (d60f4bd) for combined pr-prep — publish-path + git-sync
+
+### Metadata
+- commit_hash: 6248d81a
+- branch: devex-publish-path-repo-root
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260812-0858-d60f4bd.md
+usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-a16b9043-on-devex-publish-path-repo-root-20260812-0857.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-8a533701-on-devex-publish-path-repo-root-20260811-1642.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-8a533701-on-devex-publish-path-repo-root-20260811-1642.md
@@ -1,0 +1,164 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-11T08:42
+status: created
+priority: normal
+subject: "Committed 8a533701 on devex-publish-path-repo-root: fix(publish-path): add -C repo-root targeting so pr-captain-land signs and gates the scratch, not the captain checkout
+
+pr-captain-land runs the captain's trusted tools against a scratch worktree by
+setting the cwd — captain's code, scratch's data. receipt-sign, pr-create and
+dispatch resolved their target repo from SCRIPT_DIR/../.. (their install
+location) and ignored cwd, so on a real land the landing receipt was written
+into the captain's main checkout, the find-in-scratch returned nothing, and the
+land aborted with 'landing receipt was signed but could not be located'. Clean
+rollback, origin untouched — the safety design held; only the targeting was
+wrong.
+
+Adds '-C <repo-root>' as the FIRST argument to receipt-sign, pr-create and
+dispatch. Absent, behaviour is byte-identical to before, so no existing caller
+changes. For pr-create, -C retargets DATA only: receipt-verify and
+resolve-default-branch still run from its own SCRIPT_DIR, so a branch cannot
+ship its own verifier and pass its own gate.
+
+- git-safe-commit forwards its cwd-derived PROJECT_ROOT to dispatch via -C, so
+  commit-announce payloads stop leaking into the tool's own checkout.
+- pr-captain-land passes -C at steps 5 and 6, and names REPO_ROOT explicitly on
+  both dispatch calls (the validation-failure notice is written moments before
+  destroy_scratch and must not land in a directory about to be deleted).
+- pr-merge loses a dead PROJECT_ROOT — same install-rooted pattern, unused but
+  waiting to be picked up.
+
+Closes the coverage gap behind this: --rehearse stops at step 3, so steps 4-9
+had no test at all. Two new suites, 37 tests, both two-repo by construction
+because a single-repo fixture cannot tell 'honoured -C' from 'fell back to the
+install dir'. pr-captain-land-publish-locality.bats runs steps 4-5 for real and
+lifts the receipt-locate expression out of the script itself rather than
+restating it, since the original bug was the sign call and the locate call
+disagreeing about which repo they meant. Mutation-checked: removing either fix
+turns the suites red.
+
+Also repoints five BATS fixtures from claude/config to agency/config — a
+great-rename sweep miss that aborted them in setup(), so the ISCP suites were
+erroring rather than running. Targeted baseline vs branch: 225 to 295 passing,
+90 to 20 failing, zero new failures. Three more files have the same defect but
+fail for deeper unrelated reasons; left alone and documented in #465."
+in_reply_to: null
+---
+
+# Committed 8a533701 on devex-publish-path-repo-root: fix(publish-path): add -C repo-root targeting so pr-captain-land signs and gates the scratch, not the captain checkout
+
+pr-captain-land runs the captain's trusted tools against a scratch worktree by
+setting the cwd — captain's code, scratch's data. receipt-sign, pr-create and
+dispatch resolved their target repo from SCRIPT_DIR/../.. (their install
+location) and ignored cwd, so on a real land the landing receipt was written
+into the captain's main checkout, the find-in-scratch returned nothing, and the
+land aborted with 'landing receipt was signed but could not be located'. Clean
+rollback, origin untouched — the safety design held; only the targeting was
+wrong.
+
+Adds '-C <repo-root>' as the FIRST argument to receipt-sign, pr-create and
+dispatch. Absent, behaviour is byte-identical to before, so no existing caller
+changes. For pr-create, -C retargets DATA only: receipt-verify and
+resolve-default-branch still run from its own SCRIPT_DIR, so a branch cannot
+ship its own verifier and pass its own gate.
+
+- git-safe-commit forwards its cwd-derived PROJECT_ROOT to dispatch via -C, so
+  commit-announce payloads stop leaking into the tool's own checkout.
+- pr-captain-land passes -C at steps 5 and 6, and names REPO_ROOT explicitly on
+  both dispatch calls (the validation-failure notice is written moments before
+  destroy_scratch and must not land in a directory about to be deleted).
+- pr-merge loses a dead PROJECT_ROOT — same install-rooted pattern, unused but
+  waiting to be picked up.
+
+Closes the coverage gap behind this: --rehearse stops at step 3, so steps 4-9
+had no test at all. Two new suites, 37 tests, both two-repo by construction
+because a single-repo fixture cannot tell 'honoured -C' from 'fell back to the
+install dir'. pr-captain-land-publish-locality.bats runs steps 4-5 for real and
+lifts the receipt-locate expression out of the script itself rather than
+restating it, since the original bug was the sign call and the locate call
+disagreeing about which repo they meant. Mutation-checked: removing either fix
+turns the suites red.
+
+Also repoints five BATS fixtures from claude/config to agency/config — a
+great-rename sweep miss that aborted them in setup(), so the ISCP suites were
+erroring rather than running. Targeted baseline vs branch: 225 to 295 passing,
+90 to 20 failing, zero new failures. Three more files have the same defect but
+fail for deeper unrelated reasons; left alone and documented in #465.
+
+## Commit: 8a533701
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: fix(publish-path): add -C repo-root targeting so pr-captain-land signs and gates the scratch, not the captain checkout
+
+pr-captain-land runs the captain's trusted tools against a scratch worktree by
+setting the cwd — captain's code, scratch's data. receipt-sign, pr-create and
+dispatch resolved their target repo from SCRIPT_DIR/../.. (their install
+location) and ignored cwd, so on a real land the landing receipt was written
+into the captain's main checkout, the find-in-scratch returned nothing, and the
+land aborted with 'landing receipt was signed but could not be located'. Clean
+rollback, origin untouched — the safety design held; only the targeting was
+wrong.
+
+Adds '-C <repo-root>' as the FIRST argument to receipt-sign, pr-create and
+dispatch. Absent, behaviour is byte-identical to before, so no existing caller
+changes. For pr-create, -C retargets DATA only: receipt-verify and
+resolve-default-branch still run from its own SCRIPT_DIR, so a branch cannot
+ship its own verifier and pass its own gate.
+
+- git-safe-commit forwards its cwd-derived PROJECT_ROOT to dispatch via -C, so
+  commit-announce payloads stop leaking into the tool's own checkout.
+- pr-captain-land passes -C at steps 5 and 6, and names REPO_ROOT explicitly on
+  both dispatch calls (the validation-failure notice is written moments before
+  destroy_scratch and must not land in a directory about to be deleted).
+- pr-merge loses a dead PROJECT_ROOT — same install-rooted pattern, unused but
+  waiting to be picked up.
+
+Closes the coverage gap behind this: --rehearse stops at step 3, so steps 4-9
+had no test at all. Two new suites, 37 tests, both two-repo by construction
+because a single-repo fixture cannot tell 'honoured -C' from 'fell back to the
+install dir'. pr-captain-land-publish-locality.bats runs steps 4-5 for real and
+lifts the receipt-locate expression out of the script itself rather than
+restating it, since the original bug was the sign call and the locate call
+disagreeing about which repo they meant. Mutation-checked: removing either fix
+turns the suites red.
+
+Also repoints five BATS fixtures from claude/config to agency/config — a
+great-rename sweep miss that aborted them in setup(), so the ISCP suites were
+erroring rather than running. Targeted baseline vs branch: 225 to 295 passing,
+90 to 20 failing, zero new failures. Three more files have the same defect but
+fail for deeper unrelated reasons; left alone and documented in #465.
+
+### Metadata
+- commit_hash: 8a533701
+- branch: devex-publish-path-repo-root
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-land/reference.md
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+agency/tools/dispatch
+agency/tools/git-safe-commit
+agency/tools/pr-create
+agency/tools/pr-merge
+agency/tools/receipt-sign
+src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+src/agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+src/agency/tools/dispatch
+src/agency/tools/git-safe-commit
+src/agency/tools/pr-create
+src/agency/tools/pr-merge
+src/agency/tools/receipt-sign
+src/claude/skills/pr-captain-land/SKILL.md
+src/claude/skills/pr-captain-land/reference.md
+src/claude/skills/pr-captain-land/scripts/pr-captain-land
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-a16b9043-on-devex-publish-path-repo-root-20260812-0857.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-a16b9043-on-devex-publish-path-repo-root-20260812-0857.md
@@ -1,0 +1,176 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-12T00:57
+status: created
+priority: normal
+subject: "Committed a16b9043 on devex-publish-path-repo-root: fix(git-sync): QG findings — detached HEAD, swallowed conflicts, self-corrupting log
+
+The gate mutation-tested the guard I had just written and found the clause the
+commit message argued hardest for was not covered at all: deleting the
+resolved-default-branch test left 16/16 green, because every case reached the
+block through the two hardcoded literals instead. Three tests also passed for
+reasons other than the ones their comments claimed.
+
+Tool:
+- Detached HEAD was unguarded. `git branch --show-current` prints nothing, which
+  matched no clause, so the tool ran `git push -u origin ""` — fatal, so origin
+  was never at risk, but only after appending a push-log row with an empty
+  branch column and reporting "push failed" instead of "you are not on a
+  branch". Now refused by name.
+- A conflicted pull was treated as identical to "no remote branch yet": the
+  merge was left half-done with conflict markers in the tree, the push was
+  attempted anyway, and the output never mentioned the conflict. Now
+  distinguished — the run stops, the merge is left in place deliberately, and
+  the message says how to resolve or abort.
+- Every push-log row after the first sync was split across two lines.
+  `grep -c ... || echo "0"` appended a second zero on top of grep's own, since
+  grep -c prints 0 AND exits 1 when nothing matches. The log this change exists
+  to make usable was corrupting itself on every run. Now `|| true`.
+- The guard now reports through output_failure like every other failure path,
+  instead of speaking only on stderr where callers grepping stdout could not
+  see it, and it runs before the uncommitted-changes check so `--check` on a
+  dirty main answers BLOCKED rather than "uncommitted changes".
+
+Tests (16 → 23):
+- Added a genuinely trunk-default repo, so the resolver clause is exercised at
+  all; and a trunk-default repo carrying a stale local master, which is the only
+  case that makes the two literals load-bearing. Both clauses are now
+  independently mutation-verified: remove either one and exactly one test fails.
+- "master-default repo" only renamed the LOCAL branch, leaving origin on main,
+  so it tested the literal it claimed to be testing the alternative to. Rebuilt
+  via a helper that makes origin/HEAD agree.
+- "remote unreachable" did not make resolution fail — resolve-default-branch
+  reads refs/remotes/origin/main, which is local data.
+- The merge test could not fail: GIT_CONFIG_GLOBAL is nulled so git already
+  defaults to merge. Sets pull.rebase=true, the config --no-rebase exists to
+  defeat.
+- "identity never blocks the push" never reached the failure path (the tool is
+  invoked by absolute path, so PATH changes nothing). Shadows agent-identity
+  with a failing stub and asserts both the successful push and the degraded row.
+- The 'not unknown' assertion passed vacuously when grep matched nothing — which
+  the split rows made likely. Asserts positively now, plus a row-integrity test.
+- Added detached-HEAD, merge-conflict, and src/-parity tests. The parity test
+  caught its own un-mirrored copy on first run."
+in_reply_to: null
+---
+
+# Committed a16b9043 on devex-publish-path-repo-root: fix(git-sync): QG findings — detached HEAD, swallowed conflicts, self-corrupting log
+
+The gate mutation-tested the guard I had just written and found the clause the
+commit message argued hardest for was not covered at all: deleting the
+resolved-default-branch test left 16/16 green, because every case reached the
+block through the two hardcoded literals instead. Three tests also passed for
+reasons other than the ones their comments claimed.
+
+Tool:
+- Detached HEAD was unguarded. `git branch --show-current` prints nothing, which
+  matched no clause, so the tool ran `git push -u origin ""` — fatal, so origin
+  was never at risk, but only after appending a push-log row with an empty
+  branch column and reporting "push failed" instead of "you are not on a
+  branch". Now refused by name.
+- A conflicted pull was treated as identical to "no remote branch yet": the
+  merge was left half-done with conflict markers in the tree, the push was
+  attempted anyway, and the output never mentioned the conflict. Now
+  distinguished — the run stops, the merge is left in place deliberately, and
+  the message says how to resolve or abort.
+- Every push-log row after the first sync was split across two lines.
+  `grep -c ... || echo "0"` appended a second zero on top of grep's own, since
+  grep -c prints 0 AND exits 1 when nothing matches. The log this change exists
+  to make usable was corrupting itself on every run. Now `|| true`.
+- The guard now reports through output_failure like every other failure path,
+  instead of speaking only on stderr where callers grepping stdout could not
+  see it, and it runs before the uncommitted-changes check so `--check` on a
+  dirty main answers BLOCKED rather than "uncommitted changes".
+
+Tests (16 → 23):
+- Added a genuinely trunk-default repo, so the resolver clause is exercised at
+  all; and a trunk-default repo carrying a stale local master, which is the only
+  case that makes the two literals load-bearing. Both clauses are now
+  independently mutation-verified: remove either one and exactly one test fails.
+- "master-default repo" only renamed the LOCAL branch, leaving origin on main,
+  so it tested the literal it claimed to be testing the alternative to. Rebuilt
+  via a helper that makes origin/HEAD agree.
+- "remote unreachable" did not make resolution fail — resolve-default-branch
+  reads refs/remotes/origin/main, which is local data.
+- The merge test could not fail: GIT_CONFIG_GLOBAL is nulled so git already
+  defaults to merge. Sets pull.rebase=true, the config --no-rebase exists to
+  defeat.
+- "identity never blocks the push" never reached the failure path (the tool is
+  invoked by absolute path, so PATH changes nothing). Shadows agent-identity
+  with a failing stub and asserts both the successful push and the degraded row.
+- The 'not unknown' assertion passed vacuously when grep matched nothing — which
+  the split rows made likely. Asserts positively now, plus a row-integrity test.
+- Added detached-HEAD, merge-conflict, and src/-parity tests. The parity test
+  caught its own un-mirrored copy on first run.
+
+## Commit: a16b9043
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: fix(git-sync): QG findings — detached HEAD, swallowed conflicts, self-corrupting log
+
+The gate mutation-tested the guard I had just written and found the clause the
+commit message argued hardest for was not covered at all: deleting the
+resolved-default-branch test left 16/16 green, because every case reached the
+block through the two hardcoded literals instead. Three tests also passed for
+reasons other than the ones their comments claimed.
+
+Tool:
+- Detached HEAD was unguarded. `git branch --show-current` prints nothing, which
+  matched no clause, so the tool ran `git push -u origin ""` — fatal, so origin
+  was never at risk, but only after appending a push-log row with an empty
+  branch column and reporting "push failed" instead of "you are not on a
+  branch". Now refused by name.
+- A conflicted pull was treated as identical to "no remote branch yet": the
+  merge was left half-done with conflict markers in the tree, the push was
+  attempted anyway, and the output never mentioned the conflict. Now
+  distinguished — the run stops, the merge is left in place deliberately, and
+  the message says how to resolve or abort.
+- Every push-log row after the first sync was split across two lines.
+  `grep -c ... || echo "0"` appended a second zero on top of grep's own, since
+  grep -c prints 0 AND exits 1 when nothing matches. The log this change exists
+  to make usable was corrupting itself on every run. Now `|| true`.
+- The guard now reports through output_failure like every other failure path,
+  instead of speaking only on stderr where callers grepping stdout could not
+  see it, and it runs before the uncommitted-changes check so `--check` on a
+  dirty main answers BLOCKED rather than "uncommitted changes".
+
+Tests (16 → 23):
+- Added a genuinely trunk-default repo, so the resolver clause is exercised at
+  all; and a trunk-default repo carrying a stale local master, which is the only
+  case that makes the two literals load-bearing. Both clauses are now
+  independently mutation-verified: remove either one and exactly one test fails.
+- "master-default repo" only renamed the LOCAL branch, leaving origin on main,
+  so it tested the literal it claimed to be testing the alternative to. Rebuilt
+  via a helper that makes origin/HEAD agree.
+- "remote unreachable" did not make resolution fail — resolve-default-branch
+  reads refs/remotes/origin/main, which is local data.
+- The merge test could not fail: GIT_CONFIG_GLOBAL is nulled so git already
+  defaults to merge. Sets pull.rebase=true, the config --no-rebase exists to
+  defeat.
+- "identity never blocks the push" never reached the failure path (the tool is
+  invoked by absolute path, so PATH changes nothing). Shadows agent-identity
+  with a failing stub and asserts both the successful push and the degraded row.
+- The 'not unknown' assertion passed vacuously when grep matched nothing — which
+  the split rows made likely. Asserts positively now, plus a row-integrity test.
+- Added detached-HEAD, merge-conflict, and src/-parity tests. The parity test
+  caught its own un-mirrored copy on first run.
+
+### Metadata
+- commit_hash: a16b9043
+- branch: devex-publish-path-repo-root
+- files_changed: 5
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/git-sync
+history/push-log.md
+src/agency/tools/git-sync
+src/tests/tools/git-sync-guard.bats
+usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-ded0dd41-on-devex-publish-path-repo-root-20260812-0840.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-da24c758-on-devex-publish-path-repo-root-20260811-1704.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-da24c758-on-devex-publish-path-repo-root-20260811-1704.md
@@ -1,0 +1,32 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-11T09:04
+status: created
+priority: normal
+subject: "Committed da24c758 on devex-publish-path-repo-root: misc(devex): QGR receipt (8f81cef) for pr-prep on -C repo-root targeting"
+in_reply_to: null
+---
+
+# Committed da24c758 on devex-publish-path-repo-root: misc(devex): QGR receipt (8f81cef) for pr-prep on -C repo-root targeting
+
+## Commit: da24c758
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: misc(devex): QGR receipt (8f81cef) for pr-prep on -C repo-root targeting
+
+### Metadata
+- commit_hash: da24c758
+- branch: devex-publish-path-repo-root
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260811-1704-8f81cef.md
+usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-386fdbf1-on-devex-publish-path-repo-root-20260811-1703.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-ded0dd41-on-devex-publish-path-repo-root-20260812-0840.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/commit-to-captain-committed-ded0dd41-on-devex-publish-path-repo-root-20260812-0840.md
@@ -1,0 +1,133 @@
+---
+type: commit
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency/jordan/captain
+date: 2026-08-12T00:40
+status: created
+priority: normal
+subject: "Committed ded0dd41 on devex-publish-path-repo-root: fix(git-sync): refuse on the default branch and merge instead of rebasing
+
+git-sync violated two of the framework's sacred invariants and nothing stopped
+it. It ran `git pull --rebase origin $BRANCH` — the rule is merge, never
+rebase — and `git push -u origin $BRANCH` with no main/master guard at all —
+the rule is that nothing reaches the default branch except through a PR.
+Invoked on main it did both at once: rewrote main's history and pushed main
+straight past the PR flow. That happened; the content was benign captain
+coordination so it was recoverable. git-push sits in the same directory and has
+blocked main since Day 40, so the tool contradicted the methodology and its own
+neighbour simultaneously.
+
+- Refuses on main/master, and on the default branch resolved via
+  resolve-default-branch rather than hardcoded, so master-default repos are
+  covered too. Both literals are ALSO checked unconditionally: the resolver
+  falls back to "main" when it cannot reach origin, and a guard that softens
+  when the network does is not a guard. The check sits before the pull, the
+  push, AND the push-log append, so a refused run mutates nothing.
+- Pull is now `--no-rebase`, explicitly rather than by relying on git's
+  default — pull.rebase=true in a user's global config would otherwise quietly
+  restore the rewrite.
+- The push log recorded every agent as "unknown" because it read $AGENTNAME,
+  which Claude Code does not set; an accountability log that accounts for nobody
+  is decoration. Resolves via agent-identity, best-effort, and never blocks a
+  push on failing to.
+
+16 tests against a REAL local bare origin, not a mock — a refusal that holds
+only because the network was absent proves nothing. Each refusal case asserts
+both the block and that nothing moved: origin's main unchanged, local history
+unchanged, no push-log row. The merge behaviour is proved behaviourally by
+diverging two clones and asserting the pre-sync commit survives under its
+ORIGINAL sha with a merge commit present. Mutation-checked: disabling the guard
+fails 8 tests including the one that catches the real push to origin; restoring
+--rebase fails 3 including the divergence test."
+in_reply_to: null
+---
+
+# Committed ded0dd41 on devex-publish-path-repo-root: fix(git-sync): refuse on the default branch and merge instead of rebasing
+
+git-sync violated two of the framework's sacred invariants and nothing stopped
+it. It ran `git pull --rebase origin $BRANCH` — the rule is merge, never
+rebase — and `git push -u origin $BRANCH` with no main/master guard at all —
+the rule is that nothing reaches the default branch except through a PR.
+Invoked on main it did both at once: rewrote main's history and pushed main
+straight past the PR flow. That happened; the content was benign captain
+coordination so it was recoverable. git-push sits in the same directory and has
+blocked main since Day 40, so the tool contradicted the methodology and its own
+neighbour simultaneously.
+
+- Refuses on main/master, and on the default branch resolved via
+  resolve-default-branch rather than hardcoded, so master-default repos are
+  covered too. Both literals are ALSO checked unconditionally: the resolver
+  falls back to "main" when it cannot reach origin, and a guard that softens
+  when the network does is not a guard. The check sits before the pull, the
+  push, AND the push-log append, so a refused run mutates nothing.
+- Pull is now `--no-rebase`, explicitly rather than by relying on git's
+  default — pull.rebase=true in a user's global config would otherwise quietly
+  restore the rewrite.
+- The push log recorded every agent as "unknown" because it read $AGENTNAME,
+  which Claude Code does not set; an accountability log that accounts for nobody
+  is decoration. Resolves via agent-identity, best-effort, and never blocks a
+  push on failing to.
+
+16 tests against a REAL local bare origin, not a mock — a refusal that holds
+only because the network was absent proves nothing. Each refusal case asserts
+both the block and that nothing moved: origin's main unchanged, local history
+unchanged, no push-log row. The merge behaviour is proved behaviourally by
+diverging two clones and asserting the pre-sync commit survives under its
+ORIGINAL sha with a merge commit present. Mutation-checked: disabling the guard
+fails 8 tests including the one that catches the real push to origin; restoring
+--rebase fails 3 including the divergence test.
+
+## Commit: ded0dd41
+
+**Branch:** devex-publish-path-repo-root
+**Agent:** the-agency/jordan/devex-publish-path-repo-root
+**Message:** housekeeping/captain: fix(git-sync): refuse on the default branch and merge instead of rebasing
+
+git-sync violated two of the framework's sacred invariants and nothing stopped
+it. It ran `git pull --rebase origin $BRANCH` — the rule is merge, never
+rebase — and `git push -u origin $BRANCH` with no main/master guard at all —
+the rule is that nothing reaches the default branch except through a PR.
+Invoked on main it did both at once: rewrote main's history and pushed main
+straight past the PR flow. That happened; the content was benign captain
+coordination so it was recoverable. git-push sits in the same directory and has
+blocked main since Day 40, so the tool contradicted the methodology and its own
+neighbour simultaneously.
+
+- Refuses on main/master, and on the default branch resolved via
+  resolve-default-branch rather than hardcoded, so master-default repos are
+  covered too. Both literals are ALSO checked unconditionally: the resolver
+  falls back to "main" when it cannot reach origin, and a guard that softens
+  when the network does is not a guard. The check sits before the pull, the
+  push, AND the push-log append, so a refused run mutates nothing.
+- Pull is now `--no-rebase`, explicitly rather than by relying on git's
+  default — pull.rebase=true in a user's global config would otherwise quietly
+  restore the rewrite.
+- The push log recorded every agent as "unknown" because it read $AGENTNAME,
+  which Claude Code does not set; an accountability log that accounts for nobody
+  is decoration. Resolves via agent-identity, best-effort, and never blocks a
+  push on failing to.
+
+16 tests against a REAL local bare origin, not a mock — a refusal that holds
+only because the network was absent proves nothing. Each refusal case asserts
+both the block and that nothing moved: origin's main unchanged, local history
+unchanged, no push-log row. The merge behaviour is proved behaviourally by
+diverging two clones and asserting the pre-sync commit survives under its
+ORIGINAL sha with a merge commit present. Mutation-checked: disabling the guard
+fails 8 tests including the one that catches the real push to origin; restoring
+--rebase fails 3 including the divergence test.
+
+### Metadata
+- commit_hash: ded0dd41
+- branch: devex-publish-path-repo-root
+- files_changed: 4
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/git-sync
+src/agency/tools/git-sync
+src/tests/tools/git-sync-guard.bats
+usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260811-1705.md
+```

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260811-1705.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260811-1705.md
@@ -1,0 +1,60 @@
+---
+type: dispatch
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency-ai/jordan/captain
+date: 2026-08-11T09:05
+status: created
+priority: normal
+subject: "Ready for PR landing: devex-publish-path-repo-root — -C repo-root targeting so pr-captain-land's publish path signs and gates the scratch worktree, not the captain checkout; plus first test coverage of steps 4-9"
+in_reply_to: null
+---
+
+# Ready for PR landing: devex-publish-path-repo-root — -C repo-root targeting so pr-captain-land's publish path signs and gates the scratch worktree, not the captain checkout; plus first test coverage of steps 4-9
+
+# Ready for PR landing — -C repo-root targeting so pr-captain-land's publish path signs and gates the scratch worktree, not the captain checkout; plus first test coverage of steps 4-9
+
+## Branch ready
+
+- **Branch:** `devex-publish-path-repo-root`
+- **Agent:** the-agency-ai/jordan/the-agency/jordan/devex-publish-path-repo-root
+- **HEAD:** `acc733acdac59e77cf9da3c382aeaa6f5260ad99` (pushed to origin)
+- **Diff base:** `origin/main`
+- **Diff hash:** `8f81cef`
+
+## QGR receipt
+
+- **Path:** `agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260811-1704-8f81cef.md`
+- **Verified:** local receipt file matches current state
+
+## Scope summary
+
+-C repo-root targeting so pr-captain-land's publish path signs and gates the scratch worktree, not the captain checkout; plus first test coverage of steps 4-9
+
+## Captain action requested
+
+Run /pr-captain-land on branch `devex-publish-path-repo-root` (local-first):
+
+1. Cut a scratch worktree `_land-devex-publish-path-repo-root` at `origin/devex-publish-path-repo-root` — my branch is never checked out
+2. Verify this QGR receipt against that tree, BEFORE any mutation
+3. Validate locally in the scratch (build + tests + commit-precheck) — this is the gate
+4. Bump `agency_version` in the scratch (serialized — single writer)
+5. Sign a captain landing receipt chained to this one
+6. Push the scratch branch and open the PR
+7. Wait on the aggregate status check rollup, merge when green
+8. Create GitHub release v{agency_version}, dispatch back with confirmation
+
+If local validation fails, nothing is published and I get a dispatch naming the
+failing step.
+
+## What I (agent) will NOT do
+
+- Create the PR myself
+- Bump `agency_version` myself
+- Merge myself
+- Create the release myself
+
+Captain owns the PR lifecycle. I stand by to /pr-respond if review comments come.
+
+Over.
+
+-- the-agency-ai/jordan/the-agency/jordan/devex-publish-path-repo-root

--- a/usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260812-0858.md
+++ b/usr/jordan/devex-publish-path-repo-root/dispatches/dispatch-to-captain-ready-for-pr-landing-devex-publish-path-repo-root--20260812-0858.md
@@ -1,0 +1,60 @@
+---
+type: dispatch
+from: the-agency/jordan/devex-publish-path-repo-root
+to: the-agency-ai/jordan/captain
+date: 2026-08-12T00:58
+status: created
+priority: normal
+subject: "Ready for PR landing: devex-publish-path-repo-root — -C repo-root targeting for the pr-captain-land publish path (steps 4-9) + git-sync default-branch guard and merge-not-rebase fix"
+in_reply_to: null
+---
+
+# Ready for PR landing: devex-publish-path-repo-root — -C repo-root targeting for the pr-captain-land publish path (steps 4-9) + git-sync default-branch guard and merge-not-rebase fix
+
+# Ready for PR landing — -C repo-root targeting for the pr-captain-land publish path (steps 4-9) + git-sync default-branch guard and merge-not-rebase fix
+
+## Branch ready
+
+- **Branch:** `devex-publish-path-repo-root`
+- **Agent:** the-agency-ai/jordan/the-agency/jordan/devex-publish-path-repo-root
+- **HEAD:** `2a07f80a059945340dbc1419864802efe382cc0d` (pushed to origin)
+- **Diff base:** `origin/main`
+- **Diff hash:** `d60f4bd`
+
+## QGR receipt
+
+- **Path:** `agency/workstreams/devex/qgr/the-agency-jordan-devex-devex-publish-path-repo-root-qgr-pr-prep-20260812-0858-d60f4bd.md`
+- **Verified:** local receipt file matches current state
+
+## Scope summary
+
+-C repo-root targeting for the pr-captain-land publish path (steps 4-9) + git-sync default-branch guard and merge-not-rebase fix
+
+## Captain action requested
+
+Run /pr-captain-land on branch `devex-publish-path-repo-root` (local-first):
+
+1. Cut a scratch worktree `_land-devex-publish-path-repo-root` at `origin/devex-publish-path-repo-root` — my branch is never checked out
+2. Verify this QGR receipt against that tree, BEFORE any mutation
+3. Validate locally in the scratch (build + tests + commit-precheck) — this is the gate
+4. Bump `agency_version` in the scratch (serialized — single writer)
+5. Sign a captain landing receipt chained to this one
+6. Push the scratch branch and open the PR
+7. Wait on the aggregate status check rollup, merge when green
+8. Create GitHub release v{agency_version}, dispatch back with confirmation
+
+If local validation fails, nothing is published and I get a dispatch naming the
+failing step.
+
+## What I (agent) will NOT do
+
+- Create the PR myself
+- Bump `agency_version` myself
+- Merge myself
+- Create the release myself
+
+Captain owns the PR lifecycle. I stand by to /pr-respond if review comments come.
+
+Over.
+
+-- the-agency-ai/jordan/the-agency/jordan/devex-publish-path-repo-root

--- a/usr/jordan/reports/REPORTS-INDEX.md
+++ b/usr/jordan/reports/REPORTS-INDEX.md
@@ -28,6 +28,7 @@ Each row is one filing. Click through to the per-report markdown for full contex
 | 2026-05-09 | git-safe family lacks 'init' subcommand — blocks bare-repo bootstrap | friction | the-agency-ai/the-agency | #437 | [report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509](usr/jordan/reports/report-agency-issue-git-safe-family-lacks-init-subcommand-blocks-bare--20260509.md) | open |
 | 2026-05-09 | git-safe lacks 'remote' subcommand + run-in bypasses hookify rules | bug | the-agency-ai/the-agency | #439 | [report-agency-issue-git-safe-lacks-remote-subcommand-run-in-bypasses-h-20260509](usr/jordan/reports/report-agency-issue-git-safe-lacks-remote-subcommand-run-in-bypasses-h-20260509.md) | open |
 | 2026-05-09 | git-push blocks main, but new-repo bootstrap requires initial push to main | bug | the-agency-ai/the-agency | #440 | [report-agency-issue-git-push-blocks-main-but-new-repo-bootstrap-requir-20260509](usr/jordan/reports/report-agency-issue-git-push-blocks-main-but-new-repo-bootstrap-requir-20260509.md) | open |
+| 2026-08-11 | BATS fixtures still mkdir claude/config after the great-rename — 12 test files error out in setup() | bug | the-agency-ai/the-agency | #465 | [report-agency-issue-bats-fixtures-still-mkdir-claude-config-after-the--20260811](usr/jordan/reports/report-agency-issue-bats-fixtures-still-mkdir-claude-config-after-the--20260811.md) | open |
 <!-- AGENCY-ISSUE-INDEX-END -->
 
 ## How to add an entry

--- a/usr/jordan/reports/report-agency-issue-bats-fixtures-still-mkdir-claude-config-after-the--20260811.md
+++ b/usr/jordan/reports/report-agency-issue-bats-fixtures-still-mkdir-claude-config-after-the--20260811.md
@@ -1,0 +1,73 @@
+---
+report_type: agency-issue
+issue_type: bug
+filing_agent: the-agency/jordan/devex-publish-path-repo-root
+filed_by: jordan
+date_filed: 2026-08-11
+target_repo: the-agency-ai/the-agency
+github_issue: https://github.com/the-agency-ai/the-agency/issues/465
+github_issue_number: 465
+status: open
+---
+
+# BATS fixtures still mkdir claude/config after the great-rename — 12 test files error out in setup()
+
+**Filed:** 2026-08-11T08:17:51Z
+**Target:** [the-agency-ai/the-agency](https://github.com/the-agency-ai/the-agency)
+**Issue:** [#465](https://github.com/the-agency-ai/the-agency/issues/465)
+**Type:** bug
+**Status:** open
+
+## Filed Body
+
+**Type:** bug
+
+## Summary
+
+A large block of the BATS suite has not been *running* — the tests error out in `setup()` rather than failing an assertion, so the red has been easy to read as ordinary flakiness. Root cause is a single unswept path from the great-rename: fixtures `mkdir -p "$MOCK_REPO/claude/config"` but the tools they exercise now read `agency/config/agency.yaml`. The subsequent `cat > .../agency/config/agency.yaml` fails, `setup()` aborts, and **every test in the file errors**.
+
+Found while checking the ISCP suites for regressions from the `-C` repo-root work (publish-path fix for `pr-captain-land`).
+
+## Scope
+
+Confirmed on pristine `main` — this is not caused by the `-C` branch.
+
+**Fixed in the `-C` PR** (in blast radius; needed to prove no regression in the `dispatch` tool):
+`iscp-check.bats`, `iscp-db.bats`, `dispatch-create.bats`, `flag.bats`, `agent-identity.bats`, `multi-principal.bats`, `address-parse.bats`, `iscp-migrate.bats`
+
+That recovered **70 tests** on the targeted set alone (225 → 295 passing).
+
+**Still broken — not touched, to keep that PR scoped:**
+
+| File | Line(s) |
+|---|---|
+| `agency-update.bats` | 40, 41, 234, 250, 267 |
+| `agency-init.bats` | 63 |
+| `agent-create.bats` | 28 |
+| `commit-prefix.bats` | 17 |
+| `deploy.bats` | 20, 257 |
+| `preview.bats` | 20, 263 |
+| `platform-setup.bats` | 53 |
+| `terminal-setup.bats` | 47, 75 |
+| `provider-resolve.bats` | 19 |
+| `release-plan.bats` | 32 |
+| `sandbox-sync.bats` | 33 |
+| `session-handoff.bats` | 25 |
+
+## Fix
+
+Mechanical, one token per site: `claude/config` → `agency/config` in the `mkdir -p`. In each ISCP file already fixed, the `mkdir` was the file's *only* `claude/config` reference while the body wrote to `agency/config`, so the replacement was 1:1 with no ambiguity. Worth confirming the same holds for each file above before swapping (`deploy.bats` and `preview.bats` also create `claude/tools`, which may be a separate stale path).
+
+## Separate defect found in the same sweep
+
+`iscp-migrate.bats` (14 tests) fails for a *different* reason after the path fix: `setup()` copies `agency/tools/iscp-migrate`, which does not exist in the repo. Either the tool was removed without removing its suite, or it was never landed. Needs a decision — restore the tool or delete the suite. Left alone for now.
+
+## Why this matters beyond the count
+
+These files error in `setup()`, so they report as failures without ever asserting anything. A suite that is loudly red in a way everyone has learned to scroll past provides no signal — the `-C` bug this was found alongside slipped through partly because nobody could tell which red was new. Recommend fixing the remaining twelve in one mechanical sweep and then treating the suite as gating.
+
+## Response Log
+
+_(append responses, comments, and state changes here as they occur)_
+
+- **2026-08-11:** Filed via `agency-issue file`. Issue created at https://github.com/the-agency-ai/the-agency/issues/465


### PR DESCRIPTION
## What

Hardens the delivery path so the local-first `pr-captain-land` can actually publish (steps 4-9), and fixes `git-sync` to refuse the default branch and merge instead of rebase.

### Fix A — publish-path repo-root targeting
The first real (publish) land of the v2 `pr-captain-land` failed: `receipt-sign`, `pr-create`, and `dispatch` resolved REPO_ROOT from their **install** dir (the main checkout) rather than the scratch worktree, so the landing receipt was written to the wrong tree and the find-in-scratch step failed → clean rollback. This adds `-C <repo-root>` targeting to those tools (default behavior unchanged, zero regression) and `pr-captain-land` passes `-C "$SCRATCH_DIR"`. Plus coverage of steps 4-9 (two-repo tests) and two more bugs found along the way.

### Fix B — git-sync default-branch guard (flag #229)
`git-sync` did `pull --rebase` + `push` with **no** guard against the default branch — something ran it on main and rebased + pushed main. Now guards main/master/resolved-default, merges instead of rebasing, records the real agent in the push-log. Re-QG found 3 more git-sync bugs (detached-HEAD → `push origin ""`, swallowed conflicts, self-corrupting push-log) — all fixed and mutation-verified.

## Receipts
- Agent pr-prep QGR: `d60f4bd` (workstream devex)
- Captain landing receipt: `b21fea5` (chains to d60f4bd; agency_version 46.28 → 46.29)

🤖 Generated with [Claude Code](https://claude.com/claude-code)