### PR TITLE
fix(agents): repair broken @claude/ imports in agent registrations → @agency/ (flag #246)

### DIFF
--- a/.claude/agents/jordan/captain.md
+++ b/.claude/agents/jordan/captain.md
@@ -4,7 +4,7 @@ description: "Captain — coordination, dispatch routing, quality gates, PR life
 model: opus[1m]
 ---
 
-@claude/agents/captain/agent.md
+@agency/agents/captain/agent.md
 @usr/jordan/captain/CLAUDE-CAPTAIN.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/designex.md
+++ b/.claude/agents/jordan/designex.md
@@ -4,8 +4,8 @@ description: "Design Experience — Figma-to-code pipeline, design tokens, compo
 model: opus
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/designex/CLAUDE-DESIGNEX.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/designex/CLAUDE-DESIGNEX.md
 @usr/jordan/designex/CLAUDE-DESIGNEX.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/devex.md
+++ b/.claude/agents/jordan/devex.md
@@ -4,8 +4,8 @@ description: "DevEx — test infrastructure, commit workflow, permission model, 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/devex/CLAUDE-DEVEX.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/devex/CLAUDE-DEVEX.md
 @usr/jordan/devex/CLAUDE-DEVEX.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/iscp.md
+++ b/.claude/agents/jordan/iscp.md
@@ -4,8 +4,8 @@ description: "ISCP agent — flag, dispatch, and inter-session communication pro
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/iscp/CLAUDE-ISCP.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/iscp/CLAUDE-ISCP.md
 @usr/jordan/iscp/CLAUDE-ISCP.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/mdpal-app.md
+++ b/.claude/agents/jordan/mdpal-app.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Markdown Pal — a macOS native app for 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdpal/CLAUDE-MDPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdpal/CLAUDE-MDPAL.md
 @usr/jordan/mdpal-app/CLAUDE-MDPAL-APP.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/mdpal-cli.md
+++ b/.claude/agents/jordan/mdpal-cli.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Markdown Pal CLI — the section-oriente
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdpal/CLAUDE-MDPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdpal/CLAUDE-MDPAL.md
 @usr/jordan/mdpal-cli/CLAUDE-MDPAL-CLI.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/mdslidepal-mac.md
+++ b/.claude/agents/jordan/mdslidepal-mac.md
@@ -4,8 +4,8 @@ description: "Build mdslidepal-mac — a native macOS slide presentation app usi
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
 @usr/jordan/mdslidepal-mac/CLAUDE-MDSLIDEPAL-MAC.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/mdslidepal-web.md
+++ b/.claude/agents/jordan/mdslidepal-web.md
@@ -4,8 +4,8 @@ description: "Build mdslidepal-web — a markdown-to-slides CLI tool using revea
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
 @usr/jordan/mdslidepal-web/CLAUDE-MDSLIDEPAL-WEB.md
 
 **On startup, immediately do these in order:**

--- a/.claude/agents/jordan/mock-and-mark.md
+++ b/.claude/agents/jordan/mock-and-mark.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Mock and Mark — an iPad-native visual 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
 @usr/jordan/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
 
 **On startup, immediately do these in order:**

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.37",
+  "agency_version": "46.38",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-13T04:21:47Z"
+    "updated_at": "2026-08-13T07:43:06Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-13T04:21:47Z"
+  "updated_at": "2026-08-13T07:43:06Z"
 }

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-agent-imports-qgr-pr-captain-land-20260813-1543-1df9c4d.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-agent-imports-qgr-pr-captain-land-20260813-1543-1df9c4d.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-agent-imports
+diff_base: origin/main
+hash_a: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+hash_b: d84cad3f45fb4d3483a915775b86be3f27bbf0c210432d3df000b25532ff2d30
+hash_c: d84cad3f45fb4d3483a915775b86be3f27bbf0c210432d3df000b25532ff2d30
+hash_d: d84cad3f45fb4d3483a915775b86be3f27bbf0c210432d3df000b25532ff2d30
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: 1df9c4dc6442c42dba653827c7a5def6fb4eeb0a72a74741c7a828fb5539a239
+date: 2026-08-13T15:43
+---
+
+# Receipt: pr-captain-land — fix-agent-imports
+
+## Chain of Trust
+- A (original): 290fb1b
+- B (findings): d84cad3
+- C (triage): d84cad3
+- D (principal): d84cad3 — principal-approved flag passed by captain at land time
+- E (final): 1df9c4d
+
+## Review Summary
+Local-first landing of fix-agent-imports. Integrated in scratch worktree _land-fix-agent-imports cut from origin/fix-agent-imports; 1 local validation step(s) passed against origin/main; agency_version 46.37 → 46.38. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-agent-imports-qgr-pr-prep-20260813-1519-290fb1b.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-agent-imports-qgr-pr-prep-20260813-1519-290fb1b.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-agent-imports-qgr-pr-prep-20260813-1519-290fb1b.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-agent-imports
+diff_base: origin/main
+hash_a: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+hash_b: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+hash_c: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+hash_d: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+hash_d_source: "auto-approved — captain-authored; parallel QG via the newly-registered reviewer-design + reviewer-test agents, both CLEAN (0 blocking defects). Validation: new @claude/-guard test + 15/15 skill-validation green; 0 @claude/ imports remain; mirrors byte-identical; resolvable targets confirmed."
+hash_e: 290fb1b2f4cb5a4c55f20bcae354ba64be6466b69e9feddd7543febd14287417
+date: 2026-08-13T15:19
+---
+
+# Receipt: pr-prep — fix-agent-imports
+
+## Chain of Trust
+- A (original): 290fb1b
+- B (findings): 290fb1b
+- C (triage): 290fb1b
+- D (principal): 290fb1b — auto-approved — captain-authored; parallel QG via the newly-registered reviewer-design + reviewer-test agents, both CLEAN (0 blocking defects). Validation: new @claude/-guard test + 15/15 skill-validation green; 0 @claude/ imports remain; mirrors byte-identical; resolvable targets confirmed.
+- E (final): 290fb1b
+
+## Review Summary
+flag #246: repair broken @claude/ imports in agent registrations -> @agency/ (18 files) + guard test. Content gaps (missing workstream fragments/per-agent docs) flagged #248.

