### PR TITLE
fix(pr-captain-land): stop --delete-branch aborting the land after a successful merge

### DIFF
--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -201,11 +201,11 @@ v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved]
 ./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure.
+True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure. No `--delete-branch`: it would also delete the still-checked-out local `_land-<slug>` branch and abort the step after a successful merge — the remote branch is deleted explicitly in step 9 instead.
 
 If no release was cut (`--no-release`, or `gh-release` failed), the pending post-merge state is deliberately **left set** — that guard exists precisely for "merged but release not cut".
 

--- a/.claude/skills/pr-captain-land/reference.md
+++ b/.claude/skills/pr-captain-land/reference.md
@@ -206,11 +206,13 @@ Max 45 attempts × 20s = 15 minutes.
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved]
 ./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
 ```
 
 True merge commit — never squash, never rebase.
+
+**Why no `--delete-branch`:** `gh pr merge --delete-branch=true` deletes the *local* `_land-<slug>` branch too, but the scratch worktree still holds it at merge time (it is torn down in step 9). The local delete fails, `pr-merge` exits non-zero, and the whole step aborts *after* the server-side merge already landed — release uncut, reconcile un-run. The remote branch is instead deleted explicitly in step 9, once the scratch is gone.
 
 `--principal-approved` is forwarded **only** when the captain passed it to `/pr-captain-land`. `pr-merge` treats that flag as the captain's attestation that the principal verbally approved, and it is the only route to `gh pr merge --admin`; asserting it unconditionally in a non-interactive script would make branch-protection bypass the fleet's default merge mode. Default behaviour is to defer to GitHub's gates, and the failure message says to re-run with the flag if protection is the blocker.
 
@@ -218,7 +220,7 @@ Both calls capture their output and print the tail on failure. Silencing them at
 
 ### Step 9 — Cleanup, notify, reconcile
 
-1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
+1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`, then delete the **remote** ref via `gh-api /repos/<org>/<repo>/git/refs/heads/_land-<branch> --method DELETE` (best-effort). The remote delete is *not* done with `git-push` (no delete mode — it would re-push the branch) and *not* folded into `pr-merge --delete-branch` (that also targets the still-checked-out local branch — see Step 8).
 2. `dispatch create --type master-updated` to the agent. The recipient is resolved against the agent registry, not guessed from the branch prefix — `pr-lifecycle-v2` would otherwise yield `pr`, and the dispatch (best-effort by design) would vanish. An unresolvable name routes to captain with a note.
 3. `post-merge-state clear <num>` — **only if a release was actually cut.** Clearing it after `--no-release` or a failed `gh-release` discards exactly the "merged but release not cut" signal the guard exists to carry.
 4. `git-captain merge-from-origin` — reconcile local main with the server merge.

--- a/.claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/.claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -948,9 +948,18 @@ fi
 # the only route to `gh pr merge --admin`. Hardcoding it in a non-interactive
 # script would turn a deliberate human gate into a constant and make branch-
 # protection bypass the fleet's default merge mode. Default: defer to GitHub.
-MERGE_ARGS="--delete-branch"
+#
+# We do NOT pass --delete-branch here. `gh pr merge --delete-branch=true` deletes
+# the LOCAL branch as well as the remote, but _land-<slug> is still checked out
+# in the scratch worktree at this point (it is not torn down until step 9). The
+# local delete therefore fails, pr-merge exits non-zero, and this whole step
+# aborts AFTER the server-side merge already succeeded — leaving the release
+# uncut and the reconcile un-run for a merge that actually landed. Instead:
+# merge here, tear down the scratch in step 9 (which frees and deletes the local
+# branch), then delete the REMOTE branch explicitly.
+MERGE_ARGS=""
 if [[ "$PRINCIPAL_APPROVED" == true ]]; then
-    MERGE_ARGS="--principal-approved --delete-branch"
+    MERGE_ARGS="--principal-approved"
 fi
 
 echo "→ Merging PR #$PR_NUM (true merge commit)..."
@@ -996,10 +1005,15 @@ fi
 echo "→ Cleaning up scratch worktree and land branch..."
 destroy_scratch
 rm -f "$VALIDATION_LOG"
