### PR TITLE
fix(worktree-create): resolve origin-only branches (DWIM) + QG hardening — rebuilt on v46.32

### DIFF
--- a/.claude/skills/worktree-create/SKILL.md
+++ b/.claude/skills/worktree-create/SKILL.md
@@ -60,20 +60,40 @@ Parse:
 
 ### Step 1: Validate the name
 
-1. Must be kebab-case: lowercase letters, numbers, and hyphens only.
-2. Check for conflicts:
-   - `git worktree list` — abort if `.claude/worktrees/<name>` already exists
-   - `git show-ref refs/heads/<name>` — abort if branch exists
+1. Kebab-case: letters, numbers, hyphens and underscores. A leading underscore is
+   reserved for machine-created scratch worktrees (`_land-<branch>`, cut and
+   deleted by `/pr-captain-land`) — don't use it for agent worktrees.
+2. Abort if `.claude/worktrees/<name>` already exists (`git worktree list`).
 
-### Step 2: Validate base ref (if provided)
+Do NOT abort merely because a branch of that name exists — an existing branch is
+a normal input, resolved in Step 3.
 
-If `--from <branch>` was specified: `git rev-parse --verify <branch>` — abort if invalid.
-
-### Step 3: Create branch and worktree
+### Step 2: Create the worktree with the tool
 
 ```
-git worktree add .claude/worktrees/<name> -b <name> [<base-ref>]
+./agency/tools/worktree-create <name> [--branch <branch>] [--from <ref>]
+./agency/tools/worktree-create --workstream <ws> --agent <ag> [--from <ref>]
 ```
+
+Never hand-roll `git worktree add` — the tool owns branch resolution, validation
+and bootstrap.
+
+### Step 3: Branch resolution (what the tool does, first match wins)
+
+| Condition | Result |
+|-----------|--------|
+| Local branch `<branch>` exists | Check it out (passing `--from` here is an error) |
+| `--from <ref>` given | New branch at `<ref>`; announced if it shadows a remote branch of the same name |
+| `<remote>/<branch>` exists | New local branch **tracking** it (`origin` wins if several remotes carry it; otherwise ambiguity is refused) |
+| None of the above | New branch from current HEAD |
+
+The remote-tracking case is the stale-PR-revival path: creating a fresh branch
+from HEAD over a branch that already exists on origin hands the agent an empty
+tree and makes their first push a non-fast-forward against their own work.
+
+Remote-tracking refs are only as fresh as the last fetch. Fetch before reviving
+a stale PR branch; the tool prints the resolved commit and its distance from HEAD
+so a stale checkout is never silent.
 
 ### Step 3b: Write .agency-agent identity file
 

--- a/.claude/skills/worktree-create/SKILL.md
+++ b/.claude/skills/worktree-create/SKILL.md
@@ -72,7 +72,7 @@ a normal input, resolved in Step 3.
 
 ```
 ./agency/tools/worktree-create <name> [--branch <branch>] [--from <ref>]
-./agency/tools/worktree-create --workstream <ws> --agent <ag> [--from <ref>]
+./agency/tools/worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
 ```
 
 Never hand-roll `git worktree add` — the tool owns branch resolution, validation

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.32",
+  "agency_version": "46.33",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-12T06:47:27Z"
+    "updated_at": "2026-08-12T11:42:30Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-12T06:47:27Z"
+  "updated_at": "2026-08-12T11:42:30Z"
 }

--- a/agency/tools/worktree-create
+++ b/agency/tools/worktree-create
@@ -3,8 +3,8 @@
 # worktree-create — Create a git worktree for parallel agent sessions
 #
 # Usage:
-#   worktree-create <name> [--branch <branch>]
-#   worktree-create --workstream <ws> --agent <ag> [--branch <branch>]
+#   worktree-create <name> [--branch <branch>] [--from <ref>]
+#   worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
 #   worktree-create --compute-only --workstream <ws> --agent <ag>
 #
 # Creates a worktree at .claude/worktrees/<name>/ on branch <name> (or --branch).
@@ -26,13 +26,36 @@
 # creating anything — useful for tests and programmatic callers that want
 # to know the canonical name for a {workstream, agent} pair.
 #
+# Branch resolution is DWIM (v2.3.0), in this order:
+#
+#   1. An existing LOCAL branch                  → check it out
+#   2. An explicit --from <ref>                  → new branch at that ref
+#   3. An existing <remote>/<branch>             → new local tracking branch
+#   4. Nothing matches                           → new branch from current HEAD
+#
+# Case 2 is the local-first landing path: `pr-captain-land` cuts its scratch
+# worktree from a pristine `origin/<agent-branch>` under a `_land-` name that
+# exists nowhere else, so an explicit start point must outrank the DWIM search.
+#
+# Case 3 is the stale-PR-revival path. Before v2.2.0 a branch that existed only
+# on a remote fell through to case 4 and produced an EMPTY branch from HEAD,
+# silently discarding the PR's content (this bit the revival of PR #426).
+#
 # This is a FIRST-CLASS PRIMITIVE in Agency 2.0 — worktree isolation
 # enables multiple agent sessions to work in parallel without conflicts.
 
 set -euo pipefail
 
-VERSION="2.2.0"
+VERSION="2.3.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Capture a caller-supplied project root BEFORE sourcing the helpers.
+# lib/_path-resolve re-derives AGENCY_PROJECT_ROOT from this script's own
+# location on source, unconditionally overwriting whatever the caller set.
+# Without this capture the `${AGENCY_PROJECT_ROOT:-...}` default below is dead
+# code, and a caller that points the tool at another checkout (tests, adopter
+# scripts) silently gets a worktree in the WRONG repo.
+CALLER_PROJECT_ROOT="${AGENCY_PROJECT_ROOT:-}"
 
 # Source helpers
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
@@ -64,6 +87,18 @@ compute_worktree_name() {
     fi
 }
 
+# _require_value <flag> [next ...]
+#
+# Guard for option parsing: under `set -u` a trailing flag with no argument
+# ("worktree-create foo --branch") expands "$2" unbound and dies with a raw
+# bash error instead of a usage hint. Call with the remaining "$@".
+_require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Error: $1 requires a value" >&2
+        exit 1
+    fi
+}
+
 # --- Flags ---
 show_help() {
     cat <<HELP
@@ -78,13 +113,13 @@ Options:
   --workstream <ws> Workstream name (pairs with --agent to compute name)
   --agent <ag>      Agent name (pairs with --workstream to compute name)
   --branch <name>   Branch name (default: same as worktree name)
-  --from <ref>      Start point for a NEW branch (default: current HEAD).
-                    Accepts any committish, including a remote-tracking ref
-                    such as origin/main or origin/some-agent-branch. It is an
-                    ERROR to pass --from when the branch already exists — the
-                    branch has a tip already, and silently ignoring the flag
-                    would put the worktree somewhere the caller did not ask
-                    for.
+  --from <ref>      Start point for a NEW branch. Accepts any committish,
+                    including a remote-tracking ref such as origin/main or
+                    origin/some-agent-branch. Outranks the remote-branch
+                    search below. It is an ERROR to pass --from when the
+                    branch already exists locally — the branch has a tip
+                    already, and silently ignoring the flag would put the
+                    worktree somewhere the caller did not ask for.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help
@@ -92,6 +127,17 @@ Options:
 Naming rule when both --workstream and --agent are given:
   agent == workstream OR agent starts with "workstream-"  → worktree = agent
   otherwise                                                → worktree = workstream-agent
+
+Branch resolution (first match wins):
+  local branch <branch> exists      → check it out
+  --from <ref> given                → new branch at <ref>
+  <remote>/<branch> exists          → new local branch tracking it (origin wins
+                                      if several remotes carry the branch)
+  none of the above                 → new branch from current HEAD
+
+Remote-tracking refs are only as fresh as your last fetch — fetch before
+reviving a stale PR branch, or you will get an out-of-date worktree. The tool
+prints the resolved commit and its distance from HEAD so you can tell.
 
 Examples:
   worktree-create --workstream devex --agent devex       → devex
@@ -108,8 +154,8 @@ if [[ "${1:-}" == "--compute-only" ]]; then
     _ag=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --workstream) _ws="$2"; shift 2 ;;
-            --agent) _ag="$2"; shift 2 ;;
+            --workstream) _require_value "$@"; _ws="$2"; shift 2 ;;
+            --agent) _require_value "$@"; _ag="$2"; shift 2 ;;
             *) echo "Unknown option: $1" >&2; exit 1 ;;
         esac
     done
@@ -127,10 +173,10 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --version|-v) echo "worktree-create $VERSION"; exit 0 ;;
         --help|-h) show_help; exit 0 ;;
-        --branch) BRANCH="$2"; shift 2 ;;
-        --from) FROM_REF="$2"; shift 2 ;;
-        --workstream) WORKSTREAM="$2"; shift 2 ;;
-        --agent) AGENT="$2"; shift 2 ;;
+        --branch) _require_value "$@"; BRANCH="$2"; shift 2 ;;
+        --from) _require_value "$@"; FROM_REF="$2"; shift 2 ;;
+        --workstream) _require_value "$@"; WORKSTREAM="$2"; shift 2 ;;
+        --agent) _require_value "$@"; AGENT="$2"; shift 2 ;;
         -*) echo "Unknown option: $1" >&2; exit 1 ;;
         *) NAME="$1"; shift ;;
     esac