--- a/src/claude/agents/jordan/captain.md
+++ b/src/claude/agents/jordan/captain.md
@@ -4,7 +4,7 @@ description: "Captain — coordination, dispatch routing, quality gates, PR life
 model: opus[1m]
 ---
 
-@claude/agents/captain/agent.md
+@agency/agents/captain/agent.md
 @usr/jordan/captain/CLAUDE-CAPTAIN.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/designex.md
+++ b/src/claude/agents/jordan/designex.md
@@ -4,8 +4,8 @@ description: "Design Experience — Figma-to-code pipeline, design tokens, compo
 model: opus
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/designex/CLAUDE-DESIGNEX.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/designex/CLAUDE-DESIGNEX.md
 @usr/jordan/designex/CLAUDE-DESIGNEX.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/devex.md
+++ b/src/claude/agents/jordan/devex.md
@@ -4,8 +4,8 @@ description: "DevEx — test infrastructure, commit workflow, permission model, 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/devex/CLAUDE-DEVEX.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/devex/CLAUDE-DEVEX.md
 @usr/jordan/devex/CLAUDE-DEVEX.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/iscp.md
+++ b/src/claude/agents/jordan/iscp.md
@@ -4,8 +4,8 @@ description: "ISCP agent — flag, dispatch, and inter-session communication pro
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/iscp/CLAUDE-ISCP.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/iscp/CLAUDE-ISCP.md
 @usr/jordan/iscp/CLAUDE-ISCP.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/mdpal-app.md
+++ b/src/claude/agents/jordan/mdpal-app.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Markdown Pal — a macOS native app for 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdpal/CLAUDE-MDPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdpal/CLAUDE-MDPAL.md
 @usr/jordan/mdpal-app/CLAUDE-MDPAL-APP.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/mdpal-cli.md
+++ b/src/claude/agents/jordan/mdpal-cli.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Markdown Pal CLI — the section-oriente
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdpal/CLAUDE-MDPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdpal/CLAUDE-MDPAL.md
 @usr/jordan/mdpal-cli/CLAUDE-MDPAL-CLI.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/mdslidepal-mac.md
+++ b/src/claude/agents/jordan/mdslidepal-mac.md
@@ -4,8 +4,8 @@ description: "Build mdslidepal-mac — a native macOS slide presentation app usi
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
 @usr/jordan/mdslidepal-mac/CLAUDE-MDSLIDEPAL-MAC.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/mdslidepal-web.md