-# The REMOTE copy of the land branch is deleted by `pr-merge --delete-branch`
-# above. It is deliberately NOT retried here: git-push takes a branch name
-# positionally and has no delete mode, so a "belt and braces" call would
-# re-PUSH the branch rather than remove it.
+# Delete the REMOTE land branch now that destroy_scratch has removed the scratch
+# worktree and its local branch. This is NOT done via `pr-merge --delete-branch`
+# (step 8 explains why: that flag also targets the local branch, which the scratch
+# worktree still holds at merge time). git-push has no delete mode — it takes a
+# branch name positionally and would re-PUSH — so the ref is deleted through the
+# API. Best-effort: the land has already succeeded, so a leftover remote branch is
+# cosmetic, not a failure.
+bash "$TOOLS/gh-api" "/repos/$ORG/$REPO/git/refs/heads/$LAND_SLUG" --method DELETE \
+    >/dev/null 2>&1 || true
 
 AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.31",
+  "agency_version": "46.32",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-12T04:57:08Z"
+    "updated_at": "2026-08-12T06:47:27Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-12T04:57:08Z"
+  "updated_at": "2026-08-12T06:47:27Z"
 }

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-captain-land-20260812-1447-f4c1d73.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-captain-land-20260812-1447-f4c1d73.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-pr-land-cleanup
+diff_base: origin/main
+hash_a: 2ad66d792164737b9a68d664ab648ca3430ff288fb13f0cc574d16143ec949e2
+hash_b: 64454f7855a7e51f19daa1e8bf7e698a138bceb1a35e565df12345d948f5453e
+hash_c: 64454f7855a7e51f19daa1e8bf7e698a138bceb1a35e565df12345d948f5453e
+hash_d: 64454f7855a7e51f19daa1e8bf7e698a138bceb1a35e565df12345d948f5453e
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: f4c1d73f16a47211bdcb8fdb74d372efcef7662c4763ce0e0a837a547cde7782
+date: 2026-08-12T14:47
+---
+
+# Receipt: pr-captain-land — fix-pr-land-cleanup
+
+## Chain of Trust
+- A (original): 2ad66d7
+- B (findings): 64454f7
+- C (triage): 64454f7
+- D (principal): 64454f7 — principal-approved flag passed by captain at land time
+- E (final): f4c1d73
+
+## Review Summary
+Local-first landing of fix-pr-land-cleanup. Integrated in scratch worktree _land-fix-pr-land-cleanup cut from origin/fix-pr-land-cleanup; 1 local validation step(s) passed against origin/main; agency_version 46.31 → 46.32. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-prep-20260812-1315-2ad66d7.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-prep-20260812-1315-2ad66d7.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-prep-20260812-1315-2ad66d7.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-pr-land-cleanup
+diff_base: origin/main
+hash_a: 2ad66d792164737b9a68d664ab648ca3430ff288fb13f0cc574d16143ec949e2
+hash_b: 6f8961b396d3e773a031c56d61b236dd05f0321f94f15060f618ccb2a9f0b81a
+hash_c: 6f8961b396d3e773a031c56d61b236dd05f0321f94f15060f618ccb2a9f0b81a
+hash_d: 6f8961b396d3e773a031c56d61b236dd05f0321f94f15060f618ccb2a9f0b81a
+hash_d_source: "auto-approved — no principal 1B1 (multi-agent QG, captain-consolidated)"
+hash_e: 2ad66d792164737b9a68d664ab648ca3430ff288fb13f0cc574d16143ec949e2
+date: 2026-08-12T13:15
+---
+
+# Receipt: pr-prep — fix-pr-land-cleanup
+
+## Chain of Trust
+- A (original): 2ad66d7
+- B (findings): 6f8961b
+- C (triage): 6f8961b
+- D (principal): 6f8961b — auto-approved — no principal 1B1 (multi-agent QG, captain-consolidated)
+- E (final): 2ad66d7
+
+## Review Summary
+pr-captain-land scratch-branch-delete cleanup fix: drop --delete-branch from pr-merge, delete remote land branch via gh-api in step 9. 3-reviewer QG, 2 test gaps closed, 48/48 bats.

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -201,11 +201,11 @@ v1 hardcoded a check named `lint-and-test` that does not exist in this repo, so 
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved]
 ./agency/tools/gh-release create v<new> --target <default> ...
 ```
 
-True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure.
+True merge commit — never squash, never rebase. `--principal-approved` is forwarded **only** when the captain passed it; by default the merge defers to branch protection. Both the merge and the release capture their output and print it on failure. No `--delete-branch`: it would also delete the still-checked-out local `_land-<slug>` branch and abort the step after a successful merge — the remote branch is deleted explicitly in step 9 instead.
 
 If no release was cut (`--no-release`, or `gh-release` failed), the pending post-merge state is deliberately **left set** — that guard exists precisely for "merged but release not cut".
 

--- a/src/claude/skills/pr-captain-land/reference.md
+++ b/src/claude/skills/pr-captain-land/reference.md
@@ -206,11 +206,13 @@ Max 45 attempts × 20s = 15 minutes.
 ### Step 8 — Merge + release
 
 ```
