### PR TITLE
feat(git-captain): cherry-pick + feature-merge subcommands (flag #120/#109) — v1.1.0

### DIFF
--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.38",
+  "agency_version": "46.39",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-13T07:43:06Z"
+    "updated_at": "2026-08-13T08:32:23Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-13T07:43:06Z"
+  "updated_at": "2026-08-13T08:32:23Z"
 }

--- a/agency/tools/git-captain
+++ b/agency/tools/git-captain
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
@@ -55,6 +55,12 @@ Usage: ./agency/tools/git-captain <subcommand> [args...]
 
 Subcommands:
   merge-to-master <branch>       Merge branch into main/master (--no-ff)
+  merge <branch>                 Merge branch into the current FEATURE branch
+                                 (--no-ff). Refuses on the default branch — use
+                                 merge-to-master or the PR flow for that.
+  cherry-pick <commit>...        Apply commit(s) onto the current feature branch.
+                                 --continue / --abort to resume or unwind after
+                                 conflicts. Refuses on the default branch.
   checkout-branch <name>         Create and switch to a new branch
   switch-branch <name>           Switch to an existing branch (including main)
   sync-main                      Fast-forward main to origin/main (requires clean tree, on main)
@@ -105,6 +111,97 @@ cmd_merge_to_master() {
         echo "${GREEN}Merge complete.${NC} $branch merged into $main_branch."
     else
         die "Merge failed — resolve conflicts manually, then commit."
+    fi
+}
+
+# --- Subcommand: merge (feature → feature) ---
+# Merge another branch INTO the current feature branch. merge-to-master handles
+# integration into the default branch; this is the sibling for the common
+# feature-branch-syncs-from-another-feature-branch case that previously forced a
+# raw `git merge` (blocked by hookify).
+cmd_merge() {
+    [[ $# -eq 0 ]] && die "Usage: git-captain merge <branch>  (merge <branch> into the current feature branch)"
+
+    local branch="$1"
+    local current_branch main_branch
+    current_branch=$(git branch --show-current)
+    main_branch=$(detect_main_branch)
+
+    [[ -z "$current_branch" ]] && die "Not on a branch (detached HEAD) — cannot merge."
+
+    # feature→feature only. Integrating INTO the default branch goes through
+    # merge-to-master (which enforces you are on it) or the PR flow — never here.
+    if [[ "$current_branch" == "$main_branch" ]]; then
+        die "On $main_branch — use 'git-captain merge-to-master <branch>' or the PR flow to integrate into the default branch."
+    fi
+
+    if [[ "$branch" == "$current_branch" ]]; then
+        die "Cannot merge '$branch' into itself."
+    fi
+
+    if ! git show-ref --verify "refs/heads/$branch" &>/dev/null; then
+        die "Branch '$branch' does not exist."
+    fi
+
+    echo "${BLUE}Merging $branch into $current_branch (--no-ff)...${NC}"
+    if git merge "$branch" --no-ff --no-edit; then
+        echo "${GREEN}Merge complete.${NC} $branch merged into $current_branch."
+    else
+        die "Merge hit conflicts — resolve, 'git-safe add <files>', then 'git-captain merge-continue'."
+    fi
+}
+
+# --- Subcommand: cherry-pick ---
+# Apply one or more commits onto the current feature branch. The isolate-good-
+# commits-off-a-mixed-branch case (e.g. lifting a fix off a branch that also
+# carries WIP) previously required a raw `git cherry-pick`, which hookify blocks.
+cmd_cherry_pick() {
+    [[ $# -eq 0 ]] && die "Usage: git-captain cherry-pick <commit> [<commit>...]  (or --continue / --abort)"
+
+    # Resume or abort an in-progress cherry-pick.
+    case "$1" in
+        --continue)
+            if git cherry-pick --continue; then
+                echo "${GREEN}Cherry-pick continued.${NC}"
+            else
+                die "cherry-pick --continue failed — resolve conflicts, 'git-safe add <files>', then retry."
+            fi
+            return ;;
+        --abort)
+            if git cherry-pick --abort; then
+                echo "${GREEN}Cherry-pick aborted.${NC}"
+            else
+                die "cherry-pick --abort failed."
+            fi
+            return ;;
+    esac
+
+    local current_branch main_branch
+    current_branch=$(git branch --show-current)
+    main_branch=$(detect_main_branch)
+
+    [[ -z "$current_branch" ]] && die "Not on a branch (detached HEAD) — cherry-pick requires a branch."
+
+    # Refuse onto the default branch — that rewrites shared history outside the
+    # PR flow, the same reason the merge guards refuse it.
+    if [[ "$current_branch" == "$main_branch" ]]; then
+        die "Refusing to cherry-pick onto $main_branch — cherry-pick onto a feature branch, not the default branch."
+    fi
+
+    # Validate every ref before starting, so a typo fails fast instead of
+    # leaving a partially-applied sequence.
+    local c
+    for c in "$@"; do
+        if ! git rev-parse --verify --quiet "$c^{commit}" >/dev/null; then
+            die "Not a valid commit: $c"
+        fi
+    done
+
+    echo "${BLUE}Cherry-picking $# commit(s) onto $current_branch...${NC}"
+    if git cherry-pick "$@"; then
+        echo "${GREEN}Cherry-pick complete.${NC}"
+    else
+        die "Cherry-pick hit conflicts — resolve, 'git-safe add <files>', then 'git-captain cherry-pick --continue' (or --abort)."
     fi
 }
 
@@ -531,6 +628,8 @@ case "$1" in
     --help|-h)          usage ;;
     --version)          echo "git-captain $TOOL_VERSION"; exit 0 ;;
     merge-to-master)    shift; cmd_merge_to_master "$@" ;;