@@ -170,7 +216,18 @@ if ! [[ "$NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*$ ]]; then
 fi
 
 BRANCH="${BRANCH:-$NAME}"
-PROJECT_ROOT="${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# NAME is regex-restricted above because it becomes a path component. BRANCH is
+# NOT — branch names legitimately contain slashes (fix/foo, the usual PR shape).
+# But it still has to be a legal git branch name, or `worktree add -b` fails
+# with a raw plumbing error. `--branch HEAD` is the easy way to hit this: it
+# matches refs/remotes/origin/HEAD, which exists in every clone.
+if ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+    echo "Error: '$BRANCH' is not a valid git branch name" >&2
+    exit 1
+fi
+
+PROJECT_ROOT="${CALLER_PROJECT_ROOT:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
 WORKTREE_DIR="$PROJECT_ROOT/.claude/worktrees/$NAME"
 
 # Check if worktree already exists
@@ -182,15 +239,66 @@ fi
 # Create worktree
 echo "Creating worktree: $NAME"
 echo "  Branch: $BRANCH"
-[[ -n "$FROM_REF" ]] && echo "  From:   $FROM_REF"
+if [[ -n "$FROM_REF" ]]; then
+    echo "  From:   $FROM_REF"
+fi
 echo "  Path: .claude/worktrees/$NAME/"
 
 mkdir -p "$PROJECT_ROOT/.claude/worktrees"
 
-# Create branch + worktree
+# remotes_with_branch <branch>
+#
+# Print a space-separated list of remotes whose tracking ref carries <branch>
+# (empty if none). Never fails — the caller decides what an ambiguous result
+# means, which differs between the --from path (irrelevant) and the DWIM path
+# (fatal unless origin breaks the tie).
+#
+# Enumerating `git remote` and probing each with show-ref (rather than globbing
+# refs/remotes/*/<branch>) keeps this correct for slash-bearing branch names,
+# where a single `*` would otherwise have to span path components.
+remotes_with_branch() {
+    local branch="$1"
+    local r matches=""
+    while IFS= read -r r; do
+        [[ -z "$r" ]] && continue
+        if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/remotes/$r/$branch" 2>/dev/null; then
+            matches="$matches $r"
+        fi
+    done <<< "$(git -C "$PROJECT_ROOT" remote 2>/dev/null || true)"
+    echo "${matches# }"
+}
+
+# --- Resolve which of the four cases applies (see the header) ---
+LOCAL_EXISTS=0
 if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
-    # Branch exists — use it. --from would be a lie here (the branch already has
-    # a tip); say so instead of silently ignoring it.
+    LOCAL_EXISTS=1
+fi
+
+REMOTE=""
+REMOTE_MATCHES=""
+if [[ $LOCAL_EXISTS -eq 0 ]]; then
+    REMOTE_MATCHES="$(remotes_with_branch "$BRANCH")"
+    for _r in $REMOTE_MATCHES; do
+        if [[ "$_r" == "origin" ]]; then
+            REMOTE="origin"
+        elif [[ -z "$REMOTE" ]]; then
+            REMOTE="$_r"
+        fi
+    done
+    # `origin` wins when several remotes carry the same branch; when several do
+    # and none is `origin`, that is genuinely ambiguous. An explicit --from
+    # settles it, so only the DWIM path refuses.
+    if [[ -z "$FROM_REF" ]] && [[ "$REMOTE" != "origin" ]] \
+        && [[ $(echo "$REMOTE_MATCHES" | wc -w) -gt 1 ]]; then
+        echo "Error: branch '$BRANCH' exists on multiple remotes ($REMOTE_MATCHES)." >&2
+        echo "       Refusing to guess. Pass --from <remote>/$BRANCH, or create the local branch yourself." >&2
+        exit 1
+    fi
+fi
+
+if [[ $LOCAL_EXISTS -eq 1 ]]; then
+    # Local branch exists — use it. --from would be a lie here (the branch
+    # already has a tip); say so instead of silently ignoring it.
     if [[ -n "$FROM_REF" ]]; then
         echo "Error: --from $FROM_REF given but branch '$BRANCH' already exists" >&2
         echo "  Refusing to guess. Delete the branch or drop --from." >&2
@@ -198,16 +306,43 @@ if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/
     fi
     git -C "$PROJECT_ROOT" worktree add "$WORKTREE_DIR" "$BRANCH"
 elif [[ -n "$FROM_REF" ]]; then
-    # Create new branch at an explicit start point (e.g. origin/main, or an
-    # agent's remote branch — the local-first landing flow cuts its scratch
-    # worktree from pristine origin refs, never from a local tip).
+    # Explicit start point (e.g. origin/main, or an agent's remote branch — the
+    # local-first landing flow cuts its scratch worktree from pristine origin
+    # refs, never from a local tip). Explicit beats the DWIM search below.
     if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
         echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
         exit 1
     fi
+    if [[ -n "$REMOTE" ]]; then
+        # A remote branch of the same name exists but --from names a different
+        # start point. Honor the explicit flag, but never do it silently: an
+        # unnoticed shadow of a real remote branch is the exact failure this
+        # tool's branch resolution exists to prevent.
+        echo "  Note: '$BRANCH' also exists on '$REMOTE' — --from wins, NOT tracking $REMOTE/$BRANCH"
+    fi
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
+elif [[ -n "$REMOTE" ]]; then
+    # Remote-only branch — create a local branch tracking <remote>/<branch>.
+    #
+    # This is the stale-PR-revival path, and it deliberately applies even when
+    # --branch was not passed (i.e. when the branch name defaulted to the
+    # worktree name). Creating a fresh local branch that shadows an existing
+    # remote branch of the same name gives the agent an empty tree and makes
+    # their first push a non-fast-forward against their own real work.
+    #
+    # Report what is actually being checked out: a remote-tracking ref is only
+    # as fresh as the last fetch, and a months-stale branch looks identical to
+    # a current one unless we say so.
+    echo "  Branch exists on '$REMOTE' only — tracking $REMOTE/$BRANCH"
+    echo "    commit: $(git -C "$PROJECT_ROOT" log -1 --format='%h %cs %s' "$REMOTE/$BRANCH" 2>/dev/null || echo unknown)"
+    echo "    vs HEAD: $(git -C "$PROJECT_ROOT" rev-list --count "HEAD..$REMOTE/$BRANCH" 2>/dev/null || echo '?') ahead, $(git -C "$PROJECT_ROOT" rev-list --count "$REMOTE/$BRANCH..HEAD" 2>/dev/null || echo '?') behind"
+    echo "    (remote-tracking refs are only as fresh as your last fetch)"
+    git -C "$PROJECT_ROOT" worktree add --track -b "$BRANCH" "$WORKTREE_DIR" "$REMOTE/$BRANCH"
 else
-    # Create new branch from HEAD
+    # Create new branch from HEAD. If the caller expected to land on an
+    # existing remote branch, an un-fetched remote is the usual reason.
+    echo "  No local or remote branch '$BRANCH' — creating it fresh from HEAD"
+    echo "    (if you expected an existing remote branch, fetch first)"
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR"
 fi
 

--- a/agency/tools/worktree-create
+++ b/agency/tools/worktree-create
@@ -37,9 +37,10 @@
 # worktree from a pristine `origin/<agent-branch>` under a `_land-` name that
 # exists nowhere else, so an explicit start point must outrank the DWIM search.
 #
-# Case 3 is the stale-PR-revival path. Before v2.2.0 a branch that existed only
-# on a remote fell through to case 4 and produced an EMPTY branch from HEAD,
-# silently discarding the PR's content (this bit the revival of PR #426).
+# Case 3 is the stale-PR-revival path, new in v2.3.0. Through v2.2.0 a branch
+# that existed only on a remote fell through to case 4 and produced an EMPTY
+# branch from HEAD, silently discarding the PR's content (this bit the revival
+# of PR #426).
 #
 # This is a FIRST-CLASS PRIMITIVE in Agency 2.0 — worktree isolation
 # enables multiple agent sessions to work in parallel without conflicts.
@@ -95,6 +96,15 @@ compute_worktree_name() {
 _require_value() {
     if [[ $# -lt 2 ]]; then
         echo "Error: $1 requires a value" >&2
+        exit 1
+    fi
+    # A value that looks like a flag is a missing value in disguise:
+    # "worktree-create foo --branch --from bar" would otherwise set
+    # BRANCH=--from and fail much later with a confusing git error. Nothing
+    # legal is rejected here — git forbids branch names starting with '-',
+    # and a committish cannot start with one either.
+    if [[ "$2" == -* ]]; then
+        echo "Error: $1 requires a value (got '$2', which looks like a flag)" >&2
         exit 1
     fi
 }
@@ -168,6 +178,7 @@ BRANCH=""
 WORKSTREAM=""
 AGENT=""
 FROM_REF=""
+FROM_SHA=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -309,7 +320,11 @@ elif [[ -n "$FROM_REF" ]]; then
     # Explicit start point (e.g. origin/main, or an agent's remote branch — the
     # local-first landing flow cuts its scratch worktree from pristine origin
     # refs, never from a local tip). Explicit beats the DWIM search below.
-    if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
+    # Resolve to a bare SHA and hand git THAT, not the caller's string. git
+    # re-scans its whole argv for options, including the trailing commit-ish
+    # position, so an unvalidated ref could be read as a `worktree add` flag.
+    # A resolved SHA can never look like one.
+    if ! FROM_SHA="$(git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}")"; then
         echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
         exit 1
     fi
@@ -320,7 +335,7 @@ elif [[ -n "$FROM_REF" ]]; then
         # tool's branch resolution exists to prevent.
         echo "  Note: '$BRANCH' also exists on '$REMOTE' — --from wins, NOT tracking $REMOTE/$BRANCH"
     fi
-    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
+    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_SHA"
 elif [[ -n "$REMOTE" ]]; then
     # Remote-only branch — create a local branch tracking <remote>/<branch>.
     #

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-worktree-create-qgr-pr-captain-land-20260812-1942-b18f845.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-worktree-create-qgr-pr-captain-land-20260812-1942-b18f845.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-worktree-create
+diff_base: origin/main
+hash_a: 5014a4977c4fea2d28603fd45c0835a4e053433bd861283a656d7a898697d376
+hash_b: 53030b2c0c12a03e2114627fbb0b27f462cf646c14e927bf173e9cf914a4d95d
+hash_c: 53030b2c0c12a03e2114627fbb0b27f462cf646c14e927bf173e9cf914a4d95d
+hash_d: 53030b2c0c12a03e2114627fbb0b27f462cf646c14e927bf173e9cf914a4d95d
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: b18f845610f9ebcac9ea8c04f0fbd1951a04e570acbb3a0ffb628566f616832d
+date: 2026-08-12T19:42
+---
+
+# Receipt: pr-captain-land — fix-worktree-create
+
+## Chain of Trust
+- A (original): 5014a49
+- B (findings): 53030b2
+- C (triage): 53030b2
+- D (principal): 53030b2 — principal-approved flag passed by captain at land time
+- E (final): b18f845
+
+## Review Summary
+Local-first landing of fix-worktree-create. Integrated in scratch worktree _land-fix-worktree-create cut from origin/fix-worktree-create; 1 local validation step(s) passed against origin/main; agency_version 46.32 → 46.33. Chains to agent receipt agency/workstreams/devex/qgr/the-agency-jordan-fix-worktree-create-devex-worktree-create-origin-branch-fix-qgr-pr-prep-20260812-1937-5014a49.md.

--- a/agency/workstreams/devex/qgr/the-agency-jordan-fix-worktree-create-devex-worktree-create-origin-branch-fix-qgr-pr-prep-20260812-1937-5014a49.md
+++ b/agency/workstreams/devex/qgr/the-agency-jordan-fix-worktree-create-devex-worktree-create-origin-branch-fix-qgr-pr-prep-20260812-1937-5014a49.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: fix-worktree-create
+workstream: devex
+project: worktree-create-origin-branch-fix
+diff_base: origin/main
+hash_a: 962b2db8e0ac3065c2908e06b03faddad2856a2fea5989731edd4342e4307332
+hash_b: 50fbcb3eb33437777e319eb02b27362fc55ef1265c18e84bb33c84b6b4648d3a
+hash_c: 4cc93a24362b37cadb51965f9c7aaefc25c42a92aa192b62b86d207a8ae86ac9
+hash_d: 4cc93a24362b37cadb51965f9c7aaefc25c42a92aa192b62b86d207a8ae86ac9
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 5014a4977c4fea2d28603fd45c0835a4e053433bd861283a656d7a898697d376
+date: 2026-08-12T19:37
+---
+
+# Receipt: pr-prep — worktree-create-origin-branch-fix
+
+## Chain of Trust
+- A (original): 962b2db
+- B (findings): 50fbcb3
+- C (triage): 4cc93a2
+- D (principal): 4cc93a2 — auto-approved — no principal 1B1
+- E (final): 5014a49
+
+## Review Summary
+worktree-create origin-branch fix — rebuilt on main v46.32, isolated from test-monitor WIP

--- a/src/agency/tools/worktree-create
+++ b/src/agency/tools/worktree-create
@@ -3,8 +3,8 @@
 # worktree-create — Create a git worktree for parallel agent sessions
 #
 # Usage:
-#   worktree-create <name> [--branch <branch>]
-#   worktree-create --workstream <ws> --agent <ag> [--branch <branch>]
+#   worktree-create <name> [--branch <branch>] [--from <ref>]
+#   worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
 #   worktree-create --compute-only --workstream <ws> --agent <ag>
 #
 # Creates a worktree at .claude/worktrees/<name>/ on branch <name> (or --branch).
@@ -26,13 +26,36 @@
 # creating anything — useful for tests and programmatic callers that want
 # to know the canonical name for a {workstream, agent} pair.
 #
+# Branch resolution is DWIM (v2.3.0), in this order:
+#
+#   1. An existing LOCAL branch                  → check it out
+#   2. An explicit --from <ref>                  → new branch at that ref
+#   3. An existing <remote>/<branch>             → new local tracking branch
+#   4. Nothing matches                           → new branch from current HEAD
+#
+# Case 2 is the local-first landing path: `pr-captain-land` cuts its scratch
+# worktree from a pristine `origin/<agent-branch>` under a `_land-` name that
+# exists nowhere else, so an explicit start point must outrank the DWIM search.
+#
+# Case 3 is the stale-PR-revival path. Before v2.2.0 a branch that existed only
+# on a remote fell through to case 4 and produced an EMPTY branch from HEAD,
+# silently discarding the PR's content (this bit the revival of PR #426).
+#
 # This is a FIRST-CLASS PRIMITIVE in Agency 2.0 — worktree isolation
 # enables multiple agent sessions to work in parallel without conflicts.
 
 set -euo pipefail
 
-VERSION="2.2.0"
+VERSION="2.3.0"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Capture a caller-supplied project root BEFORE sourcing the helpers.
+# lib/_path-resolve re-derives AGENCY_PROJECT_ROOT from this script's own
+# location on source, unconditionally overwriting whatever the caller set.
+# Without this capture the `${AGENCY_PROJECT_ROOT:-...}` default below is dead
+# code, and a caller that points the tool at another checkout (tests, adopter
+# scripts) silently gets a worktree in the WRONG repo.
+CALLER_PROJECT_ROOT="${AGENCY_PROJECT_ROOT:-}"
 
 # Source helpers
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
@@ -64,6 +87,18 @@ compute_worktree_name() {
     fi
 }
 
+# _require_value <flag> [next ...]
+#
+# Guard for option parsing: under `set -u` a trailing flag with no argument
+# ("worktree-create foo --branch") expands "$2" unbound and dies with a raw
+# bash error instead of a usage hint. Call with the remaining "$@".
+_require_value() {
+    if [[ $# -lt 2 ]]; then
+        echo "Error: $1 requires a value" >&2
+        exit 1
+    fi
+}
+
 # --- Flags ---
 show_help() {
     cat <<HELP
@@ -78,13 +113,13 @@ Options:
   --workstream <ws> Workstream name (pairs with --agent to compute name)
   --agent <ag>      Agent name (pairs with --workstream to compute name)
   --branch <name>   Branch name (default: same as worktree name)
-  --from <ref>      Start point for a NEW branch (default: current HEAD).
-                    Accepts any committish, including a remote-tracking ref
-                    such as origin/main or origin/some-agent-branch. It is an
-                    ERROR to pass --from when the branch already exists — the
-                    branch has a tip already, and silently ignoring the flag
-                    would put the worktree somewhere the caller did not ask
-                    for.
+  --from <ref>      Start point for a NEW branch. Accepts any committish,
+                    including a remote-tracking ref such as origin/main or
+                    origin/some-agent-branch. Outranks the remote-branch
+                    search below. It is an ERROR to pass --from when the
+                    branch already exists locally — the branch has a tip
+                    already, and silently ignoring the flag would put the
+                    worktree somewhere the caller did not ask for.
   --compute-only    Print the computed name and exit (no worktree creation)
   --version         Show version
   --help            Show this help
@@ -92,6 +127,17 @@ Options:
 Naming rule when both --workstream and --agent are given:
   agent == workstream OR agent starts with "workstream-"  → worktree = agent
   otherwise                                                → worktree = workstream-agent
+
+Branch resolution (first match wins):
+  local branch <branch> exists      → check it out
+  --from <ref> given                → new branch at <ref>
+  <remote>/<branch> exists          → new local branch tracking it (origin wins
+                                      if several remotes carry the branch)
+  none of the above                 → new branch from current HEAD
+
+Remote-tracking refs are only as fresh as your last fetch — fetch before
+reviving a stale PR branch, or you will get an out-of-date worktree. The tool
+prints the resolved commit and its distance from HEAD so you can tell.
 
 Examples:
   worktree-create --workstream devex --agent devex       → devex
@@ -108,8 +154,8 @@ if [[ "${1:-}" == "--compute-only" ]]; then
     _ag=""
     while [[ $# -gt 0 ]]; do
         case "$1" in
-            --workstream) _ws="$2"; shift 2 ;;
-            --agent) _ag="$2"; shift 2 ;;
+            --workstream) _require_value "$@"; _ws="$2"; shift 2 ;;
+            --agent) _require_value "$@"; _ag="$2"; shift 2 ;;
             *) echo "Unknown option: $1" >&2; exit 1 ;;
         esac
     done
@@ -127,10 +173,10 @@ while [[ $# -gt 0 ]]; do
     case "$1" in
         --version|-v) echo "worktree-create $VERSION"; exit 0 ;;
         --help|-h) show_help; exit 0 ;;
-        --branch) BRANCH="$2"; shift 2 ;;
-        --from) FROM_REF="$2"; shift 2 ;;
-        --workstream) WORKSTREAM="$2"; shift 2 ;;
-        --agent) AGENT="$2"; shift 2 ;;
+        --branch) _require_value "$@"; BRANCH="$2"; shift 2 ;;
+        --from) _require_value "$@"; FROM_REF="$2"; shift 2 ;;
+        --workstream) _require_value "$@"; WORKSTREAM="$2"; shift 2 ;;
+        --agent) _require_value "$@"; AGENT="$2"; shift 2 ;;
         -*) echo "Unknown option: $1" >&2; exit 1 ;;
         *) NAME="$1"; shift ;;
     esac