-./agency/tools/pr-merge <num> [--principal-approved] --delete-branch
+./agency/tools/pr-merge <num> [--principal-approved]
 ./agency/tools/gh-release create v<new> --target <default> --title ... --notes ...
 ```
 
 True merge commit — never squash, never rebase.
+
+**Why no `--delete-branch`:** `gh pr merge --delete-branch=true` deletes the *local* `_land-<slug>` branch too, but the scratch worktree still holds it at merge time (it is torn down in step 9). The local delete fails, `pr-merge` exits non-zero, and the whole step aborts *after* the server-side merge already landed — release uncut, reconcile un-run. The remote branch is instead deleted explicitly in step 9, once the scratch is gone.
 
 `--principal-approved` is forwarded **only** when the captain passed it to `/pr-captain-land`. `pr-merge` treats that flag as the captain's attestation that the principal verbally approved, and it is the only route to `gh pr merge --admin`; asserting it unconditionally in a non-interactive script would make branch-protection bypass the fleet's default merge mode. Default behaviour is to defer to GitHub's gates, and the failure message says to re-run with the flag if protection is the blocker.
 
@@ -218,7 +220,7 @@ Both calls capture their output and print the tail on failure. Silencing them at
 
 ### Step 9 — Cleanup, notify, reconcile
 
-1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`. (The remote copy was deleted by `pr-merge --delete-branch`; this is *not* retried with `git-push`, which has no delete mode and would re-push the branch.)
+1. `worktree-delete _land-<branch> --force` + `git-captain branch-delete _land-<branch> --force`, then delete the **remote** ref via `gh-api /repos/<org>/<repo>/git/refs/heads/_land-<branch> --method DELETE` (best-effort). The remote delete is *not* done with `git-push` (no delete mode — it would re-push the branch) and *not* folded into `pr-merge --delete-branch` (that also targets the still-checked-out local branch — see Step 8).
 2. `dispatch create --type master-updated` to the agent. The recipient is resolved against the agent registry, not guessed from the branch prefix — `pr-lifecycle-v2` would otherwise yield `pr`, and the dispatch (best-effort by design) would vanish. An unresolvable name routes to captain with a note.
 3. `post-merge-state clear <num>` — **only if a release was actually cut.** Clearing it after `--no-release` or a failed `gh-release` discards exactly the "merged but release not cut" signal the guard exists to carry.
 4. `git-captain merge-from-origin` — reconcile local main with the server merge.

--- a/src/claude/skills/pr-captain-land/scripts/pr-captain-land
+++ b/src/claude/skills/pr-captain-land/scripts/pr-captain-land
@@ -948,9 +948,18 @@ fi
 # the only route to `gh pr merge --admin`. Hardcoding it in a non-interactive
 # script would turn a deliberate human gate into a constant and make branch-
 # protection bypass the fleet's default merge mode. Default: defer to GitHub.
-MERGE_ARGS="--delete-branch"
+#
+# We do NOT pass --delete-branch here. `gh pr merge --delete-branch=true` deletes
+# the LOCAL branch as well as the remote, but _land-<slug> is still checked out
+# in the scratch worktree at this point (it is not torn down until step 9). The
+# local delete therefore fails, pr-merge exits non-zero, and this whole step
+# aborts AFTER the server-side merge already succeeded — leaving the release
+# uncut and the reconcile un-run for a merge that actually landed. Instead:
+# merge here, tear down the scratch in step 9 (which frees and deletes the local
+# branch), then delete the REMOTE branch explicitly.
+MERGE_ARGS=""
 if [[ "$PRINCIPAL_APPROVED" == true ]]; then
-    MERGE_ARGS="--principal-approved --delete-branch"
+    MERGE_ARGS="--principal-approved"
 fi
 
 echo "→ Merging PR #$PR_NUM (true merge commit)..."
@@ -996,10 +1005,15 @@ fi
 echo "→ Cleaning up scratch worktree and land branch..."
 destroy_scratch
 rm -f "$VALIDATION_LOG"