+    merge)              shift; cmd_merge "$@" ;;
+    cherry-pick)        shift; cmd_cherry_pick "$@" ;;
     checkout-branch)    shift; cmd_checkout_branch "$@" ;;
     switch-branch)      shift; cmd_switch_branch "$@" ;;
     sync-main)          shift; cmd_sync_main "$@" ;;

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-git-captain-enhance-qgr-pr-captain-land-20260813-1632-558a383.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-git-captain-enhance-qgr-pr-captain-land-20260813-1632-558a383.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: git-captain-enhance
+diff_base: origin/main
+hash_a: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+hash_b: 59d126fca273b88729fd61e356fe18fda439f6dfb9618ab1bdc7dc4c1a7b8f17
+hash_c: 59d126fca273b88729fd61e356fe18fda439f6dfb9618ab1bdc7dc4c1a7b8f17
+hash_d: 59d126fca273b88729fd61e356fe18fda439f6dfb9618ab1bdc7dc4c1a7b8f17
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: 558a383eda40515c6472e8dfc900f9cf1fb0cf745b9a955892a043d595e3f62a
+date: 2026-08-13T16:32
+---
+
+# Receipt: pr-captain-land — git-captain-enhance
+
+## Chain of Trust
+- A (original): 15be0e9
+- B (findings): 59d126f
+- C (triage): 59d126f
+- D (principal): 59d126f — principal-approved flag passed by captain at land time
+- E (final): 558a383
+
+## Review Summary
+Local-first landing of git-captain-enhance. Integrated in scratch worktree _land-git-captain-enhance cut from origin/git-captain-enhance; 1 local validation step(s) passed against origin/main; agency_version 46.38 → 46.39. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-git-captain-enhance-qgr-pr-prep-20260813-1617-15be0e9.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-git-captain-enhance-qgr-pr-prep-20260813-1617-15be0e9.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-git-captain-enhance-qgr-pr-prep-20260813-1617-15be0e9.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: git-captain-enhance
+diff_base: origin/main
+hash_a: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+hash_b: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+hash_c: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+hash_d: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+hash_d_source: "auto-approved — captain-authored; parallel QG via reviewer-code (CLEAN — guards/quoting/conflict-handling correct) + reviewer-test (coverage gaps addressed with 8 more tests; its 'merge-continue missing' finding was a diff-only false positive, verified). Validation: 79 git-captain bats green; syntax OK; mirror byte-identical."
+hash_e: 15be0e9d2d78674dc8f717b49b96ec2c8644d1bbb8a98cc7baa40e4a6c2cfa97
+date: 2026-08-13T16:17
+---
+
+# Receipt: pr-prep — git-captain-enhance
+
+## Chain of Trust
+- A (original): 15be0e9
+- B (findings): 15be0e9
+- C (triage): 15be0e9
+- D (principal): 15be0e9 — auto-approved — captain-authored; parallel QG via reviewer-code (CLEAN — guards/quoting/conflict-handling correct) + reviewer-test (coverage gaps addressed with 8 more tests; its 'merge-continue missing' finding was a diff-only false positive, verified). Validation: 79 git-captain bats green; syntax OK; mirror byte-identical.
+- E (final): 15be0e9
+
+## Review Summary
+flag #120/#109: git-captain cherry-pick + feature-merge subcommands (v1.1.0) + 18 bats (conflict/continue/abort/detached/multi-commit). #115 already handled by resolve-default-branch.