@@ -170,7 +216,18 @@ if ! [[ "$NAME" =~ ^[a-zA-Z_][a-zA-Z0-9_-]*$ ]]; then
 fi
 
 BRANCH="${BRANCH:-$NAME}"
-PROJECT_ROOT="${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# NAME is regex-restricted above because it becomes a path component. BRANCH is
+# NOT — branch names legitimately contain slashes (fix/foo, the usual PR shape).
+# But it still has to be a legal git branch name, or `worktree add -b` fails
+# with a raw plumbing error. `--branch HEAD` is the easy way to hit this: it
+# matches refs/remotes/origin/HEAD, which exists in every clone.
+if ! git check-ref-format --branch "$BRANCH" >/dev/null 2>&1; then
+    echo "Error: '$BRANCH' is not a valid git branch name" >&2
+    exit 1
+fi
+
+PROJECT_ROOT="${CALLER_PROJECT_ROOT:-${AGENCY_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}}"
 WORKTREE_DIR="$PROJECT_ROOT/.claude/worktrees/$NAME"
 
 # Check if worktree already exists
@@ -182,15 +239,66 @@ fi
 # Create worktree
 echo "Creating worktree: $NAME"
 echo "  Branch: $BRANCH"
-[[ -n "$FROM_REF" ]] && echo "  From:   $FROM_REF"
+if [[ -n "$FROM_REF" ]]; then
+    echo "  From:   $FROM_REF"
+fi
 echo "  Path: .claude/worktrees/$NAME/"
 
 mkdir -p "$PROJECT_ROOT/.claude/worktrees"
 