+++ b/src/claude/agents/jordan/mdslidepal-web.md
@@ -4,8 +4,8 @@ description: "Build mdslidepal-web — a markdown-to-slides CLI tool using revea
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mdslidepal/CLAUDE-MDSLIDEPAL.md
 @usr/jordan/mdslidepal-web/CLAUDE-MDSLIDEPAL-WEB.md
 
 **On startup, immediately do these in order:**

--- a/src/claude/agents/jordan/mock-and-mark.md
+++ b/src/claude/agents/jordan/mock-and-mark.md
@@ -4,8 +4,8 @@ description: "Define, design, and build Mock and Mark — an iPad-native visual 
 model: opus[1m]
 ---
 
-@claude/agents/tech-lead/agent.md
-@claude/workstreams/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
+@agency/agents/tech-lead/agent.md
+@agency/workstreams/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
 @usr/jordan/mock-and-mark/CLAUDE-MOCK-AND-MARK.md
 
 **On startup, immediately do these in order:**

--- a/src/tests/skills/skill-validation.bats
+++ b/src/tests/skills/skill-validation.bats
@@ -242,6 +242,20 @@ print("\n".join(out))
     fi
 }
 
+@test "agents: registrations import via @agency/, never the pre-Rename @claude/" {
+    # Guard for flag #246: agent registrations imported @claude/agents/... and
+    # @claude/workstreams/... but claude/ was renamed to agency/, so every agent
+    # loaded its frontmatter (name/description/model) but NOT its class definition
+    # or workstream context on startup — a silent context degradation.
+    local hits
+    hits=$(grep -rn "@claude/" "$REPO_ROOT/.claude/agents" 2>/dev/null || true)
+    if [ -n "$hits" ]; then
+        echo "agent registrations still import pre-Rename @claude/ paths:" >&2
+        echo "$hits" >&2
+        return 1
+    fi
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Ref-injector security
 # ─────────────────────────────────────────────────────────────────────────────

--- a/usr/jordan/_land-fix-agent-imports/dispatches/commit-to-captain-committed-0c371f41-on-land-fix-agent-imports-chore-20260813-1543.md
+++ b/usr/jordan/_land-fix-agent-imports/dispatches/commit-to-captain-committed-0c371f41-on-land-fix-agent-imports-chore-20260813-1543.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-agent-imports
+to: the-agency/jordan/captain
+date: 2026-08-13T07:43
+status: created
+priority: normal
+subject: "Committed 0c371f41 on _land-fix-agent-imports: chore(manifest): bump agency_version 46.37 → 46.38 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 0c371f41 on _land-fix-agent-imports: chore(manifest): bump agency_version 46.37 → 46.38 for PR landing (captain)
+
+## Commit: 0c371f41
+
+**Branch:** _land-fix-agent-imports
+**Agent:** the-agency/jordan/_land-fix-agent-imports
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.37 → 46.38 for PR landing (captain)
+
+### Metadata
+- commit_hash: 0c371f41
+- branch: _land-fix-agent-imports
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/fix-agent-imports/dispatches/commit-to-captain-committed-43cf658d-on-fix-agent-imports-fix-agents-20260813-1518.md
+++ b/usr/jordan/fix-agent-imports/dispatches/commit-to-captain-committed-43cf658d-on-fix-agent-imports-fix-agents-20260813-1518.md
@@ -1,0 +1,97 @@
+---
+type: commit
+from: the-agency/jordan/fix-agent-imports
+to: the-agency/jordan/captain
+date: 2026-08-13T07:18
+status: created
+priority: normal
+subject: "Committed 43cf658d on fix-agent-imports: fix(agents): repair broken @claude/ imports in agent registrations → @agency/ (flag #246)
+
+Every .claude/agents/jordan/*.md registration (+ src mirrors) imported
+@claude/agents/<class>/agent.md and @claude/workstreams/<ws>/CLAUDE-*.md, but
+claude/ was renamed to agency/ long ago. So agents loaded their frontmatter
+(name/description/model — enough to be an available subagent type) but NOT their
+class definition or workstream context on startup. Silent context degradation
+fleet-wide. Swept @claude/ → @agency/ across 18 files; resolvable targets
+(captain/tech-lead classes, devex/iscp/mdpal/mock-and-mark workstream fragments)
+now load.
+
+Guard test: new skill-validation test asserts no registration imports the
+pre-Rename @claude/ prefix.
+
+Scope: prefix-only. The 2 workstream fragments designex/mdslidepal genuinely
+don't exist, and several @usr/jordan/<agent>/CLAUDE-*.md per-agent docs were
+never created — a content gap, not rename rot, flagged separately (#248)."
+in_reply_to: null
+---
+
+# Committed 43cf658d on fix-agent-imports: fix(agents): repair broken @claude/ imports in agent registrations → @agency/ (flag #246)
+
+Every .claude/agents/jordan/*.md registration (+ src mirrors) imported
+@claude/agents/<class>/agent.md and @claude/workstreams/<ws>/CLAUDE-*.md, but
+claude/ was renamed to agency/ long ago. So agents loaded their frontmatter
+(name/description/model — enough to be an available subagent type) but NOT their
+class definition or workstream context on startup. Silent context degradation
+fleet-wide. Swept @claude/ → @agency/ across 18 files; resolvable targets
+(captain/tech-lead classes, devex/iscp/mdpal/mock-and-mark workstream fragments)
+now load.
+
+Guard test: new skill-validation test asserts no registration imports the
+pre-Rename @claude/ prefix.
+
+Scope: prefix-only. The 2 workstream fragments designex/mdslidepal genuinely
+don't exist, and several @usr/jordan/<agent>/CLAUDE-*.md per-agent docs were
+never created — a content gap, not rename rot, flagged separately (#248).
+
+## Commit: 43cf658d
+
+**Branch:** fix-agent-imports
+**Agent:** the-agency/jordan/fix-agent-imports
+**Message:** housekeeping/captain: fix(agents): repair broken @claude/ imports in agent registrations → @agency/ (flag #246)
+
+Every .claude/agents/jordan/*.md registration (+ src mirrors) imported
+@claude/agents/<class>/agent.md and @claude/workstreams/<ws>/CLAUDE-*.md, but
+claude/ was renamed to agency/ long ago. So agents loaded their frontmatter
+(name/description/model — enough to be an available subagent type) but NOT their
+class definition or workstream context on startup. Silent context degradation
+fleet-wide. Swept @claude/ → @agency/ across 18 files; resolvable targets
+(captain/tech-lead classes, devex/iscp/mdpal/mock-and-mark workstream fragments)
+now load.
+
+Guard test: new skill-validation test asserts no registration imports the
+pre-Rename @claude/ prefix.
+
+Scope: prefix-only. The 2 workstream fragments designex/mdslidepal genuinely
+don't exist, and several @usr/jordan/<agent>/CLAUDE-*.md per-agent docs were
+never created — a content gap, not rename rot, flagged separately (#248).
+
+### Metadata
+- commit_hash: 43cf658d
+- branch: fix-agent-imports
+- files_changed: 19
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/agents/jordan/captain.md
+.claude/agents/jordan/designex.md
+.claude/agents/jordan/devex.md
+.claude/agents/jordan/iscp.md
+.claude/agents/jordan/mdpal-app.md
+.claude/agents/jordan/mdpal-cli.md
+.claude/agents/jordan/mdslidepal-mac.md
+.claude/agents/jordan/mdslidepal-web.md
+.claude/agents/jordan/mock-and-mark.md
+src/claude/agents/jordan/captain.md
+src/claude/agents/jordan/designex.md
+src/claude/agents/jordan/devex.md
+src/claude/agents/jordan/iscp.md
+src/claude/agents/jordan/mdpal-app.md
+src/claude/agents/jordan/mdpal-cli.md
+src/claude/agents/jordan/mdslidepal-mac.md
+src/claude/agents/jordan/mdslidepal-web.md
+src/claude/agents/jordan/mock-and-mark.md
+src/tests/skills/skill-validation.bats
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-agent-imports` (untouched; this PR rides `_land-fix-agent-imports`)
- Integrated in a scratch worktree cut from `origin/fix-agent-imports`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-agent-imports-qgr-pr-prep-20260813-1519-290fb1b.md` (hash `290fb1b`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-agent-imports-qgr-pr-captain-land-20260813-1543-1df9c4d.md` (hash `1df9c4d`)
- `agency_version`: 46.37 → 46.38
- Release v46.38 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)