--- a/src/agency/tools/git-captain
+++ b/src/agency/tools/git-captain
@@ -17,7 +17,7 @@
 
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.1.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
@@ -55,6 +55,12 @@ Usage: ./agency/tools/git-captain <subcommand> [args...]
 
 Subcommands:
   merge-to-master <branch>       Merge branch into main/master (--no-ff)
+  merge <branch>                 Merge branch into the current FEATURE branch
+                                 (--no-ff). Refuses on the default branch — use
+                                 merge-to-master or the PR flow for that.
+  cherry-pick <commit>...        Apply commit(s) onto the current feature branch.
+                                 --continue / --abort to resume or unwind after
+                                 conflicts. Refuses on the default branch.
   checkout-branch <name>         Create and switch to a new branch
   switch-branch <name>           Switch to an existing branch (including main)
   sync-main                      Fast-forward main to origin/main (requires clean tree, on main)
@@ -105,6 +111,97 @@ cmd_merge_to_master() {
         echo "${GREEN}Merge complete.${NC} $branch merged into $main_branch."
     else
         die "Merge failed — resolve conflicts manually, then commit."
+    fi
+}
+
+# --- Subcommand: merge (feature → feature) ---
+# Merge another branch INTO the current feature branch. merge-to-master handles
+# integration into the default branch; this is the sibling for the common
+# feature-branch-syncs-from-another-feature-branch case that previously forced a
+# raw `git merge` (blocked by hookify).
+cmd_merge() {
+    [[ $# -eq 0 ]] && die "Usage: git-captain merge <branch>  (merge <branch> into the current feature branch)"
+
+    local branch="$1"
+    local current_branch main_branch
+    current_branch=$(git branch --show-current)
+    main_branch=$(detect_main_branch)
+
+    [[ -z "$current_branch" ]] && die "Not on a branch (detached HEAD) — cannot merge."
+
+    # feature→feature only. Integrating INTO the default branch goes through
+    # merge-to-master (which enforces you are on it) or the PR flow — never here.
+    if [[ "$current_branch" == "$main_branch" ]]; then
+        die "On $main_branch — use 'git-captain merge-to-master <branch>' or the PR flow to integrate into the default branch."
+    fi
+
+    if [[ "$branch" == "$current_branch" ]]; then
+        die "Cannot merge '$branch' into itself."
+    fi
+
+    if ! git show-ref --verify "refs/heads/$branch" &>/dev/null; then
+        die "Branch '$branch' does not exist."
+    fi
+
+    echo "${BLUE}Merging $branch into $current_branch (--no-ff)...${NC}"
+    if git merge "$branch" --no-ff --no-edit; then
+        echo "${GREEN}Merge complete.${NC} $branch merged into $current_branch."
+    else
+        die "Merge hit conflicts — resolve, 'git-safe add <files>', then 'git-captain merge-continue'."
+    fi
+}
+
+# --- Subcommand: cherry-pick ---
+# Apply one or more commits onto the current feature branch. The isolate-good-
+# commits-off-a-mixed-branch case (e.g. lifting a fix off a branch that also
+# carries WIP) previously required a raw `git cherry-pick`, which hookify blocks.
+cmd_cherry_pick() {
+    [[ $# -eq 0 ]] && die "Usage: git-captain cherry-pick <commit> [<commit>...]  (or --continue / --abort)"
+
+    # Resume or abort an in-progress cherry-pick.
+    case "$1" in
+        --continue)
+            if git cherry-pick --continue; then
+                echo "${GREEN}Cherry-pick continued.${NC}"
+            else
+                die "cherry-pick --continue failed — resolve conflicts, 'git-safe add <files>', then retry."
+            fi
+            return ;;
+        --abort)
+            if git cherry-pick --abort; then
+                echo "${GREEN}Cherry-pick aborted.${NC}"
+            else
+                die "cherry-pick --abort failed."
+            fi
+            return ;;
+    esac
+
+    local current_branch main_branch
+    current_branch=$(git branch --show-current)
+    main_branch=$(detect_main_branch)
+
+    [[ -z "$current_branch" ]] && die "Not on a branch (detached HEAD) — cherry-pick requires a branch."
+
+    # Refuse onto the default branch — that rewrites shared history outside the
+    # PR flow, the same reason the merge guards refuse it.
+    if [[ "$current_branch" == "$main_branch" ]]; then
+        die "Refusing to cherry-pick onto $main_branch — cherry-pick onto a feature branch, not the default branch."
+    fi
+
+    # Validate every ref before starting, so a typo fails fast instead of
+    # leaving a partially-applied sequence.
+    local c
+    for c in "$@"; do
+        if ! git rev-parse --verify --quiet "$c^{commit}" >/dev/null; then
+            die "Not a valid commit: $c"
+        fi
+    done
+
+    echo "${BLUE}Cherry-picking $# commit(s) onto $current_branch...${NC}"
+    if git cherry-pick "$@"; then
+        echo "${GREEN}Cherry-pick complete.${NC}"
+    else
+        die "Cherry-pick hit conflicts — resolve, 'git-safe add <files>', then 'git-captain cherry-pick --continue' (or --abort)."
     fi
 }
 
@@ -531,6 +628,8 @@ case "$1" in
     --help|-h)          usage ;;
     --version)          echo "git-captain $TOOL_VERSION"; exit 0 ;;
     merge-to-master)    shift; cmd_merge_to_master "$@" ;;
