### PR TITLE
fix(refs): repair Great-Rename REFERENCE-path rot across skills/hookify/README/templates + validator (flag #213)

### DIFF
--- a/.claude/skills/agency-issue/SKILL.md
+++ b/.claude/skills/agency-issue/SKILL.md
@@ -70,7 +70,7 @@ Shows the issue body, metadata, and all comments.
 
 ## Issue body format
 
-For consistency, follow the same structure as `/feedback` (per `claude/REFERENCE-FEEDBACK-FORMAT.md`):
+For consistency, follow the same structure as `/feedback` (per `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md`):
 
 - **Problem** — what's broken or missing, who hits it, what the impact is
 - **Steps to Reproduce** — exact commands or sequence (for bugs); use case description (for features)

--- a/.claude/skills/captain-log/SKILL.md
+++ b/.claude/skills/captain-log/SKILL.md
@@ -6,7 +6,7 @@ when_to_use: "Capturing the narrative thread of a session as work happens — de
 argument-hint: "[entry text | -c <category> <text> | read [YYYYMMDD] | list | path]"
 paths: []
 required_reading:
-  - agency/REFERENCE-AGENT-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md
 ---
 
 <!--
@@ -38,7 +38,7 @@ The richer the log, the more useful the mining. Log proactively; don't batch.
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
-- `agency/REFERENCE-AGENT-DISCIPLINE.md` — Two Priorities + Over/Over-and-out. The log is a working-session practice; it sits inside the agent-discipline frame.
+- `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md` — Two Priorities + Over/Over-and-out. The log is a working-session practice; it sits inside the agent-discipline frame.
 
 ## Usage
 
@@ -115,7 +115,7 @@ The log is a **side-channel** practice — it never blocks the work. Capture the
 - **Read for a day with no entries**: tool reports "no log for that day" and exits non-zero. Confirm the date or use `list` to see what exists.
 - **Entry text contains shell metacharacters**: quote the argument so the shell passes it intact. Unquoted entries with `&`, `|`, `;`, or `*` will lose content.
 - **Wrong category**: log is append-only — there is no edit-in-place. File a new entry with a correction note, or leave it and move on (the mining step handles noise).
-- **Tool output suggests a bug**: do not fix it here — report it via `/flag` or `/agency-issue` per `agency/REFERENCE-AGENT-DISCIPLINE.md`.
+- **Tool output suggests a bug**: do not fix it here — report it via `/flag` or `/agency-issue` per `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md`.
 
 ## What this does NOT do
 

--- a/.claude/skills/captain-release/SKILL.md
+++ b/.claude/skills/captain-release/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain has staged coordination work on a captain-* branch and want
 argument-hint: "[--no-push] [--no-pr] <commit description>"
 paths: []
 required_reading:
-  - agency/REFERENCE-QUALITY-GATE.md
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
 ---
 
 <!--

--- a/.claude/skills/captain-review/SKILL.md
+++ b/.claude/skills/captain-review/SKILL.md
@@ -6,8 +6,8 @@ when_to_use: "Captain on master wants to triage the open draft-PR queue — eith
 argument-hint: "[<pr-number> | <project-name> | --all]"
 paths: []
 required_reading:
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-ISCP-PROTOCOL.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md
 ---
 
 <!--
@@ -38,8 +38,8 @@ The boundary is deliberate: this is a captain-side triage pass, not a gate. Boun
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
-- `agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md` — distinguishes the review tools, PR lifecycle, review/dispatch file conventions.
-- `agency/REFERENCE-ISCP-PROTOCOL.md` — dispatch format, filenames, addressing; this skill emits dispatches.
+- `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md` — distinguishes the review tools, PR lifecycle, review/dispatch file conventions.
+- `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` — dispatch format, filenames, addressing; this skill emits dispatches.
 
 ## Usage
 

--- a/.claude/skills/captain-sync-all/SKILL.md
+++ b/.claude/skills/captain-sync-all/SKILL.md
@@ -12,9 +12,9 @@ when_to_use: |
 argument-hint: "(no args)"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-WORKTREE-DISCIPLINE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -188,7 +188,7 @@ Light update to captain handoff: "what synced, what was merged into master, any 
 - `/sync` — agent-side push skill (different scope entirely)
 - `/worktree-sync` — single-worktree sync (agent-side; this skill calls it across all worktrees)
 - `agency/tools/git-captain` — safe captain-side git operations
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
-- `agency/REFERENCE-WORKTREE-DISCIPLINE.md` — worktree model
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- `agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md` — worktree model
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/captain-sync-all/examples.md
+++ b/.claude/skills/captain-sync-all/examples.md
@@ -77,7 +77,7 @@ Expected:
 ```
 ABORT: master working tree is dirty (2 uncommitted files).
   Commit or stash before sync:
-    M claude/REFERENCE-X.md
+    M agency/REFERENCE/REFERENCE-X.md
     ?? usr/{principal}/captain/dispatches/new-one.md
 ```
 
@@ -94,12 +94,12 @@ Captain's local master has a coord commit that conflicts with origin/master:
 Expected:
 ```
 ABORT: merge origin/master conflicted:
-  CONFLICT (content): claude/REFERENCE-SKILLS-INDEX.md
+  CONFLICT (content): agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
   
 Resolve manually:
   git status
   # edit conflicted files
-  git-safe add claude/REFERENCE-SKILLS-INDEX.md
+  git-safe add agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
   git-captain merge-continue
   # re-run /captain-sync-all
 ```

--- a/.claude/skills/compact-prepare/reference.md
+++ b/.claude/skills/compact-prepare/reference.md
@@ -2,7 +2,7 @@
 
 This skill has no unique protocol beyond what `required_reading` covers in `SKILL.md`. See:
 
-- `agency/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape, `mode: continuation` requirement.
-- `agency/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pause`).
+- `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape, `mode: continuation` requirement.
+- `agency/REFERENCE/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pause`).
 
 MAR R3 note: Step 3.1a in `SKILL.md` is a workaround for the-agency#355 (handoff must force-commit). When #355 lands upstream, that step moves into the `session-pause` tool and this skill drops its Step 1. See `usr/{principal}/captain/session-lifecycle-refactor/plan.md` HG-7.

--- a/.claude/skills/compact-resume/reference.md
+++ b/.claude/skills/compact-resume/reference.md
@@ -2,7 +2,7 @@
 
 This skill has no unique protocol beyond what `required_reading` covers in `SKILL.md`. See:
 
-- `agency/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape; `mode: continuation` is what this skill expects to read.
-- `agency/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pickup` per agency#348).
+- `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape; `mode: continuation` is what this skill expects to read.
+- `agency/REFERENCE/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pickup` per agency#348).
 
 Design detail: the `--from compact` mode of session-pickup deliberately skips worktree-sync and full preflight — `/compact` is in-process, master cannot have moved, and the preflight questions (monitor running? tree clean? handoff loaded?) are already answered by the PAUSE + PICKUP flow itself. `/session-resume` is the fresh-session equivalent that runs the full preflight after `/exit`.

--- a/.claude/skills/iteration-complete/SKILL.md
+++ b/.claude/skills/iteration-complete/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: "<phase.iter>: <description> [--base <ref>]"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-QUALITY-GATE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--

--- a/.claude/skills/phase-complete/SKILL.md
+++ b/.claude/skills/phase-complete/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: "<phase>: <description>"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-QUALITY-GATE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--

--- a/.claude/skills/post-merge/SKILL.md
+++ b/.claude/skills/post-merge/SKILL.md
@@ -11,7 +11,7 @@ description: Run after a PR is merged on GitHub. Verifies merge, merges origin i
 
 # Post-Merge
 
-Run after a PR is merged on GitHub. Verifies the merge, merges origin into master, then invokes `/sync-all`. **Never resets master to origin.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+Run after a PR is merged on GitHub. Verifies the merge, merges origin into master, then invokes `/sync-all`. **Never resets master to origin.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ## Arguments
 
@@ -49,7 +49,7 @@ If diverged (both sides > 0 — expected after squash PR merge):
 
 If behind only: `git merge origin/master`
 
-**Never `git reset --hard origin/master`.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+**Never `git reset --hard origin/master`.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 5: Invoke sync-all
 

--- a/.claude/skills/pr-captain-land/SKILL.md
+++ b/.claude/skills/pr-captain-land/SKILL.md
@@ -6,10 +6,10 @@ when_to_use: Captain on master in main checkout, after a /pr-submit dispatch fro
 argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release] [--principal-approved] [--allow-unvalidated]"
 paths: []
 required_reading:
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-RECEIPT-INFRASTRUCTURE.md
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--

--- a/.claude/skills/pr-captain-merge/SKILL.md
+++ b/.claude/skills/pr-captain-merge/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain on master in main checkout, after PR has passed CI and prin
 argument-hint: "<pr-number> [--principal-approved] [--delete-branch] [--dry-run]"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
 ---
 
 <!--
@@ -162,7 +162,7 @@ Defense in depth against accidental invocation from the wrong context:
 - `/pr-captain-post-merge` (TBD refactored to `/pr-captain-post-merge`) — release + fleet-notify after merge
 - `agency/tools/pr-merge` — the underlying safe-merge tool
 - `claude/hookify/hookify.block-raw-gh-pr-merge.md` — hookify rule that blocks bare `gh pr merge`
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the discipline rationale
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the discipline rationale
 - the-agency#296 — PR lifecycle ownership (the-agency direction)
 - the-agency#298 — skill refactor recommendation (the methodology)
 

--- a/.claude/skills/pr-captain-merge/examples.md
+++ b/.claude/skills/pr-captain-merge/examples.md
@@ -122,7 +122,7 @@ No flag exists on the skill or the tool to squash or rebase. If an agent tries `
 
 ```
 REFUSED: --squash is not supported. pr-captain-merge always uses true merge commit.
-See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md for rationale.
+See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md for rationale.
 ```
 
 Exit 2.

--- a/.claude/skills/pr-captain-post-merge/SKILL.md
+++ b/.claude/skills/pr-captain-post-merge/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain on master in main checkout, immediately after a PR has merg
 argument-hint: "<pr-number>"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-WORKTREE-DISCIPLINE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -202,7 +202,7 @@ Post-merge complete:
 - `/release` (TBD refactored to `/captain-release`) — alternate entry point that runs /pr-captain-merge + this skill in one flow
 - `agency/tools/gh-release` — the release-creation tool
 - `agency/tools/git-captain` — safe captain-side git operations
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
 - the-agency#296 — PR lifecycle ownership (Phase 1 pilot context)
 - the-agency#315 — V1→V2 migration (this refactor lives under Tier 1)
 

--- a/.claude/skills/pr-merge/SKILL.md
+++ b/.claude/skills/pr-merge/SKILL.md
@@ -121,6 +121,6 @@ have to read the same history.
 
 - Tool: `agency/tools/pr-merge`
 - Hookify: `agency/hookify/hookify.block-raw-gh-pr-merge.md` (blocks bare `gh pr merge`)
-- Discipline: `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`
+- Discipline: `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/pr-submit/SKILL.md
+++ b/.claude/skills/pr-submit/SKILL.md
@@ -7,9 +7,9 @@ argument-hint: "--scope \"one-line PR summary\" [--priority normal|high]"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
-  - claude/REFERENCE-ISCP-PROTOCOL.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md
 ---
 
 <!--

--- a/.claude/skills/pr-submit/scripts/README.md
+++ b/.claude/skills/pr-submit/scripts/README.md
@@ -40,4 +40,4 @@ Multiple preflight checks + hash computation + glob lookup + dispatch emission i
 
 ## Skill-tools versioning
 