-# Create branch + worktree
+# remotes_with_branch <branch>
+#
+# Print a space-separated list of remotes whose tracking ref carries <branch>
+# (empty if none). Never fails — the caller decides what an ambiguous result
+# means, which differs between the --from path (irrelevant) and the DWIM path
+# (fatal unless origin breaks the tie).
+#
+# Enumerating `git remote` and probing each with show-ref (rather than globbing
+# refs/remotes/*/<branch>) keeps this correct for slash-bearing branch names,
+# where a single `*` would otherwise have to span path components.
+remotes_with_branch() {
+    local branch="$1"
+    local r matches=""
+    while IFS= read -r r; do
+        [[ -z "$r" ]] && continue
+        if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/remotes/$r/$branch" 2>/dev/null; then
+            matches="$matches $r"
+        fi
+    done <<< "$(git -C "$PROJECT_ROOT" remote 2>/dev/null || true)"
+    echo "${matches# }"
+}
+
+# --- Resolve which of the four cases applies (see the header) ---
+LOCAL_EXISTS=0
 if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/null; then
-    # Branch exists — use it. --from would be a lie here (the branch already has
-    # a tip); say so instead of silently ignoring it.
+    LOCAL_EXISTS=1
+fi
+
+REMOTE=""
+REMOTE_MATCHES=""
+if [[ $LOCAL_EXISTS -eq 0 ]]; then
+    REMOTE_MATCHES="$(remotes_with_branch "$BRANCH")"
+    for _r in $REMOTE_MATCHES; do
+        if [[ "$_r" == "origin" ]]; then
+            REMOTE="origin"
+        elif [[ -z "$REMOTE" ]]; then
+            REMOTE="$_r"
+        fi
+    done
+    # `origin` wins when several remotes carry the same branch; when several do
+    # and none is `origin`, that is genuinely ambiguous. An explicit --from
+    # settles it, so only the DWIM path refuses.
+    if [[ -z "$FROM_REF" ]] && [[ "$REMOTE" != "origin" ]] \
+        && [[ $(echo "$REMOTE_MATCHES" | wc -w) -gt 1 ]]; then
+        echo "Error: branch '$BRANCH' exists on multiple remotes ($REMOTE_MATCHES)." >&2
+        echo "       Refusing to guess. Pass --from <remote>/$BRANCH, or create the local branch yourself." >&2
+        exit 1
+    fi
+fi
+
+if [[ $LOCAL_EXISTS -eq 1 ]]; then
+    # Local branch exists — use it. --from would be a lie here (the branch
+    # already has a tip); say so instead of silently ignoring it.
     if [[ -n "$FROM_REF" ]]; then
         echo "Error: --from $FROM_REF given but branch '$BRANCH' already exists" >&2
         echo "  Refusing to guess. Delete the branch or drop --from." >&2
@@ -198,16 +306,43 @@ if git -C "$PROJECT_ROOT" show-ref --verify --quiet "refs/heads/$BRANCH" 2>/dev/
     fi
     git -C "$PROJECT_ROOT" worktree add "$WORKTREE_DIR" "$BRANCH"
 elif [[ -n "$FROM_REF" ]]; then
-    # Create new branch at an explicit start point (e.g. origin/main, or an
-    # agent's remote branch — the local-first landing flow cuts its scratch
-    # worktree from pristine origin refs, never from a local tip).
+    # Explicit start point (e.g. origin/main, or an agent's remote branch — the
+    # local-first landing flow cuts its scratch worktree from pristine origin
+    # refs, never from a local tip). Explicit beats the DWIM search below.
     if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
         echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
         exit 1
     fi
+    if [[ -n "$REMOTE" ]]; then
+        # A remote branch of the same name exists but --from names a different
+        # start point. Honor the explicit flag, but never do it silently: an
+        # unnoticed shadow of a real remote branch is the exact failure this
+        # tool's branch resolution exists to prevent.
+        echo "  Note: '$BRANCH' also exists on '$REMOTE' — --from wins, NOT tracking $REMOTE/$BRANCH"
+    fi
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
+elif [[ -n "$REMOTE" ]]; then
+    # Remote-only branch — create a local branch tracking <remote>/<branch>.
+    #
+    # This is the stale-PR-revival path, and it deliberately applies even when
+    # --branch was not passed (i.e. when the branch name defaulted to the
+    # worktree name). Creating a fresh local branch that shadows an existing
+    # remote branch of the same name gives the agent an empty tree and makes
+    # their first push a non-fast-forward against their own real work.
+    #
+    # Report what is actually being checked out: a remote-tracking ref is only
+    # as fresh as the last fetch, and a months-stale branch looks identical to
+    # a current one unless we say so.
+    echo "  Branch exists on '$REMOTE' only — tracking $REMOTE/$BRANCH"
+    echo "    commit: $(git -C "$PROJECT_ROOT" log -1 --format='%h %cs %s' "$REMOTE/$BRANCH" 2>/dev/null || echo unknown)"
+    echo "    vs HEAD: $(git -C "$PROJECT_ROOT" rev-list --count "HEAD..$REMOTE/$BRANCH" 2>/dev/null || echo '?') ahead, $(git -C "$PROJECT_ROOT" rev-list --count "$REMOTE/$BRANCH..HEAD" 2>/dev/null || echo '?') behind"
+    echo "    (remote-tracking refs are only as fresh as your last fetch)"
+    git -C "$PROJECT_ROOT" worktree add --track -b "$BRANCH" "$WORKTREE_DIR" "$REMOTE/$BRANCH"
 else
-    # Create new branch from HEAD
+    # Create new branch from HEAD. If the caller expected to land on an
+    # existing remote branch, an un-fetched remote is the usual reason.
+    echo "  No local or remote branch '$BRANCH' — creating it fresh from HEAD"
+    echo "    (if you expected an existing remote branch, fetch first)"
     git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR"
 fi
 

--- a/src/agency/tools/worktree-create
+++ b/src/agency/tools/worktree-create
@@ -37,9 +37,10 @@
 # worktree from a pristine `origin/<agent-branch>` under a `_land-` name that
 # exists nowhere else, so an explicit start point must outrank the DWIM search.
 #
-# Case 3 is the stale-PR-revival path. Before v2.2.0 a branch that existed only
-# on a remote fell through to case 4 and produced an EMPTY branch from HEAD,
-# silently discarding the PR's content (this bit the revival of PR #426).
+# Case 3 is the stale-PR-revival path, new in v2.3.0. Through v2.2.0 a branch
+# that existed only on a remote fell through to case 4 and produced an EMPTY
+# branch from HEAD, silently discarding the PR's content (this bit the revival
+# of PR #426).
 #
 # This is a FIRST-CLASS PRIMITIVE in Agency 2.0 — worktree isolation
 # enables multiple agent sessions to work in parallel without conflicts.