+    merge)              shift; cmd_merge "$@" ;;
+    cherry-pick)        shift; cmd_cherry_pick "$@" ;;
     checkout-branch)    shift; cmd_checkout_branch "$@" ;;
     switch-branch)      shift; cmd_switch_branch "$@" ;;
     sync-main)          shift; cmd_sync_main "$@" ;;

--- a/src/tests/tools/git-captain.bats
+++ b/src/tests/tools/git-captain.bats
@@ -18,6 +18,8 @@ setup() {
     git config user.email "test@example.com"
     git config user.name "Test User"
     git config commit.gpgsign false
+    # Non-interactive: cherry-pick --continue must not open an editor.
+    export GIT_EDITOR=true
 
     mkdir -p agency/tools/lib
     cp "${REPO_ROOT}/agency/tools/git-captain" agency/tools/git-captain
@@ -54,6 +56,24 @@ make_feature_branch() {
     git add feature.txt
     git commit -q -m "feature commit on $name"
     git checkout -q main
+}
+
+# Helper: two branches (branch-a, branch-b) that change the SAME line of
+# conflict.txt differently, so merging/cherry-picking one onto the other
+# conflicts. Leaves us checked out on branch-b.
+make_conflicting_branches() {
+    echo "base line" > conflict.txt
+    git add conflict.txt
+    git commit -q -m "add conflict.txt"
+    git checkout -q -b branch-a
+    echo "branch-a line" > conflict.txt
+    git add conflict.txt
+    git commit -q -m "a changes conflict.txt"
+    git checkout -q main
+    git checkout -q -b branch-b
+    echo "branch-b line" > conflict.txt
+    git add conflict.txt
+    git commit -q -m "b changes conflict.txt"
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -750,4 +770,85 @@ make_feature_branch() {
     assert_success
     assert_output_contains "cherry-pick <commit>"
     assert_output_contains "merge <branch>"
+}
+
+@test "merge: refuses on detached HEAD" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_feature_branch source-feat
+    git checkout -q --detach HEAD
+    run ./agency/tools/git-captain merge source-feat
+    assert_failure
+    assert_output_contains "detached HEAD"
+}
+
+@test "merge: conflict leaves a recoverable state and points at merge-continue" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_conflicting_branches                 # on branch-b
+    run ./agency/tools/git-captain merge branch-a
+    assert_failure
+    assert_output_contains "merge-continue"
+    [ -f .git/MERGE_HEAD ]                     # recoverable: merge in progress
+}
+
+@test "cherry-pick: applies multiple commits in order" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b source-feat
+    echo one > one.txt; git add one.txt; git commit -q -m "one"
+    local sha1; sha1=$(git rev-parse HEAD)
+    echo two > two.txt; git add two.txt; git commit -q -m "two"
+    local sha2; sha2=$(git rev-parse HEAD)
+    git checkout -q main
+    git checkout -q -b target-feat
+    run ./agency/tools/git-captain cherry-pick "$sha1" "$sha2"
+    assert_success
+    [ -f one.txt ]
+    [ -f two.txt ]
+}
+
+@test "cherry-pick: refuses on detached HEAD" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b source-feat
+    echo x > x.txt; git add x.txt; git commit -q -m "c"
+    local sha; sha=$(git rev-parse HEAD)
+    git checkout -q --detach HEAD
+    run ./agency/tools/git-captain cherry-pick "$sha"
+    assert_failure
+    assert_output_contains "detached HEAD"
+}
+
+@test "cherry-pick: conflict leaves a recoverable state and points at --continue" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_conflicting_branches                 # on branch-b
+    local sha; sha=$(git rev-parse branch-a)
+    run ./agency/tools/git-captain cherry-pick "$sha"
+    assert_failure
+    assert_output_contains "cherry-pick --continue"
+    [ -f .git/CHERRY_PICK_HEAD ]
+}
+
+@test "cherry-pick: --continue completes after conflict resolution" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_conflicting_branches                 # on branch-b
+    local sha; sha=$(git rev-parse branch-a)
+    ./agency/tools/git-captain cherry-pick "$sha" || true   # conflicts
+    echo "resolved" > conflict.txt
+    git add conflict.txt
+    run ./agency/tools/git-captain cherry-pick --continue
+    assert_success
+    assert_output_contains "continued"
+    [ ! -f .git/CHERRY_PICK_HEAD ]
+}
+
+@test "cherry-pick: --abort restores the pre-cherry-pick state" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_conflicting_branches                 # on branch-b
+    local before; before=$(git rev-parse HEAD)
+    local sha; sha=$(git rev-parse branch-a)
+    ./agency/tools/git-captain cherry-pick "$sha" || true   # conflicts
+    run ./agency/tools/git-captain cherry-pick --abort
+    assert_success
+    [ ! -f .git/CHERRY_PICK_HEAD ]
+    [ "$(git rev-parse HEAD)" = "$before" ]   # HEAD restored
+    run cat conflict.txt
+    assert_output_contains "branch-b line"    # working tree restored
 }

