### PR TITLE
fix(diff-hash): --working mode so the QG can hash uncommitted work incl. untracked files (flag #207)

### DIFF
--- a/.claude/skills/quality-gate/SKILL.md
+++ b/.claude/skills/quality-gate/SKILL.md
@@ -35,7 +35,7 @@ Parse `--base <ref>` out of `$ARGUMENTS` at the start of Step 0. The remainder i
 2. Run `./agency/tools/skill-verify --quiet`. If it fails, report the missing/invalid skills and stop — the framework is incomplete.
 3. Run `git diff --stat HEAD` and `git status`. If no changed files, report "Nothing to gate — no changes since last commit" and stop.
 4. Collect the list of changed files (staged + unstaged + untracked). This is the review scope.
-5. **Capture Hash A** (original artifact into review): run `./agency/tools/diff-hash --base "$BASE_REF" --json` and capture the full SHA-256 from the JSON output. Record as `HASH_A`. This is the state of the code BEFORE any QG work begins.
+5. **Capture Hash A** (original artifact into review): run `./agency/tools/diff-hash --base "$BASE_REF" --working --json` and capture the full SHA-256 from the JSON output. Record as `HASH_A`. This is the state of the code BEFORE any QG work begins. `--working` hashes BASE vs the working tree so the **uncommitted** artifact under review is seen — without it, `diff-hash` compares BASE..HEAD and is blind to uncommitted work, collapsing Hash A onto whatever was last committed (flag #207).
 
 ## Step 1: Parallel review — Formal agents + own review
 
@@ -168,7 +168,7 @@ After presenting the QGR, sign a receipt via `./agency/tools/receipt-sign`. Rece
 
 ### Capture Hash E (final state)
 
-After Step 8 confirmed everything is clean and all fixes are staged/written to disk, run `./agency/tools/diff-hash --base "$BASE_REF" --json` and capture the full SHA-256 as `HASH_E`. This is the final artifact state — what will be committed.
+After Step 8 confirmed everything is clean and all fixes are staged/written to disk, run `./agency/tools/diff-hash --base "$BASE_REF" --working --json` and capture the full SHA-256 as `HASH_E`. This is the final artifact state — what will be committed. `--working` is essential here (flag #207): the QG signs the receipt BEFORE the caller commits, so a plain `diff-hash` (BASE..HEAD) would be blind to the uncommitted fixes and make Hash E == Hash A. `--working` hashes BASE vs the working tree, and — because a clean post-commit tree makes `git diff BASE` == `git diff BASE..HEAD` — the value is stable across the commit boundary, so `receipt-verify` (which runs on the committed tree) still matches.
 
 ### Parse boundary and metadata
 

--- a/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+++ b/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
@@ -68,8 +68,17 @@ To audit all auto-approvals: grep `agency/workstreams/*/qgr/` for `hash_d_source
 ./agency/tools/diff-hash --base v39.1             # phase start tag
 ./agency/tools/diff-hash --base abc1234           # prior iteration commit
 ./agency/tools/diff-hash --file <path>            # single artifact file hash
+./agency/tools/diff-hash --working                # BASE vs WORKING TREE (uncommitted)
 ./agency/tools/diff-hash --json                   # JSON output with full SHA-256
 ```
+
+**`--working` (flag #207):** by default `diff-hash` compares `BASE..HEAD` — the
+*committed* tip — so it is blind to uncommitted work. The QG signs its receipt
+BEFORE the caller commits, so Hash A and Hash E must be captured with `--working`
+(BASE vs the working tree) to reflect the real artifact under review. This is
+safe for the chain: once the work is committed and the tree is clean, `git diff
+BASE` equals `git diff BASE..HEAD`, so `receipt-verify` (default, run on the
+committed tree) still matches the `--working` hash the QG recorded.
 
 Each receipt records which base was used: `diff_base: origin/main`.
 

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.39",
+  "agency_version": "46.40",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-13T08:32:23Z"
+    "updated_at": "2026-08-13T09:37:32Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-13T08:32:23Z"
+  "updated_at": "2026-08-13T09:37:32Z"
 }

--- a/agency/tools/diff-hash
+++ b/agency/tools/diff-hash
@@ -46,6 +46,7 @@ fi
 BASE="origin/main"
 FILE=""
 JSON=false
+WORKING=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -61,10 +62,21 @@ while [[ $# -gt 0 ]]; do
             JSON=true
             shift
             ;;
+        --working)
+            WORKING=true
+            shift
+            ;;
         --help)
-            echo "Usage: diff-hash [--base <ref>] [--file <path>] [--json]"
+            echo "Usage: diff-hash [--base <ref>] [--file <path>] [--working] [--json]"
             echo "  --base <ref>   Base ref for diff (default: origin/main)"
             echo "  --file <path>  Hash a single file instead of diff"
+            echo "  --working      Hash BASE vs the WORKING TREE (sees staged +"
+            echo "                 unstaged changes), not BASE..HEAD. Use this to"
+            echo "                 hash uncommitted work — e.g. a QG capturing the"
+            echo "                 final state BEFORE the caller commits (flag #207)."
+            echo "                 Consistent across the commit boundary: once the"
+            echo "                 work is committed and the tree is clean, this"
+            echo "                 equals the default BASE..HEAD hash."
             echo "  --json         JSON output with full SHA-256"
             exit 0
             ;;
@@ -104,7 +116,23 @@ else
     # V5 Phase 4 (2026-04-22): src/agency/workstreams/*/qgr + rgr added —
     # Phase 4 src/ split duplicated these to src/ side too; both sides must
     # be excluded for the chicken-and-egg fix to hold.
-    DIFF_OUTPUT=$(git diff "$BASE"..HEAD -- . \
+    #
+    # DIFF_REF selects what "final state" means (flag #207):
+    #   default  BASE..HEAD  — BASE vs the committed tip. Blind to uncommitted
+    #                          work, so a QG that hashes before the caller commits
+    #                          gets a stale hash (Hash E == Hash A).
+    #   --working  BASE      — BASE vs the WORKING TREE (staged + unstaged). Sees
+    #                          uncommitted work. Once that work is committed and
+    #                          the tree is clean, `git diff BASE` == `git diff
+    #                          BASE..HEAD`, so the hash is stable across the commit
+    #                          boundary and receipt-verify (default) still matches.
+    if [[ "$WORKING" == "true" ]]; then
+        DIFF_REF="$BASE"
+    else
+        DIFF_REF="$BASE..HEAD"
+    fi
+
+    DIFF_OUTPUT=$(git diff "$DIFF_REF" -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
         ':(exclude,glob)agency/workstreams/*/rgr/**' \
@@ -117,13 +145,13 @@ else
         2>/dev/null)
 
     if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff between $BASE and HEAD (excluding receipts, dispatches, and handoffs)" >&2
+        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
         exit 1
     fi
 
     FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
-    FILE_COUNT=$(git diff "$BASE"..HEAD --name-only -- . \
+    FILE_COUNT=$(git diff "$DIFF_REF" --name-only -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
         ':(exclude,glob)agency/workstreams/*/rgr/**' \

--- a/agency/tools/diff-hash
+++ b/agency/tools/diff-hash
@@ -70,13 +70,15 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: diff-hash [--base <ref>] [--file <path>] [--working] [--json]"
             echo "  --base <ref>   Base ref for diff (default: origin/main)"
             echo "  --file <path>  Hash a single file instead of diff"
-            echo "  --working      Hash BASE vs the WORKING TREE (sees staged +"
-            echo "                 unstaged changes), not BASE..HEAD. Use this to"
-            echo "                 hash uncommitted work — e.g. a QG capturing the"
+            echo "  --working      Hash BASE vs the WORKING TREE — staged, unstaged,"
+            echo "                 AND untracked new files — not BASE..HEAD. Use this"
+            echo "                 to hash uncommitted work, e.g. a QG capturing the"
             echo "                 final state BEFORE the caller commits (flag #207)."
-            echo "                 Consistent across the commit boundary: once the"
-            echo "                 work is committed and the tree is clean, this"
-            echo "                 equals the default BASE..HEAD hash."
+            echo "                 Untracked files are surfaced via intent-to-add in"
+            echo "                 a throwaway index (real staging state untouched)."
+            echo "                 Consistent across the commit boundary: after the"
+            echo "                 work is committed (git add -A), this equals the"
+            echo "                 default BASE..HEAD hash, so receipt-verify matches."
             echo "  --json         JSON output with full SHA-256"
             exit 0
             ;;
@@ -90,6 +92,10 @@ done
 # Validate mutual exclusion
 if [[ -n "$FILE" && "$BASE" != "origin/main" ]]; then
     echo "Error: --file and --base are mutually exclusive" >&2
+    exit 1
+fi
+if [[ -n "$FILE" && "$WORKING" == "true" ]]; then
+    echo "Error: --file and --working are mutually exclusive (--working is a diff-mode option)" >&2
     exit 1
 fi
 
@@ -121,13 +127,29 @@ else
     #   default  BASE..HEAD  — BASE vs the committed tip. Blind to uncommitted
     #                          work, so a QG that hashes before the caller commits
     #                          gets a stale hash (Hash E == Hash A).
-    #   --working  BASE      — BASE vs the WORKING TREE (staged + unstaged). Sees
-    #                          uncommitted work. Once that work is committed and
-    #                          the tree is clean, `git diff BASE` == `git diff
-    #                          BASE..HEAD`, so the hash is stable across the commit
-    #                          boundary and receipt-verify (default) still matches.
+    #   --working  BASE      — BASE vs the WORKING TREE. Sees uncommitted work.
+    #                          Once committed with a clean tree, `git diff BASE`
+    #                          == `git diff BASE..HEAD`, so the hash is stable
+    #                          across the commit boundary and receipt-verify
+    #                          (default) still matches.
+    #
+    # Untracked files: `git diff <ref>` ignores them, but git-safe-commit runs
+    # `git add -A`, so a QG's NEW files (new tests/fixes) DO get committed. If
+    # --working omitted them, Hash E would undercount and receipt-verify would
+    # later BLOCK a legitimate commit. So in --working mode we mark untracked
+    # files intent-to-add (`git add -N`) so they surface as new-file diffs —
+    # done in a THROWAWAY copy of the index (GIT_INDEX_FILE) so the caller's
+    # real staging state is never mutated.
+    WORKING_TMP_INDEX=""
     if [[ "$WORKING" == "true" ]]; then
         DIFF_REF="$BASE"
+        WORKING_TMP_INDEX=$(mktemp "${TMPDIR:-/tmp}/diff-hash-index.XXXXXX")
+        _GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+        if [[ -n "$_GIT_DIR" && -f "$_GIT_DIR/index" ]]; then
+            cp "$_GIT_DIR/index" "$WORKING_TMP_INDEX"
+        fi
+        export GIT_INDEX_FILE="$WORKING_TMP_INDEX"
+        git add -N -- . >/dev/null 2>&1 || true
     else
         DIFF_REF="$BASE..HEAD"
     fi
@@ -144,13 +166,6 @@ else
         ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null)
 
-    if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
-        exit 1
-    fi
-
-    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
-    SHORT_HASH="${FULL_HASH:0:7}"
     FILE_COUNT=$(git diff "$DIFF_REF" --name-only -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
@@ -162,6 +177,21 @@ else
         ':(exclude,glob)usr/**/*-handoff.md' \
         ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null | wc -l | tr -d ' ')
+
+    # Tear down the throwaway index BEFORE any exit, so the caller's environment
+    # and real index are always left exactly as we found them.
+    if [[ -n "$WORKING_TMP_INDEX" ]]; then
+        unset GIT_INDEX_FILE
+        rm -f "$WORKING_TMP_INDEX"
+    fi
+
+    if [[ -z "$DIFF_OUTPUT" ]]; then
+        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
+        exit 1
+    fi
+
+    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
+    SHORT_HASH="${FULL_HASH:0:7}"
 
     if [[ "$JSON" == "true" ]]; then
         echo "{\"hash\":\"$SHORT_HASH\",\"full_hash\":\"$FULL_HASH\",\"mode\":\"diff\",\"base\":\"$BASE\",\"file_count\":$FILE_COUNT}"

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-qg-hash-order-qgr-pr-captain-land-20260813-1737-b988a60.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-qg-hash-order-qgr-pr-captain-land-20260813-1737-b988a60.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-qg-hash-order
+diff_base: origin/main
+hash_a: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+hash_b: 3ce6199ac547fbd1b0d531441ae381236d44c99a596fb3de2432ffee9879e089
+hash_c: 3ce6199ac547fbd1b0d531441ae381236d44c99a596fb3de2432ffee9879e089
+hash_d: 3ce6199ac547fbd1b0d531441ae381236d44c99a596fb3de2432ffee9879e089
+hash_d_source: "principal-approved flag passed by captain at land time"
+hash_e: b988a607d073d4e88f01f7c7943317c67e8a8172b4332086110e03fc00fde507
+date: 2026-08-13T17:37
+---
+
+# Receipt: pr-captain-land — fix-qg-hash-order
+
+## Chain of Trust
+- A (original): 58a86b3
+- B (findings): 3ce6199
+- C (triage): 3ce6199
+- D (principal): 3ce6199 — principal-approved flag passed by captain at land time
+- E (final): b988a60
+
+## Review Summary
+Local-first landing of fix-qg-hash-order. Integrated in scratch worktree _land-fix-qg-hash-order cut from origin/fix-qg-hash-order; 1 local validation step(s) passed against origin/main; agency_version 46.39 → 46.40. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-qg-hash-order-qgr-pr-prep-20260813-1734-58a86b3.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-qg-hash-order-qgr-pr-prep-20260813-1734-58a86b3.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-qg-hash-order-qgr-pr-prep-20260813-1734-58a86b3.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: qg-hash-order
+diff_base: origin/main
+hash_a: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+hash_b: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+hash_c: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+hash_d: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+hash_d_source: "auto-approved — captain-authored; parallel QG via reviewer-code + reviewer-test. Both found a real defect (untracked files omitted by --working → false receipt BLOCK); FIXED via temp-index intent-to-add (their recommended approach), proven: untracked matches post-commit, real index untouched, worktree-compatible. 20 diff-hash tests green incl. the exact scenario; receipt-sign/verify unaffected."
+hash_e: 58a86b33441bcaa19f4165225121e3d45a67a18819f5a34bc66b4cc99ebe7dff
+date: 2026-08-13T17:34
+---
+
+# Receipt: pr-prep — qg-hash-order
+
+## Chain of Trust
+- A (original): 58a86b3
+- B (findings): 58a86b3
+- C (triage): 58a86b3
+- D (principal): 58a86b3 — auto-approved — captain-authored; parallel QG via reviewer-code + reviewer-test. Both found a real defect (untracked files omitted by --working → false receipt BLOCK); FIXED via temp-index intent-to-add (their recommended approach), proven: untracked matches post-commit, real index untouched, worktree-compatible. 20 diff-hash tests green incl. the exact scenario; receipt-sign/verify unaffected.
+- E (final): 58a86b3
+
+## Review Summary
+flag #207: diff-hash --working (BASE vs working tree incl. untracked via throwaway-index intent-to-add) so the QG hashes uncommitted work; Hash A/E use it. Cross-boundary consistent — receipt-verify (default) still matches.

--- a/src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+++ b/src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
@@ -68,8 +68,17 @@ To audit all auto-approvals: grep `agency/workstreams/*/qgr/` for `hash_d_source
 ./agency/tools/diff-hash --base v39.1             # phase start tag
 ./agency/tools/diff-hash --base abc1234           # prior iteration commit
 ./agency/tools/diff-hash --file <path>            # single artifact file hash
+./agency/tools/diff-hash --working                # BASE vs WORKING TREE (uncommitted)
 ./agency/tools/diff-hash --json                   # JSON output with full SHA-256
 ```
+
+**`--working` (flag #207):** by default `diff-hash` compares `BASE..HEAD` — the
+*committed* tip — so it is blind to uncommitted work. The QG signs its receipt
+BEFORE the caller commits, so Hash A and Hash E must be captured with `--working`
+(BASE vs the working tree) to reflect the real artifact under review. This is
+safe for the chain: once the work is committed and the tree is clean, `git diff
+BASE` equals `git diff BASE..HEAD`, so `receipt-verify` (default, run on the
+committed tree) still matches the `--working` hash the QG recorded.
 
 Each receipt records which base was used: `diff_base: origin/main`.
 

--- a/src/agency/tools/diff-hash
+++ b/src/agency/tools/diff-hash
@@ -46,6 +46,7 @@ fi
 BASE="origin/main"
 FILE=""
 JSON=false
+WORKING=false
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -61,10 +62,21 @@ while [[ $# -gt 0 ]]; do
             JSON=true
             shift
             ;;
+        --working)
+            WORKING=true
+            shift
+            ;;
         --help)
-            echo "Usage: diff-hash [--base <ref>] [--file <path>] [--json]"
+            echo "Usage: diff-hash [--base <ref>] [--file <path>] [--working] [--json]"
             echo "  --base <ref>   Base ref for diff (default: origin/main)"
             echo "  --file <path>  Hash a single file instead of diff"
+            echo "  --working      Hash BASE vs the WORKING TREE (sees staged +"
+            echo "                 unstaged changes), not BASE..HEAD. Use this to"
+            echo "                 hash uncommitted work — e.g. a QG capturing the"
+            echo "                 final state BEFORE the caller commits (flag #207)."
+            echo "                 Consistent across the commit boundary: once the"
+            echo "                 work is committed and the tree is clean, this"
+            echo "                 equals the default BASE..HEAD hash."
             echo "  --json         JSON output with full SHA-256"
             exit 0
             ;;
@@ -104,7 +116,23 @@ else
     # V5 Phase 4 (2026-04-22): src/agency/workstreams/*/qgr + rgr added —
     # Phase 4 src/ split duplicated these to src/ side too; both sides must
     # be excluded for the chicken-and-egg fix to hold.
-    DIFF_OUTPUT=$(git diff "$BASE"..HEAD -- . \
+    #
+    # DIFF_REF selects what "final state" means (flag #207):
+    #   default  BASE..HEAD  — BASE vs the committed tip. Blind to uncommitted
+    #                          work, so a QG that hashes before the caller commits
+    #                          gets a stale hash (Hash E == Hash A).
+    #   --working  BASE      — BASE vs the WORKING TREE (staged + unstaged). Sees
+    #                          uncommitted work. Once that work is committed and
+    #                          the tree is clean, `git diff BASE` == `git diff
+    #                          BASE..HEAD`, so the hash is stable across the commit
+    #                          boundary and receipt-verify (default) still matches.
+    if [[ "$WORKING" == "true" ]]; then
+        DIFF_REF="$BASE"
+    else
+        DIFF_REF="$BASE..HEAD"
+    fi
+
+    DIFF_OUTPUT=$(git diff "$DIFF_REF" -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
         ':(exclude,glob)agency/workstreams/*/rgr/**' \
@@ -117,13 +145,13 @@ else
         2>/dev/null)
 
     if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff between $BASE and HEAD (excluding receipts, dispatches, and handoffs)" >&2
+        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
         exit 1
     fi
 
     FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
-    FILE_COUNT=$(git diff "$BASE"..HEAD --name-only -- . \
+    FILE_COUNT=$(git diff "$DIFF_REF" --name-only -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
         ':(exclude,glob)agency/workstreams/*/rgr/**' \

--- a/src/agency/tools/diff-hash
+++ b/src/agency/tools/diff-hash
@@ -70,13 +70,15 @@ while [[ $# -gt 0 ]]; do
             echo "Usage: diff-hash [--base <ref>] [--file <path>] [--working] [--json]"
             echo "  --base <ref>   Base ref for diff (default: origin/main)"
             echo "  --file <path>  Hash a single file instead of diff"
-            echo "  --working      Hash BASE vs the WORKING TREE (sees staged +"
-            echo "                 unstaged changes), not BASE..HEAD. Use this to"
-            echo "                 hash uncommitted work — e.g. a QG capturing the"
+            echo "  --working      Hash BASE vs the WORKING TREE — staged, unstaged,"
+            echo "                 AND untracked new files — not BASE..HEAD. Use this"
+            echo "                 to hash uncommitted work, e.g. a QG capturing the"
             echo "                 final state BEFORE the caller commits (flag #207)."
-            echo "                 Consistent across the commit boundary: once the"
-            echo "                 work is committed and the tree is clean, this"
-            echo "                 equals the default BASE..HEAD hash."
+            echo "                 Untracked files are surfaced via intent-to-add in"
+            echo "                 a throwaway index (real staging state untouched)."
+            echo "                 Consistent across the commit boundary: after the"
+            echo "                 work is committed (git add -A), this equals the"
+            echo "                 default BASE..HEAD hash, so receipt-verify matches."
             echo "  --json         JSON output with full SHA-256"
             exit 0
             ;;
@@ -90,6 +92,10 @@ done
 # Validate mutual exclusion
 if [[ -n "$FILE" && "$BASE" != "origin/main" ]]; then
     echo "Error: --file and --base are mutually exclusive" >&2
+    exit 1
+fi
+if [[ -n "$FILE" && "$WORKING" == "true" ]]; then
+    echo "Error: --file and --working are mutually exclusive (--working is a diff-mode option)" >&2
     exit 1
 fi
 
@@ -121,13 +127,29 @@ else
     #   default  BASE..HEAD  — BASE vs the committed tip. Blind to uncommitted
     #                          work, so a QG that hashes before the caller commits
     #                          gets a stale hash (Hash E == Hash A).
-    #   --working  BASE      — BASE vs the WORKING TREE (staged + unstaged). Sees
-    #                          uncommitted work. Once that work is committed and
-    #                          the tree is clean, `git diff BASE` == `git diff
-    #                          BASE..HEAD`, so the hash is stable across the commit
-    #                          boundary and receipt-verify (default) still matches.
+    #   --working  BASE      — BASE vs the WORKING TREE. Sees uncommitted work.
+    #                          Once committed with a clean tree, `git diff BASE`
+    #                          == `git diff BASE..HEAD`, so the hash is stable
+    #                          across the commit boundary and receipt-verify
+    #                          (default) still matches.
+    #
+    # Untracked files: `git diff <ref>` ignores them, but git-safe-commit runs
+    # `git add -A`, so a QG's NEW files (new tests/fixes) DO get committed. If
+    # --working omitted them, Hash E would undercount and receipt-verify would
+    # later BLOCK a legitimate commit. So in --working mode we mark untracked
+    # files intent-to-add (`git add -N`) so they surface as new-file diffs —
+    # done in a THROWAWAY copy of the index (GIT_INDEX_FILE) so the caller's
+    # real staging state is never mutated.
+    WORKING_TMP_INDEX=""
     if [[ "$WORKING" == "true" ]]; then
         DIFF_REF="$BASE"
+        WORKING_TMP_INDEX=$(mktemp "${TMPDIR:-/tmp}/diff-hash-index.XXXXXX")
+        _GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+        if [[ -n "$_GIT_DIR" && -f "$_GIT_DIR/index" ]]; then
+            cp "$_GIT_DIR/index" "$WORKING_TMP_INDEX"
+        fi
+        export GIT_INDEX_FILE="$WORKING_TMP_INDEX"
+        git add -N -- . >/dev/null 2>&1 || true
     else
         DIFF_REF="$BASE..HEAD"
     fi
@@ -144,13 +166,6 @@ else
         ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null)
 
-    if [[ -z "$DIFF_OUTPUT" ]]; then
-        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
-        exit 1
-    fi
-
-    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
-    SHORT_HASH="${FULL_HASH:0:7}"
     FILE_COUNT=$(git diff "$DIFF_REF" --name-only -- . \
         ':(exclude)agency/receipts/' \
         ':(exclude,glob)agency/workstreams/*/qgr/**' \
@@ -162,6 +177,21 @@ else
         ':(exclude,glob)usr/**/*-handoff.md' \
         ':(exclude,glob)usr/**/handoff-*.md' \
         2>/dev/null | wc -l | tr -d ' ')
+
+    # Tear down the throwaway index BEFORE any exit, so the caller's environment
+    # and real index are always left exactly as we found them.
+    if [[ -n "$WORKING_TMP_INDEX" ]]; then
+        unset GIT_INDEX_FILE
+        rm -f "$WORKING_TMP_INDEX"
+    fi
+
+    if [[ -z "$DIFF_OUTPUT" ]]; then
+        echo "Error: no diff for $DIFF_REF (excluding receipts, dispatches, and handoffs)" >&2
+        exit 1
+    fi
+
+    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
+    SHORT_HASH="${FULL_HASH:0:7}"
 
     if [[ "$JSON" == "true" ]]; then
         echo "{\"hash\":\"$SHORT_HASH\",\"full_hash\":\"$FULL_HASH\",\"mode\":\"diff\",\"base\":\"$BASE\",\"file_count\":$FILE_COUNT}"

--- a/src/claude/skills/quality-gate/SKILL.md
+++ b/src/claude/skills/quality-gate/SKILL.md
@@ -35,7 +35,7 @@ Parse `--base <ref>` out of `$ARGUMENTS` at the start of Step 0. The remainder i
 2. Run `./agency/tools/skill-verify --quiet`. If it fails, report the missing/invalid skills and stop — the framework is incomplete.
 3. Run `git diff --stat HEAD` and `git status`. If no changed files, report "Nothing to gate — no changes since last commit" and stop.
 4. Collect the list of changed files (staged + unstaged + untracked). This is the review scope.
-5. **Capture Hash A** (original artifact into review): run `./agency/tools/diff-hash --base "$BASE_REF" --json` and capture the full SHA-256 from the JSON output. Record as `HASH_A`. This is the state of the code BEFORE any QG work begins.
+5. **Capture Hash A** (original artifact into review): run `./agency/tools/diff-hash --base "$BASE_REF" --working --json` and capture the full SHA-256 from the JSON output. Record as `HASH_A`. This is the state of the code BEFORE any QG work begins. `--working` hashes BASE vs the working tree so the **uncommitted** artifact under review is seen — without it, `diff-hash` compares BASE..HEAD and is blind to uncommitted work, collapsing Hash A onto whatever was last committed (flag #207).
 
 ## Step 1: Parallel review — Formal agents + own review
 
@@ -168,7 +168,7 @@ After presenting the QGR, sign a receipt via `./agency/tools/receipt-sign`. Rece
 
 ### Capture Hash E (final state)
 
-After Step 8 confirmed everything is clean and all fixes are staged/written to disk, run `./agency/tools/diff-hash --base "$BASE_REF" --json` and capture the full SHA-256 as `HASH_E`. This is the final artifact state — what will be committed.
+After Step 8 confirmed everything is clean and all fixes are staged/written to disk, run `./agency/tools/diff-hash --base "$BASE_REF" --working --json` and capture the full SHA-256 as `HASH_E`. This is the final artifact state — what will be committed. `--working` is essential here (flag #207): the QG signs the receipt BEFORE the caller commits, so a plain `diff-hash` (BASE..HEAD) would be blind to the uncommitted fixes and make Hash E == Hash A. `--working` hashes BASE vs the working tree, and — because a clean post-commit tree makes `git diff BASE` == `git diff BASE..HEAD` — the value is stable across the commit boundary, so `receipt-verify` (which runs on the committed tree) still matches.
 
 ### Parse boundary and metadata
 

--- a/src/tests/tools/diff-hash.bats
+++ b/src/tests/tools/diff-hash.bats
@@ -228,3 +228,36 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" =~ ^[a-f0-9]{7}$ ]]
 }
+
+@test "diff-hash: --working includes an UNTRACKED-unstaged new file (matches post-commit, #207)" {
+    # The load-bearing case: a QG writes a new test/fix file and does NOT stage
+    # it; git-safe-commit's `git add -A` then commits it. --working must include
+    # it (via intent-to-add) so Hash E matches the post-commit hash — otherwise
+    # receipt-verify BLOCKS a legitimate commit.
+    cd "$TEST_REPO"
+    echo "uncommitted new" > brand_new.txt      # UNTRACKED, unstaged
+    local working_pre
+    working_pre=$(bash "$DIFF_HASH" --base main --working)
+    git add -A                                   # what git-safe-commit does
+    git commit -q -m "commit incl. new file" --no-verify
+    local default_post
+    default_post=$(bash "$DIFF_HASH" --base main)
+    [ "$working_pre" = "$default_post" ]
+}
+
+@test "diff-hash: --working leaves the real index untouched (throwaway index)" {
+    cd "$TEST_REPO"
+    echo "still untracked" > untracked.txt       # UNTRACKED
+    bash "$DIFF_HASH" --base main --working >/dev/null
+    # The intent-to-add happens in a throwaway index; the real one is unchanged,
+    # so the file must still be reported as untracked ('??'), not staged.
+    run git status --porcelain untracked.txt
+    [[ "$output" == '??'* ]]
+}
+
+@test "diff-hash: --file and --working are mutually exclusive" {
+    cd "$TEST_REPO"
+    run bash "$DIFF_HASH" --file file.txt --working
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"mutually exclusive"* ]]
+}

--- a/src/tests/tools/diff-hash.bats
+++ b/src/tests/tools/diff-hash.bats
@@ -179,3 +179,52 @@ teardown() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"Usage"* ]]
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# --working mode (flag #207) — hash uncommitted work, consistent across commit
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "diff-hash: --help documents --working" {
+    run bash "$DIFF_HASH" --help
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -q -- "--working"
+}
+
+@test "diff-hash: --working sees uncommitted changes that BASE..HEAD misses" {
+    cd "$TEST_REPO"
+    local committed
+    committed=$(bash "$DIFF_HASH" --base main)   # hash of the committed change
+    echo "more uncommitted work" >> file.txt      # UNCOMMITTED
+    # default (BASE..HEAD) is blind to it — hash unchanged
+    run bash "$DIFF_HASH" --base main
+    [ "$status" -eq 0 ]
+    [ "$output" = "$committed" ]
+    # --working sees it — hash differs
+    run bash "$DIFF_HASH" --base main --working
+    [ "$status" -eq 0 ]
+    [ "$output" != "$committed" ]
+    [[ "$output" =~ ^[a-f0-9]{7}$ ]]
+}
+
+@test "diff-hash: --working pre-commit equals default post-commit (receipt-safe, #207)" {
+    cd "$TEST_REPO"
+    echo "qg fix" >> file.txt          # uncommitted QG fix
+    git add file.txt
+    local working_pre
+    working_pre=$(bash "$DIFF_HASH" --base main --working)
+    git commit -q -m "commit the fix" --no-verify
+    local default_post
+    default_post=$(bash "$DIFF_HASH" --base main)
+    # The hash the QG records with --working (pre-commit) must equal what
+    # receipt-verify computes with the default (BASE..HEAD) on the committed tree.
+    [ "$working_pre" = "$default_post" ]
+}
+
+@test "diff-hash: --working includes a newly staged file" {
+    cd "$TEST_REPO"
+    echo "brand new" > newfile.txt
+    git add newfile.txt                # staged, uncommitted
+    run bash "$DIFF_HASH" --base main --working
+    [ "$status" -eq 0 ]
+    [[ "$output" =~ ^[a-f0-9]{7}$ ]]
+}

--- a/usr/jordan/_land-fix-qg-hash-order/dispatches/commit-to-captain-committed-ffe67b71-on-land-fix-qg-hash-order-chore-20260813-1737.md
+++ b/usr/jordan/_land-fix-qg-hash-order/dispatches/commit-to-captain-committed-ffe67b71-on-land-fix-qg-hash-order-chore-20260813-1737.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-qg-hash-order
+to: the-agency/jordan/captain
+date: 2026-08-13T09:37
+status: created
+priority: normal
+subject: "Committed ffe67b71 on _land-fix-qg-hash-order: chore(manifest): bump agency_version 46.39 → 46.40 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed ffe67b71 on _land-fix-qg-hash-order: chore(manifest): bump agency_version 46.39 → 46.40 for PR landing (captain)
+
+## Commit: ffe67b71
+
+**Branch:** _land-fix-qg-hash-order
+**Agent:** the-agency/jordan/_land-fix-qg-hash-order
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.39 → 46.40 for PR landing (captain)
+
+### Metadata
+- commit_hash: ffe67b71
+- branch: _land-fix-qg-hash-order
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/fix-qg-hash-order/dispatches/commit-to-captain-committed-3144c225-on-fix-qg-hash-order-fix-diff-h-20260813-1733.md
+++ b/usr/jordan/fix-qg-hash-order/dispatches/commit-to-captain-committed-3144c225-on-fix-qg-hash-order-fix-diff-h-20260813-1733.md
@@ -1,0 +1,82 @@
+---
+type: commit
+from: the-agency/jordan/fix-qg-hash-order
+to: the-agency/jordan/captain
+date: 2026-08-13T09:33
+status: created
+priority: normal
+subject: "Committed 3144c225 on fix-qg-hash-order: fix(diff-hash): --working now includes untracked new files (QG review)
+
+Both QG reviewers found a real hole: 'git diff <ref>' ignores UNTRACKED files,
+but git-safe-commit runs 'git add -A' — so a QG's new test/fix files get
+committed while --working (pre-commit) omitted them. Hash E would undercount and
+receipt-verify would then BLOCK the legitimate commit (receipt churn, opposite
+direction).
+
+Fix: in --working mode, mark untracked files intent-to-add ('git add -N') so
+they surface as new-file diffs matching the post-commit BASE..HEAD hash — done
+in a THROWAWAY copy of the index (GIT_INDEX_FILE) so the caller's real staging
+state is never mutated. Teardown runs before any exit.
+
+Proven: --working with an untracked new file == default post-commit hash, and
+the real index is left untouched (file stays '??'). +3 tests (untracked
+consistency, index-untouched, --file/--working guard) → 20 diff-hash tests green,
+receipt-sign/verify unaffected."
+in_reply_to: null
+---
+
+# Committed 3144c225 on fix-qg-hash-order: fix(diff-hash): --working now includes untracked new files (QG review)
+
+Both QG reviewers found a real hole: 'git diff <ref>' ignores UNTRACKED files,
+but git-safe-commit runs 'git add -A' — so a QG's new test/fix files get
+committed while --working (pre-commit) omitted them. Hash E would undercount and
+receipt-verify would then BLOCK the legitimate commit (receipt churn, opposite
+direction).
+
+Fix: in --working mode, mark untracked files intent-to-add ('git add -N') so
+they surface as new-file diffs matching the post-commit BASE..HEAD hash — done
+in a THROWAWAY copy of the index (GIT_INDEX_FILE) so the caller's real staging
+state is never mutated. Teardown runs before any exit.
+
+Proven: --working with an untracked new file == default post-commit hash, and
+the real index is left untouched (file stays '??'). +3 tests (untracked
+consistency, index-untouched, --file/--working guard) → 20 diff-hash tests green,
+receipt-sign/verify unaffected.
+
+## Commit: 3144c225
+
+**Branch:** fix-qg-hash-order
+**Agent:** the-agency/jordan/fix-qg-hash-order
+**Message:** housekeeping/captain: fix(diff-hash): --working now includes untracked new files (QG review)
+
+Both QG reviewers found a real hole: 'git diff <ref>' ignores UNTRACKED files,
+but git-safe-commit runs 'git add -A' — so a QG's new test/fix files get
+committed while --working (pre-commit) omitted them. Hash E would undercount and
+receipt-verify would then BLOCK the legitimate commit (receipt churn, opposite
+direction).
+
+Fix: in --working mode, mark untracked files intent-to-add ('git add -N') so
+they surface as new-file diffs matching the post-commit BASE..HEAD hash — done
+in a THROWAWAY copy of the index (GIT_INDEX_FILE) so the caller's real staging
+state is never mutated. Teardown runs before any exit.
+
+Proven: --working with an untracked new file == default post-commit hash, and
+the real index is left untouched (file stays '??'). +3 tests (untracked
+consistency, index-untouched, --file/--working guard) → 20 diff-hash tests green,
+receipt-sign/verify unaffected.
+
+### Metadata
+- commit_hash: 3144c225
+- branch: fix-qg-hash-order
+- files_changed: 4
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/tools/diff-hash
+src/agency/tools/diff-hash
+src/tests/tools/diff-hash.bats
+usr/jordan/fix-qg-hash-order/dispatches/commit-to-captain-committed-5cad4b14-on-fix-qg-hash-order-fix-diff-h-20260813-1723.md
+```

--- a/usr/jordan/fix-qg-hash-order/dispatches/commit-to-captain-committed-5cad4b14-on-fix-qg-hash-order-fix-diff-h-20260813-1723.md
+++ b/usr/jordan/fix-qg-hash-order/dispatches/commit-to-captain-committed-5cad4b14-on-fix-qg-hash-order-fix-diff-h-20260813-1723.md
@@ -1,0 +1,85 @@
+---
+type: commit
+from: the-agency/jordan/fix-qg-hash-order
+to: the-agency/jordan/captain
+date: 2026-08-13T09:23
+status: created
+priority: normal
+subject: "Committed 5cad4b14 on fix-qg-hash-order: fix(diff-hash): add --working mode so the QG can hash uncommitted work (flag #207)
+
+The QG signs its receipt BEFORE the caller commits, but diff-hash compared
+BASE..HEAD (committed tip only) — blind to the uncommitted fixes. So Hash E
+collapsed onto Hash A (the mdslidepal QG hit exactly this: first receipt came
+back E==A). Agents worked around it by committing first, then hashing.
+
+Fix: 'diff-hash --working' hashes BASE vs the WORKING TREE (staged + unstaged),
+so it sees uncommitted work. It is safe for the five-hash chain: once the work
+is committed and the tree is clean, 'git diff BASE' == 'git diff BASE..HEAD', so
+receipt-verify (which runs default, on the committed tree) still matches the
+--working hash the QG recorded. Proven by a cross-boundary bats test.
+
+quality-gate SKILL.md now captures Hash A (Step 0) and Hash E (Step 10) with
+--working. REFERENCE-RECEIPT-INFRASTRUCTURE documents the mode. 4 new diff-hash
+bats (18 total): sees-uncommitted, cross-boundary consistency (#207), new staged
+file, --help. Zero regressions in receipt-sign/verify."
+in_reply_to: null
+---
+
+# Committed 5cad4b14 on fix-qg-hash-order: fix(diff-hash): add --working mode so the QG can hash uncommitted work (flag #207)
+
+The QG signs its receipt BEFORE the caller commits, but diff-hash compared
+BASE..HEAD (committed tip only) — blind to the uncommitted fixes. So Hash E
+collapsed onto Hash A (the mdslidepal QG hit exactly this: first receipt came
+back E==A). Agents worked around it by committing first, then hashing.
+
+Fix: 'diff-hash --working' hashes BASE vs the WORKING TREE (staged + unstaged),
+so it sees uncommitted work. It is safe for the five-hash chain: once the work
+is committed and the tree is clean, 'git diff BASE' == 'git diff BASE..HEAD', so
+receipt-verify (which runs default, on the committed tree) still matches the
+--working hash the QG recorded. Proven by a cross-boundary bats test.
+
+quality-gate SKILL.md now captures Hash A (Step 0) and Hash E (Step 10) with
+--working. REFERENCE-RECEIPT-INFRASTRUCTURE documents the mode. 4 new diff-hash
+bats (18 total): sees-uncommitted, cross-boundary consistency (#207), new staged
+file, --help. Zero regressions in receipt-sign/verify.
+
+## Commit: 5cad4b14
+
+**Branch:** fix-qg-hash-order
+**Agent:** the-agency/jordan/fix-qg-hash-order
+**Message:** housekeeping/captain: fix(diff-hash): add --working mode so the QG can hash uncommitted work (flag #207)
+
+The QG signs its receipt BEFORE the caller commits, but diff-hash compared
+BASE..HEAD (committed tip only) — blind to the uncommitted fixes. So Hash E
+collapsed onto Hash A (the mdslidepal QG hit exactly this: first receipt came
+back E==A). Agents worked around it by committing first, then hashing.
+
+Fix: 'diff-hash --working' hashes BASE vs the WORKING TREE (staged + unstaged),
+so it sees uncommitted work. It is safe for the five-hash chain: once the work
+is committed and the tree is clean, 'git diff BASE' == 'git diff BASE..HEAD', so
+receipt-verify (which runs default, on the committed tree) still matches the
+--working hash the QG recorded. Proven by a cross-boundary bats test.
+
+quality-gate SKILL.md now captures Hash A (Step 0) and Hash E (Step 10) with
+--working. REFERENCE-RECEIPT-INFRASTRUCTURE documents the mode. 4 new diff-hash
+bats (18 total): sees-uncommitted, cross-boundary consistency (#207), new staged
+file, --help. Zero regressions in receipt-sign/verify.
+
+### Metadata
+- commit_hash: 5cad4b14
+- branch: fix-qg-hash-order
+- files_changed: 7
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+.claude/skills/quality-gate/SKILL.md
+agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+agency/tools/diff-hash
+src/agency/REFERENCE/REFERENCE-RECEIPT-INFRASTRUCTURE.md
+src/agency/tools/diff-hash
+src/claude/skills/quality-gate/SKILL.md
+src/tests/tools/diff-hash.bats
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-qg-hash-order` (untouched; this PR rides `_land-fix-qg-hash-order`)
- Integrated in a scratch worktree cut from `origin/fix-qg-hash-order`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-qg-hash-order-qgr-pr-prep-20260813-1734-58a86b3.md` (hash `58a86b3`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-qg-hash-order-qgr-pr-captain-land-20260813-1737-b988a60.md` (hash `b988a60`)
- `agency_version`: 46.39 → 46.40
- Release v46.40 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)