-# The REMOTE copy of the land branch is deleted by `pr-merge --delete-branch`
-# above. It is deliberately NOT retried here: git-push takes a branch name
-# positionally and has no delete mode, so a "belt and braces" call would
-# re-PUSH the branch rather than remove it.
+# Delete the REMOTE land branch now that destroy_scratch has removed the scratch
+# worktree and its local branch. This is NOT done via `pr-merge --delete-branch`
+# (step 8 explains why: that flag also targets the local branch, which the scratch
+# worktree still holds at merge time). git-push has no delete mode — it takes a
+# branch name positionally and would re-PUSH — so the ref is deleted through the
+# API. Best-effort: the land has already succeeded, so a leftover remote branch is
+# cosmetic, not a failure.
+bash "$TOOLS/gh-api" "/repos/$ORG/$REPO/git/refs/heads/$LAND_SLUG" --method DELETE \
+    >/dev/null 2>&1 || true
 
 AGENT_NAME="$(resolve_agent_name)"
 echo "→ Dispatching $AGENT_NAME with merge outcome..."

--- a/src/tests/skills/pr-captain-land-localfirst.bats
+++ b/src/tests/skills/pr-captain-land-localfirst.bats
@@ -270,6 +270,45 @@ live_code() {
     [ "$status" -ne 0 ]
 }
 