--- a/src/tests/tools/git-captain.bats
+++ b/src/tests/tools/git-captain.bats
@@ -647,3 +647,107 @@ make_feature_branch() {
     assert_success
     assert_output_contains "reset-soft"
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# merge (feature → feature) — flag #109
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "merge: requires a branch argument" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b feat-x
+    run ./agency/tools/git-captain merge
+    assert_failure
+    assert_output_contains "Usage"
+}
+
+@test "merge: merges a feature branch into the current feature branch (--no-ff)" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_feature_branch source-feat      # creates source-feat w/ feature.txt, back on main
+    git checkout -q -b target-feat
+    run ./agency/tools/git-captain merge source-feat
+    assert_success
+    assert_output_contains "Merge complete"
+    [ -f feature.txt ]                   # content from source-feat landed
+    run git log --oneline -1
+    assert_output_contains "Merge"       # --no-ff created a merge commit
+}
+
+@test "merge: refuses on the default branch" {
+    cd "${BATS_TEST_TMPDIR}"
+    make_feature_branch source-feat      # leaves us on main
+    run ./agency/tools/git-captain merge source-feat
+    assert_failure
+    assert_output_contains "merge-to-master"
+}
+
+@test "merge: refuses merging a branch into itself" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b feat-x
+    run ./agency/tools/git-captain merge feat-x
+    assert_failure
+    assert_output_contains "into itself"
+}
+
+@test "merge: refuses a non-existent branch" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b feat-x
+    run ./agency/tools/git-captain merge nope
+    assert_failure
+    assert_output_contains "does not exist"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# cherry-pick — flag #120
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "cherry-pick: requires a commit argument" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b feat-x
+    run ./agency/tools/git-captain cherry-pick
+    assert_failure
+    assert_output_contains "Usage"
+}
+
+@test "cherry-pick: applies a commit onto the current feature branch" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b source-feat
+    echo "picked" > picked.txt
+    git add picked.txt
+    git commit -q -m "commit to pick"
+    local sha
+    sha=$(git rev-parse HEAD)
+    git checkout -q main
+    git checkout -q -b target-feat
+    run ./agency/tools/git-captain cherry-pick "$sha"
+    assert_success
+    assert_output_contains "Cherry-pick complete"
+    [ -f picked.txt ]
+}
+
+@test "cherry-pick: refuses onto the default branch" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b source-feat
+    echo x > x.txt; git add x.txt; git commit -q -m "c"
+    local sha
+    sha=$(git rev-parse HEAD)
+    git checkout -q main
+    run ./agency/tools/git-captain cherry-pick "$sha"
+    assert_failure
+    assert_output_contains "Refusing to cherry-pick onto"
+}
+
+@test "cherry-pick: refuses an invalid commit ref" {
+    cd "${BATS_TEST_TMPDIR}"
+    git checkout -q -b feat-x
+    run ./agency/tools/git-captain cherry-pick deadbeefdeadbeef
+    assert_failure
+    assert_output_contains "Not a valid commit"
+}
+
+@test "git-captain --help mentions merge and cherry-pick" {
+    cd "${BATS_TEST_TMPDIR}"
+    run ./agency/tools/git-captain --help
+    assert_success
+    assert_output_contains "cherry-pick <commit>"
+    assert_output_contains "merge <branch>"
+}