-The `scripts/` directory pattern is part of the v2 bundle structure (see `claude/REFERENCE-SKILL-AUTHORING.md` §5). Each skill gets its own `scripts/` namespace; no global `agency/tools/` collision.
+The `scripts/` directory pattern is part of the v2 bundle structure (see `agency/REFERENCE/REFERENCE-SKILL-AUTHORING.md` §5). Each skill gets its own `scripts/` namespace; no global `agency/tools/` collision.

--- a/.claude/skills/principal-create/SKILL.md
+++ b/.claude/skills/principal-create/SKILL.md
@@ -130,7 +130,7 @@ principal's captain:
 - Tool: `agency/tools/principal-onboard`
 - Templates: `agency/templates/principal-v2/`
 - Schema: `agency/config/agency.yaml` (`principals:` block)
-- Concept: `agency/REFERENCE-AGENT-ADDRESSING.md`
+- Concept: `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md`
 - Worknote: `agency/docs/worknotes/WORKNOTE-principal-tooling.md`
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/.claude/skills/rebase/SKILL.md
+++ b/.claude/skills/rebase/SKILL.md
@@ -13,7 +13,7 @@ description: DEPRECATED — use `git merge <target>` or `/sync` instead. Rebase 
 
 **This skill is deprecated.** All branch synchronization now uses merge, not rebase.
 
-Rebase rewrites history, breaks worktree merge-bases, and caused a fleet-wide data loss incident in a multi-worktree monorepo. See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` for the full rationale and incident report.
+Rebase rewrites history, breaks worktree merge-bases, and caused a fleet-wide data loss incident in a multi-worktree monorepo. See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` for the full rationale and incident report.
 
 ## Use Instead
 

--- a/.claude/skills/sync-all/SKILL.md
+++ b/.claude/skills/sync-all/SKILL.md
@@ -40,7 +40,7 @@ If diverged (squash PR scenario):
 
 If behind only: `git merge origin/master`
 
-**Never `git reset --hard origin/master`. Never `git rebase origin/master`.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+**Never `git reset --hard origin/master`. Never `git rebase origin/master`.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 4: Enumerate worktrees
 