@@ -95,6 +96,15 @@ compute_worktree_name() {
 _require_value() {
     if [[ $# -lt 2 ]]; then
         echo "Error: $1 requires a value" >&2
+        exit 1
+    fi
+    # A value that looks like a flag is a missing value in disguise:
+    # "worktree-create foo --branch --from bar" would otherwise set
+    # BRANCH=--from and fail much later with a confusing git error. Nothing
+    # legal is rejected here — git forbids branch names starting with '-',
+    # and a committish cannot start with one either.
+    if [[ "$2" == -* ]]; then
+        echo "Error: $1 requires a value (got '$2', which looks like a flag)" >&2
         exit 1
     fi
 }
@@ -168,6 +178,7 @@ BRANCH=""
 WORKSTREAM=""
 AGENT=""
 FROM_REF=""
+FROM_SHA=""
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -309,7 +320,11 @@ elif [[ -n "$FROM_REF" ]]; then
     # Explicit start point (e.g. origin/main, or an agent's remote branch — the
     # local-first landing flow cuts its scratch worktree from pristine origin
     # refs, never from a local tip). Explicit beats the DWIM search below.
-    if ! git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}" >/dev/null; then
+    # Resolve to a bare SHA and hand git THAT, not the caller's string. git
+    # re-scans its whole argv for options, including the trailing commit-ish
+    # position, so an unvalidated ref could be read as a `worktree add` flag.
+    # A resolved SHA can never look like one.
+    if ! FROM_SHA="$(git -C "$PROJECT_ROOT" rev-parse --verify --quiet "${FROM_REF}^{commit}")"; then
         echo "Error: --from ref '$FROM_REF' does not resolve to a commit" >&2
         exit 1
     fi
@@ -320,7 +335,7 @@ elif [[ -n "$FROM_REF" ]]; then
         # tool's branch resolution exists to prevent.
         echo "  Note: '$BRANCH' also exists on '$REMOTE' — --from wins, NOT tracking $REMOTE/$BRANCH"
     fi
-    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_REF"
+    git -C "$PROJECT_ROOT" worktree add -b "$BRANCH" "$WORKTREE_DIR" "$FROM_SHA"
 elif [[ -n "$REMOTE" ]]; then
     # Remote-only branch — create a local branch tracking <remote>/<branch>.
     #

--- a/src/tests/tools/worktree-create.bats
+++ b/src/tests/tools/worktree-create.bats
@@ -2,25 +2,137 @@
 #
 # Tests for agency/tools/worktree-create
 #
-# Focus: the --workstream/--agent collapse rule (dispatch #166, resolved in
-# #169). These tests use --compute-only mode so no real worktrees are created.
+# Two contracts are covered here:
 #
-# The full end-to-end worktree creation path (git worktree add, dependency
-# install, branch management) is not tested here — those operations are
-# integration-tested by actually using the tool during real worktree-create
-# workflows. This file verifies the NAMING CONTRACT only.
+#   1. NAMING — the --workstream/--agent collapse rule (dispatch #166, resolved
+#      in #169). Exercised via --compute-only; no worktrees are created.
+#
+#   2. BRANCH RESOLUTION — the local / --from / remote-tracking / fresh-from-HEAD
+#      decision (v2.3.0). These DO create real worktrees, so they run against
+#      an isolated bare-origin + clone fixture (make_origin_repo) and never
+#      touch the live checkout.
+#
+# ISOLATION IS LOAD-BEARING HERE. The only thing keeping group 2 out of the
+# live repo is worktree-create honoring AGENCY_PROJECT_ROOT — and during
+# development it did NOT (lib/_path-resolve reassigns that variable on source),
+# which put three real worktrees in the live devex checkout. Two guards now
+# make a regression fail loudly instead of scribbling on the repo:
+#   - setup() points AGENCY_PROJECT_ROOT at a nonexistent path, so any test
+#     that reaches the creation path without the fixture dies there.
+#   - assert_no_live_repo_leak() checks the live repo after each creation test.
 #
 # Written: 2026-04-09 — dispatch #166/#169, task #9
+# Extended: 2026-08-08 — branch-resolution DWIM + isolation guards (v2.2.0)
+# Extended: 2026-08-12 — reconciled with --from / local-first landing (v2.3.0)
 
 load test_helper
 
 setup() {
     test_isolation_setup
     export TOOL="${REPO_ROOT}/agency/tools/worktree-create"
+
+    # Poison the default. Only make_origin_repo sets a usable root; anything
+    # else that reaches the worktree-creation path fails on a missing dir
+    # rather than defaulting to the live repo. See the header note.
+    export AGENCY_PROJECT_ROOT="${BATS_TEST_TMPDIR}/no-such-project-root"
+
+    # Snapshot the live repo's worktrees and branches. teardown() diffs these,
+    # so a leak is caught no matter where in the test body it happened — an
+    # in-body assertion would be skipped by an earlier failure.
+    git -C "$REPO_ROOT" worktree list > "${BATS_TEST_TMPDIR}/wt-before" 2>/dev/null || true
+    git -C "$REPO_ROOT" for-each-ref --format='%(refname)' refs/heads \
+        > "${BATS_TEST_TMPDIR}/heads-before" 2>/dev/null || true
 }
 
 teardown() {
+    # Leak guard first — report it even if the isolation teardown also fails.
+    local leaked=0
+    git -C "$REPO_ROOT" worktree list > "${BATS_TEST_TMPDIR}/wt-after" 2>/dev/null || true
+    git -C "$REPO_ROOT" for-each-ref --format='%(refname)' refs/heads \
+        > "${BATS_TEST_TMPDIR}/heads-after" 2>/dev/null || true
+
+    if ! diff -q "${BATS_TEST_TMPDIR}/wt-before" "${BATS_TEST_TMPDIR}/wt-after" >/dev/null 2>&1; then
+        echo "LEAK: this test changed the live repo's worktree list:" >&2
+        diff "${BATS_TEST_TMPDIR}/wt-before" "${BATS_TEST_TMPDIR}/wt-after" >&2 || true
+        leaked=1
+    fi
+    if ! diff -q "${BATS_TEST_TMPDIR}/heads-before" "${BATS_TEST_TMPDIR}/heads-after" >/dev/null 2>&1; then
+        echo "LEAK: this test created or removed branches in the live repo:" >&2
+        diff "${BATS_TEST_TMPDIR}/heads-before" "${BATS_TEST_TMPDIR}/heads-after" >&2 || true
+        leaked=1
+    fi
+
     test_isolation_teardown
+    return "$leaked"
+}
+
+# In-body companion to the teardown guard — asserts at the point of use that a
+# named worktree did not land in the live checkout. Redundant by design: the
+# teardown catches everything, this makes the intent legible where it matters.
+assert_no_live_repo_leak() {
+    local name
+    for name in "$@"; do
+        if [[ -e "${REPO_ROOT}/.claude/worktrees/${name}" ]]; then
+            echo "LEAK: ${REPO_ROOT}/.claude/worktrees/${name} was created" >&2
+            return 1
+        fi
+    done
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Fixture: an isolated clone with a branch that exists ONLY on origin
+#
+# Builds:
+#   $BATS_TEST_TMPDIR/upstream.git  — bare "origin"
+#   $BATS_TEST_TMPDIR/clone         — working clone, exports TEST_REPO
+#
+# On exit, 'stale-pr' exists as refs/remotes/origin/stale-pr in the clone but
+# NOT as refs/heads/stale-pr. That is exactly the stale-PR-revival shape.
+# ─────────────────────────────────────────────────────────────────────────────
+make_origin_repo() {
+    local upstream="${BATS_TEST_TMPDIR}/upstream.git"
+    local seed="${BATS_TEST_TMPDIR}/seed"
+    export TEST_REPO="${BATS_TEST_TMPDIR}/clone"
+
+    git init --bare --quiet --initial-branch=main "$upstream" 2>/dev/null \
+        || git init --bare --quiet "$upstream"
+
+    # git < 2.28 ignores --initial-branch, leaving the bare HEAD on master.
+    # Repoint it explicitly or the second clone below checks out nothing and
+    # the tests fail with a confusing unborn-HEAD error instead of a clear one.
+    git -C "$upstream" symbolic-ref HEAD refs/heads/main
+
+    git clone --quiet "$upstream" "$seed" 2>/dev/null
+    git -C "$seed" config user.email "test@test.com"
+    git -C "$seed" config user.name "Test"
+    git -C "$seed" config commit.gpgsign false
+    git -C "$seed" symbolic-ref HEAD refs/heads/main
+
+    echo "base content" > "$seed/base.txt"
+    git -C "$seed" add base.txt
+    git -C "$seed" commit -m "initial" --quiet --no-verify
+    git -C "$seed" push --quiet origin main
+
+    # The stale PR branch — carries a file that does NOT exist on main, so a
+    # worktree created from HEAD instead of origin/stale-pr is detectable.
+    git -C "$seed" checkout -b stale-pr --quiet
+    echo "pr content" > "$seed/pr-only.txt"
+    git -C "$seed" add pr-only.txt
+    git -C "$seed" commit -m "stale pr work" --quiet --no-verify
+    git -C "$seed" push --quiet origin stale-pr
+
+    # 'local-work' exists on origin at MAIN's commit. Tests that want to prove
+    # local-beats-remote precedence create a local local-work pointing
+    # somewhere else, so the two candidates are distinguishable by SHA.
+    git -C "$seed" push --quiet origin main:refs/heads/local-work
+
+    # Fresh clone: has origin/stale-pr, has no local stale-pr.
+    git clone --quiet "$upstream" "$TEST_REPO"
+    git -C "$TEST_REPO" config user.email "test@test.com"
+    git -C "$TEST_REPO" config user.name "Test"
+    git -C "$TEST_REPO" config commit.gpgsign false
+
+    export AGENCY_PROJECT_ROOT="$TEST_REPO"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -138,18 +250,29 @@ teardown() {
     [[ "$output" == *"--agent"* ]]
 }
 
-@test "positional mode: --version shows new version" {
+@test "positional mode: --version shows a semver version" {
     run "$TOOL" --version
+    # Pin the tool name + a semver shape, not an exact patch level — the exact
+    # string churns on every feature bump.
     [ "$status" -eq 0 ]
-    # Pin the tool name + a 2.x line, not an exact patch level — the exact
-    # string churns on every feature bump (2.1 → 2.2 added --from).
-    [[ "$output" == *"worktree-create 2."* ]]
+    [[ "$output" =~ ^worktree-create\ [0-9]+\.[0-9]+\.[0-9]+$ ]]
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# --from <ref> — explicit start point (local-first landing cuts its scratch
-# worktree from a pristine origin ref, never from whatever HEAD happens to be)
+# Help text includes the naming rule
 # ─────────────────────────────────────────────────────────────────────────────
+
+@test "help: includes collapse rule description" {
+    run "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"collapse"* ]] || [[ "$output" == *"Naming rule"* ]]
+}
+
+@test "help: includes example with --workstream" {
+    run "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--workstream"* ]]
+}
 
 @test "help: documents --from" {
     run "$TOOL" --help
@@ -157,11 +280,25 @@ teardown() {
     [[ "$output" == *"--from"* ]]
 }
 
-@test "--from: rejects a ref that does not resolve to a commit" {
-    run "$TOOL" _scratch-nope --from no/such/ref
-    [ "$status" -ne 0 ]
-    [[ "$output" == *"does not resolve"* ]]
+@test "help: documents the branch-resolution order" {
+    run "$TOOL" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Branch resolution"* ]]
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Mixing modes is an error
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "invalid: positional + --workstream + --agent is ambiguous" {
+    run "$TOOL" someName --workstream devex --agent devex
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"cannot mix"* ]] || [[ "$output" == *"ambiguous"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Name validation
+# ─────────────────────────────────────────────────────────────────────────────
 
 @test "name validation: a leading underscore is allowed (machine scratch worktrees)" {
     # The name must survive validation; the run may still fail later for
@@ -183,27 +320,351 @@ teardown() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
-# Help text includes the naming rule
+# Branch resolution — four cases (v2.3.0)
+#
+# The origin-only case is the regression these tests exist for: before v2.2.0
+# the tool fell through to `worktree add -b <branch>` and created an EMPTY
+# branch from HEAD, silently discarding the PR's content.
 # ─────────────────────────────────────────────────────────────────────────────
 
-@test "help: includes collapse rule description" {
-    run "$TOOL" --help
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"collapse"* ]] || [[ "$output" == *"Naming rule"* ]]
-}
+@test "branch resolution: origin-only branch is checked out, not recreated from HEAD" {
+    make_origin_repo
+    cd "$TEST_REPO"
 
-@test "help: includes example with --workstream" {
-    run "$TOOL" --help
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"--workstream"* ]]
-}
-
-# ─────────────────────────────────────────────────────────────────────────────
-# Mixing modes is an error
-# ─────────────────────────────────────────────────────────────────────────────
-
-@test "invalid: positional + --workstream + --agent is ambiguous" {
-    run "$TOOL" someName --workstream devex --agent devex
+    # Precondition: the branch is remote-only.
+    run git -C "$TEST_REPO" show-ref --verify --quiet refs/heads/stale-pr
     [ "$status" -ne 0 ]
-    [[ "$output" == *"cannot mix"* ]] || [[ "$output" == *"ambiguous"* ]]
+    git -C "$TEST_REPO" show-ref --verify --quiet refs/remotes/origin/stale-pr
+
+    run "$TOOL" revive --branch stale-pr
+    [ "$status" -eq 0 ]
+
+    local wt="${TEST_REPO}/.claude/worktrees/revive"
+    [ -d "$wt" ]
+
+    # On the right branch...
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "stale-pr" ]
+
+    # ...at origin/stale-pr's commit, not main's.
+    local wt_sha origin_sha main_sha
+    wt_sha=$(git -C "$wt" rev-parse HEAD)
+    origin_sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/stale-pr)
+    main_sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/main)
+    [ "$wt_sha" = "$origin_sha" ]
+    [ "$wt_sha" != "$main_sha" ]
+
+    # ...with the PR's content actually present.
+    [ -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak revive
+}
+
+@test "branch resolution: origin-only branch sets upstream tracking and a local ref" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" revive --branch stale-pr
+    [ "$status" -eq 0 ]
+    # The tool must say which path it took — a matching SHA alone could be luck.
+    [[ "$output" == *"tracking origin/stale-pr"* ]]
+
+    run git -C "${TEST_REPO}/.claude/worktrees/revive" \
+        rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'
+    [ "$status" -eq 0 ]
+    [ "$output" = "origin/stale-pr" ]
+
+    # Observable side effect in the parent repo: the local branch now exists.
+    git -C "$TEST_REPO" show-ref --verify --quiet refs/heads/stale-pr
+
+    assert_no_live_repo_leak revive
+}
+
+@test "branch resolution: local branch WINS over a same-named origin branch" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # origin/local-work sits at main. Point the LOCAL local-work at stale-pr's
+    # commit instead, so the two candidates have different SHAs and the
+    # precedence question actually has an observable answer.
+    git -C "$TEST_REPO" branch local-work refs/remotes/origin/stale-pr
+
+    local origin_sha local_sha
+    origin_sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/local-work)
+    local_sha=$(git -C "$TEST_REPO" rev-parse refs/heads/local-work)
+    [ "$origin_sha" != "$local_sha" ]
+
+    run "$TOOL" reuse --branch local-work
+    [ "$status" -eq 0 ]
+    # Must NOT have taken the remote path.
+    [[ "$output" != *"tracking origin/local-work"* ]]
+
+    local wt="${TEST_REPO}/.claude/worktrees/reuse"
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "local-work" ]
+
+    # Landed on the LOCAL sha, not origin's — this fails if the remote check
+    # is ever hoisted above the local one.
+    local wt_sha
+    wt_sha=$(git -C "$wt" rev-parse HEAD)
+    [ "$wt_sha" = "$local_sha" ]
+    [ "$wt_sha" != "$origin_sha" ]
+    [ -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak reuse
+}
+
+@test "branch resolution: unknown branch is created fresh from HEAD" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" brandnew --branch never-seen
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"creating it fresh from HEAD"* ]]
+
+    local wt="${TEST_REPO}/.claude/worktrees/brandnew"
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "never-seen" ]
+
+    # Fresh from HEAD (main), so the PR-only file must NOT be there.
+    [ ! -f "$wt/pr-only.txt" ]
+
+    local wt_sha head_sha
+    wt_sha=$(git -C "$wt" rev-parse HEAD)
+    head_sha=$(git -C "$TEST_REPO" rev-parse HEAD)
+    [ "$wt_sha" = "$head_sha" ]
+
+    # No upstream — it is a purely local branch.
+    run git -C "$wt" rev-parse --abbrev-ref --symbolic-full-name '@{upstream}'
+    [ "$status" -ne 0 ]
+
+    assert_no_live_repo_leak brandnew
+}
+
+@test "branch resolution: no --branch defaults to the worktree name" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # The most common real invocation, and previously untested end-to-end.
+    run "$TOOL" solo
+    [ "$status" -eq 0 ]
+
+    local wt="${TEST_REPO}/.claude/worktrees/solo"
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "solo" ]
+
+    assert_no_live_repo_leak solo
+}
+
+@test "branch resolution: default branch name also resolves an origin-only branch" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # Worktree name == branch name is how agents are created (worktree 'devex'
+    # on branch 'devex'). If that branch already exists on origin, creating a
+    # fresh one from HEAD would shadow the agent's real work — so the remote
+    # path must apply here too, not only when --branch is typed.
+    run "$TOOL" stale-pr
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tracking origin/stale-pr"* ]]
+
+    local wt="${TEST_REPO}/.claude/worktrees/stale-pr"
+    [ -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak stale-pr
+}
+
+@test "branch resolution: slash-bearing remote branch resolves (the real PR shape)" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    git -C "$TEST_REPO" push --quiet origin \
+        refs/remotes/origin/stale-pr:refs/heads/fix/pr-submit-org-resolution
+    git -C "$TEST_REPO" fetch --quiet origin
+
+    run "$TOOL" slashy --branch fix/pr-submit-org-resolution
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tracking origin/fix/pr-submit-org-resolution"* ]]
+
+    local wt="${TEST_REPO}/.claude/worktrees/slashy"
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "fix/pr-submit-org-resolution" ]
+    [ -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak slashy
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --from <ref> — explicit start point (local-first landing cuts its scratch
+# worktree from a pristine origin ref, never from whatever HEAD happens to be)
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "--from: rejects a ref that does not resolve to a commit" {
+    run "$TOOL" _scratch-nope --from no/such/ref
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"does not resolve"* ]]
+}
+
+@test "--from: cuts a new branch at the given ref (the _land- scratch shape)" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" _land-stale-pr --branch _land-stale-pr --from origin/stale-pr
+    [ "$status" -eq 0 ]
+
+    local wt="${TEST_REPO}/.claude/worktrees/_land-stale-pr"
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "_land-stale-pr" ]
+
+    local wt_sha origin_sha
+    wt_sha=$(git -C "$wt" rev-parse HEAD)
+    origin_sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/stale-pr)
+    [ "$wt_sha" = "$origin_sha" ]
+    [ -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak _land-stale-pr
+}
+
+@test "--from: refuses when the branch already exists locally" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    git -C "$TEST_REPO" branch already-here refs/remotes/origin/stale-pr
+
+    run "$TOOL" clash --branch already-here --from origin/main
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"already exists"* ]]
+
+    [ ! -d "${TEST_REPO}/.claude/worktrees/clash" ]
+    assert_no_live_repo_leak clash
+}
+
+@test "--from: outranks the remote-branch search, and says so" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # origin/stale-pr exists, but the caller explicitly asked for origin/main.
+    # Explicit wins — and the shadowing must be announced, not silent.
+    run "$TOOL" explicit --branch stale-pr --from origin/main
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"tracking origin/stale-pr"* ]]
+    [[ "$output" == *"--from wins"* ]]
+
+    local wt="${TEST_REPO}/.claude/worktrees/explicit"
+    local wt_sha main_sha
+    wt_sha=$(git -C "$wt" rev-parse HEAD)
+    main_sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/main)
+    [ "$wt_sha" = "$main_sha" ]
+    [ ! -f "$wt/pr-only.txt" ]
+
+    assert_no_live_repo_leak explicit
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Branch-resolution error paths
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "branch resolution: existing worktree directory is refused" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    mkdir -p "${TEST_REPO}/.claude/worktrees/taken"
+    run "$TOOL" taken --branch never-seen
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"already exists"* ]]
+}
+
+@test "branch resolution: branch already checked out elsewhere fails cleanly" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" first --branch stale-pr
+    [ "$status" -eq 0 ]
+
+    # git refuses to check the same branch out twice; the tool must surface it.
+    run "$TOOL" second --branch stale-pr
+    [ "$status" -ne 0 ]
+
+    assert_no_live_repo_leak first second
+}
+
+@test "branch resolution: origin wins when several remotes carry the branch" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # A second remote that also has 'stale-pr'. origin must break the tie.
+    git -C "$TEST_REPO" remote add mirror "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" fetch --quiet mirror
+
+    run "$TOOL" tiebreak --branch stale-pr
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tracking origin/stale-pr"* ]]
+
+    assert_no_live_repo_leak tiebreak
+}
+
+@test "branch resolution: several non-origin remotes is refused, not guessed" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # Two remotes carry 'stale-pr' and neither is 'origin' — genuinely
+    # ambiguous, so the tool must refuse rather than pick one.
+    git -C "$TEST_REPO" remote add mirror-a "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" remote add mirror-b "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" fetch --quiet mirror-a
+    git -C "$TEST_REPO" fetch --quiet mirror-b
+    git -C "$TEST_REPO" remote remove origin
+
+    run "$TOOL" ambiguous --branch stale-pr
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"multiple remotes"* ]]
+    [ ! -d "${TEST_REPO}/.claude/worktrees/ambiguous" ]
+
+    assert_no_live_repo_leak ambiguous
+}
+
+@test "branch resolution: --from settles a multi-remote ambiguity" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    git -C "$TEST_REPO" remote add mirror-a "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" remote add mirror-b "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" fetch --quiet mirror-a
+    git -C "$TEST_REPO" fetch --quiet mirror-b
+    git -C "$TEST_REPO" remote remove origin
+
+    run "$TOOL" settled --branch stale-pr --from mirror-a/stale-pr
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_REPO}/.claude/worktrees/settled/pr-only.txt" ]
+
+    assert_no_live_repo_leak settled
+}
+
+@test "invalid: --branch with an illegal git branch name is rejected" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" bad --branch "HEAD"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"not a valid git branch name"* ]]
+}
+
+@test "invalid: --branch with no value fails with a usage hint, not a bash error" {
+    run "$TOOL" foo --branch
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "invalid: --from with no value fails with a usage hint, not a bash error" {
+    run "$TOOL" foo --from
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" != *"unbound variable"* ]]
 }

--- a/src/tests/tools/worktree-create.bats
+++ b/src/tests/tools/worktree-create.bats
@@ -22,8 +22,9 @@
 #   - assert_no_live_repo_leak() checks the live repo after each creation test.
 #
 # Written: 2026-04-09 — dispatch #166/#169, task #9
-# Extended: 2026-08-08 — branch-resolution DWIM + isolation guards (v2.2.0)
-# Extended: 2026-08-12 — reconciled with --from / local-first landing (v2.3.0)
+# Extended: 2026-08-08 — --from / local-first landing start point (v2.2.0)
+# Extended: 2026-08-12 — branch-resolution DWIM + isolation guards, reconciled
+#                        with --from into one four-case ladder (v2.3.0)
 
 load test_helper
 
@@ -62,7 +63,12 @@ teardown() {
         leaked=1
     fi
 
-    test_isolation_teardown
+    # The shared teardown has its own guard (it detects live .git/config
+    # pollution and returns 1). Swallowing that status would let exactly the
+    # class of incident this file's isolation story exists to prevent pass
+    # silently whenever the two diffs above happen to be clean.
+    test_isolation_teardown || leaked=1
+
     return "$leaked"
 }
 
@@ -505,9 +511,36 @@ make_origin_repo() {
 # ─────────────────────────────────────────────────────────────────────────────
 
 @test "--from: rejects a ref that does not resolve to a commit" {
+    # Against a REAL repo, so the rejection proves the ref lookup failed — not
+    # merely that $PROJECT_ROOT wasn't a git repo at all.
+    make_origin_repo
+    cd "$TEST_REPO"
+
     run "$TOOL" _scratch-nope --from no/such/ref
     [ "$status" -ne 0 ]
     [[ "$output" == *"does not resolve"* ]]
+    [ ! -d "${TEST_REPO}/.claude/worktrees/_scratch-nope" ]
+
+    assert_no_live_repo_leak _scratch-nope
+}
+
+@test "--from: a tag and a raw SHA both resolve" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    git -C "$TEST_REPO" tag pinned refs/remotes/origin/stale-pr
+    local sha
+    sha=$(git -C "$TEST_REPO" rev-parse refs/remotes/origin/stale-pr)
+
+    run "$TOOL" from-tag --branch from-tag --from pinned
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_REPO}/.claude/worktrees/from-tag/pr-only.txt" ]
+
+    run "$TOOL" from-sha --branch from-sha --from "$sha"
+    [ "$status" -eq 0 ]
+    [ -f "${TEST_REPO}/.claude/worktrees/from-sha/pr-only.txt" ]
+
+    assert_no_live_repo_leak from-tag from-sha
 }
 
 @test "--from: cuts a new branch at the given ref (the _land- scratch shape)" {
@@ -609,6 +642,24 @@ make_origin_repo() {
     assert_no_live_repo_leak tiebreak
 }
 
+@test "branch resolution: a single non-origin remote is used without complaint" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # No origin at all — exactly one remote carries the branch, so there is
+    # nothing ambiguous and the DWIM path must still fire.
+    git -C "$TEST_REPO" remote add mirror "${BATS_TEST_TMPDIR}/upstream.git"
+    git -C "$TEST_REPO" fetch --quiet mirror
+    git -C "$TEST_REPO" remote remove origin
+
+    run "$TOOL" solo-remote --branch stale-pr
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tracking mirror/stale-pr"* ]]
+    [ -f "${TEST_REPO}/.claude/worktrees/solo-remote/pr-only.txt" ]
+
+    assert_no_live_repo_leak solo-remote
+}
+
 @test "branch resolution: several non-origin remotes is refused, not guessed" {
     make_origin_repo
     cd "$TEST_REPO"
@@ -667,4 +718,144 @@ make_origin_repo() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"requires a value"* ]]
     [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "invalid: --workstream with no value fails with a usage hint" {
+    run "$TOOL" --workstream
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "invalid: --agent with no value fails with a usage hint" {
+    run "$TOOL" --workstream devex --agent
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "invalid: --compute-only --workstream with no value fails with a usage hint" {
+    run "$TOOL" --compute-only --workstream
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" != *"unbound variable"* ]]
+}
+
+@test "invalid: a flag swallowed as another flag's value is rejected" {
+    # Without the look-ahead guard this sets BRANCH=--from and dies much later
+    # with a raw git message about an invalid branch name.
+    run "$TOOL" foo --branch --from bar
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"requires a value"* ]]
+    [[ "$output" == *"looks like a flag"* ]]
+}
+
+@test "invalid: an unknown option is rejected in the main flow" {
+    run "$TOOL" foo --bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+@test "invalid: an unknown option is rejected in --compute-only mode" {
+    run "$TOOL" --compute-only --bogus x
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Unknown option"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --workstream/--agent through the REAL creation path
+#
+# Every other collapse-rule test uses --compute-only, which short-circuits
+# before the main flag loop. The real path re-implements the pairing check and
+# feeds the computed name into branch resolution — separate code, separate risk.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "workstream form: creates a worktree at the collapsed name" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" --workstream mdpal --agent mdpal-app
+    [ "$status" -eq 0 ]
+
+    local wt="${TEST_REPO}/.claude/worktrees/mdpal-app"
+    [ -d "$wt" ]
+    run git -C "$wt" rev-parse --abbrev-ref HEAD
+    [ "$status" -eq 0 ]
+    [ "$output" = "mdpal-app" ]
+
+    assert_no_live_repo_leak mdpal-app
+}
+
+@test "workstream form: computed name still resolves an origin-only branch" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # Push the branch the collapse rule will compute, so the DWIM path must
+    # apply to a name the caller never typed.
+    git -C "$TEST_REPO" push --quiet origin \
+        refs/remotes/origin/stale-pr:refs/heads/agency-captain
+
+    run "$TOOL" --workstream agency --agent captain
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tracking origin/agency-captain"* ]]
+    [ -f "${TEST_REPO}/.claude/worktrees/agency-captain/pr-only.txt" ]
+
+    assert_no_live_repo_leak agency-captain
+}
+
+@test "workstream form: --workstream without --agent fails in the real path too" {
+    run "$TOOL" --workstream devex
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"must be given together"* ]]
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Dependency bootstrap
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "bootstrap: no package.json means no install is attempted" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    run "$TOOL" nodeps --branch never-seen
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Installing dependencies"* ]]
+
+    assert_no_live_repo_leak nodeps
+}
+
+@test "bootstrap: package-lock.json selects npm, and a failing install is not fatal" {
+    make_origin_repo
+    cd "$TEST_REPO"
+
+    # Commit a node-shaped project on a branch, so the new worktree has one.
+    git -C "$TEST_REPO" checkout --quiet -b nodeish
+    echo '{"name":"fixture","version":"1.0.0"}' > "$TEST_REPO/package.json"
+    echo '{}' > "$TEST_REPO/package-lock.json"
+    git -C "$TEST_REPO" add package.json package-lock.json
+    git -C "$TEST_REPO" commit --quiet --no-verify -m "node fixture"
+    git -C "$TEST_REPO" checkout --quiet main
+
+    # Stub npm so the test neither hits the network nor depends on a real npm.
+    # It records the invocation and exits nonzero — the tool swallows install
+    # failures by design, so the worktree must still be reported as created.
+    mkdir -p "${BATS_TEST_TMPDIR}/bin"
+    cat > "${BATS_TEST_TMPDIR}/bin/npm" <<'STUB'
+#!/bin/bash
+echo "$@" >> "${NPM_STUB_LOG}"
+exit 3
+STUB
+    chmod +x "${BATS_TEST_TMPDIR}/bin/npm"
+    export NPM_STUB_LOG="${BATS_TEST_TMPDIR}/npm-calls"
+    export PATH="${BATS_TEST_TMPDIR}/bin:$PATH"
+
+    run "$TOOL" nodey --branch nodeish
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Installing dependencies"* ]]
+    [[ "$output" == *"created successfully"* ]]
+
+    [ -f "$NPM_STUB_LOG" ]
+    grep -q "ci" "$NPM_STUB_LOG"
+
+    assert_no_live_repo_leak nodey
 }