+@test "pr-captain-land v2: --delete-branch is never handed to pr-merge (the scratch still holds the local branch)" {
+    # gh pr merge --delete-branch=true deletes the LOCAL _land-<slug> branch too,
+    # but the scratch worktree still holds it at merge time (torn down in step 9).
+    # The local delete fails, pr-merge exits non-zero, and the step aborts AFTER
+    # the server-side merge already landed. So --delete-branch must appear nowhere
+    # in live code — the remote ref is deleted explicitly in step 9 instead.
+    run bash -c "$(declare -f live_code); LAND='$LAND'; live_code | grep -n -- '--delete-branch'"
+    [ "$status" -ne 0 ]
+}
+
+@test "pr-captain-land v2: the remote land branch is deleted via gh-api DELETE, after the merge" {
+    # The remote ref is removed explicitly, once destroy_scratch has freed and
+    # deleted the local branch — never with git-push (no delete mode) and never
+    # via pr-merge --delete-branch (see the guard above).
+    live_code | grep -qE 'gh-api" "/repos/\$ORG/\$REPO/git/refs/heads/\$LAND_SLUG" --method DELETE'
+    merge_line=$(grep -n 'pr-merge" "\$PR_NUM"' "$LAND" | head -1 | cut -d: -f1)
+    del_line=$(grep -n 'git/refs/heads/\$LAND_SLUG" --method DELETE' "$LAND" | head -1 | cut -d: -f1)
+    [ -n "$merge_line" ]
+    [ -n "$del_line" ]
+    [ "$del_line" -gt "$merge_line" ]
+}
+
+@test "pr-captain-land v2: the remote branch delete is best-effort, never fatal after a landed merge" {
+    # The merge + release have already landed by step 9. A post-merge cleanup step
+    # that could exit non-zero (ref already gone → gh 404, transient API blip)
+    # would re-introduce the exact "abort after a landed merge" failure class this
+    # fix exists to eliminate. The DELETE must be best-effort (|| true).
+    run bash -c "grep -A1 'git/refs/heads/\$LAND_SLUG\" --method DELETE' '$LAND' | grep -q '|| true'"
+    [ "$status" -eq 0 ]
+}
+
+@test "pr-captain-land v2: --principal-approved is forwarded into the merge args when set" {
+    # MERGE_ARGS was rewritten by the --delete-branch fix. Deleting the forwarding
+    # block leaves MERGE_ARGS always empty — the only route to the admin-override
+    # merge — and every other principal-approved assertion still passes. Pin the
+    # forwarding path positively.
+    live_code | grep -q 'MERGE_ARGS="--principal-approved"'
+}
+
 @test "pr-captain-land v2: the preflight fetch failure is fatal, not swallowed" {
     # Every downstream guarantee — base freshness, the receipt's diff_base,
     # "validated against pristine origin/<default>" — assumes origin refs are

--- a/usr/jordan/_land-fix-pr-land-cleanup/dispatches/commit-to-captain-committed-f0be467b-on-land-fix-pr-land-cleanup-cho-20260812-1447.md
+++ b/usr/jordan/_land-fix-pr-land-cleanup/dispatches/commit-to-captain-committed-f0be467b-on-land-fix-pr-land-cleanup-cho-20260812-1447.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-pr-land-cleanup
+to: the-agency/jordan/captain
+date: 2026-08-12T06:47
+status: created
+priority: normal
+subject: "Committed f0be467b on _land-fix-pr-land-cleanup: chore(manifest): bump agency_version 46.31 → 46.32 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed f0be467b on _land-fix-pr-land-cleanup: chore(manifest): bump agency_version 46.31 → 46.32 for PR landing (captain)
+
+## Commit: f0be467b
+
+**Branch:** _land-fix-pr-land-cleanup
+**Agent:** the-agency/jordan/_land-fix-pr-land-cleanup
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.31 → 46.32 for PR landing (captain)
+
+### Metadata
+- commit_hash: f0be467b
+- branch: _land-fix-pr-land-cleanup
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/fix-pr-land-cleanup/dispatches/commit-to-captain-committed-4ae7eb23-on-fix-pr-land-cleanup-fix-pr-c-20260812-1315.md
+++ b/usr/jordan/fix-pr-land-cleanup/dispatches/commit-to-captain-committed-4ae7eb23-on-fix-pr-land-cleanup-fix-pr-c-20260812-1315.md
@@ -1,0 +1,67 @@
+---
+type: commit
+from: the-agency/jordan/fix-pr-land-cleanup
+to: the-agency/jordan/captain
+date: 2026-08-12T05:15
+status: created
+priority: normal
+subject: "Committed 4ae7eb23 on fix-pr-land-cleanup: fix(pr-captain-land): stop passing --delete-branch to pr-merge; delete remote land branch explicitly in step 9
+
+gh pr merge --delete-branch=true also deletes the LOCAL _land-<slug> branch,
+but the scratch worktree still holds it at merge time (torn down in step 9).
+The local delete failed, pr-merge exited non-zero, and the whole step aborted
+AFTER the server-side merge already landed — release uncut, reconcile un-run.
+Observed live on PRs #467 and #468 (flag #236).
+
+Fix: drop --delete-branch from the merge args; after destroy_scratch frees the
+local branch, delete the REMOTE ref via gh-api ... --method DELETE (best-effort).
+Docs + comments updated; 4 regression bats added (48/48 green)."
+in_reply_to: null
+---
+
+# Committed 4ae7eb23 on fix-pr-land-cleanup: fix(pr-captain-land): stop passing --delete-branch to pr-merge; delete remote land branch explicitly in step 9
+
+gh pr merge --delete-branch=true also deletes the LOCAL _land-<slug> branch,
+but the scratch worktree still holds it at merge time (torn down in step 9).
+The local delete failed, pr-merge exited non-zero, and the whole step aborted
+AFTER the server-side merge already landed — release uncut, reconcile un-run.
+Observed live on PRs #467 and #468 (flag #236).
+
+Fix: drop --delete-branch from the merge args; after destroy_scratch frees the
+local branch, delete the REMOTE ref via gh-api ... --method DELETE (best-effort).
+Docs + comments updated; 4 regression bats added (48/48 green).
+
+## Commit: 4ae7eb23
+
+**Branch:** fix-pr-land-cleanup
+**Agent:** the-agency/jordan/fix-pr-land-cleanup
+**Message:** housekeeping/captain: fix(pr-captain-land): stop passing --delete-branch to pr-merge; delete remote land branch explicitly in step 9
+
+gh pr merge --delete-branch=true also deletes the LOCAL _land-<slug> branch,
+but the scratch worktree still holds it at merge time (torn down in step 9).
+The local delete failed, pr-merge exited non-zero, and the whole step aborted
+AFTER the server-side merge already landed — release uncut, reconcile un-run.
+Observed live on PRs #467 and #468 (flag #236).
+
+Fix: drop --delete-branch from the merge args; after destroy_scratch frees the
+local branch, delete the REMOTE ref via gh-api ... --method DELETE (best-effort).
+Docs + comments updated; 4 regression bats added (48/48 green).
+
+### Metadata
+- commit_hash: 4ae7eb23
+- branch: fix-pr-land-cleanup
+- files_changed: 7
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-land/reference.md
+.claude/skills/pr-captain-land/scripts/pr-captain-land
+src/claude/skills/pr-captain-land/SKILL.md
+src/claude/skills/pr-captain-land/reference.md
+src/claude/skills/pr-captain-land/scripts/pr-captain-land
+src/tests/skills/pr-captain-land-localfirst.bats
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-pr-land-cleanup` (untouched; this PR rides `_land-fix-pr-land-cleanup`)
- Integrated in a scratch worktree cut from `origin/fix-pr-land-cleanup`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-prep-20260812-1315-2ad66d7.md` (hash `2ad66d7`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-pr-land-cleanup-qgr-pr-captain-land-20260812-1447-f4c1d73.md` (hash `f4c1d73`)
- `agency_version`: 46.31 → 46.32
- Release v46.32 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)