--- a/.claude/skills/sync/SKILL.md
+++ b/.claude/skills/sync/SKILL.md
@@ -6,8 +6,8 @@ when_to_use: On any non-master branch (worktree agent branch OR captain-* branch
 argument-hint: "[<target-branch>]"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -139,6 +139,6 @@ Pushing is destructive and requires principal confirmation. This skill is intend
 - `/worktree-sync` — worktree sync (never pushes; local master merge only)
 - `agency/tools/git-push` — underlying authorized push tool
 - `agency/hookify/hookify.block-raw-git-push.md` — blocks raw `git push`
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/agency/CLAUDE-THEAGENCY.md
+++ b/agency/CLAUDE-THEAGENCY.md
@@ -128,7 +128,7 @@ Loop: **Friction → Telemetry → Tool → Block → Flow.** Pattern appears in
 
 ## Universal Agent Discipline
 
-Every agent — captain, worktree, subagent — follows two standing priorities and the Over / Over-and-out protocol. Full spec: `claude/REFERENCE-AGENT-DISCIPLINE.md` (read on demand).
+Every agent — captain, worktree, subagent — follows two standing priorities and the Over / Over-and-out protocol. Full spec: `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md` (read on demand).
 
 1. **Principal first.** When the principal speaks, stop current work and respond. You give full attention to what they bring.
 2. **Dispatches second.** Read unread dispatches at session start, before other work. An unread dispatch is a blocked person.

--- a/agency/README-GETTINGSTARTED.md
+++ b/agency/README-GETTINGSTARTED.md
@@ -113,7 +113,7 @@ Narrow permission patterns (the old approach) created friction — every new com
 |-----------|------|---------|
 | `agency/tools/` | CLI tools with logging and telemetry | `dispatch`, `flag`, `handoff`, `git-safe-commit` |
 | `agency/hookify/` | Behavioral rules (warn/block) | `hookify.block-git-safe-commit.md` |
-| `claude/REFERENCE-*.md` | Reference docs (injected on demand) | `REFERENCE-QUALITY-GATE.md`, `REFERENCE-ISCP-PROTOCOL.md` |
+| `agency/REFERENCE/REFERENCE-*.md` | Reference docs (injected on demand) | `REFERENCE-QUALITY-GATE.md`, `REFERENCE-ISCP-PROTOCOL.md` |
 | `agency/agents/` | Agent class definitions | `captain/agent.md`, `tech-lead/agent.md` |
 | `agency/hooks/` | Session lifecycle hooks | `ref-injector.sh` |
 | `agency/config/agency.yaml` | Principal mapping, providers, collaboration repos | configured during init |

--- a/agency/README-THEAGENCY.md
+++ b/agency/README-THEAGENCY.md
@@ -428,7 +428,7 @@ The 1B1 protocol applies to ALL structured discussions, not just when `/discuss`
 
 When agents encounter issues with Claude Code itself (bugs, missing features, unexpected behavior), they draft structured feedback using a standard format that includes diagnostic evidence, reproduction steps, and root cause analysis when known. The format ensures Anthropic's team can triage quickly.
 
-The key principle: **draft it, then wait for approval.** Agents never send feedback externally without the principal reviewing it first. The full format template is in `claude/REFERENCE-FEEDBACK-FORMAT.md` and gets injected automatically when feedback skills are invoked.
+The key principle: **draft it, then wait for approval.** Agents never send feedback externally without the principal reviewing it first. The full format template is in `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md` and gets injected automatically when feedback skills are invoked.
 
 ## Testing & Quality Discipline
 

--- a/agency/README/README-ENFORCEMENT.md
+++ b/agency/README/README-ENFORCEMENT.md
@@ -10,7 +10,7 @@ Enforcement in TheAgency operates at **five layers**, from soft to hard:
 
 | Layer | Mechanism | What | Examples |
 |-------|-----------|------|----------|
-| 1. Documentation | Markdown in `claude/REFERENCE-*.md`, `CLAUDE-THEAGENCY.md` | Human and agent readable conventions | Methodology, address format |
+| 1. Documentation | Markdown in `agency/REFERENCE/REFERENCE-*.md`, `CLAUDE-THEAGENCY.md` | Human and agent readable conventions | Methodology, address format |
 | 2. Skills | `.claude/skills/{name}/SKILL.md` | Discoverable invocations of conventions | `/handoff`, `/iteration-complete` |
 | 3. Tools | `agency/tools/{name}` | Mechanical capabilities with logging and telemetry | `dispatch`, `git-safe-commit`, `stage-hash` |
 | 4. Hookify rules | `agency/hookify/hookify.{name}.md` | PreToolUse hooks that block or warn on patterns | `block-git-safe-commit`, `warn-compound-bash` |
@@ -199,7 +199,7 @@ These fire constantly and shape day-to-day agent behavior. Every adopter must un
 
 ## Quality Gates
 
-Quality gates are tiered checkpoints that run at every commit boundary. Each tier has a different scope and time budget. See `claude/REFERENCE-QUALITY-GATE.md` for the full protocol.
+Quality gates are tiered checkpoints that run at every commit boundary. Each tier has a different scope and time budget. See `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` for the full protocol.
 
 | Tier | Boundary | Checks | Time budget | Skill |
 |------|----------|--------|-------------|-------|

--- a/agency/README/README-SAFE-TOOLS.md
+++ b/agency/README/README-SAFE-TOOLS.md
@@ -58,4 +58,4 @@ Wraps `gh pr merge` with true merge commit enforcement (never squash, never reba
 
 ## Reference
 
-Full subcommand specs, exit codes, and exemption rules: `claude/REFERENCE-SAFE-TOOLS.md`
+Full subcommand specs, exit codes, and exemption rules: `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md`

--- a/agency/agents/captain/agent.md
+++ b/agency/agents/captain/agent.md
@@ -210,7 +210,7 @@ When you launch me, I'll read the handoff and pick up where we left off.
 - Ask me any question about The Agency
 - Type `/agency-welcome` for the interactive tour
 - Read `CLAUDE.md` for the complete guide
-- Check `claude/REFERENCE-*.md` for detailed documentation
+- Check `agency/REFERENCE/REFERENCE-*.md` for detailed documentation
 
 ## Agency 2.0: Coordination Responsibilities
 

--- a/agency/agents/templates/docs/agent.md
+++ b/agency/agents/templates/docs/agent.md
@@ -84,4 +84,4 @@ This agent specializes in:
 - `agency/agents/{{AGENT_NAME}}/` - Agent identity
 - `agency/workstreams/{{WORKSTREAM}}/` - Work artifacts
 - `agency/knowledge/documentation-patterns/` - Documentation patterns
-- `claude/REFERENCE-*.md` - Agency documentation
+- `agency/REFERENCE/REFERENCE-*.md` - Agency documentation

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.35",
+  "agency_version": "46.36",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-12T13:51:08Z"
+    "updated_at": "2026-08-13T03:24:17Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-12T13:51:08Z"
+  "updated_at": "2026-08-13T03:24:17Z"
 }

--- a/agency/hookify/hookify.compound-bash-block.md
+++ b/agency/hookify/hookify.compound-bash-block.md
@@ -40,7 +40,7 @@ You wrote a bash command with `&&`, `||`, `;`, `|`, `$(…)`, backticks, or `cd 
 
 - Tool: `agency/tools/run-in` (replacement for the `cd X && cmd` pattern)
 - Skill: `/run-in`
-- Reference: `claude/REFERENCE-PROVENANCE-HEADERS.md`
+- Reference: `agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md`
 - Companion workstream: telemetry analysis of compound command patterns (flag #54) — mines the log of compound command attempts to identify which OTHER patterns deserve their own purpose-built tool
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/agency/hookify/hookify.compound-bash-warn.md
+++ b/agency/hookify/hookify.compound-bash-warn.md
@@ -7,4 +7,4 @@ exclude_pattern: (git commit -m "\$\(cat <<|PATH=.*\bbash -c\b|2>&1 \||\| head -
 action: warn
 ---
 
-Compound bash detected. Run each command as a single Bash tool call — parallel when independent, sequential when dependent. See claude/REFERENCE-PROVENANCE-HEADERS.md — FEAR THE KITTENS!
+Compound bash detected. Run each command as a single Bash tool call — parallel when independent, sequential when dependent. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.destructive-git-warn.md
+++ b/agency/hookify/hookify.destructive-git-warn.md
@@ -6,4 +6,4 @@ pattern: git\s+(reset\s+--hard|checkout\s+\.|restore\s+\.|clean\s+-f|branch\s+-D
 action: warn
 ---
 
-Destructive git operation — verify the principal explicitly requested this and no work will be lost. See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!
+Destructive git operation — verify the principal explicitly requested this and no work will be lost. See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.enter-worktree-warn.md
+++ b/agency/hookify/hookify.enter-worktree-warn.md
@@ -6,4 +6,4 @@ pattern: EnterWorktree
 action: warn
 ---
 
-Use `/worktree-create` instead of built-in `EnterWorktree`. See claude/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!
+Use `/worktree-create` instead of built-in `EnterWorktree`. See agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.env-files-warn.md
+++ b/agency/hookify/hookify.env-files-warn.md
@@ -8,4 +8,4 @@ conditions:
     pattern: \.env$
 ---
 
-Editing `.env` directly — use `/secret` for secret management. `.env` files should be in `.gitignore`. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+Editing `.env` directly — use `/secret` for secret management. `.env` files should be in `.gitignore`. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.external-git-actions-warn.md
+++ b/agency/hookify/hookify.external-git-actions-warn.md
@@ -6,4 +6,4 @@ pattern: gh\s+(pr\s+create|pr\s+comment|pr\s+close|pr\s+merge|issue\s+create|rel
 action: warn
 ---
 
-External action — this affects GitHub or a remote. Only proceed if the principal explicitly asked. See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!
+External action — this affects GitHub or a remote. Only proceed if the principal explicitly asked. See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.no-verify-block.md
+++ b/agency/hookify/hookify.no-verify-block.md
@@ -6,4 +6,4 @@ pattern: --no-verify
 action: block
 ---
 
-`--no-verify` is blocked. Fix the hook failure, don't skip it. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+`--no-verify` is blocked. Fix the hook failure, don't skip it. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.plan-update-require.md
+++ b/agency/hookify/hookify.plan-update-require.md
@@ -6,4 +6,4 @@ pattern: 'git commit'
 action: warn
 ---
 
-Update the Plan file with this commit — QGR, phase/iteration status, findings. See claude/REFERENCE-DEVELOPMENT-METHODOLOGY.md — FEAR THE KITTENS!
+Update the Plan file with this commit — QGR, phase/iteration status, findings. See agency/REFERENCE/REFERENCE-DEVELOPMENT-METHODOLOGY.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.qgr-require.md
+++ b/agency/hookify/hookify.qgr-require.md
@@ -6,4 +6,4 @@ pattern: 'git commit'
 action: warn
 ---
 
-Ensure a QGR exists for this commit — `/git-safe-commit` checks for a matching receipt. See claude/REFERENCE-QUALITY-GATE.md — FEAR THE KITTENS!
+Ensure a QGR exists for this commit — `/git-safe-commit` checks for a matching receipt. See agency/REFERENCE/REFERENCE-QUALITY-GATE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.raw-git-merge-master-block.md
+++ b/agency/hookify/hookify.raw-git-merge-master-block.md
@@ -6,4 +6,4 @@ pattern: git merge (--\S+\s+)*(origin/)?master
 action: warn
 ---
 
-Use `/worktree-sync` instead of raw `git merge master`. See claude/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!
+Use `/worktree-sync` instead of raw `git merge master`. See agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.script-persistence-warn.md
+++ b/agency/hookify/hookify.script-persistence-warn.md
@@ -14,7 +14,7 @@ Script written outside `tools/` directories. Save reusable scripts to `usr/{prin
 # Written: YYYY-MM-DD during <phase/task>
 ```
 
-Framework tools go to `agency/tools/`. See claude/REFERENCE-PROVENANCE-HEADERS.md.
+Framework tools go to `agency/tools/`. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md.
 
 **Scope limitation:** This rule catches Write tool calls to `.sh`/`.py` files. It does NOT catch heredocs in Bash tool calls, scripts without extensions, or writes to `tmp/`. It is a nudge, not a gate — pair with telemetry for full observability.
 

--- a/agency/hookify/hookify.secrets-warn.md
+++ b/agency/hookify/hookify.secrets-warn.md
@@ -8,4 +8,4 @@ conditions:
     pattern: credentials|secrets|\.pem$|\.key$
 ---
 
-Sensitive file detected — ensure no hardcoded secrets, file is in `.gitignore`, use `/secret` for secret management. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+Sensitive file detected — ensure no hardcoded secrets, file is in `.gitignore`, use `/secret` for secret management. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.system-install-block.md
+++ b/agency/hookify/hookify.system-install-block.md
@@ -6,4 +6,4 @@ pattern: 'brew\s+(install|upgrade)|sudo\s|apt-get\s+install|apt\s+install|yum\s+
 action: block
 ---
 
-System package installation blocked. Report the missing dependency and suggest the command for the principal to run. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+System package installation blocked. Report the missing dependency and suggest the command for the principal to run. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/agency/hookify/hookify.testuser-paths-block.md
+++ b/agency/hookify/hookify.testuser-paths-block.md
@@ -8,6 +8,6 @@ action: block
 
 STOP. You are writing to `usr/testuser/` — this means `AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite into your shell environment. Run `unset AGENCY_PRINCIPAL` and retry. The flag tool (and any tool using `_path-resolve`) will resolve to the wrong principal until this is cleared.
 
-See `claude/REFERENCE-AGENT-ADDRESSING.md` — principal resolution uses `agency.yaml`, not raw env vars.
+See `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md` — principal resolution uses `agency.yaml`, not raw env vars.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/agency/hookify/hookify.whw-header-warn.md
+++ b/agency/hookify/hookify.whw-header-warn.md
@@ -6,6 +6,6 @@ pattern: (\.sh|\.py|\.ts|\.js|\.rs|\.go|\.rb|\.java|\.c|\.cpp|\.h|agency/tools/|
 action: warn
 ---
 
-**WHW header required.** Source code files need a What/How/Why provenance header — "What Problem" (what need drove creation), "How & Why" (approach and reasoning), "Written" (date/context). New files must include one; edits to existing files should keep it current. See claude/REFERENCE-PROVENANCE-HEADERS.md.
+**WHW header required.** Source code files need a What/How/Why provenance header — "What Problem" (what need drove creation), "How & Why" (approach and reasoning), "Written" (date/context). New files must include one; edits to existing files should keep it current. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/agency/templates/CLAUDE-USER.md
+++ b/agency/templates/CLAUDE-USER.md
@@ -10,7 +10,7 @@ Discuss -> Plan Mode (explore + design) -> Review Plan -> Revise -> Review -> Fi
 
 ## Quality Gate (QG)
 
-Quality gates (QGs) run at every commit boundary. The PM agent (`project-manager`) owns the full protocol — see `claude/REFERENCE-QUALITY-GATE.md` for the complete steps and report format. Use `/iteration-complete` at iteration boundaries (scoped QG, auto-commit), `/phase-complete` at phase boundaries (deep QG, full codebase, approval required), `/plan-complete` at project completion. Run `/pre-phase-review` before starting each new phase.
+Quality gates (QGs) run at every commit boundary. The PM agent (`project-manager`) owns the full protocol — see `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` for the complete steps and report format. Use `/iteration-complete` at iteration boundaries (scoped QG, auto-commit), `/phase-complete` at phase boundaries (deep QG, full codebase, approval required), `/plan-complete` at project completion. Run `/pre-phase-review` before starting each new phase.
 
 ## Development Methodology
 
@@ -93,11 +93,11 @@ Run each shell command as a **single, simple command** — no `&&`, `||`, `;`, p
 
 ## Feedback & Bug Reports
 
-When drafting feedback or bug reports, follow the format in `claude/REFERENCE-FEEDBACK-FORMAT.md`. Always include the identity block. Always wait for principal approval before sending.
+When drafting feedback or bug reports, follow the format in `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md`. Always include the identity block. Always wait for principal approval before sending.
 
 ## Code Review
 
-The captain manages code review dispatch via `/captain-review`. Worktree agents handle dispatched findings via `/iteration-complete`. Three review tools serve different purposes: `/code-review` (captain, 7-agent), `/review-pr` (ad-hoc), `/phase-complete` (deep QG with fix cycle). For the full dispatch-handling protocol, see `claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md`.
+The captain manages code review dispatch via `/captain-review`. Worktree agents handle dispatched findings via `/iteration-complete`. Three review tools serve different purposes: `/code-review` (captain, 7-agent), `/review-pr` (ad-hoc), `/phase-complete` (deep QG with fix cycle). For the full dispatch-handling protocol, see `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md`.
 
 ## Session Handoff
 

--- a/agency/templates/YOUR-FIRST-RELEASE.md
+++ b/agency/templates/YOUR-FIRST-RELEASE.md
@@ -240,9 +240,9 @@ The release skill runs `/pr-prep` (quality gate + tests), bumps the version, com
 
 ## Reference
 
-- Safe tools full spec: `claude/REFERENCE-SAFE-TOOLS.md`
+- Safe tools full spec: `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md`
 - Safe tools overview: `agency/README-SAFE-TOOLS.md`
 - Receipt infrastructure: `agency/README-RECEIPT-INFRASTRUCTURE.md`
-- Quality gate protocol: `claude/REFERENCE-QUALITY-GATE.md`
-- Git discipline: `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`
-- Receipt infrastructure: `claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md`
+- Quality gate protocol: `agency/REFERENCE/REFERENCE-QUALITY-GATE.md`
+- Git discipline: `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`
+- Receipt infrastructure: `agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md`

--- a/agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
+++ b/agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
@@ -78,16 +78,16 @@ The rest of The Agency's documentation lives in `claude/`:
 | Topic | Document |
 |-------|----------|
 | Agency bootloader (tools, skills, gates, principles) | `agency/CLAUDE-THEAGENCY.md` |
-| Repo structure | `claude/REFERENCE-REPO-STRUCTURE.md` |
-| Agent & principal addressing | `claude/REFERENCE-AGENT-ADDRESSING.md` |
-| Quality gate protocol | `claude/REFERENCE-QUALITY-GATE.md` |
-| Development methodology (Valueflow, MAR, three-bucket) | `claude/REFERENCE-DEVELOPMENT-METHODOLOGY.md` |
-| Worktree discipline | `claude/REFERENCE-WORKTREE-DISCIPLINE.md` |
-| Handoff spec | `claude/REFERENCE-HANDOFF-SPEC.md` |
-| ISCP protocol | `claude/REFERENCE-ISCP-PROTOCOL.md` |
-| Code review & PR lifecycle | `claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md` |
-| Git discipline (merge, never rebase) | `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` |
-| Safe tools family | `claude/REFERENCE-SAFE-TOOLS.md` |
+| Repo structure | `agency/REFERENCE/REFERENCE-REPO-STRUCTURE.md` |
+| Agent & principal addressing | `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md` |
+| Quality gate protocol | `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` |
+| Development methodology (Valueflow, MAR, three-bucket) | `agency/REFERENCE/REFERENCE-DEVELOPMENT-METHODOLOGY.md` |
+| Worktree discipline | `agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md` |
+| Handoff spec | `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` |
+| ISCP protocol | `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` |
+| Code review & PR lifecycle | `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md` |
+| Git discipline (merge, never rebase) | `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` |
+| Safe tools family | `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md` |
 | Enforcement model | `agency/README-ENFORCEMENT.md` |
 
 Relevant docs are auto-injected when you invoke a skill. Read them directly when you're working outside a skill context.

--- a/agency/templates/principal-v2/captain-handoff.md.template
+++ b/agency/templates/principal-v2/captain-handoff.md.template
@@ -38,7 +38,7 @@ Your ISCP DB is empty for this principal — **no inherited dispatches, no flags
 
 ### Cross-repo collaboration
 
-If {{PRINCIPAL_DISPLAY_NAME}} participates in cross-repo dispatches with other agencies (monofolk, etc.), the `/collaborate` skill is your interface. Check `claude/REFERENCE-ISCP-PROTOCOL.md` for the 4-segment addressing model (`org/repo/principal/agent`). No inbound cross-repo traffic yet — you'll wire that up when there's something to coordinate.
+If {{PRINCIPAL_DISPLAY_NAME}} participates in cross-repo dispatches with other agencies (monofolk, etc.), the `/collaborate` skill is your interface. Check `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` for the 4-segment addressing model (`org/repo/principal/agent`). No inbound cross-repo traffic yet — you'll wire that up when there's something to coordinate.
 
 ### Key skills to remember
 

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-reference-paths-qgr-pr-captain-land-20260813-1124-57fe234.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-reference-paths-qgr-pr-captain-land-20260813-1124-57fe234.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-reference-paths
+diff_base: origin/main
+hash_a: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+hash_b: e2174652f87260fde767a2b973c18c1ed1a9feae147f03c5079a6f817de593ce
+hash_c: e2174652f87260fde767a2b973c18c1ed1a9feae147f03c5079a6f817de593ce
+hash_d: e2174652f87260fde767a2b973c18c1ed1a9feae147f03c5079a6f817de593ce
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: 57fe23470e86427c2036de4134e08b29d12b6c1cbf62a02a6dcc2cc071243d90
+date: 2026-08-13T11:24
+---
+
+# Receipt: pr-captain-land — fix-reference-paths
+
+## Chain of Trust
+- A (original): a31378e
+- B (findings): e217465
+- C (triage): e217465
+- D (principal): e217465 — principal-approved flag passed by captain at land time
+- E (final): 57fe234
+
+## Review Summary
+Local-first landing of fix-reference-paths. Integrated in scratch worktree _land-fix-reference-paths cut from origin/fix-reference-paths; 1 local validation step(s) passed against origin/main; agency_version 46.35 → 46.36. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-reference-path-sweep-qgr-pr-prep-20260813-1057-a31378e.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-reference-path-sweep-qgr-pr-prep-20260813-1057-a31378e.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-reference-path-sweep-qgr-pr-prep-20260813-1057-a31378e.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: reference-path-sweep
+diff_base: origin/main
+hash_a: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+hash_b: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+hash_c: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+hash_d: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+hash_d_source: "auto-approved — captain-authored Great-Rename REFERENCE-path sweep; focused QG review returned CLEAN (0 defects) and flagged incomplete scope, now extended to adopter templates/READMEs. Validation: new required_reading guard + 123 skills tests green; 0 broken active-doc pointers remain; all targets resolve; mirror parity (2 intentional Telemetry-section drifts excluded + documented)."
+hash_e: a31378e75cde6ba2096483e814a74049aa83145b7182e744d46fc9103219b4b3
+date: 2026-08-13T10:57
+---
+
+# Receipt: pr-prep — reference-path-sweep
+
+## Chain of Trust
+- A (original): a31378e
+- B (findings): a31378e
+- C (triage): a31378e
+- D (principal): a31378e — auto-approved — captain-authored Great-Rename REFERENCE-path sweep; focused QG review returned CLEAN (0 defects) and flagged incomplete scope, now extended to adopter templates/READMEs. Validation: new required_reading guard + 123 skills tests green; 0 broken active-doc pointers remain; all targets resolve; mirror parity (2 intentional Telemetry-section drifts excluded + documented).
+- E (final): a31378e
+
+## Review Summary
+flag #213 + full class: fix claude/REFERENCE-* and agency/REFERENCE-* pointers -> agency/REFERENCE/REFERENCE-* across skills/hookify/README/agents/templates (99 files); add required_reading validator; sync 2 stale-src mirrors.

--- a/src/agency/CLAUDE-THEAGENCY.md
+++ b/src/agency/CLAUDE-THEAGENCY.md
@@ -122,7 +122,7 @@ Full content included verbatim below from `agency/CLAUDE-DONT-DO-THIS.md`:
 
 ## Universal Agent Discipline
 
-Every agent — captain, worktree, subagent — follows two standing priorities and the Over / Over-and-out protocol. Full spec: `claude/REFERENCE-AGENT-DISCIPLINE.md` (read on demand).
+Every agent — captain, worktree, subagent — follows two standing priorities and the Over / Over-and-out protocol. Full spec: `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md` (read on demand).
 
 1. **Principal first.** When the principal speaks, stop current work and respond. You give full attention to what they bring.
 2. **Dispatches second.** Read unread dispatches at session start, before other work. An unread dispatch is a blocked person.

--- a/src/agency/README-GETTINGSTARTED.md
+++ b/src/agency/README-GETTINGSTARTED.md
@@ -113,7 +113,7 @@ Narrow permission patterns (the old approach) created friction — every new com
 |-----------|------|---------|
 | `agency/tools/` | CLI tools with logging and telemetry | `dispatch`, `flag`, `handoff`, `git-safe-commit` |
 | `agency/hookify/` | Behavioral rules (warn/block) | `hookify.block-git-safe-commit.md` |
-| `claude/REFERENCE-*.md` | Reference docs (injected on demand) | `REFERENCE-QUALITY-GATE.md`, `REFERENCE-ISCP-PROTOCOL.md` |
+| `agency/REFERENCE/REFERENCE-*.md` | Reference docs (injected on demand) | `REFERENCE-QUALITY-GATE.md`, `REFERENCE-ISCP-PROTOCOL.md` |
 | `agency/agents/` | Agent class definitions | `captain/agent.md`, `tech-lead/agent.md` |
 | `agency/hooks/` | Session lifecycle hooks | `ref-injector.sh` |
 | `agency/config/agency.yaml` | Principal mapping, providers, collaboration repos | configured during init |

--- a/src/agency/README-THEAGENCY.md
+++ b/src/agency/README-THEAGENCY.md
@@ -392,7 +392,7 @@ The 1B1 protocol applies to ALL structured discussions, not just when `/discuss`
 
 When agents encounter issues with Claude Code itself (bugs, missing features, unexpected behavior), they draft structured feedback using a standard format that includes diagnostic evidence, reproduction steps, and root cause analysis when known. The format ensures Anthropic's team can triage quickly.
 
-The key principle: **draft it, then wait for approval.** Agents never send feedback externally without the principal reviewing it first. The full format template is in `claude/REFERENCE-FEEDBACK-FORMAT.md` and gets injected automatically when feedback skills are invoked.
+The key principle: **draft it, then wait for approval.** Agents never send feedback externally without the principal reviewing it first. The full format template is in `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md` and gets injected automatically when feedback skills are invoked.
 
 ## Testing & Quality Discipline
 

--- a/src/agency/README/README-ENFORCEMENT.md
+++ b/src/agency/README/README-ENFORCEMENT.md
@@ -10,7 +10,7 @@ Enforcement in TheAgency operates at **five layers**, from soft to hard:
 
 | Layer | Mechanism | What | Examples |
 |-------|-----------|------|----------|
-| 1. Documentation | Markdown in `claude/REFERENCE-*.md`, `CLAUDE-THEAGENCY.md` | Human and agent readable conventions | Methodology, address format |
+| 1. Documentation | Markdown in `agency/REFERENCE/REFERENCE-*.md`, `CLAUDE-THEAGENCY.md` | Human and agent readable conventions | Methodology, address format |
 | 2. Skills | `.claude/skills/{name}/SKILL.md` | Discoverable invocations of conventions | `/handoff`, `/iteration-complete` |
 | 3. Tools | `agency/tools/{name}` | Mechanical capabilities with logging and telemetry | `dispatch`, `git-safe-commit`, `stage-hash` |
 | 4. Hookify rules | `agency/hookify/hookify.{name}.md` | PreToolUse hooks that block or warn on patterns | `block-git-safe-commit`, `warn-compound-bash` |
@@ -199,7 +199,7 @@ These fire constantly and shape day-to-day agent behavior. Every adopter must un
 
 ## Quality Gates
 
-Quality gates are tiered checkpoints that run at every commit boundary. Each tier has a different scope and time budget. See `claude/REFERENCE-QUALITY-GATE.md` for the full protocol.
+Quality gates are tiered checkpoints that run at every commit boundary. Each tier has a different scope and time budget. See `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` for the full protocol.
 
 | Tier | Boundary | Checks | Time budget | Skill |
 |------|----------|--------|-------------|-------|

--- a/src/agency/README/README-SAFE-TOOLS.md
+++ b/src/agency/README/README-SAFE-TOOLS.md
@@ -58,4 +58,4 @@ Wraps `gh pr merge` with true merge commit enforcement (never squash, never reba
 
 ## Reference
 
-Full subcommand specs, exit codes, and exemption rules: `claude/REFERENCE-SAFE-TOOLS.md`
+Full subcommand specs, exit codes, and exemption rules: `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md`

--- a/src/agency/agents/captain/agent.md
+++ b/src/agency/agents/captain/agent.md
@@ -210,7 +210,7 @@ When you launch me, I'll read the handoff and pick up where we left off.
 - Ask me any question about The Agency
 - Type `/agency-welcome` for the interactive tour
 - Read `CLAUDE.md` for the complete guide
-- Check `claude/REFERENCE-*.md` for detailed documentation
+- Check `agency/REFERENCE/REFERENCE-*.md` for detailed documentation
 
 ## Agency 2.0: Coordination Responsibilities
 

--- a/src/agency/agents/templates/docs/agent.md
+++ b/src/agency/agents/templates/docs/agent.md
@@ -84,4 +84,4 @@ This agent specializes in:
 - `agency/agents/{{AGENT_NAME}}/` - Agent identity
 - `agency/workstreams/{{WORKSTREAM}}/` - Work artifacts
 - `agency/knowledge/documentation-patterns/` - Documentation patterns
-- `claude/REFERENCE-*.md` - Agency documentation
+- `agency/REFERENCE/REFERENCE-*.md` - Agency documentation

--- a/src/agency/hookify/hookify.compound-bash-block.md
+++ b/src/agency/hookify/hookify.compound-bash-block.md
@@ -40,7 +40,7 @@ You wrote a bash command with `&&`, `||`, `;`, `|`, `$(…)`, backticks, or `cd 
 
 - Tool: `agency/tools/run-in` (replacement for the `cd X && cmd` pattern)
 - Skill: `/run-in`
-- Reference: `claude/REFERENCE-PROVENANCE-HEADERS.md`
+- Reference: `agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md`
 - Companion workstream: telemetry analysis of compound command patterns (flag #54) — mines the log of compound command attempts to identify which OTHER patterns deserve their own purpose-built tool
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/agency/hookify/hookify.compound-bash-warn.md
+++ b/src/agency/hookify/hookify.compound-bash-warn.md
@@ -7,4 +7,4 @@ exclude_pattern: (git commit -m "\$\(cat <<|PATH=.*\bbash -c\b|2>&1 \||\| head -
 action: warn
 ---
 
-Compound bash detected. Run each command as a single Bash tool call — parallel when independent, sequential when dependent. See claude/REFERENCE-PROVENANCE-HEADERS.md — FEAR THE KITTENS!
+Compound bash detected. Run each command as a single Bash tool call — parallel when independent, sequential when dependent. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.destructive-git-warn.md
+++ b/src/agency/hookify/hookify.destructive-git-warn.md
@@ -6,4 +6,4 @@ pattern: git\s+(reset\s+--hard|checkout\s+\.|restore\s+\.|clean\s+-f|branch\s+-D
 action: warn
 ---
 
-Destructive git operation — verify the principal explicitly requested this and no work will be lost. See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!
+Destructive git operation — verify the principal explicitly requested this and no work will be lost. See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.enter-worktree-warn.md
+++ b/src/agency/hookify/hookify.enter-worktree-warn.md
@@ -6,4 +6,4 @@ pattern: EnterWorktree
 action: warn
 ---
 
-Use `/worktree-create` instead of built-in `EnterWorktree`. See claude/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!
+Use `/worktree-create` instead of built-in `EnterWorktree`. See agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.env-files-warn.md
+++ b/src/agency/hookify/hookify.env-files-warn.md
@@ -8,4 +8,4 @@ conditions:
     pattern: \.env$
 ---
 
-Editing `.env` directly — use `/secret` for secret management. `.env` files should be in `.gitignore`. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+Editing `.env` directly — use `/secret` for secret management. `.env` files should be in `.gitignore`. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.external-git-actions-warn.md
+++ b/src/agency/hookify/hookify.external-git-actions-warn.md
@@ -6,4 +6,4 @@ pattern: gh\s+(pr\s+create|pr\s+comment|pr\s+close|pr\s+merge|issue\s+create|rel
 action: warn
 ---
 
-External action — this affects GitHub or a remote. Only proceed if the principal explicitly asked. See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!
+External action — this affects GitHub or a remote. Only proceed if the principal explicitly asked. See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.no-verify-block.md
+++ b/src/agency/hookify/hookify.no-verify-block.md
@@ -6,4 +6,4 @@ pattern: --no-verify
 action: block
 ---
 
-`--no-verify` is blocked. Fix the hook failure, don't skip it. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+`--no-verify` is blocked. Fix the hook failure, don't skip it. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.plan-update-require.md
+++ b/src/agency/hookify/hookify.plan-update-require.md
@@ -6,4 +6,4 @@ pattern: 'git commit'
 action: warn
 ---
 
-Update the Plan file with this commit — QGR, phase/iteration status, findings. See claude/REFERENCE-DEVELOPMENT-METHODOLOGY.md — FEAR THE KITTENS!
+Update the Plan file with this commit — QGR, phase/iteration status, findings. See agency/REFERENCE/REFERENCE-DEVELOPMENT-METHODOLOGY.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.qgr-require.md
+++ b/src/agency/hookify/hookify.qgr-require.md
@@ -6,4 +6,4 @@ pattern: 'git commit'
 action: warn
 ---
 
-Ensure a QGR exists for this commit — `/git-safe-commit` checks for a matching receipt. See claude/REFERENCE-QUALITY-GATE.md — FEAR THE KITTENS!
+Ensure a QGR exists for this commit — `/git-safe-commit` checks for a matching receipt. See agency/REFERENCE/REFERENCE-QUALITY-GATE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.raw-git-merge-master-block.md
+++ b/src/agency/hookify/hookify.raw-git-merge-master-block.md
@@ -6,4 +6,4 @@ pattern: git merge (--\S+\s+)*(origin/)?master
 action: warn
 ---
 
-Use `/worktree-sync` instead of raw `git merge master`. See claude/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!
+Use `/worktree-sync` instead of raw `git merge master`. See agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.script-persistence-warn.md
+++ b/src/agency/hookify/hookify.script-persistence-warn.md
@@ -14,7 +14,7 @@ Script written outside `tools/` directories. Save reusable scripts to `usr/{prin
 # Written: YYYY-MM-DD during <phase/task>
 ```
 
-Framework tools go to `agency/tools/`. See claude/REFERENCE-PROVENANCE-HEADERS.md.
+Framework tools go to `agency/tools/`. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md.
 
 **Scope limitation:** This rule catches Write tool calls to `.sh`/`.py` files. It does NOT catch heredocs in Bash tool calls, scripts without extensions, or writes to `tmp/`. It is a nudge, not a gate — pair with telemetry for full observability.
 

--- a/src/agency/hookify/hookify.secrets-warn.md
+++ b/src/agency/hookify/hookify.secrets-warn.md
@@ -8,4 +8,4 @@ conditions:
     pattern: credentials|secrets|\.pem$|\.key$
 ---
 
-Sensitive file detected — ensure no hardcoded secrets, file is in `.gitignore`, use `/secret` for secret management. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+Sensitive file detected — ensure no hardcoded secrets, file is in `.gitignore`, use `/secret` for secret management. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.system-install-block.md
+++ b/src/agency/hookify/hookify.system-install-block.md
@@ -6,4 +6,4 @@ pattern: 'brew\s+(install|upgrade)|sudo\s|apt-get\s+install|apt\s+install|yum\s+
 action: block
 ---
 
-System package installation blocked. Report the missing dependency and suggest the command for the principal to run. See claude/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!
+System package installation blocked. Report the missing dependency and suggest the command for the principal to run. See agency/REFERENCE/REFERENCE-QUALITY-DISCIPLINE.md — FEAR THE KITTENS!

--- a/src/agency/hookify/hookify.testuser-paths-block.md
+++ b/src/agency/hookify/hookify.testuser-paths-block.md
@@ -8,6 +8,6 @@ action: block
 
 STOP. You are writing to `usr/testuser/` — this means `AGENCY_PRINCIPAL=testuser` leaked from the BATS test suite into your shell environment. Run `unset AGENCY_PRINCIPAL` and retry. The flag tool (and any tool using `_path-resolve`) will resolve to the wrong principal until this is cleared.
 
-See `claude/REFERENCE-AGENT-ADDRESSING.md` — principal resolution uses `agency.yaml`, not raw env vars.
+See `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md` — principal resolution uses `agency.yaml`, not raw env vars.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/agency/hookify/hookify.whw-header-warn.md
+++ b/src/agency/hookify/hookify.whw-header-warn.md
@@ -6,6 +6,6 @@ pattern: (\.sh|\.py|\.ts|\.js|\.rs|\.go|\.rb|\.java|\.c|\.cpp|\.h|agency/tools/|
 action: warn
 ---
 
-**WHW header required.** Source code files need a What/How/Why provenance header — "What Problem" (what need drove creation), "How & Why" (approach and reasoning), "Written" (date/context). New files must include one; edits to existing files should keep it current. See claude/REFERENCE-PROVENANCE-HEADERS.md.
+**WHW header required.** Source code files need a What/How/Why provenance header — "What Problem" (what need drove creation), "How & Why" (approach and reasoning), "Written" (date/context). New files must include one; edits to existing files should keep it current. See agency/REFERENCE/REFERENCE-PROVENANCE-HEADERS.md.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/agency/templates/CLAUDE-USER.md
+++ b/src/agency/templates/CLAUDE-USER.md
@@ -10,7 +10,7 @@ Discuss -> Plan Mode (explore + design) -> Review Plan -> Revise -> Review -> Fi
 
 ## Quality Gate (QG)
 
-Quality gates (QGs) run at every commit boundary. The PM agent (`project-manager`) owns the full protocol — see `claude/REFERENCE-QUALITY-GATE.md` for the complete steps and report format. Use `/iteration-complete` at iteration boundaries (scoped QG, auto-commit), `/phase-complete` at phase boundaries (deep QG, full codebase, approval required), `/plan-complete` at project completion. Run `/pre-phase-review` before starting each new phase.
+Quality gates (QGs) run at every commit boundary. The PM agent (`project-manager`) owns the full protocol — see `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` for the complete steps and report format. Use `/iteration-complete` at iteration boundaries (scoped QG, auto-commit), `/phase-complete` at phase boundaries (deep QG, full codebase, approval required), `/plan-complete` at project completion. Run `/pre-phase-review` before starting each new phase.
 
 ## Development Methodology
 
@@ -93,11 +93,11 @@ Run each shell command as a **single, simple command** — no `&&`, `||`, `;`, p
 
 ## Feedback & Bug Reports
 
-When drafting feedback or bug reports, follow the format in `claude/REFERENCE-FEEDBACK-FORMAT.md`. Always include the identity block. Always wait for principal approval before sending.
+When drafting feedback or bug reports, follow the format in `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md`. Always include the identity block. Always wait for principal approval before sending.
 
 ## Code Review
 
-The captain manages code review dispatch via `/captain-review`. Worktree agents handle dispatched findings via `/iteration-complete`. Three review tools serve different purposes: `/code-review` (captain, 7-agent), `/review-pr` (ad-hoc), `/phase-complete` (deep QG with fix cycle). For the full dispatch-handling protocol, see `claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md`.
+The captain manages code review dispatch via `/captain-review`. Worktree agents handle dispatched findings via `/iteration-complete`. Three review tools serve different purposes: `/code-review` (captain, 7-agent), `/review-pr` (ad-hoc), `/phase-complete` (deep QG with fix cycle). For the full dispatch-handling protocol, see `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md`.
 
 ## Session Handoff
 

--- a/src/agency/templates/YOUR-FIRST-RELEASE.md
+++ b/src/agency/templates/YOUR-FIRST-RELEASE.md
@@ -240,9 +240,9 @@ The release skill runs `/pr-prep` (quality gate + tests), bumps the version, com
 
 ## Reference
 
-- Safe tools full spec: `claude/REFERENCE-SAFE-TOOLS.md`
+- Safe tools full spec: `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md`
 - Safe tools overview: `agency/README-SAFE-TOOLS.md`
 - Receipt infrastructure: `agency/README-RECEIPT-INFRASTRUCTURE.md`
-- Quality gate protocol: `claude/REFERENCE-QUALITY-GATE.md`
-- Git discipline: `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`
-- Receipt infrastructure: `claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md`
+- Quality gate protocol: `agency/REFERENCE/REFERENCE-QUALITY-GATE.md`
+- Git discipline: `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`
+- Receipt infrastructure: `agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md`

--- a/src/agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
+++ b/src/agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
@@ -78,16 +78,16 @@ The rest of The Agency's documentation lives in `claude/`:
 | Topic | Document |
 |-------|----------|
 | Agency bootloader (tools, skills, gates, principles) | `agency/CLAUDE-THEAGENCY.md` |
-| Repo structure | `claude/REFERENCE-REPO-STRUCTURE.md` |
-| Agent & principal addressing | `claude/REFERENCE-AGENT-ADDRESSING.md` |
-| Quality gate protocol | `claude/REFERENCE-QUALITY-GATE.md` |
-| Development methodology (Valueflow, MAR, three-bucket) | `claude/REFERENCE-DEVELOPMENT-METHODOLOGY.md` |
-| Worktree discipline | `claude/REFERENCE-WORKTREE-DISCIPLINE.md` |
-| Handoff spec | `claude/REFERENCE-HANDOFF-SPEC.md` |
-| ISCP protocol | `claude/REFERENCE-ISCP-PROTOCOL.md` |
-| Code review & PR lifecycle | `claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md` |
-| Git discipline (merge, never rebase) | `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` |
-| Safe tools family | `claude/REFERENCE-SAFE-TOOLS.md` |
+| Repo structure | `agency/REFERENCE/REFERENCE-REPO-STRUCTURE.md` |
+| Agent & principal addressing | `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md` |
+| Quality gate protocol | `agency/REFERENCE/REFERENCE-QUALITY-GATE.md` |
+| Development methodology (Valueflow, MAR, three-bucket) | `agency/REFERENCE/REFERENCE-DEVELOPMENT-METHODOLOGY.md` |
+| Worktree discipline | `agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md` |
+| Handoff spec | `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` |
+| ISCP protocol | `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` |
+| Code review & PR lifecycle | `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md` |
+| Git discipline (merge, never rebase) | `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` |
+| Safe tools family | `agency/REFERENCE/REFERENCE-SAFE-TOOLS.md` |
 | Enforcement model | `agency/README-ENFORCEMENT.md` |
 
 Relevant docs are auto-injected when you invoke a skill. Read them directly when you're working outside a skill context.

--- a/src/agency/templates/principal-v2/captain-handoff.md.template
+++ b/src/agency/templates/principal-v2/captain-handoff.md.template
@@ -38,7 +38,7 @@ Your ISCP DB is empty for this principal — **no inherited dispatches, no flags
 
 ### Cross-repo collaboration
 
-If {{PRINCIPAL_DISPLAY_NAME}} participates in cross-repo dispatches with other agencies (monofolk, etc.), the `/collaborate` skill is your interface. Check `claude/REFERENCE-ISCP-PROTOCOL.md` for the 4-segment addressing model (`org/repo/principal/agent`). No inbound cross-repo traffic yet — you'll wire that up when there's something to coordinate.
+If {{PRINCIPAL_DISPLAY_NAME}} participates in cross-repo dispatches with other agencies (monofolk, etc.), the `/collaborate` skill is your interface. Check `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` for the 4-segment addressing model (`org/repo/principal/agent`). No inbound cross-repo traffic yet — you'll wire that up when there's something to coordinate.
 
 ### Key skills to remember
 

--- a/src/claude/skills/agency-issue/SKILL.md
+++ b/src/claude/skills/agency-issue/SKILL.md
@@ -70,7 +70,7 @@ Shows the issue body, metadata, and all comments.
 
 ## Issue body format
 
-For consistency, follow the same structure as `/feedback` (per `claude/REFERENCE-FEEDBACK-FORMAT.md`):
+For consistency, follow the same structure as `/feedback` (per `agency/REFERENCE/REFERENCE-FEEDBACK-FORMAT.md`):
 
 - **Problem** — what's broken or missing, who hits it, what the impact is
 - **Steps to Reproduce** — exact commands or sequence (for bugs); use case description (for features)

--- a/src/claude/skills/captain-log/SKILL.md
+++ b/src/claude/skills/captain-log/SKILL.md
@@ -6,7 +6,7 @@ when_to_use: "Capturing the narrative thread of a session as work happens — de
 argument-hint: "[entry text | -c <category> <text> | read [YYYYMMDD] | list | path]"
 paths: []
 required_reading:
-  - agency/REFERENCE-AGENT-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md
 ---
 
 <!--
@@ -38,7 +38,7 @@ The richer the log, the more useful the mining. Log proactively; don't batch.
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
-- `agency/REFERENCE-AGENT-DISCIPLINE.md` — Two Priorities + Over/Over-and-out. The log is a working-session practice; it sits inside the agent-discipline frame.
+- `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md` — Two Priorities + Over/Over-and-out. The log is a working-session practice; it sits inside the agent-discipline frame.
 
 ## Usage
 
@@ -115,7 +115,7 @@ The log is a **side-channel** practice — it never blocks the work. Capture the
 - **Read for a day with no entries**: tool reports "no log for that day" and exits non-zero. Confirm the date or use `list` to see what exists.
 - **Entry text contains shell metacharacters**: quote the argument so the shell passes it intact. Unquoted entries with `&`, `|`, `;`, or `*` will lose content.
 - **Wrong category**: log is append-only — there is no edit-in-place. File a new entry with a correction note, or leave it and move on (the mining step handles noise).
-- **Tool output suggests a bug**: do not fix it here — report it via `/flag` or `/agency-issue` per `agency/REFERENCE-AGENT-DISCIPLINE.md`.
+- **Tool output suggests a bug**: do not fix it here — report it via `/flag` or `/agency-issue` per `agency/REFERENCE/REFERENCE-AGENT-DISCIPLINE.md`.
 
 ## What this does NOT do
 

--- a/src/claude/skills/captain-release/SKILL.md
+++ b/src/claude/skills/captain-release/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain has staged coordination work on a captain-* branch and want
 argument-hint: "[--no-push] [--no-pr] <commit description>"
 paths: []
 required_reading:
-  - agency/REFERENCE-QUALITY-GATE.md
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
 ---
 
 <!--

--- a/src/claude/skills/captain-review/SKILL.md
+++ b/src/claude/skills/captain-review/SKILL.md
@@ -6,8 +6,8 @@ when_to_use: "Captain on master wants to triage the open draft-PR queue — eith
 argument-hint: "[<pr-number> | <project-name> | --all]"
 paths: []
 required_reading:
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-ISCP-PROTOCOL.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md
 ---
 
 <!--
@@ -38,8 +38,8 @@ The boundary is deliberate: this is a captain-side triage pass, not a gate. Boun
 
 Before running, Read the files listed in `required_reading:` frontmatter.
 
-- `agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md` — distinguishes the review tools, PR lifecycle, review/dispatch file conventions.
-- `agency/REFERENCE-ISCP-PROTOCOL.md` — dispatch format, filenames, addressing; this skill emits dispatches.
+- `agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md` — distinguishes the review tools, PR lifecycle, review/dispatch file conventions.
+- `agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md` — dispatch format, filenames, addressing; this skill emits dispatches.
 
 ## Usage
 

--- a/src/claude/skills/captain-sync-all/SKILL.md
+++ b/src/claude/skills/captain-sync-all/SKILL.md
@@ -12,9 +12,9 @@ when_to_use: |
 argument-hint: "(no args)"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-WORKTREE-DISCIPLINE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -120,13 +120,15 @@ For each worktree with commits ahead of master:
 - Ask principal for confirmation.
 - If yes: `git merge <branch> --no-ff`.
 
-### Step 5b: Dispatch main-updated
+### Step 5b: Dispatch master-updated
 
-If any worktree work merged into master in Step 5, dispatch `main-updated` to all agents with worktrees:
+If any worktree work merged into master in Step 5, dispatch `master-updated` to all agents with worktrees:
 
 ```
-./agency/tools/dispatch create --type main-updated --to <repo>/<principal>/<agent> --subject "Main updated — new work merged"
+./agency/tools/dispatch create --type master-updated --to <repo>/<principal>/<agent> --subject "Master updated — new work merged"
 ```
+
+Note: `master-updated` is the canonical dispatch type. Legacy docs may say `main-updated`; the dispatch tool aliases that to `master-updated` for backward compatibility.
 
 Agents see this on their next `iscp-check` / `/session-resume`.
 
@@ -186,7 +188,7 @@ Light update to captain handoff: "what synced, what was merged into master, any 
 - `/sync` — agent-side push skill (different scope entirely)
 - `/worktree-sync` — single-worktree sync (agent-side; this skill calls it across all worktrees)
 - `agency/tools/git-captain` — safe captain-side git operations
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
-- `agency/REFERENCE-WORKTREE-DISCIPLINE.md` — worktree model
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- `agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md` — worktree model
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/claude/skills/captain-sync-all/examples.md
+++ b/src/claude/skills/captain-sync-all/examples.md
@@ -77,7 +77,7 @@ Expected:
 ```
 ABORT: master working tree is dirty (2 uncommitted files).
   Commit or stash before sync:
-    M claude/REFERENCE-X.md
+    M agency/REFERENCE/REFERENCE-X.md
     ?? usr/{principal}/captain/dispatches/new-one.md
 ```
 
@@ -94,12 +94,12 @@ Captain's local master has a coord commit that conflicts with origin/master:
 Expected:
 ```
 ABORT: merge origin/master conflicted:
-  CONFLICT (content): claude/REFERENCE-SKILLS-INDEX.md
+  CONFLICT (content): agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
   
 Resolve manually:
   git status
   # edit conflicted files
-  git-safe add claude/REFERENCE-SKILLS-INDEX.md
+  git-safe add agency/REFERENCE/REFERENCE-SKILLS-INDEX.md
   git-captain merge-continue
   # re-run /captain-sync-all
 ```

--- a/src/claude/skills/compact-prepare/reference.md
+++ b/src/claude/skills/compact-prepare/reference.md
@@ -2,7 +2,7 @@
 
 This skill has no unique protocol beyond what `required_reading` covers in `SKILL.md`. See:
 
-- `agency/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape, `mode: continuation` requirement.
-- `agency/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pause`).
+- `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape, `mode: continuation` requirement.
+- `agency/REFERENCE/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pause`).
 
 MAR R3 note: Step 3.1a in `SKILL.md` is a workaround for the-agency#355 (handoff must force-commit). When #355 lands upstream, that step moves into the `session-pause` tool and this skill drops its Step 1. See `usr/{principal}/captain/session-lifecycle-refactor/plan.md` HG-7.

--- a/src/claude/skills/compact-resume/reference.md
+++ b/src/claude/skills/compact-resume/reference.md
@@ -2,7 +2,7 @@
 
 This skill has no unique protocol beyond what `required_reading` covers in `SKILL.md`. See:
 
-- `agency/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape; `mode: continuation` is what this skill expects to read.
-- `agency/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pickup` per agency#348).
+- `agency/REFERENCE/REFERENCE-HANDOFF-SPEC.md` — handoff frontmatter shape; `mode: continuation` is what this skill expects to read.
+- `agency/REFERENCE/REFERENCE-SKILL-CONVENTIONS.md` — primitive-composition pattern (skill shells to `agency/tools/session-pickup` per agency#348).
 
 Design detail: the `--from compact` mode of session-pickup deliberately skips worktree-sync and full preflight — `/compact` is in-process, master cannot have moved, and the preflight questions (monitor running? tree clean? handoff loaded?) are already answered by the PAUSE + PICKUP flow itself. `/session-resume` is the fresh-session equivalent that runs the full preflight after `/exit`.

--- a/src/claude/skills/iteration-complete/SKILL.md
+++ b/src/claude/skills/iteration-complete/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: "<phase.iter>: <description> [--base <ref>]"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-QUALITY-GATE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--

--- a/src/claude/skills/phase-complete/SKILL.md
+++ b/src/claude/skills/phase-complete/SKILL.md
@@ -7,8 +7,8 @@ argument-hint: "<phase>: <description>"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-QUALITY-GATE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-QUALITY-GATE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
 ---
 
 <!--

--- a/src/claude/skills/post-merge/SKILL.md
+++ b/src/claude/skills/post-merge/SKILL.md
@@ -11,7 +11,7 @@ description: Run after a PR is merged on GitHub. Verifies merge, merges origin i
 
 # Post-Merge
 
-Run after a PR is merged on GitHub. Verifies the merge, merges origin into master, then invokes `/sync-all`. **Never resets master to origin.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+Run after a PR is merged on GitHub. Verifies the merge, merges origin into master, then invokes `/sync-all`. **Never resets master to origin.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ## Arguments
 
@@ -49,7 +49,7 @@ If diverged (both sides > 0 — expected after squash PR merge):
 
 If behind only: `git merge origin/master`
 
-**Never `git reset --hard origin/master`.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+**Never `git reset --hard origin/master`.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 5: Invoke sync-all
 

--- a/src/claude/skills/pr-captain-land/SKILL.md
+++ b/src/claude/skills/pr-captain-land/SKILL.md
@@ -6,10 +6,10 @@ when_to_use: Captain on master in main checkout, after a /pr-submit dispatch fro
 argument-hint: "<agent-branch> [--rehearse] [--dry-run] [--title \"...\"] [--agent <name>] [--no-release] [--principal-approved] [--allow-unvalidated]"
 paths: []
 required_reading:
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - agency/REFERENCE-RECEIPT-INFRASTRUCTURE.md
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--

--- a/src/claude/skills/pr-captain-merge/SKILL.md
+++ b/src/claude/skills/pr-captain-merge/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain on master in main checkout, after PR has passed CI and prin
 argument-hint: "<pr-number> [--principal-approved] [--delete-branch] [--dry-run]"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
-  - agency/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
 ---
 
 <!--
@@ -162,7 +162,7 @@ Defense in depth against accidental invocation from the wrong context:
 - `/pr-captain-post-merge` (TBD refactored to `/pr-captain-post-merge`) — release + fleet-notify after merge
 - `agency/tools/pr-merge` — the underlying safe-merge tool
 - `claude/hookify/hookify.block-raw-gh-pr-merge.md` — hookify rule that blocks bare `gh pr merge`
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the discipline rationale
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the discipline rationale
 - the-agency#296 — PR lifecycle ownership (the-agency direction)
 - the-agency#298 — skill refactor recommendation (the methodology)
 

--- a/src/claude/skills/pr-captain-merge/examples.md
+++ b/src/claude/skills/pr-captain-merge/examples.md
@@ -122,7 +122,7 @@ No flag exists on the skill or the tool to squash or rebase. If an agent tries `
 
 ```
 REFUSED: --squash is not supported. pr-captain-merge always uses true merge commit.
-See claude/REFERENCE-GIT-MERGE-NOT-REBASE.md for rationale.
+See agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md for rationale.
 ```
 
 Exit 2.

--- a/src/claude/skills/pr-captain-post-merge/SKILL.md
+++ b/src/claude/skills/pr-captain-post-merge/SKILL.md
@@ -6,9 +6,9 @@ when_to_use: Captain on master in main checkout, immediately after a PR has merg
 argument-hint: "<pr-number>"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-WORKTREE-DISCIPLINE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-WORKTREE-DISCIPLINE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -202,7 +202,7 @@ Post-merge complete:
 - `/release` (TBD refactored to `/captain-release`) — alternate entry point that runs /pr-captain-merge + this skill in one flow
 - `agency/tools/gh-release` — the release-creation tool
 - `agency/tools/git-captain` — safe captain-side git operations
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — the merge discipline
 - the-agency#296 — PR lifecycle ownership (Phase 1 pilot context)
 - the-agency#315 — V1→V2 migration (this refactor lives under Tier 1)
 

--- a/src/claude/skills/pr-merge/SKILL.md
+++ b/src/claude/skills/pr-merge/SKILL.md
@@ -121,6 +121,6 @@ have to read the same history.
 
 - Tool: `agency/tools/pr-merge`
 - Hookify: `agency/hookify/hookify.block-raw-gh-pr-merge.md` (blocks bare `gh pr merge`)
-- Discipline: `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`
+- Discipline: `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/claude/skills/pr-submit/SKILL.md
+++ b/src/claude/skills/pr-submit/SKILL.md
@@ -7,9 +7,9 @@ argument-hint: "--scope \"one-line PR summary\" [--priority normal|high]"
 paths:
   - .claude/worktrees/**
 required_reading:
-  - claude/REFERENCE-CODE-REVIEW-LIFECYCLE.md
-  - claude/REFERENCE-RECEIPT-INFRASTRUCTURE.md
-  - claude/REFERENCE-ISCP-PROTOCOL.md
+  - agency/REFERENCE/REFERENCE-CODE-REVIEW-LIFECYCLE.md
+  - agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+  - agency/REFERENCE/REFERENCE-ISCP-PROTOCOL.md
 ---
 
 <!--

--- a/src/claude/skills/pr-submit/scripts/README.md
+++ b/src/claude/skills/pr-submit/scripts/README.md
@@ -40,4 +40,4 @@ Multiple preflight checks + hash computation + glob lookup + dispatch emission i
 
 ## Skill-tools versioning
 
-The `scripts/` directory pattern is part of the v2 bundle structure (see `claude/REFERENCE-SKILL-AUTHORING.md` §5). Each skill gets its own `scripts/` namespace; no global `agency/tools/` collision.
+The `scripts/` directory pattern is part of the v2 bundle structure (see `agency/REFERENCE/REFERENCE-SKILL-AUTHORING.md` §5). Each skill gets its own `scripts/` namespace; no global `agency/tools/` collision.

--- a/src/claude/skills/principal-create/SKILL.md
+++ b/src/claude/skills/principal-create/SKILL.md
@@ -130,7 +130,7 @@ principal's captain:
 - Tool: `agency/tools/principal-onboard`
 - Templates: `agency/templates/principal-v2/`
 - Schema: `agency/config/agency.yaml` (`principals:` block)
-- Concept: `agency/REFERENCE-AGENT-ADDRESSING.md`
+- Concept: `agency/REFERENCE/REFERENCE-AGENT-ADDRESSING.md`
 - Worknote: `agency/docs/worknotes/WORKNOTE-principal-tooling.md`
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/claude/skills/rebase/SKILL.md
+++ b/src/claude/skills/rebase/SKILL.md
@@ -13,7 +13,7 @@ description: DEPRECATED — use `git merge <target>` or `/sync` instead. Rebase 
 
 **This skill is deprecated.** All branch synchronization now uses merge, not rebase.
 
-Rebase rewrites history, breaks worktree merge-bases, and caused a fleet-wide data loss incident in a multi-worktree monorepo. See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md` for the full rationale and incident report.
+Rebase rewrites history, breaks worktree merge-bases, and caused a fleet-wide data loss incident in a multi-worktree monorepo. See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` for the full rationale and incident report.
 
 ## Use Instead
 

--- a/src/claude/skills/sync-all/SKILL.md
+++ b/src/claude/skills/sync-all/SKILL.md
@@ -40,7 +40,7 @@ If diverged (squash PR scenario):
 
 If behind only: `git merge origin/master`
 
-**Never `git reset --hard origin/master`. Never `git rebase origin/master`.** See `claude/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
+**Never `git reset --hard origin/master`. Never `git rebase origin/master`.** See `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md`.
 
 ### Step 4: Enumerate worktrees
 
@@ -56,16 +56,18 @@ For each worktree with commits ahead of master:
 - Ask the user if they should be merged
 - If yes: `git merge {branch} --no-ff`
 
-### Step 5b: Dispatch main-updated
+### Step 5b: Dispatch master-updated
 
-If any worktree work was merged in Step 5, dispatch `main-updated` to all agents that have worktrees:
+If any worktree work was merged in Step 5, dispatch `master-updated` to all agents that have worktrees:
 
 For each worktree agent that was synced:
 ```
-./agency/tools/dispatch create --type main-updated --to {repo}/{principal}/{agent} --subject "Main updated — new work merged"
+./agency/tools/dispatch create --type master-updated --to {repo}/{principal}/{agent} --subject "Master updated — new work merged"
 ```
 
-This notifies agents that main has new content. They'll see it on their next `iscp-check`.
+This notifies agents that master has new content. They'll see it on their next `iscp-check`.
+
+Note: `master-updated` is the canonical dispatch type (matches the dispatch tool's VALID_TYPES and DB CHECK constraint). Legacy docs may reference `main-updated` — that is aliased in the dispatch tool for backward compatibility.
 
 ### Step 6: Sync worktrees to master
 

--- a/src/claude/skills/sync/SKILL.md
+++ b/src/claude/skills/sync/SKILL.md
@@ -6,8 +6,8 @@ when_to_use: On any non-master branch (worktree agent branch OR captain-* branch
 argument-hint: "[<target-branch>]"
 paths: []
 required_reading:
-  - agency/REFERENCE-GIT-MERGE-NOT-REBASE.md
-  - agency/REFERENCE-SAFE-TOOLS.md
+  - agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md
+  - agency/REFERENCE/REFERENCE-SAFE-TOOLS.md
 ---
 
 <!--
@@ -139,6 +139,6 @@ Pushing is destructive and requires principal confirmation. This skill is intend
 - `/worktree-sync` — worktree sync (never pushes; local master merge only)
 - `agency/tools/git-push` — underlying authorized push tool
 - `agency/hookify/hookify.block-raw-git-push.md` — blocks raw `git push`
-- `agency/REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
+- `agency/REFERENCE/REFERENCE-GIT-MERGE-NOT-REBASE.md` — merge discipline
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/src/claude/skills/worktree-create/SKILL.md
+++ b/src/claude/skills/worktree-create/SKILL.md
@@ -60,20 +60,40 @@ Parse:
 
 ### Step 1: Validate the name
 
-1. Must be kebab-case: lowercase letters, numbers, and hyphens only.
-2. Check for conflicts:
-   - `git worktree list` — abort if `.claude/worktrees/<name>` already exists
-   - `git show-ref refs/heads/<name>` — abort if branch exists
+1. Kebab-case: letters, numbers, hyphens and underscores. A leading underscore is
+   reserved for machine-created scratch worktrees (`_land-<branch>`, cut and
+   deleted by `/pr-captain-land`) — don't use it for agent worktrees.
+2. Abort if `.claude/worktrees/<name>` already exists (`git worktree list`).
 
-### Step 2: Validate base ref (if provided)
+Do NOT abort merely because a branch of that name exists — an existing branch is
+a normal input, resolved in Step 3.
 
-If `--from <branch>` was specified: `git rev-parse --verify <branch>` — abort if invalid.
-
-### Step 3: Create branch and worktree
+### Step 2: Create the worktree with the tool
 
 ```
-git worktree add .claude/worktrees/<name> -b <name> [<base-ref>]
+./agency/tools/worktree-create <name> [--branch <branch>] [--from <ref>]
+./agency/tools/worktree-create --workstream <ws> --agent <ag> [--branch <branch>] [--from <ref>]
 ```
+
+Never hand-roll `git worktree add` — the tool owns branch resolution, validation
+and bootstrap.
+
+### Step 3: Branch resolution (what the tool does, first match wins)
+
+| Condition | Result |
+|-----------|--------|
+| Local branch `<branch>` exists | Check it out (passing `--from` here is an error) |
+| `--from <ref>` given | New branch at `<ref>`; announced if it shadows a remote branch of the same name |
+| `<remote>/<branch>` exists | New local branch **tracking** it (`origin` wins if several remotes carry it; otherwise ambiguity is refused) |
+| None of the above | New branch from current HEAD |
+
+The remote-tracking case is the stale-PR-revival path: creating a fresh branch
+from HEAD over a branch that already exists on origin hands the agent an empty
+tree and makes their first push a non-fast-forward against their own work.
+
+Remote-tracking refs are only as fresh as the last fetch. Fetch before reviving
+a stale PR branch; the tool prints the resolved commit and its distance from HEAD
+so a stale checkout is never silent.
 
 ### Step 3b: Write .agency-agent identity file
 

--- a/src/tests/skills/skill-validation.bats
+++ b/src/tests/skills/skill-validation.bats
@@ -174,6 +174,47 @@ EXPECTED_SKILL_MIN=50
     fi
 }
 
+@test "skills: required_reading frontmatter paths point to existing files" {
+    # Regression guard for flag #213: 11 skills' required_reading pointed at
+    # pre-Great-Rename paths (agency/REFERENCE-*.md instead of
+    # agency/REFERENCE/REFERENCE-*.md) and rotted silently because nothing
+    # checked them. Every path listed under a required_reading: block must exist.
+    local failures=""
+    for skill_file in "$SKILLS_DIR"/*/SKILL.md; do
+        [ -f "$skill_file" ] || continue
+        local name
+        name=$(basename "$(dirname "$skill_file")")
+        local paths
+        paths=$(SKILL_FILE="$skill_file" python3 -c '
+import os, re
+text = open(os.environ["SKILL_FILE"]).read()
+# List items must be INDENTED (leading whitespace) so the column-0 "---"
+# frontmatter terminator is not mistaken for an entry.
+m = re.search(r"^required_reading:[ \t]*\n((?:[ \t]+-[ \t]*.+\n?)+)", text, re.M)
+out = []
+if m:
+    for line in m.group(1).splitlines():
+        s = line.strip()
+        if s.startswith("-"):
+            p = s[1:].strip().strip("\"").strip("'"'"'")
+            # Real required_reading entries are file paths (have a directory
+            # component); skip anything that is not path-shaped.
+            if p and "/" in p:
+                out.append(p)
+print("\n".join(out))
+' 2>/dev/null)
+        for p in $paths; do
+            if [ ! -f "$REPO_ROOT/$p" ]; then
+                failures="${failures}$name required_reading missing: $p\n"
+            fi
+        done
+    done
+    if [ -n "$failures" ]; then
+        echo -e "$failures" >&2
+        return 1
+    fi
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Ref-injector security
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/skills/skill-validation.bats
+++ b/src/tests/skills/skill-validation.bats
@@ -179,6 +179,9 @@ EXPECTED_SKILL_MIN=50
     # pre-Great-Rename paths (agency/REFERENCE-*.md instead of
     # agency/REFERENCE/REFERENCE-*.md) and rotted silently because nothing
     # checked them. Every path listed under a required_reading: block must exist.
+    # Parser assumes block-style YAML (one "  - path" per line, no trailing
+    # inline comments). Flow-style (required_reading: [a, b]) would be skipped;
+    # no skill uses it today. Broaden the parser if that convention ever changes.
     local failures=""
     for skill_file in "$SKILLS_DIR"/*/SKILL.md; do
         [ -f "$skill_file" ] || continue

--- a/usr/jordan/_land-fix-reference-paths/dispatches/commit-to-captain-committed-255d5795-on-land-fix-reference-paths-cho-20260813-1124.md
+++ b/usr/jordan/_land-fix-reference-paths/dispatches/commit-to-captain-committed-255d5795-on-land-fix-reference-paths-cho-20260813-1124.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-reference-paths
+to: the-agency/jordan/captain
+date: 2026-08-13T03:24
+status: created
+priority: normal
+subject: "Committed 255d5795 on _land-fix-reference-paths: chore(manifest): bump agency_version 46.35 → 46.36 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 255d5795 on _land-fix-reference-paths: chore(manifest): bump agency_version 46.35 → 46.36 for PR landing (captain)
+
+## Commit: 255d5795
+
+**Branch:** _land-fix-reference-paths
+**Agent:** the-agency/jordan/_land-fix-reference-paths
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.35 → 46.36 for PR landing (captain)
+
+### Metadata
+- commit_hash: 255d5795
+- branch: _land-fix-reference-paths
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/fix-reference-paths/dispatches/commit-to-captain-committed-7fd05be0-on-fix-reference-paths-fix-refs-20260813-1057.md
+++ b/usr/jordan/fix-reference-paths/dispatches/commit-to-captain-committed-7fd05be0-on-fix-reference-paths-fix-refs-20260813-1057.md
@@ -1,0 +1,86 @@
+---
+type: commit
+from: the-agency/jordan/fix-reference-paths
+to: the-agency/jordan/captain
+date: 2026-08-13T02:57
+status: created
+priority: normal
+subject: "Committed 7fd05be0 on fix-reference-paths: fix(refs): extend REFERENCE-path sweep to adopter templates + top-level READMEs
+
+Follow-up in the same PR after review found the sweep stopped short of the
+adopter-facing surface: README-GETTINGSTARTED, README-THEAGENCY, templates/
+CLAUDE-USER, YOUR-FIRST-RELEASE, and the principal-v2 CLAUDE-PRINCIPAL +
+captain-handoff templates all still carried pre-Rename claude/REFERENCE-*.md
+pointers. These SHIP to adopters, so leaving them broken was the worst place to
+stop. Fixed; all targets resolve; 0 broken active-doc pointers remain repo-wide.
+
+Also added a parser-limitation note to the new required_reading test.
+
+Pre-existing src-mirror drift LEFT AS-IS (both README-THEAGENCY and
+CLAUDE-THEAGENCY): the running copies carry an internal 'Telemetry-Driven Tool
+Discovery' section (referencing our flotsam seed) that the adopter src/ payload
+deliberately omits — an intentional internal-vs-adopter difference, not rot."
+in_reply_to: null
+---
+
+# Committed 7fd05be0 on fix-reference-paths: fix(refs): extend REFERENCE-path sweep to adopter templates + top-level READMEs
+
+Follow-up in the same PR after review found the sweep stopped short of the
+adopter-facing surface: README-GETTINGSTARTED, README-THEAGENCY, templates/
+CLAUDE-USER, YOUR-FIRST-RELEASE, and the principal-v2 CLAUDE-PRINCIPAL +
+captain-handoff templates all still carried pre-Rename claude/REFERENCE-*.md
+pointers. These SHIP to adopters, so leaving them broken was the worst place to
+stop. Fixed; all targets resolve; 0 broken active-doc pointers remain repo-wide.
+
+Also added a parser-limitation note to the new required_reading test.
+
+Pre-existing src-mirror drift LEFT AS-IS (both README-THEAGENCY and
+CLAUDE-THEAGENCY): the running copies carry an internal 'Telemetry-Driven Tool
+Discovery' section (referencing our flotsam seed) that the adopter src/ payload
+deliberately omits — an intentional internal-vs-adopter difference, not rot.
+
+## Commit: 7fd05be0
+
+**Branch:** fix-reference-paths
+**Agent:** the-agency/jordan/fix-reference-paths
+**Message:** housekeeping/captain: fix(refs): extend REFERENCE-path sweep to adopter templates + top-level READMEs
+
+Follow-up in the same PR after review found the sweep stopped short of the
+adopter-facing surface: README-GETTINGSTARTED, README-THEAGENCY, templates/
+CLAUDE-USER, YOUR-FIRST-RELEASE, and the principal-v2 CLAUDE-PRINCIPAL +
+captain-handoff templates all still carried pre-Rename claude/REFERENCE-*.md
+pointers. These SHIP to adopters, so leaving them broken was the worst place to
+stop. Fixed; all targets resolve; 0 broken active-doc pointers remain repo-wide.
+
+Also added a parser-limitation note to the new required_reading test.
+
+Pre-existing src-mirror drift LEFT AS-IS (both README-THEAGENCY and
+CLAUDE-THEAGENCY): the running copies carry an internal 'Telemetry-Driven Tool
+Discovery' section (referencing our flotsam seed) that the adopter src/ payload
+deliberately omits — an intentional internal-vs-adopter difference, not rot.
+
+### Metadata
+- commit_hash: 7fd05be0
+- branch: fix-reference-paths
+- files_changed: 14
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/README-GETTINGSTARTED.md
+agency/README-THEAGENCY.md
+agency/templates/CLAUDE-USER.md
+agency/templates/YOUR-FIRST-RELEASE.md
+agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
+agency/templates/principal-v2/captain-handoff.md.template
+src/agency/README-GETTINGSTARTED.md
+src/agency/README-THEAGENCY.md
+src/agency/templates/CLAUDE-USER.md
+src/agency/templates/YOUR-FIRST-RELEASE.md
+src/agency/templates/principal-v2/CLAUDE-PRINCIPAL.md.template
+src/agency/templates/principal-v2/captain-handoff.md.template
+src/tests/skills/skill-validation.bats
+usr/jordan/fix-reference-paths/dispatches/commit-to-captain-committed-dd51c370-on-fix-reference-paths-fix-refs-20260813-1049.md
+```

--- a/usr/jordan/fix-reference-paths/dispatches/commit-to-captain-committed-dd51c370-on-fix-reference-paths-fix-refs-20260813-1049.md
+++ b/usr/jordan/fix-reference-paths/dispatches/commit-to-captain-committed-dd51c370-on-fix-reference-paths-fix-refs-20260813-1049.md
@@ -1,0 +1,107 @@
+---
+type: commit
+from: the-agency/jordan/fix-reference-paths
+to: the-agency/jordan/captain
+date: 2026-08-13T02:49
+status: created
+priority: normal
+subject: "Committed dd51c370 on fix-reference-paths: fix(refs): repair Great-Rename REFERENCE-path rot across skills/hookify/README/agents + add validator (flag #213)
+
+Broken doc pointers from the claude/→agency/ Great Rename, in two forms:
+- claude/REFERENCE-X.md  (pre-Rename prefix)
+- agency/REFERENCE-X.md  (missing the /REFERENCE/ subdir)
+both should be agency/REFERENCE/REFERENCE-X.md. These sat in skills'
+required_reading frontmatter (silently breaking ref-following), skill bodies,
+hookify rule guidance, README, and agent docs. Swept all active-doc pointers to
+the correct path; every target now resolves.
+
+Durable guard: new skill-validation test asserts every required_reading path
+exists (this class rotted precisely because nothing checked it).
+
+Also synced 2 pre-existing stale-src mirror drifts found along the way:
+sync-all (main-updated → master-updated) and worktree-create (SKILL.md missing
+the v2.3.0 description from #470). CLAUDE-THEAGENCY's src mirror omits the
+internal Telemetry-Discovery section — LEFT AS-IS (likely intentional
+internal-vs-adopter difference), noted for review.
+
+86 files, +229/-164. Skills suite green (123 tests incl. the new guard)."
+in_reply_to: null
+---
+
+# Committed dd51c370 on fix-reference-paths: fix(refs): repair Great-Rename REFERENCE-path rot across skills/hookify/README/agents + add validator (flag #213)
+
+Broken doc pointers from the claude/→agency/ Great Rename, in two forms:
+- claude/REFERENCE-X.md  (pre-Rename prefix)
+- agency/REFERENCE-X.md  (missing the /REFERENCE/ subdir)
+both should be agency/REFERENCE/REFERENCE-X.md. These sat in skills'
+required_reading frontmatter (silently breaking ref-following), skill bodies,
+hookify rule guidance, README, and agent docs. Swept all active-doc pointers to
+the correct path; every target now resolves.
+
+Durable guard: new skill-validation test asserts every required_reading path
+exists (this class rotted precisely because nothing checked it).
+
+Also synced 2 pre-existing stale-src mirror drifts found along the way:
+sync-all (main-updated → master-updated) and worktree-create (SKILL.md missing
+the v2.3.0 description from #470). CLAUDE-THEAGENCY's src mirror omits the
+internal Telemetry-Discovery section — LEFT AS-IS (likely intentional
+internal-vs-adopter difference), noted for review.
+
+86 files, +229/-164. Skills suite green (123 tests incl. the new guard).
+
+## Commit: dd51c370
+
+**Branch:** fix-reference-paths
+**Agent:** the-agency/jordan/fix-reference-paths
+**Message:** housekeeping/captain: fix(refs): repair Great-Rename REFERENCE-path rot across skills/hookify/README/agents + add validator (flag #213)
+
+Broken doc pointers from the claude/→agency/ Great Rename, in two forms:
+- claude/REFERENCE-X.md  (pre-Rename prefix)
+- agency/REFERENCE-X.md  (missing the /REFERENCE/ subdir)
+both should be agency/REFERENCE/REFERENCE-X.md. These sat in skills'
+required_reading frontmatter (silently breaking ref-following), skill bodies,
+hookify rule guidance, README, and agent docs. Swept all active-doc pointers to
+the correct path; every target now resolves.
+
+Durable guard: new skill-validation test asserts every required_reading path
+exists (this class rotted precisely because nothing checked it).
+
+Also synced 2 pre-existing stale-src mirror drifts found along the way:
+sync-all (main-updated → master-updated) and worktree-create (SKILL.md missing
+the v2.3.0 description from #470). CLAUDE-THEAGENCY's src mirror omits the
+internal Telemetry-Discovery section — LEFT AS-IS (likely intentional
+internal-vs-adopter difference), noted for review.
+
+86 files, +229/-164. Skills suite green (123 tests incl. the new guard).
+
+### Metadata
+- commit_hash: dd51c370
+- branch: fix-reference-paths
+- files_changed: 20
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/agency-issue/SKILL.md
+.claude/skills/captain-log/SKILL.md
+.claude/skills/captain-release/SKILL.md
+.claude/skills/captain-review/SKILL.md
+.claude/skills/captain-sync-all/SKILL.md
+.claude/skills/captain-sync-all/examples.md
+.claude/skills/compact-prepare/reference.md
+.claude/skills/compact-resume/reference.md
+.claude/skills/iteration-complete/SKILL.md
+.claude/skills/phase-complete/SKILL.md
+.claude/skills/post-merge/SKILL.md
+.claude/skills/pr-captain-land/SKILL.md
+.claude/skills/pr-captain-merge/SKILL.md
+.claude/skills/pr-captain-merge/examples.md
+.claude/skills/pr-captain-post-merge/SKILL.md
+.claude/skills/pr-merge/SKILL.md
+.claude/skills/pr-submit/SKILL.md
+.claude/skills/pr-submit/scripts/README.md
+.claude/skills/principal-create/SKILL.md
+.claude/skills/rebase/SKILL.md
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-reference-paths` (untouched; this PR rides `_land-fix-reference-paths`)
- Integrated in a scratch worktree cut from `origin/fix-reference-paths`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-reference-path-sweep-qgr-pr-prep-20260813-1057-a31378e.md` (hash `a31378e`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-reference-paths-qgr-pr-captain-land-20260813-1124-57fe234.md` (hash `57fe234`)
- `agency_version`: 46.35 → 46.36
- Release v46.36 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)