--- a/usr/jordan/_land-fix-worktree-create/dispatches/commit-to-captain-committed-69ce1005-on-land-fix-worktree-create-cho-20260812-1942.md
+++ b/usr/jordan/_land-fix-worktree-create/dispatches/commit-to-captain-committed-69ce1005-on-land-fix-worktree-create-cho-20260812-1942.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-worktree-create
+to: the-agency/jordan/captain
+date: 2026-08-12T11:42
+status: created
+priority: normal
+subject: "Committed 69ce1005 on _land-fix-worktree-create: chore(manifest): bump agency_version 46.32 → 46.33 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 69ce1005 on _land-fix-worktree-create: chore(manifest): bump agency_version 46.32 → 46.33 for PR landing (captain)
+
+## Commit: 69ce1005
+
+**Branch:** _land-fix-worktree-create
+**Agent:** the-agency/jordan/_land-fix-worktree-create
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.32 → 46.33 for PR landing (captain)
+
+### Metadata
+- commit_hash: 69ce1005
+- branch: _land-fix-worktree-create
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-58915674-on-fix-worktree-create-fix-work-20260812-1937.md
+++ b/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-58915674-on-fix-worktree-create-fix-work-20260812-1937.md
@@ -1,0 +1,35 @@
+---
+type: commit
+from: the-agency/jordan/fix-worktree-create
+to: the-agency/jordan/captain
+date: 2026-08-12T11:37
+status: created
+priority: normal
+subject: "Committed 58915674 on fix-worktree-create: fix(worktree-create): QG hardening — arg-parse guard, SHA-resolved --from, test coverage"
+in_reply_to: null
+---
+
+# Committed 58915674 on fix-worktree-create: fix(worktree-create): QG hardening — arg-parse guard, SHA-resolved --from, test coverage
+
+## Commit: 58915674
+
+**Branch:** fix-worktree-create
+**Agent:** the-agency/jordan/fix-worktree-create
+**Message:** housekeeping/captain: fix(worktree-create): QG hardening — arg-parse guard, SHA-resolved --from, test coverage
+
+### Metadata
+- commit_hash: 58915674
+- branch: fix-worktree-create
+- files_changed: 5
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/worktree-create/SKILL.md
+agency/tools/worktree-create
+src/agency/tools/worktree-create
+src/tests/tools/worktree-create.bats
+usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-c211358d-on-fix-worktree-create-fix-work-20260812-1858.md
+```

--- a/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-c211358d-on-fix-worktree-create-fix-work-20260812-1858.md
+++ b/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-c211358d-on-fix-worktree-create-fix-work-20260812-1858.md
@@ -1,0 +1,34 @@
+---
+type: commit
+from: the-agency/jordan/fix-worktree-create
+to: the-agency/jordan/captain
+date: 2026-08-12T10:58
+status: created
+priority: normal
+subject: "Committed c211358d on fix-worktree-create: fix(worktree-create): resolve origin-only branches instead of forking from HEAD"
+in_reply_to: null
+---
+
+# Committed c211358d on fix-worktree-create: fix(worktree-create): resolve origin-only branches instead of forking from HEAD
+
+## Commit: c211358d
+
+**Branch:** fix-worktree-create
+**Agent:** the-agency/jordan/fix-worktree-create
+**Message:** housekeeping/captain: fix(worktree-create): resolve origin-only branches instead of forking from HEAD
+
+### Metadata
+- commit_hash: c211358d
+- branch: fix-worktree-create
+- files_changed: 4
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/worktree-create/SKILL.md
+agency/tools/worktree-create
+src/agency/tools/worktree-create
+src/tests/tools/worktree-create.bats
+```