--- a/usr/jordan/_land-git-captain-enhance/dispatches/commit-to-captain-committed-9306f15e-on-land-git-captain-enhance-cho-20260813-1632.md
+++ b/usr/jordan/_land-git-captain-enhance/dispatches/commit-to-captain-committed-9306f15e-on-land-git-captain-enhance-cho-20260813-1632.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-git-captain-enhance
+to: the-agency/jordan/captain
+date: 2026-08-13T08:32
+status: created
+priority: normal
+subject: "Committed 9306f15e on _land-git-captain-enhance: chore(manifest): bump agency_version 46.38 → 46.39 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 9306f15e on _land-git-captain-enhance: chore(manifest): bump agency_version 46.38 → 46.39 for PR landing (captain)
+
+## Commit: 9306f15e
+
+**Branch:** _land-git-captain-enhance
+**Agent:** the-agency/jordan/_land-git-captain-enhance
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.38 → 46.39 for PR landing (captain)
+
+### Metadata
+- commit_hash: 9306f15e
+- branch: _land-git-captain-enhance
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/git-captain-enhance/dispatches/commit-to-captain-committed-b0b4aad0-on-git-captain-enhance-test-git-20260813-1617.md
+++ b/usr/jordan/git-captain-enhance/dispatches/commit-to-captain-committed-b0b4aad0-on-git-captain-enhance-test-git-20260813-1617.md
@@ -1,0 +1,62 @@
+---
+type: commit
+from: the-agency/jordan/git-captain-enhance
+to: the-agency/jordan/captain
+date: 2026-08-13T08:17
+status: created
+priority: normal
+subject: "Committed b0b4aad0 on git-captain-enhance: test(git-captain): add conflict/–-continue/--abort/detached-HEAD/multi-commit coverage (QG)
+
+reviewer-test flagged the risky recovery paths were untested. Added 8 tests:
+merge + cherry-pick conflict (die + recoverable MERGE_HEAD/CHERRY_PICK_HEAD),
+cherry-pick --continue after resolution, --abort restore, detached-HEAD refusal
+(both), multi-commit cherry-pick. 79 tests total, all green. GIT_EDITOR=true in
+setup so cherry-pick --continue stays non-interactive.
+
+(Note: reviewer's 'merge-continue does not exist' finding was a FALSE POSITIVE
+from diff-only review — merge-continue is a pre-existing subcommand; reviewer-code
+independently confirmed the conflict guidance is correct.)"
+in_reply_to: null
+---
+
+# Committed b0b4aad0 on git-captain-enhance: test(git-captain): add conflict/–-continue/--abort/detached-HEAD/multi-commit coverage (QG)
+
+reviewer-test flagged the risky recovery paths were untested. Added 8 tests:
+merge + cherry-pick conflict (die + recoverable MERGE_HEAD/CHERRY_PICK_HEAD),
+cherry-pick --continue after resolution, --abort restore, detached-HEAD refusal
+(both), multi-commit cherry-pick. 79 tests total, all green. GIT_EDITOR=true in
+setup so cherry-pick --continue stays non-interactive.
+
+(Note: reviewer's 'merge-continue does not exist' finding was a FALSE POSITIVE
+from diff-only review — merge-continue is a pre-existing subcommand; reviewer-code
+independently confirmed the conflict guidance is correct.)
+
+## Commit: b0b4aad0
+
+**Branch:** git-captain-enhance
+**Agent:** the-agency/jordan/git-captain-enhance
+**Message:** housekeeping/captain: test(git-captain): add conflict/–-continue/--abort/detached-HEAD/multi-commit coverage (QG)
+
+reviewer-test flagged the risky recovery paths were untested. Added 8 tests:
+merge + cherry-pick conflict (die + recoverable MERGE_HEAD/CHERRY_PICK_HEAD),
+cherry-pick --continue after resolution, --abort restore, detached-HEAD refusal
+(both), multi-commit cherry-pick. 79 tests total, all green. GIT_EDITOR=true in
+setup so cherry-pick --continue stays non-interactive.
+
+(Note: reviewer's 'merge-continue does not exist' finding was a FALSE POSITIVE
+from diff-only review — merge-continue is a pre-existing subcommand; reviewer-code
+independently confirmed the conflict guidance is correct.)
+
+### Metadata
+- commit_hash: b0b4aad0
+- branch: git-captain-enhance
+- files_changed: 2
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+src/tests/tools/git-captain.bats
+usr/jordan/git-captain-enhance/dispatches/commit-to-captain-committed-e67b0c2a-on-git-captain-enhance-feat-git-20260813-1610.md
+```

--- a/usr/jordan/git-captain-enhance/dispatches/commit-to-captain-committed-e67b0c2a-on-git-captain-enhance-feat-git-20260813-1610.md
+++ b/usr/jordan/git-captain-enhance/dispatches/commit-to-captain-committed-e67b0c2a-on-git-captain-enhance-feat-git-20260813-1610.md
@@ -1,0 +1,81 @@
+---
+type: commit
+from: the-agency/jordan/git-captain-enhance
+to: the-agency/jordan/captain
+date: 2026-08-13T08:10
+status: created
+priority: normal
+subject: "Committed e67b0c2a on git-captain-enhance: feat(git-captain): add cherry-pick + feature-merge subcommands (flag #120/#109) — v1.1.0
+
+Two gaps in the captain's safe-git surface that forced raw git (hookify-blocked):
+- 'git-captain merge <branch>': merge a branch INTO the current feature branch
+  (--no-ff). merge-to-master already covered integration into the default branch;
+  this is the feature→feature sibling. Refuses on the default branch, on self,
+  on detached HEAD, and on a non-existent branch.
+- 'git-captain cherry-pick <commit>...': apply commit(s) onto the current feature
+  branch (with --continue/--abort). The isolate-good-commits-off-a-mixed-branch
+  case (hit this session lifting the worktree-create fix off devex). Validates
+  each ref up front, refuses on the default branch / detached HEAD.
+
+10 new bats (71 total, all green). Both --no-ff for visible merge commits.
+
+#115 (detect_main_branch when main is deleted locally) is already handled by the
+resolve-default-branch primitive detect_main_branch delegates to (unions local +
+origin/HEAD + origin/{main,master})."
+in_reply_to: null
+---
+
+# Committed e67b0c2a on git-captain-enhance: feat(git-captain): add cherry-pick + feature-merge subcommands (flag #120/#109) — v1.1.0
+
+Two gaps in the captain's safe-git surface that forced raw git (hookify-blocked):
+- 'git-captain merge <branch>': merge a branch INTO the current feature branch
+  (--no-ff). merge-to-master already covered integration into the default branch;
+  this is the feature→feature sibling. Refuses on the default branch, on self,
+  on detached HEAD, and on a non-existent branch.
+- 'git-captain cherry-pick <commit>...': apply commit(s) onto the current feature
+  branch (with --continue/--abort). The isolate-good-commits-off-a-mixed-branch
+  case (hit this session lifting the worktree-create fix off devex). Validates
+  each ref up front, refuses on the default branch / detached HEAD.
+
+10 new bats (71 total, all green). Both --no-ff for visible merge commits.
+
+#115 (detect_main_branch when main is deleted locally) is already handled by the
+resolve-default-branch primitive detect_main_branch delegates to (unions local +
+origin/HEAD + origin/{main,master}).
+
+## Commit: e67b0c2a
+
+**Branch:** git-captain-enhance
+**Agent:** the-agency/jordan/git-captain-enhance
+**Message:** housekeeping/captain: feat(git-captain): add cherry-pick + feature-merge subcommands (flag #120/#109) — v1.1.0
+
+Two gaps in the captain's safe-git surface that forced raw git (hookify-blocked):
+- 'git-captain merge <branch>': merge a branch INTO the current feature branch
+  (--no-ff). merge-to-master already covered integration into the default branch;
+  this is the feature→feature sibling. Refuses on the default branch, on self,
+  on detached HEAD, and on a non-existent branch.
+- 'git-captain cherry-pick <commit>...': apply commit(s) onto the current feature
+  branch (with --continue/--abort). The isolate-good-commits-off-a-mixed-branch
+  case (hit this session lifting the worktree-create fix off devex). Validates
+  each ref up front, refuses on the default branch / detached HEAD.
+
+10 new bats (71 total, all green). Both --no-ff for visible merge commits.
+
+#115 (detect_main_branch when main is deleted locally) is already handled by the
+resolve-default-branch primitive detect_main_branch delegates to (unions local +
+origin/HEAD + origin/{main,master}).
+
+### Metadata
+- commit_hash: e67b0c2a
+- branch: git-captain-enhance
+- files_changed: 3
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/git-captain
+src/agency/tools/git-captain
+src/tests/tools/git-captain.bats
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `git-captain-enhance` (untouched; this PR rides `_land-git-captain-enhance`)
- Integrated in a scratch worktree cut from `origin/git-captain-enhance`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-git-captain-enhance-qgr-pr-prep-20260813-1617-15be0e9.md` (hash `15be0e9`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-git-captain-enhance-qgr-pr-captain-land-20260813-1632-558a383.md` (hash `558a383`)
- `agency_version`: 46.38 → 46.39
- Release v46.39 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)