--- a/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-f21c1bf6-on-fix-worktree-create-qgr-fix--20260812-1938.md
+++ b/usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-f21c1bf6-on-fix-worktree-create-qgr-fix--20260812-1938.md
@@ -1,0 +1,32 @@
+---
+type: commit
+from: the-agency/jordan/fix-worktree-create
+to: the-agency/jordan/captain
+date: 2026-08-12T11:38
+status: created
+priority: normal
+subject: "Committed f21c1bf6 on fix-worktree-create: qgr(fix-worktree-create): pr-prep receipt for worktree-create origin-branch fix"
+in_reply_to: null
+---
+
+# Committed f21c1bf6 on fix-worktree-create: qgr(fix-worktree-create): pr-prep receipt for worktree-create origin-branch fix
+
+## Commit: f21c1bf6
+
+**Branch:** fix-worktree-create
+**Agent:** the-agency/jordan/fix-worktree-create
+**Message:** housekeeping/captain: qgr(fix-worktree-create): pr-prep receipt for worktree-create origin-branch fix
+
+### Metadata
+- commit_hash: f21c1bf6
+- branch: fix-worktree-create
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/workstreams/devex/qgr/the-agency-jordan-fix-worktree-create-devex-worktree-create-origin-branch-fix-qgr-pr-prep-20260812-1937-5014a49.md
+usr/jordan/fix-worktree-create/dispatches/commit-to-captain-committed-58915674-on-fix-worktree-create-fix-work-20260812-1937.md
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-worktree-create` (untouched; this PR rides `_land-fix-worktree-create`)
- Integrated in a scratch worktree cut from `origin/fix-worktree-create`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/devex/qgr/the-agency-jordan-fix-worktree-create-devex-worktree-create-origin-branch-fix-qgr-pr-prep-20260812-1937-5014a49.md` (hash `5014a49`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-worktree-create-qgr-pr-captain-land-20260812-1942-b18f845.md` (hash `b18f845`)
- `agency_version`: 46.32 → 46.33
- Release v46.33 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)