### PR TITLE
container-test-isolation

### DIFF
--- a/agency/config/agency.yaml
+++ b/agency/config/agency.yaml
@@ -104,6 +104,11 @@ platform:
 preview:
   provider: "docker-compose"  # Default: docker-compose. Alternatives: fly, vercel, cloudflare
 
+# Container runtime (test isolation, sandboxed execution)
+# Abstraction over OCI backends — see agency/tools/lib/_container-runtime.
+container:
+  provider: "auto"  # Auto-detect: apple (Apple Silicon macOS) → docker. Alternatives: apple, docker
+
 # Deploy (platform deployment)
 deploy:
   provider: "fly"  # Default: fly. Alternatives: aws, vercel, cloudflare, railway

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.43",
+  "agency_version": "46.44",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-08-14T13:47:31Z"
+    "updated_at": "2026-08-19T09:33:57Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-08-14T13:47:31Z"
+  "updated_at": "2026-08-19T09:33:57Z"
 }

--- a/agency/containers/test-runner/Dockerfile
+++ b/agency/containers/test-runner/Dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
         github-cli \
         nodejs \
         npm \
+        rsync \
         coreutils \
         findutils \
         grep \

--- a/agency/containers/test-runner/Dockerfile
+++ b/agency/containers/test-runner/Dockerfile
@@ -7,7 +7,9 @@
 # agency/tools/lib/_container-runtime.
 #
 # Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
-# python3, and the coreutils/findutils/grep/sed/gawk userland.
+# python3 (+ the yaml module for workflow-validity tests), sqlite3 (the ISCP
+# dispatch/flag DB layer), zip (safe-extract fixtures — busybox already
+# supplies unzip), and the coreutils/findutils/grep/sed/gawk userland.
 FROM alpine:3.20
 RUN apk add --no-cache \
         bash \
@@ -15,6 +17,9 @@ RUN apk add --no-cache \
         bats \
         jq \
         python3 \
+        py3-yaml \
+        sqlite \
+        zip \
         coreutils \
         findutils \
         grep \

--- a/agency/containers/test-runner/Dockerfile
+++ b/agency/containers/test-runner/Dockerfile
@@ -9,7 +9,10 @@
 # Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
 # python3 (+ the yaml module for workflow-validity tests), sqlite3 (the ISCP
 # dispatch/flag DB layer), zip (safe-extract fixtures — busybox already
-# supplies unzip), and the coreutils/findutils/grep/sed/gawk userland.
+# supplies unzip), github-cli (gh/pr-captain-land/pr-create/release/git-sync
+# dry-run + arg-validation tests), nodejs/npm/pnpm (pkg-manager resolves this
+# repo's packageManager: pnpm@9), and the coreutils/findutils/grep/sed/gawk
+# userland.
 FROM alpine:3.20
 RUN apk add --no-cache \
         bash \
@@ -20,12 +23,18 @@ RUN apk add --no-cache \
         py3-yaml \
         sqlite \
         zip \
+        github-cli \
+        nodejs \
+        npm \
         coreutils \
         findutils \
         grep \
         sed \
         gawk \
     && rm -rf /var/cache/apk/*
+# pnpm is not packaged for alpine 3.20 — install it via npm at the version this
+# repo declares (packageManager: pnpm@9.15.0) so pkg-manager resolves cleanly.
+RUN npm install -g pnpm@9.15.0 && npm cache clean --force
 # No ENTRYPOINT: the runner drives the container with an explicit `bash -c ...`
 # so it can copy the repo to a writable workdir and invoke bats with arguments.
 WORKDIR /work

--- a/agency/containers/test-runner/Dockerfile
+++ b/agency/containers/test-runner/Dockerfile
@@ -1,0 +1,26 @@
+# the-agency isolated test-runner image
+#
+# A disposable Linux environment for running the framework's bats suite in a
+# container, so a buggy test can only trash the container, never the host repo.
+# Kept minimal + OCI-standard so it runs identically under Apple `container`
+# (Apple Silicon) and Docker (Linux/CI/Intel) — the two backends behind
+# agency/tools/lib/_container-runtime.
+#
+# Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
+# python3, and the coreutils/findutils/grep/sed/gawk userland.
+FROM alpine:3.20
+RUN apk add --no-cache \
+        bash \
+        git \
+        bats \
+        jq \
+        python3 \
+        coreutils \
+        findutils \
+        grep \
+        sed \
+        gawk \
+    && rm -rf /var/cache/apk/*
+# No ENTRYPOINT: the runner drives the container with an explicit `bash -c ...`
+# so it can copy the repo to a writable workdir and invoke bats with arguments.
+WORKDIR /work

--- a/agency/tools/container-test-run
+++ b/agency/tools/container-test-run
@@ -65,12 +65,43 @@ backend="$(container_backend)" || {
 # id -un is the fallback when the invoking shell didn't export USER (#42).
 HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
 
+# Give the clone a credential-free, github-style origin URL. The raw `git clone
+# /src /work` sets origin to the local path "/src", so tools that parse ORG/REPO
+# or repo.name from the remote (pr-captain-land, agent-identity, repo-detection,
+# git-sync, handoff agent address) fail — on the host origin is a real github
+# URL. We derive org/repo from the host's origin but STRIP any embedded
+# credentials: a host remote may carry a "https://<token>@github.com/..." PAT
+# that must NEVER enter the container or the transcript. Parameter expansion
+# below drops everything up to and including "github.com", so the token is
+# removed by construction; we rebuild a clean https URL with no userinfo. (#42)
+_ho="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo '')"
+_after="${_ho#*github.com}"      # -> ":org/repo.git" or "/org/repo.git" (token gone)
+_after="${_after#[:/]}"           # strip the leading : or /
+_org_repo="${_after%.git}"        # -> "org/repo"
+if [ -n "$_org_repo" ] && [ "$_org_repo" != "$_ho" ]; then
+    CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
+else
+    CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
+fi
+
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
 RUN_CMD="set -e
 export USER=$(printf '%q' "$HOST_USER")
+# SYSTEM git identity + default branch: many tests create their own throwaway
+# repos in tmpdirs and commit WITHOUT setting local user.*, relying on an ambient
+# identity (present on a dev host, absent in a fresh container → 'git commit'
+# dies status 128 'Author identity unknown'). It MUST be --system (/etc/gitconfig),
+# NOT --global: test_isolation_setup scrubs HOME to a fakehome, so a ~/.gitconfig
+# global identity is invisible to the tests. --system is HOME-independent.
+# init.defaultBranch=main matches the framework convention so tests that expect a
+# 'main' branch behave like the host (alpine git otherwise defaults to 'master'). (#42)
+git config --system user.email ci@the-agency.local
+git config --system user.name ci
+git config --system init.defaultBranch main
 git clone -q /src /work
 cd /work
+git remote set-url origin $(printf '%q' "$CLEAN_ORIGIN")
 git config user.email ci@the-agency.local && git config user.name ci
 bats ${TESTS[*]}"
 

--- a/agency/tools/container-test-run
+++ b/agency/tools/container-test-run
@@ -71,23 +71,30 @@ HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
 # git-sync, handoff agent address) fail — on the host origin is a real github
 # URL. We derive org/repo from the host's origin but STRIP any embedded
 # credentials: a host remote may carry a "https://<token>@github.com/..." PAT
-# that must NEVER enter the container or the transcript. Parameter expansion
-# below drops everything up to and including "github.com", so the token is
-# removed by construction; we rebuild a clean https URL with no userinfo. (#42)
+# that must NEVER enter the container or the transcript.
+#
+# Security-critical (QG SEC-1/CODE-1): only process origins that ACTUALLY contain
+# "github.com", and only trust a result that is a clean "<org>/<repo>". The old
+# heuristic ("differs from the raw URL") was defeated by the trailing ".git"
+# strip alone, so a NON-github origin carrying a token (e.g.
+# "https://oauth2:TOK@gitlab.example.com/o/r.git") slipped through unstripped.
+# We now (a) gate on a real github.com match — anything else falls back to the
+# safe default — and (b) validate the parsed org/repo against a strict regex, so
+# any residual scheme/userinfo ("://", "@", ":") forces the default. The token
+# can never reach CLEAN_ORIGIN.
+CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
 _ho="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo '')"
-_after="${_ho#*github.com}"      # -> ":org/repo.git" or "/org/repo.git" (token gone)
-_after="${_after#[:/]}"           # strip the leading : or /
-_org_repo="${_after%.git}"        # -> "org/repo"
-if [ -n "$_org_repo" ] && [ "$_org_repo" != "$_ho" ]; then
-    CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
-else
-    CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
+if [[ "$_ho" == *github.com* ]]; then
+    _after="${_ho#*github.com}"   # drop everything up to & incl github.com (token gone)
+    _after="${_after#[:/]}"       # strip the leading : or /
+    _org_repo="${_after%.git}"    # -> "org/repo"
+    if [[ "$_org_repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+        CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
+    fi
 fi
 
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
-RUN_CMD="set -e
-export USER=$(printf '%q' "$HOST_USER")
 # SYSTEM git identity + default branch: many tests create their own throwaway
 # repos in tmpdirs and commit WITHOUT setting local user.*, relying on an ambient
 # identity (present on a dev host, absent in a fresh container → 'git commit'
@@ -95,7 +102,14 @@ export USER=$(printf '%q' "$HOST_USER")
 # NOT --global: test_isolation_setup scrubs HOME to a fakehome, so a ~/.gitconfig
 # global identity is invisible to the tests. --system is HOME-independent.
 # init.defaultBranch=main matches the framework convention so tests that expect a
-# 'main' branch behave like the host (alpine git otherwise defaults to 'master'). (#42)
+# 'main' branch behave like the host (alpine git otherwise defaults to 'master').
+#
+# Test paths are NOT spliced into this script — they arrive as ARGV ($1..) and
+# `bats "$@"` consumes them, so a path can never be re-parsed as shell (QG
+# SEC-2/CODE-3). $USER is supplied via --env below, not interpolated here. The
+# only interpolation is CLEAN_ORIGIN, which is validated to a clean org/repo and
+# printf-%q-quoted. (#42)
+RUN_CMD="set -e
 git config --system user.email ci@the-agency.local
 git config --system user.name ci
 git config --system init.defaultBranch main
@@ -103,16 +117,19 @@ git clone -q /src /work
 cd /work
 git remote set-url origin $(printf '%q' "$CLEAN_ORIGIN")
 git config user.email ci@the-agency.local && git config user.name ci
-bats ${TESTS[*]}"
+bats \"\$@\""
 
 echo "container-test-run: backend=$backend image=$IMAGE" >&2
 echo "container-test-run: tests=${TESTS[*]}" >&2
 
-case "$backend" in
-    apple)  container run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
-    docker) docker    run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
-    *)      echo "container-test-run: unknown backend '$backend'" >&2; exit 1 ;;
-esac
+# Route through the _container-runtime abstraction (backend-agnostic). Mount the
+# repo read-only; pass $USER via --env; hand the test paths to the container's
+# shell as ARGV after RUN_CMD ($0=container-test-run, $1.. = TESTS).
+container_run \
+    --mount "$REPO_ROOT:/src:ro" \
+    --env "USER=$HOST_USER" \
+    "$IMAGE" \
+    bash -c "$RUN_CMD" container-test-run "${TESTS[@]}"
 rc=$?
 
 if [ "$rc" -eq 0 ]; then

--- a/agency/tools/container-test-run
+++ b/agency/tools/container-test-run
@@ -58,9 +58,17 @@ backend="$(container_backend)" || {
     exit 127
 }
 
+# Replicate the host's $USER inside the container. The container runs as root
+# with USER unset, but identity resolution (agent-identity, principal) keys off
+# $USER against agency.yaml's principals map — so without this, identity-aware
+# tests (handoff agent address, principal, sandbox-sync) diverge from the host.
+# id -un is the fallback when the invoking shell didn't export USER (#42).
+HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
+
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
 RUN_CMD="set -e
+export USER=$(printf '%q' "$HOST_USER")
 git clone -q /src /work
 cd /work
 git config user.email ci@the-agency.local && git config user.name ci

--- a/agency/tools/container-test-run
+++ b/agency/tools/container-test-run
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# container-test-run - run the bats suite inside a disposable container
+#
+# What Problem: bats tests run locally, un-isolated, keep trashing the real
+# repo — a buggy test created 600+ junk git tags, leaked worktrees into the live
+# checkout, and depended on gitignored dev-only dirs. In-process isolation only
+# works if every test is written correctly, and they keep not being. The local
+# machine PERSISTS between runs, so the damage accumulates (CI runners are
+# ephemeral, so CI is already self-isolating by disposal — the pain is local).
+#
+# How & Why: STRUCTURAL containment. Mount the host repo READ-ONLY into a
+# throwaway Linux container, clone it to a writable workdir INSIDE the container,
+# and run bats there. The host repo cannot be written (read-only mount) and the
+# tests operate on the clone — so a leaky test's `git tag` / `worktree-create`
+# hits the disposable copy and evaporates when the container is removed. It
+# doesn't rely on the test being correct.
+#
+# The container backend (Apple `container` on Apple Silicon, Docker on
+# Linux/CI/Intel) is resolved by agency/tools/lib/_container-runtime from
+# agency.yaml `container.provider` — same OCI image, either runtime.
+#
+# Usage:
+#   container-test-run                         # run the full bats:all set
+#   container-test-run src/tests/tools/foo.bats  # run specific paths
+#
+# Env:
+#   CONTAINER_TEST_IMAGE   override the runner image (default: the-agency-test-runner:latest)
+#   CONTAINER_PROVIDER     force backend: apple | docker | auto (default: config/auto)
+#
+# NOTE (increment 1): this tests the COMMITTED HEAD (via `git clone`), not
+# uncommitted working-tree changes. A working-tree mode (copy tracked+untracked,
+# excluding node_modules/.claude/worktrees) is the next increment.
+#
+# Written: 2026-08-19 — container test isolation (#42), captain + principal.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$SCRIPT_DIR/lib/_log-helper" ] && source "$SCRIPT_DIR/lib/_log-helper"
+# _container-runtime sources _path-resolve, giving AGENCY_PROJECT_ROOT + backend.
+source "$SCRIPT_DIR/lib/_container-runtime"
+
+RUN_ID=$(log_start "container-test-run" "$*" 2>/dev/null) || true
+
+REPO_ROOT="${AGENCY_PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+IMAGE="${CONTAINER_TEST_IMAGE:-the-agency-test-runner:latest}"
+
+if [ "$#" -gt 0 ]; then
+    TESTS=("$@")
+else
+    TESTS=(src/tests/tools/ src/tests/hookify/ src/tests/skills/ src/tests/agents/ src/tests/docs/)
+fi
+
+backend="$(container_backend)" || {
+    echo "container-test-run: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker." >&2
+    log_end "$RUN_ID" "failure" 1 0 "no backend" 2>/dev/null || true
+    exit 127
+}
+
+# Clone the read-only-mounted repo to a writable workdir, then run bats there.
+# git identity is set so tests that commit don't fail on missing user.*.
+RUN_CMD="set -e
+git clone -q /src /work
+cd /work
+git config user.email ci@the-agency.local && git config user.name ci
+bats ${TESTS[*]}"
+
+echo "container-test-run: backend=$backend image=$IMAGE" >&2
+echo "container-test-run: tests=${TESTS[*]}" >&2
+
+case "$backend" in
+    apple)  container run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
+    docker) docker    run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
+    *)      echo "container-test-run: unknown backend '$backend'" >&2; exit 1 ;;
+esac
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+    log_end "$RUN_ID" "success" 0 0 "bats passed in container ($backend)" 2>/dev/null || true
+else
+    log_end "$RUN_ID" "failure" "$rc" 0 "bats failed in container ($backend)" 2>/dev/null || true
+fi
+exit "$rc"

--- a/agency/tools/diff-hash
+++ b/agency/tools/diff-hash
@@ -43,6 +43,20 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     exit 2
 fi
 
+# Portable SHA-256. macOS ships `shasum` (a perl tool); Linux/alpine ship
+# `sha256sum` (coreutils) but usually NOT shasum. Both print "<hex>  <name>",
+# and every caller here takes field 1, so they are drop-in equivalents at
+# `-a 256`. Resolving once keeps the receipt hash identical across platforms —
+# essential now that the suite (and CI) run inside a Linux container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256 "$@"; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum "$@"; }
+else
+    echo "Error: diff-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 BASE="origin/main"
 FILE=""
 JSON=false
@@ -106,7 +120,7 @@ if [[ -n "$FILE" ]]; then
         exit 1
     fi
 
-    FULL_HASH=$(shasum -a 256 "$FILE" | cut -d' ' -f1)
+    FULL_HASH=$(_sha256 "$FILE" | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
     FILE_COUNT=1
 
@@ -190,7 +204,7 @@ else
         exit 1
     fi
 
-    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
+    FULL_HASH=$(echo "$DIFF_OUTPUT" | _sha256 | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
 
     if [[ "$JSON" == "true" ]]; then

--- a/agency/tools/diff-hash
+++ b/agency/tools/diff-hash
@@ -43,17 +43,16 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     exit 2
 fi
 
-# Portable SHA-256. macOS ships `shasum` (a perl tool); Linux/alpine ship
-# `sha256sum` (coreutils) but usually NOT shasum. Both print "<hex>  <name>",
-# and every caller here takes field 1, so they are drop-in equivalents at
-# `-a 256`. Resolving once keeps the receipt hash identical across platforms —
-# essential now that the suite (and CI) run inside a Linux container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256 "$@"; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum "$@"; }
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on
+# Linux). Sourced so the resolution lives in ONE place across diff-hash /
+# stage-hash / monitor-register instead of three copies that must move together
+# for the next platform quirk (QG design finding, #42). Fail loud if the helper
+# is missing — diff-hash is receipt-critical and must not silently mis-hash.
+_DH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_DH_DIR/lib/_sha256" ]]; then
+    source "$_DH_DIR/lib/_sha256"
 else
-    echo "Error: diff-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    echo "Error: diff-hash requires agency/tools/lib/_sha256" >&2
     exit 2
 fi
 

--- a/agency/tools/git-captain
+++ b/agency/tools/git-captain
@@ -557,9 +557,16 @@ cmd_tag_delete() {
     # Origin-safety guard: fetch origin's tag set ONCE. A tag present on origin
     # is canonical and is NEVER deleted, regardless of the caller's list.
     echo "${BLUE}Checking origin tag set (safety guard)...${NC}" >&2
-    local origin_tags
-    origin_tags=$(git ls-remote --tags origin 2>/dev/null | grep -v '\^{}' | sed 's#.*refs/tags/##') \
+    # Check `git ls-remote` DIRECTLY for failure — do NOT fold the grep/sed
+    # filter into the same `|| die` pipeline. On an origin with ZERO tags,
+    # ls-remote succeeds with empty output but `grep -v` then exits 1 (no lines
+    # matched); under pipefail that 1 propagates and would false-die on a
+    # perfectly valid empty result, blocking tag-delete on fresh repos. Capture
+    # the raw listing first (die only if ls-remote itself fails), then filter.
+    local _lsr origin_tags
+    _lsr=$(git ls-remote --tags origin 2>/dev/null) \
         || die "Could not read origin tags — refusing to delete without the safety check."
+    origin_tags=$(printf '%s\n' "$_lsr" | grep -v '\^{}' | sed 's#.*refs/tags/##' || true)
 
     # --local-only sweep mode: enumerate ALL local tags NOT on origin (optionally
     # filtered by --match <regex>) as the candidate set. The per-name origin guard

--- a/agency/tools/git-captain
+++ b/agency/tools/git-captain
@@ -581,11 +581,18 @@ cmd_tag_delete() {
             names+=("$lt")
         done < <(git tag)
     fi
-    [[ ${#names[@]} -eq 0 ]] && die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+    # Empty candidate set: in explicit/--stdin mode that's a usage error (die).
+    # In --local-only mode it's a valid "nothing matched" result — fall through
+    # to the graceful "No local-only tags to delete" below (exit 0), don't die.
+    if [[ "$local_only" != true && ${#names[@]} -eq 0 ]]; then
+        die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+    fi
 
     local -a to_delete=() refused=() missing=()
     local t
-    for t in "${names[@]}"; do
+    # ${names[@]+...} so an empty array (valid in --local-only no-match) doesn't
+    # trip set -u "unbound variable" on bash 3.2 (macOS).
+    for t in ${names[@]+"${names[@]}"}; do
         if printf '%s\n' "$origin_tags" | grep -Fxq -- "$t"; then
             refused+=("$t")
         elif git rev-parse --verify --quiet "refs/tags/$t" >/dev/null; then

--- a/agency/tools/git-captain
+++ b/agency/tools/git-captain
@@ -69,6 +69,9 @@ Subcommands:
   push [args]                    Push to remote (blocks main/master, blocks bare --force)
   fetch                          Fetch from origin
   tag <name> [-m <msg>]          Create annotated tag
+  tag-delete <name>... | --stdin Delete LOCAL-ONLY tags. Never deletes a tag
+                                 present on origin (canonical). --dry-run to
+                                 preview. Reads names from stdin with --stdin.
   reset-soft [<ref>]             Sanctioned recovery: undo the last local
                                  commit (or reset to <ref>), keeping changes
                                  staged. REFUSES if HEAD is pushed to origin
@@ -519,6 +522,97 @@ cmd_tag() {
     echo "${GREEN}Created annotated tag:${NC} $name"
 }
 
+# --- Subcommand: tag-delete ---
+# Safe bulk deletion of LOCAL-ONLY tags. Raw `git tag -d` is hookify-blocked and
+# there was no safe path to remove tags (cmd_tag only creates), which blocked the
+# release-bug tag-pollution sweep (#42 / flag #264). The load-bearing guard: this
+# NEVER deletes a tag that exists on origin — origin tags are canonical release
+# history. It fetches origin's tag set and refuses any name found there, so even
+# a wrong caller-supplied list cannot destroy a published tag.
+#
+# Usage:
+#   git-captain tag-delete <name>...           delete the named local-only tags
+#   git-captain tag-delete --stdin             read names (one per line) from stdin
+#   git-captain tag-delete --dry-run <name>... preview only, delete nothing
+cmd_tag_delete() {
+    local dry_run=false from_stdin=false local_only=false match=""
+    local -a names=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)    dry_run=true; shift ;;
+            --stdin)      from_stdin=true; shift ;;
+            --local-only) local_only=true; shift ;;
+            --match)      [[ $# -lt 2 ]] && die "--match requires a regex"; match="$2"; shift 2 ;;
+            -*)           die "Unknown option: $1" ;;
+            *)            names+=("$1"); shift ;;
+        esac
+    done
+    if [[ "$from_stdin" == true ]]; then
+        local line
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && names+=("$line")
+        done
+    fi
+
+    # Origin-safety guard: fetch origin's tag set ONCE. A tag present on origin
+    # is canonical and is NEVER deleted, regardless of the caller's list.
+    echo "${BLUE}Checking origin tag set (safety guard)...${NC}" >&2
+    local origin_tags
+    origin_tags=$(git ls-remote --tags origin 2>/dev/null | grep -v '\^{}' | sed 's#.*refs/tags/##') \
+        || die "Could not read origin tags — refusing to delete without the safety check."
+
+    # --local-only sweep mode: enumerate ALL local tags NOT on origin (optionally
+    # filtered by --match <regex>) as the candidate set. The per-name origin guard
+    # below still runs, so this is belt-and-suspenders. Ignores positional names.
+    if [[ "$local_only" == true ]]; then
+        names=()
+        local lt
+        while IFS= read -r lt; do
+            [[ -z "$lt" ]] && continue
+            printf '%s\n' "$origin_tags" | grep -Fxq -- "$lt" && continue   # on origin — skip
+            [[ -n "$match" && ! "$lt" =~ $match ]] && continue               # pattern filter
+            names+=("$lt")
+        done < <(git tag)
+    fi
+    [[ ${#names[@]} -eq 0 ]] && die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+
+    local -a to_delete=() refused=() missing=()
+    local t
+    for t in "${names[@]}"; do
+        if printf '%s\n' "$origin_tags" | grep -Fxq -- "$t"; then
+            refused+=("$t")
+        elif git rev-parse --verify --quiet "refs/tags/$t" >/dev/null; then
+            to_delete+=("$t")
+        else
+            missing+=("$t")
+        fi
+    done
+
+    if [[ ${#refused[@]} -gt 0 ]]; then
+        echo "${YELLOW}Refusing ${#refused[@]} tag(s) present on origin (kept):${NC}" >&2
+        printf '  %s\n' "${refused[@]}" >&2
+    fi
+    [[ ${#missing[@]} -gt 0 ]] && echo "${BLUE}Skipped ${#missing[@]} tag(s) not present locally.${NC}" >&2
+
+    if [[ ${#to_delete[@]} -eq 0 ]]; then
+        echo "No local-only tags to delete."
+        return 0
+    fi
+
+    if [[ "$dry_run" == true ]]; then
+        echo "${YELLOW}[DRY RUN]${NC} Would delete ${#to_delete[@]} local-only tag(s):"
+        printf '  %s\n' "${to_delete[@]}"
+        return 0
+    fi
+
+    # git tag -d accepts many names; chunk to stay well under ARG_MAX on huge sweeps.
+    local i
+    for ((i = 0; i < ${#to_delete[@]}; i += 200)); do
+        git tag -d "${to_delete[@]:i:200}" >/dev/null
+    done
+    echo "${GREEN}Deleted ${#to_delete[@]} local-only tag(s).${NC} (${#refused[@]} on-origin kept.)"
+}
+
 # --- Subcommand: reset-soft ---
 # D41-R28 (issue #128): sanctioned recovery path for undoing a local,
 # un-pushed commit. Without this, agents who bypass /git-safe-commit (e.g.
@@ -638,6 +732,7 @@ case "$1" in
     push)               shift; cmd_push "$@" ;;
     fetch)              shift; cmd_fetch "$@" ;;
     tag)                shift; cmd_tag "$@" ;;
+    tag-delete)         shift; cmd_tag_delete "$@" ;;
     reset-soft)         shift; cmd_reset_soft "$@" ;;
     branch-delete)      shift; cmd_branch_delete "$@" ;;
     *)                  die "Unknown subcommand: $1 — run 'git-captain --help' for usage." ;;

--- a/agency/tools/great-rename-migrate
+++ b/agency/tools/great-rename-migrate
@@ -254,7 +254,7 @@ validate_prefix_pair() {
 
 # Load rename map — both old + new split on any whitespace (robust to
 # tabs, multiple spaces, trailing whitespace).
-declare -a RENAME_MAP
+declare -a RENAME_MAP=()
 if [[ -n "$MAP_FILE" ]]; then
     _lineno=0
     # `|| [[ -n "$line" ]]` picks up a final line with no trailing newline.
@@ -311,10 +311,14 @@ info "Scanned ${#CANDIDATES[@]} file(s) in worktree"
 echo
 
 # Compute rename plan
-declare -a PLAN_FROM PLAN_TO
-declare -a SKIP_TARGET_EXISTS
-declare -a SKIP_DUP_TARGET
-declare -a NO_MATCH
+# Initialize as empty arrays (=()): a bare `declare -a FOO` leaves FOO unset on
+# some bash builds (e.g. alpine's), so a later `${#FOO[@]}` / `"${FOO[@]}"` trips
+# `set -u` "unbound variable". Explicit =() is defined on every bash. (#42 — the
+# container test-isolation gate surfaced this; macOS bash tolerated the bare form.)
+declare -a PLAN_FROM=() PLAN_TO=()
+declare -a SKIP_TARGET_EXISTS=()
+declare -a SKIP_DUP_TARGET=()
+declare -a NO_MATCH=()
 
 for f in "${CANDIDATES[@]}"; do
     matched=0

--- a/agency/tools/lib/_container-runtime
+++ b/agency/tools/lib/_container-runtime
@@ -16,12 +16,19 @@
 #   source "$PROJECT_ROOT/agency/tools/lib/_container-runtime"
 #   container_backend                     # -> apple | docker  (stdout; rc1 if none)
 #   container_available                   # rc0 if a usable backend exists
-#   container_run <image> [--] <cmd...>   # run cmd in a throwaway container
+#   container_run [--mount <spec>]... [--env <K=V>]... <image> [--] <cmd...>
+#                                         # run cmd in a throwaway container
 #
 # container_run passes stdout/stderr through and returns the command's exit code.
-# Backend CLIs are near-identical OCI (`container run --rm` / `docker run --rm`),
-# so dispatch is intentionally thin; add a backend by extending the case arms in
-# _crt_have + container_run.
+# --mount <spec> maps to `-v <spec>` (repeatable, e.g. "/host:/guest:ro"); --env
+# <K=V> maps to `-e K=V`. Command args after the image are passed as argv, never
+# a shell string, so callers never string-splice untrusted values.
+#
+# NOTE on architecture: unlike _provider-resolve (which resolves a per-provider
+# TOOL FILE the caller execs), the two OCI backends here are near-identical CLIs
+# (`container run --rm` / `docker run --rm`), so their logic is inlined in the
+# case arms rather than living in separate container-apple / container-docker
+# tools. Add a backend by extending the case arms in _crt_have + container_run.
 
 # Load _path-resolve for AGENCY_PROJECT_ROOT + _pr_yaml_get (config reads),
 # mirroring how _provider-resolve bootstraps. Best-effort: the adapter still
@@ -72,18 +79,34 @@ container_backend() {
 # container_available -> rc0 if a usable backend exists
 container_available() { container_backend >/dev/null 2>&1; }
 
-# container_run <image> [--] <cmd...> -> run cmd in a throwaway container.
-# Removes the container on exit (--rm); returns the command's exit code.
+# container_run [--mount <spec>]... [--env <K=V>]... <image> [--] <cmd...>
+# Run cmd in a throwaway container. Removes it on exit (--rm); returns the
+# command's exit code. Command args are passed as argv (never a shell string).
 container_run() {
-    local image="$1"; shift
+    local -a mounts=() envs=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --mount) [[ $# -lt 2 ]] && { echo "container_run: --mount needs a value" >&2; return 2; }
+                     mounts+=("-v" "$2"); shift 2 ;;
+            --env)   [[ $# -lt 2 ]] && { echo "container_run: --env needs a value" >&2; return 2; }
+                     envs+=("-e" "$2"); shift 2 ;;
+            --)      shift; break ;;
+            *)       break ;;
+        esac
+    done
+    local image="${1:-}"; shift || true
     [[ "${1:-}" == "--" ]] && shift
+    [[ -z "$image" ]] && { echo "container_run: image required" >&2; return 2; }
     local backend
     backend="$(container_backend)" || {
         echo "_container-runtime: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker" >&2
         return 127
     }
+    # ${arr[@]+"${arr[@]}"} expands to nothing when the array is empty, which is
+    # bash-3.2-safe under `set -u` (a bare "${arr[@]}" on an empty array errors
+    # there). Keeps this sourceable into set -u callers like container-test-run.
     case "$backend" in
-        apple)  container run --rm "$image" "$@" ;;
-        docker) docker    run --rm "$image" "$@" ;;
+        apple)  container run --rm ${mounts[@]+"${mounts[@]}"} ${envs[@]+"${envs[@]}"} "$image" "$@" ;;
+        docker) docker    run --rm ${mounts[@]+"${mounts[@]}"} ${envs[@]+"${envs[@]}"} "$image" "$@" ;;
     esac
 }

--- a/agency/tools/lib/_container-runtime
+++ b/agency/tools/lib/_container-runtime
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# _container-runtime - container backend abstraction (Apple `container` + Docker)
+#
+# One interface, interchangeable OCI backends. Same shape as _provider-resolve:
+# sourced, silent, non-blocking, bash-3.2-safe (no associative arrays). The
+# active backend comes from agency.yaml `container.provider` (auto|apple|docker);
+# env CONTAINER_PROVIDER overrides. "auto" prefers Apple `container` (native,
+# daemonless, Apple-Silicon macOS) and falls back to Docker.
+#
+# Why an abstraction (not "Apple Containers everywhere"): Apple `container` is
+# the better runtime on Apple Silicon, but Docker is what runs on Linux/CI/Intel.
+# Callers say "run this in a throwaway container"; the backend is a config detail.
+#
+# Usage:
+#   source "$PROJECT_ROOT/agency/tools/lib/_container-runtime"
+#   container_backend                     # -> apple | docker  (stdout; rc1 if none)
+#   container_available                   # rc0 if a usable backend exists
+#   container_run <image> [--] <cmd...>   # run cmd in a throwaway container
+#
+# container_run passes stdout/stderr through and returns the command's exit code.
+# Backend CLIs are near-identical OCI (`container run --rm` / `docker run --rm`),
+# so dispatch is intentionally thin; add a backend by extending the case arms in
+# _crt_have + container_run.
+
+# Load _path-resolve for AGENCY_PROJECT_ROOT + _pr_yaml_get (config reads),
+# mirroring how _provider-resolve bootstraps. Best-effort: the adapter still
+# works with env/auto-detect if config is unreadable.
+if [[ -z "${AGENCY_PROJECT_ROOT:-}" ]] || ! declare -f _pr_yaml_get >/dev/null 2>&1; then
+    _crt_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    [[ -f "$_crt_lib_dir/_path-resolve" ]] && source "$_crt_lib_dir/_path-resolve"
+fi
+
+# _crt_configured_provider -> container.provider from agency.yaml, else "auto".
+# Env CONTAINER_PROVIDER wins (for tests / one-off overrides).
+_crt_configured_provider() {
+    if [[ -n "${CONTAINER_PROVIDER:-}" ]]; then
+        printf '%s' "$CONTAINER_PROVIDER"; return 0
+    fi
+    local yaml="${AGENCY_PROJECT_ROOT:-.}/agency/config/agency.yaml" val=""
+    if declare -f _pr_yaml_get >/dev/null 2>&1 && [[ -f "$yaml" ]]; then
+        val="$(_pr_yaml_get "container" "provider" "$yaml" 2>/dev/null)"
+        val="${val//\"/}"; val="${val//\'/}"; val="${val// /}"; val="${val//$'\r'/}"
+    fi
+    printf '%s' "${val:-auto}"
+}
+
+# _crt_have <apple|docker> -> rc0 if that backend's CLI is on PATH
+_crt_have() {
+    case "$1" in
+        apple)  command -v container >/dev/null 2>&1 ;;
+        docker) command -v docker    >/dev/null 2>&1 ;;
+        *)      return 1 ;;
+    esac
+}
+
+# container_backend -> resolved backend name (apple|docker) on stdout; rc1 if none
+container_backend() {
+    local pref; pref="$(_crt_configured_provider)"
+    case "$pref" in
+        apple|docker)
+            _crt_have "$pref" && { printf '%s' "$pref"; return 0; }
+            return 1 ;;
+        auto|"")
+            if _crt_have apple;  then printf 'apple';  return 0; fi
+            if _crt_have docker; then printf 'docker'; return 0; fi
+            return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+# container_available -> rc0 if a usable backend exists
+container_available() { container_backend >/dev/null 2>&1; }
+
+# container_run <image> [--] <cmd...> -> run cmd in a throwaway container.
+# Removes the container on exit (--rm); returns the command's exit code.
+container_run() {
+    local image="$1"; shift
+    [[ "${1:-}" == "--" ]] && shift
+    local backend
+    backend="$(container_backend)" || {
+        echo "_container-runtime: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker" >&2
+        return 127
+    }
+    case "$backend" in
+        apple)  container run --rm "$image" "$@" ;;
+        docker) docker    run --rm "$image" "$@" ;;
+    esac
+}

--- a/agency/tools/lib/_iscp-db
+++ b/agency/tools/lib/_iscp-db
@@ -270,8 +270,16 @@ _iscp_run_migrations() {
             return 1
         }
 
-        # Execute migration in a transaction with version bump
+        # Execute migration in a transaction with version bump.
+        # `.bail on` is REQUIRED: without it the sqlite3 CLI prints an error but
+        # CONTINUES to the next statements, so a failing ${migration_sql} would
+        # still run `PRAGMA user_version` + COMMIT — bumping (and committing) the
+        # version even though the migration failed, while the shell still sees a
+        # non-zero exit. With `.bail on`, sqlite3 stops at the first error inside
+        # the open BEGIN and exits, leaving the transaction to auto-rollback so
+        # the version stays put. macOS sqlite masked this; alpine surfaced it. (#42)
         sqlite3 "$db_path" << SQL
+.bail on
 ${preamble}
 BEGIN;
 ${migration_sql}

--- a/agency/tools/lib/_sha256
+++ b/agency/tools/lib/_sha256
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# _sha256 - portable SHA-256 helper (sourced).
+#
+# macOS ships `shasum` (a perl tool); Linux/alpine ship `sha256sum` (coreutils)
+# but usually NOT shasum. Both emit "<hex>  <name>" at -a 256 and every caller
+# takes field 1, so they are drop-in equivalents. Resolving ONCE, here, keeps a
+# single definition instead of the per-tool copies that previously drifted
+# (diff-hash/stage-hash/monitor-register) and must all move together for the next
+# platform quirk (QG design finding, #42).
+#
+# Usage (after sourcing):
+#   _sha256 <file>...     # hash each file        (shasum/sha256sum <file>...)
+#   printf '%s' "$x" | _sha256   # hash stdin      (no args -> reads stdin)
+#
+# Callers pull field 1 themselves, e.g. `_sha256 "$f" | cut -d' ' -f1` or
+# `... | _sha256 | awk '{print $1}'`. If NEITHER tool exists, _sha256 errors and
+# returns 2 at CALL time (not source time), so sourcing never kills the caller.
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256 "$@"; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum "$@"; }
+else
+    _sha256() { echo "_sha256: neither 'shasum' nor 'sha256sum' found on PATH" >&2; return 2; }
+fi

--- a/agency/tools/lib/_test-isolation
+++ b/agency/tools/lib/_test-isolation
@@ -94,19 +94,17 @@ test_isolation_setup() {
     # 2. Explicit ISCP DB path — belt-and-suspenders on top of HOME override
     export ISCP_DB_PATH="${BATS_TEST_TMPDIR}/test-iscp.db"
 
-    # 3. Git config isolation — prevent any writes to live .git/config, AND
-    #    supply a hermetic fallback identity. GLOBAL points at a throwaway
-    #    config carrying a deterministic test identity (+ init.defaultBranch)
-    #    rather than /dev/null: tests that create a repo and commit WITHOUT
-    #    setting local user.* otherwise rely on git's ambient auto-identity,
-    #    which macOS derives from the system but a minimal Linux container
-    #    cannot — failing "Author identity unknown" (#42, container gate).
-    #    Global level (not env GIT_AUTHOR_*) means a test's own local
-    #    `git config user.*` still WINS, so per-test attribution is unchanged;
-    #    this only backstops the no-local-config case. SYSTEM stays /dev/null.
-    export GIT_CONFIG_GLOBAL="${BATS_TEST_TMPDIR}/fake-gitconfig"
+    # 3. Git config isolation — prevent any writes to live .git/config.
+    #    Deliberately /dev/null (NOT a fallback identity): several tests assert
+    #    on the UNCONFIGURED-identity path (e.g. "#204 git-safe-commit errors
+    #    loudly when git identity is unconfigured") and on the default branch,
+    #    so a blanket ambient identity here regresses them. Tests that DO commit
+    #    must set their own local `git config user.*` in their fixture (the
+    #    hermetic pattern). The handful that rely on git's macOS auto-identity
+    #    are tracked as test-portability debt (#42 / flag #264), to be hardened
+    #    per-test rather than globally.
+    export GIT_CONFIG_GLOBAL=/dev/null
     export GIT_CONFIG_SYSTEM=/dev/null
-    printf '[user]\n\tname = agency-test\n\temail = agency-test@localhost\n[init]\n\tdefaultBranch = main\n' > "$GIT_CONFIG_GLOBAL"
 
     # 4. Snapshot live .git/config checksum for guard validation
     if [[ -f "$REPO_ROOT/.git/config" ]]; then

--- a/agency/tools/lib/_test-isolation
+++ b/agency/tools/lib/_test-isolation
@@ -94,9 +94,19 @@ test_isolation_setup() {
     # 2. Explicit ISCP DB path — belt-and-suspenders on top of HOME override
     export ISCP_DB_PATH="${BATS_TEST_TMPDIR}/test-iscp.db"
 
-    # 3. Git config isolation — prevent any writes to live .git/config
-    export GIT_CONFIG_GLOBAL=/dev/null
+    # 3. Git config isolation — prevent any writes to live .git/config, AND
+    #    supply a hermetic fallback identity. GLOBAL points at a throwaway
+    #    config carrying a deterministic test identity (+ init.defaultBranch)
+    #    rather than /dev/null: tests that create a repo and commit WITHOUT
+    #    setting local user.* otherwise rely on git's ambient auto-identity,
+    #    which macOS derives from the system but a minimal Linux container
+    #    cannot — failing "Author identity unknown" (#42, container gate).
+    #    Global level (not env GIT_AUTHOR_*) means a test's own local
+    #    `git config user.*` still WINS, so per-test attribution is unchanged;
+    #    this only backstops the no-local-config case. SYSTEM stays /dev/null.
+    export GIT_CONFIG_GLOBAL="${BATS_TEST_TMPDIR}/fake-gitconfig"
     export GIT_CONFIG_SYSTEM=/dev/null
+    printf '[user]\n\tname = agency-test\n\temail = agency-test@localhost\n[init]\n\tdefaultBranch = main\n' > "$GIT_CONFIG_GLOBAL"
 
     # 4. Snapshot live .git/config checksum for guard validation
     if [[ -f "$REPO_ROOT/.git/config" ]]; then

--- a/agency/tools/monitor-register
+++ b/agency/tools/monitor-register
@@ -32,6 +32,18 @@
 
 set -euo pipefail
 
+# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
+# (coreutils). Equivalent at -a 256 (callers take field 1). Keeps the monitor
+# key stable across macOS and the Linux test/CI container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum; }
+else
+    echo "Error: monitor-register requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
@@ -53,7 +65,7 @@ cmdline_hash() {
     else
         cmdline=$(ps -p "$pid" -o command= 2>/dev/null || echo "")
     fi
-    printf '%s' "$cmdline" | shasum -a 256 | awk '{print $1}' | cut -c1-16
+    printf '%s' "$cmdline" | _sha256 | awk '{print $1}' | cut -c1-16
 }
 
 # ── modes ───────────────────────────────────────────────────────────────────

--- a/agency/tools/monitor-register
+++ b/agency/tools/monitor-register
@@ -32,19 +32,15 @@
 
 set -euo pipefail
 
-# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
-# (coreutils). Equivalent at -a 256 (callers take field 1). Keeps the monitor
-# key stable across macOS and the Linux test/CI container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on Linux),
+# resolved in one place across diff-hash/stage-hash/monitor-register (#42).
+if [[ -f "$SCRIPT_DIR/lib/_sha256" ]]; then
+    source "$SCRIPT_DIR/lib/_sha256"
 else
-    echo "Error: monitor-register requires 'shasum' or 'sha256sum' on PATH" >&2
+    echo "Error: monitor-register requires agency/tools/lib/_sha256" >&2
     exit 2
 fi
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     REPO_ROOT="$CLAUDE_PROJECT_DIR"

--- a/agency/tools/pr-create
+++ b/agency/tools/pr-create
@@ -71,16 +71,21 @@ echo "✓ On branch: $BRANCH"
 # The value is already captured by `head` before the signal; `|| true` keeps
 # that nondeterministic pipeline failure from aborting the whole script. A
 # genuine empty result still falls through to the -z checks below.
-NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
+# `xargs -r` (--no-run-if-empty) is REQUIRED: without it, GNU xargs (Linux)
+# runs `ls -t` with NO args when find matches nothing, which lists the CURRENT
+# DIRECTORY and returns a spurious entry (e.g. "usr") — the -z check then passes
+# and the tool tries to verify a non-receipt. BSD xargs (macOS) skips on empty by
+# default AND supports -r, so -r is correct on both. (#42, container gate.)
+NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1 || true)
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 2: legacy flat receipts dir
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 -r ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 3: old usr/ location
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 -r ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then

--- a/agency/tools/principal
+++ b/agency/tools/principal
@@ -75,8 +75,10 @@ main() {
 
     REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-    # If already set in environment, use that
-    if [ -n "$PRINCIPAL" ]; then
+    # If already set in environment, use that. Default-expand so an unset
+    # PRINCIPAL doesn't trip `set -u` (#42 — surfaced by the container gate,
+    # where the env var is absent; the bare "$PRINCIPAL" errored "unbound").
+    if [ -n "${PRINCIPAL:-}" ]; then
         verbose_echo "Using PRINCIPAL from environment: $PRINCIPAL"
         echo "$PRINCIPAL"
         trap - EXIT

--- a/agency/tools/release
+++ b/agency/tools/release
@@ -120,7 +120,15 @@ fi
 # such as `vversion$test.3.0` can never be selected as the "last release" — which
 # would otherwise feed a non-numeric component into bump_version's arithmetic.
 get_last_release() {
-    git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1
+    # Capture the full tag list first, then take the first line via parameter
+    # expansion — NOT `| head -n 1`. Under `set -o pipefail`, head closing the
+    # pipe early makes `git tag` die with SIGPIPE (exit 141) once its output
+    # overflows the ~64KB pipe buffer (i.e. once enough tags exist), and that
+    # 141 propagates out of the `$(...)` and trips `set -e`. (#42 — the
+    # container gate reproduced this deterministically against a 620-tag repo.)
+    local _tags
+    _tags=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname)
+    printf '%s\n' "${_tags%%$'\n'*}"
 }
 
 # Extract version from tag

--- a/agency/tools/settings-merge
+++ b/agency/tools/settings-merge
@@ -88,11 +88,15 @@ MERGED=$(jq -s '
   . as $merged_hooks |
 
   # Build final result
+  # Object-construction values that use the `*` merge operator MUST be
+  # parenthesized: jq 1.7.x rejects a bare `*` as an object value ("unexpected
+  # '*', expecting '}'"), while jq 1.8.x tolerates it. Parens are valid on both.
+  # (#42 — the container test-isolation gate ships jq 1.7.1; host had 1.8.1.)
   $target * {
     hooks: $merged_hooks,
-    permissions: ($target.permissions // {}) * {
+    permissions: (($target.permissions // {}) * {
       allow: array_union($target.permissions.allow // []; $template.permissions.allow // [])
-    }
+    })
   }
 ' "$TARGET" "$TEMPLATE")
 

--- a/agency/tools/stage-hash
+++ b/agency/tools/stage-hash
@@ -23,21 +23,17 @@
 
 set -euo pipefail
 
-# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
-# (coreutils). Identical output at -a 256 (callers take field 1). Resolving once
-# keeps hashes stable across macOS and the Linux test/CI container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum; }
-else
-    echo "Error: stage-hash requires 'shasum' or 'sha256sum' on PATH" >&2
-    exit 2
-fi
-
 TOOL_VERSION="2.0.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on Linux),
+# resolved in one place across diff-hash/stage-hash/monitor-register (#42).
+if [[ -f "$SCRIPT_DIR/lib/_sha256" ]]; then
+    source "$SCRIPT_DIR/lib/_sha256"
+else
+    echo "Error: stage-hash requires agency/tools/lib/_sha256" >&2
+    exit 2
+fi
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
     # shellcheck source=lib/_log-helper
     source "$SCRIPT_DIR/lib/_log-helper"

--- a/agency/tools/stage-hash
+++ b/agency/tools/stage-hash
@@ -23,6 +23,18 @@
 
 set -euo pipefail
 
+# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
+# (coreutils). Identical output at -a 256 (callers take field 1). Resolving once
+# keeps hashes stable across macOS and the Linux test/CI container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum; }
+else
+    echo "Error: stage-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 TOOL_VERSION="2.0.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -113,7 +125,7 @@ for file in "${STAGED[@]}"; do
     fi
 done
 
-HASH=$(printf '%s' "$HASH_INPUT" | shasum -a 256 | awk '{print $1}' | cut -c1-7)
+HASH=$(printf '%s' "$HASH_INPUT" | _sha256 | awk '{print $1}' | cut -c1-7)
 
 if [[ "$JSON" == "true" ]]; then
     printf '{\n  "hash": "%s",\n  "fileCount": %d,\n  "files": [\n    %s\n  ]\n}\n' \

--- a/agency/tools/worktree-sync
+++ b/agency/tools/worktree-sync
@@ -109,7 +109,14 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     exit 1
 }
 
-MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+# Capture the full listing, then take the first line's first field via parameter
+# expansion — NOT `| head -1`. Under `set -o pipefail`, head closing the pipe
+# after the first line makes `git worktree list` die with SIGPIPE (exit 141) as
+# it writes the remaining linked worktrees, and that 141 propagates out of the
+# `$(...)` and trips `set -e`. (#42 — the container gate hit this deterministically.)
+_wt_list=$(git worktree list 2>/dev/null)
+MAIN_CHECKOUT="${_wt_list%%$'\n'*}"   # first line (main checkout is always first)
+MAIN_CHECKOUT="${MAIN_CHECKOUT%% *}"  # first whitespace-delimited field (the path)
 if [[ -z "$MAIN_CHECKOUT" ]] || [[ ! -d "$MAIN_CHECKOUT" ]]; then
     echo "worktree-sync: cannot determine main checkout" >&2
     exit 1
@@ -283,8 +290,11 @@ if [[ "$MERGED" == true ]]; then
     # Files changed in agency/ namespace
     CHANGED_FILES=$(git diff "$PRE_MERGE_HEAD"..HEAD --name-only -- agency/ .claude/ CLAUDE.md 2>/dev/null || echo "")
 
-    # Check for CLAUDE.md changes
-    if echo "$CHANGED_FILES" | grep -qE "CLAUDE\.md|CLAUDE-THEAGENCY\.md" 2>/dev/null; then
+    # Check for CLAUDE.md changes. Use a bash regex, NOT `echo | grep -q`: under
+    # pipefail, grep -q closing the pipe on first match can SIGPIPE the echo
+    # (exit 141) when CHANGED_FILES is large, tripping set -e (#42, same class as
+    # the head-pipe above). A pure-bash match has no pipe to break.
+    if [[ "$CHANGED_FILES" =~ (CLAUDE\.md|CLAUDE-THEAGENCY\.md) ]]; then
         CLAUDE_MD_CHANGED=true
     fi
 

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-container-test-isolation-qgr-pr-captain-land-20260819-1734-86b99ee.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-container-test-isolation-qgr-pr-captain-land-20260819-1734-86b99ee.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: container-test-isolation
+diff_base: origin/main
+hash_a: 7e393690270e9a3fed0fe335b4417e423c6ec978d1df8ae2213d2a69ca28b470
+hash_b: b6b3f6f46363715344c8c62e1e958342737551f1847a8ede8df528639aefb9ff
+hash_c: b6b3f6f46363715344c8c62e1e958342737551f1847a8ede8df528639aefb9ff
+hash_d: b6b3f6f46363715344c8c62e1e958342737551f1847a8ede8df528639aefb9ff
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 86b99eedda3896b645eb4743eb8b295371de57c3264f5bf5babbf22aa8ed6b61
+date: 2026-08-19T17:34
+---
+
+# Receipt: pr-captain-land — container-test-isolation
+
+## Chain of Trust
+- A (original): 7e39369
+- B (findings): b6b3f6f
+- C (triage): b6b3f6f
+- D (principal): b6b3f6f — auto-approved — no principal 1B1
+- E (final): 86b99ee
+
+## Review Summary
+Local-first landing of container-test-isolation. Integrated in scratch worktree _land-container-test-isolation cut from origin/container-test-isolation; 1 local validation step(s) passed against origin/main; agency_version 46.43 → 46.44. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-container-test-isolation-42-qgr-pr-prep-20260819-1701-7e39369.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-container-test-isolation-42-qgr-pr-prep-20260819-1701-7e39369.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-container-test-isolation-42-qgr-pr-prep-20260819-1701-7e39369.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: container-test-isolation-42
+diff_base: origin/main
+hash_a: 30e3953deb41ae9fc161f84b7e4af04d18ce64fe31dfa5615f558ef2f0380c40
+hash_b: 10094ce8ad3713a91c4a80cf29c20cd70dab01b5f5999f1bb2418635f3933f00
+hash_c: 7c9c37ba7f9c409eb9d2cba7ed7c26101645ecb51513c083340ee20cf3795aa6
+hash_d: 7c9c37ba7f9c409eb9d2cba7ed7c26101645ecb51513c083340ee20cf3795aa6
+hash_d_source: "auto-approved — no principal 1B1 transcript (decisions via in-session AskUserQuestion)"
+hash_e: 7e393690270e9a3fed0fe335b4417e423c6ec978d1df8ae2213d2a69ca28b470
+date: 2026-08-19T17:01
+---
+
+# Receipt: pr-prep — container-test-isolation-42
+
+## Chain of Trust
+- A (original): 30e3953
+- B (findings): 10094ce
+- C (triage): 7c9c37b
+- D (principal): 7c9c37b — auto-approved — no principal 1B1 transcript (decisions via in-session AskUserQuestion)
+- E (final): 7e39369
+
+## Review Summary
+container test-isolation #42: 230->0 in-container, ~12 cross-platform tool bugs + 7 image deps + test hardening + git-captain tag-delete; QG found+fixed 9 findings in the branch's own code

--- a/src/agency/config/agency.yaml
+++ b/src/agency/config/agency.yaml
@@ -104,6 +104,11 @@ platform:
 preview:
   provider: "docker-compose"  # Default: docker-compose. Alternatives: fly, vercel, cloudflare
 
+# Container runtime (test isolation, sandboxed execution)
+# Abstraction over OCI backends — see agency/tools/lib/_container-runtime.
+container:
+  provider: "auto"  # Auto-detect: apple (Apple Silicon macOS) → docker. Alternatives: apple, docker
+
 # Deploy (platform deployment)
 deploy:
   provider: "fly"  # Default: fly. Alternatives: aws, vercel, cloudflare, railway

--- a/src/agency/containers/test-runner/Dockerfile
+++ b/src/agency/containers/test-runner/Dockerfile
@@ -26,6 +26,7 @@ RUN apk add --no-cache \
         github-cli \
         nodejs \
         npm \
+        rsync \
         coreutils \
         findutils \
         grep \

--- a/src/agency/containers/test-runner/Dockerfile
+++ b/src/agency/containers/test-runner/Dockerfile
@@ -7,7 +7,9 @@
 # agency/tools/lib/_container-runtime.
 #
 # Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
-# python3, and the coreutils/findutils/grep/sed/gawk userland.
+# python3 (+ the yaml module for workflow-validity tests), sqlite3 (the ISCP
+# dispatch/flag DB layer), zip (safe-extract fixtures — busybox already
+# supplies unzip), and the coreutils/findutils/grep/sed/gawk userland.
 FROM alpine:3.20
 RUN apk add --no-cache \
         bash \
@@ -15,6 +17,9 @@ RUN apk add --no-cache \
         bats \
         jq \
         python3 \
+        py3-yaml \
+        sqlite \
+        zip \
         coreutils \
         findutils \
         grep \

--- a/src/agency/containers/test-runner/Dockerfile
+++ b/src/agency/containers/test-runner/Dockerfile
@@ -9,7 +9,10 @@
 # Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
 # python3 (+ the yaml module for workflow-validity tests), sqlite3 (the ISCP
 # dispatch/flag DB layer), zip (safe-extract fixtures — busybox already
-# supplies unzip), and the coreutils/findutils/grep/sed/gawk userland.
+# supplies unzip), github-cli (gh/pr-captain-land/pr-create/release/git-sync
+# dry-run + arg-validation tests), nodejs/npm/pnpm (pkg-manager resolves this
+# repo's packageManager: pnpm@9), and the coreutils/findutils/grep/sed/gawk
+# userland.
 FROM alpine:3.20
 RUN apk add --no-cache \
         bash \
@@ -20,12 +23,18 @@ RUN apk add --no-cache \
         py3-yaml \
         sqlite \
         zip \
+        github-cli \
+        nodejs \
+        npm \
         coreutils \
         findutils \
         grep \
         sed \
         gawk \
     && rm -rf /var/cache/apk/*
+# pnpm is not packaged for alpine 3.20 — install it via npm at the version this
+# repo declares (packageManager: pnpm@9.15.0) so pkg-manager resolves cleanly.
+RUN npm install -g pnpm@9.15.0 && npm cache clean --force
 # No ENTRYPOINT: the runner drives the container with an explicit `bash -c ...`
 # so it can copy the repo to a writable workdir and invoke bats with arguments.
 WORKDIR /work

--- a/src/agency/containers/test-runner/Dockerfile
+++ b/src/agency/containers/test-runner/Dockerfile
@@ -1,0 +1,26 @@
+# the-agency isolated test-runner image
+#
+# A disposable Linux environment for running the framework's bats suite in a
+# container, so a buggy test can only trash the container, never the host repo.
+# Kept minimal + OCI-standard so it runs identically under Apple `container`
+# (Apple Silicon) and Docker (Linux/CI/Intel) — the two backends behind
+# agency/tools/lib/_container-runtime.
+#
+# Tools mirror what the bats suite actually invokes: bash, git, bats, jq,
+# python3, and the coreutils/findutils/grep/sed/gawk userland.
+FROM alpine:3.20
+RUN apk add --no-cache \
+        bash \
+        git \
+        bats \
+        jq \
+        python3 \
+        coreutils \
+        findutils \
+        grep \
+        sed \
+        gawk \
+    && rm -rf /var/cache/apk/*
+# No ENTRYPOINT: the runner drives the container with an explicit `bash -c ...`
+# so it can copy the repo to a writable workdir and invoke bats with arguments.
+WORKDIR /work

--- a/src/agency/tools/container-test-run
+++ b/src/agency/tools/container-test-run
@@ -65,12 +65,43 @@ backend="$(container_backend)" || {
 # id -un is the fallback when the invoking shell didn't export USER (#42).
 HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
 
+# Give the clone a credential-free, github-style origin URL. The raw `git clone
+# /src /work` sets origin to the local path "/src", so tools that parse ORG/REPO
+# or repo.name from the remote (pr-captain-land, agent-identity, repo-detection,
+# git-sync, handoff agent address) fail — on the host origin is a real github
+# URL. We derive org/repo from the host's origin but STRIP any embedded
+# credentials: a host remote may carry a "https://<token>@github.com/..." PAT
+# that must NEVER enter the container or the transcript. Parameter expansion
+# below drops everything up to and including "github.com", so the token is
+# removed by construction; we rebuild a clean https URL with no userinfo. (#42)
+_ho="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo '')"
+_after="${_ho#*github.com}"      # -> ":org/repo.git" or "/org/repo.git" (token gone)
+_after="${_after#[:/]}"           # strip the leading : or /
+_org_repo="${_after%.git}"        # -> "org/repo"
+if [ -n "$_org_repo" ] && [ "$_org_repo" != "$_ho" ]; then
+    CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
+else
+    CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
+fi
+
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
 RUN_CMD="set -e
 export USER=$(printf '%q' "$HOST_USER")
+# SYSTEM git identity + default branch: many tests create their own throwaway
+# repos in tmpdirs and commit WITHOUT setting local user.*, relying on an ambient
+# identity (present on a dev host, absent in a fresh container → 'git commit'
+# dies status 128 'Author identity unknown'). It MUST be --system (/etc/gitconfig),
+# NOT --global: test_isolation_setup scrubs HOME to a fakehome, so a ~/.gitconfig
+# global identity is invisible to the tests. --system is HOME-independent.
+# init.defaultBranch=main matches the framework convention so tests that expect a
+# 'main' branch behave like the host (alpine git otherwise defaults to 'master'). (#42)
+git config --system user.email ci@the-agency.local
+git config --system user.name ci
+git config --system init.defaultBranch main
 git clone -q /src /work
 cd /work
+git remote set-url origin $(printf '%q' "$CLEAN_ORIGIN")
 git config user.email ci@the-agency.local && git config user.name ci
 bats ${TESTS[*]}"
 

--- a/src/agency/tools/container-test-run
+++ b/src/agency/tools/container-test-run
@@ -71,23 +71,30 @@ HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
 # git-sync, handoff agent address) fail — on the host origin is a real github
 # URL. We derive org/repo from the host's origin but STRIP any embedded
 # credentials: a host remote may carry a "https://<token>@github.com/..." PAT
-# that must NEVER enter the container or the transcript. Parameter expansion
-# below drops everything up to and including "github.com", so the token is
-# removed by construction; we rebuild a clean https URL with no userinfo. (#42)
+# that must NEVER enter the container or the transcript.
+#
+# Security-critical (QG SEC-1/CODE-1): only process origins that ACTUALLY contain
+# "github.com", and only trust a result that is a clean "<org>/<repo>". The old
+# heuristic ("differs from the raw URL") was defeated by the trailing ".git"
+# strip alone, so a NON-github origin carrying a token (e.g.
+# "https://oauth2:TOK@gitlab.example.com/o/r.git") slipped through unstripped.
+# We now (a) gate on a real github.com match — anything else falls back to the
+# safe default — and (b) validate the parsed org/repo against a strict regex, so
+# any residual scheme/userinfo ("://", "@", ":") forces the default. The token
+# can never reach CLEAN_ORIGIN.
+CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
 _ho="$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo '')"
-_after="${_ho#*github.com}"      # -> ":org/repo.git" or "/org/repo.git" (token gone)
-_after="${_after#[:/]}"           # strip the leading : or /
-_org_repo="${_after%.git}"        # -> "org/repo"
-if [ -n "$_org_repo" ] && [ "$_org_repo" != "$_ho" ]; then
-    CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
-else
-    CLEAN_ORIGIN="https://github.com/the-agency-ai/the-agency.git"
+if [[ "$_ho" == *github.com* ]]; then
+    _after="${_ho#*github.com}"   # drop everything up to & incl github.com (token gone)
+    _after="${_after#[:/]}"       # strip the leading : or /
+    _org_repo="${_after%.git}"    # -> "org/repo"
+    if [[ "$_org_repo" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+        CLEAN_ORIGIN="https://github.com/${_org_repo}.git"
+    fi
 fi
 
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
-RUN_CMD="set -e
-export USER=$(printf '%q' "$HOST_USER")
 # SYSTEM git identity + default branch: many tests create their own throwaway
 # repos in tmpdirs and commit WITHOUT setting local user.*, relying on an ambient
 # identity (present on a dev host, absent in a fresh container → 'git commit'
@@ -95,7 +102,14 @@ export USER=$(printf '%q' "$HOST_USER")
 # NOT --global: test_isolation_setup scrubs HOME to a fakehome, so a ~/.gitconfig
 # global identity is invisible to the tests. --system is HOME-independent.
 # init.defaultBranch=main matches the framework convention so tests that expect a
-# 'main' branch behave like the host (alpine git otherwise defaults to 'master'). (#42)
+# 'main' branch behave like the host (alpine git otherwise defaults to 'master').
+#
+# Test paths are NOT spliced into this script — they arrive as ARGV ($1..) and
+# `bats "$@"` consumes them, so a path can never be re-parsed as shell (QG
+# SEC-2/CODE-3). $USER is supplied via --env below, not interpolated here. The
+# only interpolation is CLEAN_ORIGIN, which is validated to a clean org/repo and
+# printf-%q-quoted. (#42)
+RUN_CMD="set -e
 git config --system user.email ci@the-agency.local
 git config --system user.name ci
 git config --system init.defaultBranch main
@@ -103,16 +117,19 @@ git clone -q /src /work
 cd /work
 git remote set-url origin $(printf '%q' "$CLEAN_ORIGIN")
 git config user.email ci@the-agency.local && git config user.name ci
-bats ${TESTS[*]}"
+bats \"\$@\""
 
 echo "container-test-run: backend=$backend image=$IMAGE" >&2
 echo "container-test-run: tests=${TESTS[*]}" >&2
 
-case "$backend" in
-    apple)  container run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
-    docker) docker    run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
-    *)      echo "container-test-run: unknown backend '$backend'" >&2; exit 1 ;;
-esac
+# Route through the _container-runtime abstraction (backend-agnostic). Mount the
+# repo read-only; pass $USER via --env; hand the test paths to the container's
+# shell as ARGV after RUN_CMD ($0=container-test-run, $1.. = TESTS).
+container_run \
+    --mount "$REPO_ROOT:/src:ro" \
+    --env "USER=$HOST_USER" \
+    "$IMAGE" \
+    bash -c "$RUN_CMD" container-test-run "${TESTS[@]}"
 rc=$?
 
 if [ "$rc" -eq 0 ]; then

--- a/src/agency/tools/container-test-run
+++ b/src/agency/tools/container-test-run
@@ -58,9 +58,17 @@ backend="$(container_backend)" || {
     exit 127
 }
 
+# Replicate the host's $USER inside the container. The container runs as root
+# with USER unset, but identity resolution (agent-identity, principal) keys off
+# $USER against agency.yaml's principals map — so without this, identity-aware
+# tests (handoff agent address, principal, sandbox-sync) diverge from the host.
+# id -un is the fallback when the invoking shell didn't export USER (#42).
+HOST_USER="${USER:-$(id -un 2>/dev/null || echo unknown)}"
+
 # Clone the read-only-mounted repo to a writable workdir, then run bats there.
 # git identity is set so tests that commit don't fail on missing user.*.
 RUN_CMD="set -e
+export USER=$(printf '%q' "$HOST_USER")
 git clone -q /src /work
 cd /work
 git config user.email ci@the-agency.local && git config user.name ci

--- a/src/agency/tools/container-test-run
+++ b/src/agency/tools/container-test-run
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+#
+# container-test-run - run the bats suite inside a disposable container
+#
+# What Problem: bats tests run locally, un-isolated, keep trashing the real
+# repo — a buggy test created 600+ junk git tags, leaked worktrees into the live
+# checkout, and depended on gitignored dev-only dirs. In-process isolation only
+# works if every test is written correctly, and they keep not being. The local
+# machine PERSISTS between runs, so the damage accumulates (CI runners are
+# ephemeral, so CI is already self-isolating by disposal — the pain is local).
+#
+# How & Why: STRUCTURAL containment. Mount the host repo READ-ONLY into a
+# throwaway Linux container, clone it to a writable workdir INSIDE the container,
+# and run bats there. The host repo cannot be written (read-only mount) and the
+# tests operate on the clone — so a leaky test's `git tag` / `worktree-create`
+# hits the disposable copy and evaporates when the container is removed. It
+# doesn't rely on the test being correct.
+#
+# The container backend (Apple `container` on Apple Silicon, Docker on
+# Linux/CI/Intel) is resolved by agency/tools/lib/_container-runtime from
+# agency.yaml `container.provider` — same OCI image, either runtime.
+#
+# Usage:
+#   container-test-run                         # run the full bats:all set
+#   container-test-run src/tests/tools/foo.bats  # run specific paths
+#
+# Env:
+#   CONTAINER_TEST_IMAGE   override the runner image (default: the-agency-test-runner:latest)
+#   CONTAINER_PROVIDER     force backend: apple | docker | auto (default: config/auto)
+#
+# NOTE (increment 1): this tests the COMMITTED HEAD (via `git clone`), not
+# uncommitted working-tree changes. A working-tree mode (copy tracked+untracked,
+# excluding node_modules/.claude/worktrees) is the next increment.
+#
+# Written: 2026-08-19 — container test isolation (#42), captain + principal.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+[ -f "$SCRIPT_DIR/lib/_log-helper" ] && source "$SCRIPT_DIR/lib/_log-helper"
+# _container-runtime sources _path-resolve, giving AGENCY_PROJECT_ROOT + backend.
+source "$SCRIPT_DIR/lib/_container-runtime"
+
+RUN_ID=$(log_start "container-test-run" "$*" 2>/dev/null) || true
+
+REPO_ROOT="${AGENCY_PROJECT_ROOT:-$(cd "$SCRIPT_DIR/../.." && pwd)}"
+IMAGE="${CONTAINER_TEST_IMAGE:-the-agency-test-runner:latest}"
+
+if [ "$#" -gt 0 ]; then
+    TESTS=("$@")
+else
+    TESTS=(src/tests/tools/ src/tests/hookify/ src/tests/skills/ src/tests/agents/ src/tests/docs/)
+fi
+
+backend="$(container_backend)" || {
+    echo "container-test-run: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker." >&2
+    log_end "$RUN_ID" "failure" 1 0 "no backend" 2>/dev/null || true
+    exit 127
+}
+
+# Clone the read-only-mounted repo to a writable workdir, then run bats there.
+# git identity is set so tests that commit don't fail on missing user.*.
+RUN_CMD="set -e
+git clone -q /src /work
+cd /work
+git config user.email ci@the-agency.local && git config user.name ci
+bats ${TESTS[*]}"
+
+echo "container-test-run: backend=$backend image=$IMAGE" >&2
+echo "container-test-run: tests=${TESTS[*]}" >&2
+
+case "$backend" in
+    apple)  container run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
+    docker) docker    run --rm -v "$REPO_ROOT:/src:ro" "$IMAGE" bash -c "$RUN_CMD" ;;
+    *)      echo "container-test-run: unknown backend '$backend'" >&2; exit 1 ;;
+esac
+rc=$?
+
+if [ "$rc" -eq 0 ]; then
+    log_end "$RUN_ID" "success" 0 0 "bats passed in container ($backend)" 2>/dev/null || true
+else
+    log_end "$RUN_ID" "failure" "$rc" 0 "bats failed in container ($backend)" 2>/dev/null || true
+fi
+exit "$rc"

--- a/src/agency/tools/diff-hash
+++ b/src/agency/tools/diff-hash
@@ -43,6 +43,20 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     exit 2
 fi
 
+# Portable SHA-256. macOS ships `shasum` (a perl tool); Linux/alpine ship
+# `sha256sum` (coreutils) but usually NOT shasum. Both print "<hex>  <name>",
+# and every caller here takes field 1, so they are drop-in equivalents at
+# `-a 256`. Resolving once keeps the receipt hash identical across platforms —
+# essential now that the suite (and CI) run inside a Linux container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256 "$@"; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum "$@"; }
+else
+    echo "Error: diff-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 BASE="origin/main"
 FILE=""
 JSON=false
@@ -106,7 +120,7 @@ if [[ -n "$FILE" ]]; then
         exit 1
     fi
 
-    FULL_HASH=$(shasum -a 256 "$FILE" | cut -d' ' -f1)
+    FULL_HASH=$(_sha256 "$FILE" | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
     FILE_COUNT=1
 
@@ -190,7 +204,7 @@ else
         exit 1
     fi
 
-    FULL_HASH=$(echo "$DIFF_OUTPUT" | shasum -a 256 | cut -d' ' -f1)
+    FULL_HASH=$(echo "$DIFF_OUTPUT" | _sha256 | cut -d' ' -f1)
     SHORT_HASH="${FULL_HASH:0:7}"
 
     if [[ "$JSON" == "true" ]]; then

--- a/src/agency/tools/diff-hash
+++ b/src/agency/tools/diff-hash
@@ -43,17 +43,16 @@ if ! git rev-parse --show-toplevel >/dev/null 2>&1; then
     exit 2
 fi
 
-# Portable SHA-256. macOS ships `shasum` (a perl tool); Linux/alpine ship
-# `sha256sum` (coreutils) but usually NOT shasum. Both print "<hex>  <name>",
-# and every caller here takes field 1, so they are drop-in equivalents at
-# `-a 256`. Resolving once keeps the receipt hash identical across platforms —
-# essential now that the suite (and CI) run inside a Linux container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256 "$@"; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum "$@"; }
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on
+# Linux). Sourced so the resolution lives in ONE place across diff-hash /
+# stage-hash / monitor-register instead of three copies that must move together
+# for the next platform quirk (QG design finding, #42). Fail loud if the helper
+# is missing — diff-hash is receipt-critical and must not silently mis-hash.
+_DH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -f "$_DH_DIR/lib/_sha256" ]]; then
+    source "$_DH_DIR/lib/_sha256"
 else
-    echo "Error: diff-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    echo "Error: diff-hash requires agency/tools/lib/_sha256" >&2
     exit 2
 fi
 

--- a/src/agency/tools/git-captain
+++ b/src/agency/tools/git-captain
@@ -557,9 +557,16 @@ cmd_tag_delete() {
     # Origin-safety guard: fetch origin's tag set ONCE. A tag present on origin
     # is canonical and is NEVER deleted, regardless of the caller's list.
     echo "${BLUE}Checking origin tag set (safety guard)...${NC}" >&2
-    local origin_tags
-    origin_tags=$(git ls-remote --tags origin 2>/dev/null | grep -v '\^{}' | sed 's#.*refs/tags/##') \
+    # Check `git ls-remote` DIRECTLY for failure — do NOT fold the grep/sed
+    # filter into the same `|| die` pipeline. On an origin with ZERO tags,
+    # ls-remote succeeds with empty output but `grep -v` then exits 1 (no lines
+    # matched); under pipefail that 1 propagates and would false-die on a
+    # perfectly valid empty result, blocking tag-delete on fresh repos. Capture
+    # the raw listing first (die only if ls-remote itself fails), then filter.
+    local _lsr origin_tags
+    _lsr=$(git ls-remote --tags origin 2>/dev/null) \
         || die "Could not read origin tags — refusing to delete without the safety check."
+    origin_tags=$(printf '%s\n' "$_lsr" | grep -v '\^{}' | sed 's#.*refs/tags/##' || true)
 
     # --local-only sweep mode: enumerate ALL local tags NOT on origin (optionally
     # filtered by --match <regex>) as the candidate set. The per-name origin guard

--- a/src/agency/tools/git-captain
+++ b/src/agency/tools/git-captain
@@ -581,11 +581,18 @@ cmd_tag_delete() {
             names+=("$lt")
         done < <(git tag)
     fi
-    [[ ${#names[@]} -eq 0 ]] && die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+    # Empty candidate set: in explicit/--stdin mode that's a usage error (die).
+    # In --local-only mode it's a valid "nothing matched" result — fall through
+    # to the graceful "No local-only tags to delete" below (exit 0), don't die.
+    if [[ "$local_only" != true && ${#names[@]} -eq 0 ]]; then
+        die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+    fi
 
     local -a to_delete=() refused=() missing=()
     local t
-    for t in "${names[@]}"; do
+    # ${names[@]+...} so an empty array (valid in --local-only no-match) doesn't
+    # trip set -u "unbound variable" on bash 3.2 (macOS).
+    for t in ${names[@]+"${names[@]}"}; do
         if printf '%s\n' "$origin_tags" | grep -Fxq -- "$t"; then
             refused+=("$t")
         elif git rev-parse --verify --quiet "refs/tags/$t" >/dev/null; then

--- a/src/agency/tools/git-captain
+++ b/src/agency/tools/git-captain
@@ -69,6 +69,9 @@ Subcommands:
   push [args]                    Push to remote (blocks main/master, blocks bare --force)
   fetch                          Fetch from origin
   tag <name> [-m <msg>]          Create annotated tag
+  tag-delete <name>... | --stdin Delete LOCAL-ONLY tags. Never deletes a tag
+                                 present on origin (canonical). --dry-run to
+                                 preview. Reads names from stdin with --stdin.
   reset-soft [<ref>]             Sanctioned recovery: undo the last local
                                  commit (or reset to <ref>), keeping changes
                                  staged. REFUSES if HEAD is pushed to origin
@@ -519,6 +522,97 @@ cmd_tag() {
     echo "${GREEN}Created annotated tag:${NC} $name"
 }
 
+# --- Subcommand: tag-delete ---
+# Safe bulk deletion of LOCAL-ONLY tags. Raw `git tag -d` is hookify-blocked and
+# there was no safe path to remove tags (cmd_tag only creates), which blocked the
+# release-bug tag-pollution sweep (#42 / flag #264). The load-bearing guard: this
+# NEVER deletes a tag that exists on origin — origin tags are canonical release
+# history. It fetches origin's tag set and refuses any name found there, so even
+# a wrong caller-supplied list cannot destroy a published tag.
+#
+# Usage:
+#   git-captain tag-delete <name>...           delete the named local-only tags
+#   git-captain tag-delete --stdin             read names (one per line) from stdin
+#   git-captain tag-delete --dry-run <name>... preview only, delete nothing
+cmd_tag_delete() {
+    local dry_run=false from_stdin=false local_only=false match=""
+    local -a names=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --dry-run)    dry_run=true; shift ;;
+            --stdin)      from_stdin=true; shift ;;
+            --local-only) local_only=true; shift ;;
+            --match)      [[ $# -lt 2 ]] && die "--match requires a regex"; match="$2"; shift 2 ;;
+            -*)           die "Unknown option: $1" ;;
+            *)            names+=("$1"); shift ;;
+        esac
+    done
+    if [[ "$from_stdin" == true ]]; then
+        local line
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && names+=("$line")
+        done
+    fi
+
+    # Origin-safety guard: fetch origin's tag set ONCE. A tag present on origin
+    # is canonical and is NEVER deleted, regardless of the caller's list.
+    echo "${BLUE}Checking origin tag set (safety guard)...${NC}" >&2
+    local origin_tags
+    origin_tags=$(git ls-remote --tags origin 2>/dev/null | grep -v '\^{}' | sed 's#.*refs/tags/##') \
+        || die "Could not read origin tags — refusing to delete without the safety check."
+
+    # --local-only sweep mode: enumerate ALL local tags NOT on origin (optionally
+    # filtered by --match <regex>) as the candidate set. The per-name origin guard
+    # below still runs, so this is belt-and-suspenders. Ignores positional names.
+    if [[ "$local_only" == true ]]; then
+        names=()
+        local lt
+        while IFS= read -r lt; do
+            [[ -z "$lt" ]] && continue
+            printf '%s\n' "$origin_tags" | grep -Fxq -- "$lt" && continue   # on origin — skip
+            [[ -n "$match" && ! "$lt" =~ $match ]] && continue               # pattern filter
+            names+=("$lt")
+        done < <(git tag)
+    fi
+    [[ ${#names[@]} -eq 0 ]] && die "No tag names to delete. Usage: git-captain tag-delete <name>... | --stdin | --local-only [--match <regex>]"
+
+    local -a to_delete=() refused=() missing=()
+    local t
+    for t in "${names[@]}"; do
+        if printf '%s\n' "$origin_tags" | grep -Fxq -- "$t"; then
+            refused+=("$t")
+        elif git rev-parse --verify --quiet "refs/tags/$t" >/dev/null; then
+            to_delete+=("$t")
+        else
+            missing+=("$t")
+        fi
+    done
+
+    if [[ ${#refused[@]} -gt 0 ]]; then
+        echo "${YELLOW}Refusing ${#refused[@]} tag(s) present on origin (kept):${NC}" >&2
+        printf '  %s\n' "${refused[@]}" >&2
+    fi
+    [[ ${#missing[@]} -gt 0 ]] && echo "${BLUE}Skipped ${#missing[@]} tag(s) not present locally.${NC}" >&2
+
+    if [[ ${#to_delete[@]} -eq 0 ]]; then
+        echo "No local-only tags to delete."
+        return 0
+    fi
+
+    if [[ "$dry_run" == true ]]; then
+        echo "${YELLOW}[DRY RUN]${NC} Would delete ${#to_delete[@]} local-only tag(s):"
+        printf '  %s\n' "${to_delete[@]}"
+        return 0
+    fi
+
+    # git tag -d accepts many names; chunk to stay well under ARG_MAX on huge sweeps.
+    local i
+    for ((i = 0; i < ${#to_delete[@]}; i += 200)); do
+        git tag -d "${to_delete[@]:i:200}" >/dev/null
+    done
+    echo "${GREEN}Deleted ${#to_delete[@]} local-only tag(s).${NC} (${#refused[@]} on-origin kept.)"
+}
+
 # --- Subcommand: reset-soft ---
 # D41-R28 (issue #128): sanctioned recovery path for undoing a local,
 # un-pushed commit. Without this, agents who bypass /git-safe-commit (e.g.
@@ -638,6 +732,7 @@ case "$1" in
     push)               shift; cmd_push "$@" ;;
     fetch)              shift; cmd_fetch "$@" ;;
     tag)                shift; cmd_tag "$@" ;;
+    tag-delete)         shift; cmd_tag_delete "$@" ;;
     reset-soft)         shift; cmd_reset_soft "$@" ;;
     branch-delete)      shift; cmd_branch_delete "$@" ;;
     *)                  die "Unknown subcommand: $1 — run 'git-captain --help' for usage." ;;

--- a/src/agency/tools/great-rename-migrate
+++ b/src/agency/tools/great-rename-migrate
@@ -10,12 +10,19 @@
 # mechanically on the current branch BEFORE the sync, converting conflicts
 # from "file location" (thousands) to "content only" (small, manageable).
 #
-# How & Why: Read a built-in rename map (claude/ → agency/, tests/ → src/tests/).
-# Walk git-tracked files. For each file whose path starts with an old prefix,
-# `git mv` it to the new prefix. Preserves history. Dry-run by default. Agent
-# reviews plan, then re-runs with --apply. Only handles PATH migration —
-# inline text references (e.g., `./claude/tools/X` inside a script) require
-# a separate pass (see companion tool / dispatch mapping).
+# How & Why: Read a built-in rename map covering each shipped rename wave
+# (Wave 1 = Great Rename: claude/ → agency/, tests/ → src/tests/;
+# Wave 2 = v46.1 src/ split: apps/ → src/apps/,
+# starter-packs/ → src/spec-provider/starter-packs/;
+# Wave 3 = V5 Phase 4 src/ split: agency/{workstreams,principals,REFERENCE}/
+# → src/agency/{workstreams,principals,REFERENCE}/, with workstream
+# 'the-agency' renamed to 'agency'). Walk git-tracked files. For each file
+# whose path starts with an old prefix, `git mv` it to the new prefix.
+# Preserves history. Dry-run by default. Agent reviews plan, then re-runs
+# with --apply. Map covers both input states (never-migrated and
+# v1.1-applied) so one pass handles either case. Only handles PATH
+# migration — inline text references (e.g., `./claude/tools/X` inside a
+# script) require a separate pass (see companion tool / dispatch mapping).
 #
 # Note on git-safe bypass: This tool calls `git mv` directly (not
 # `git-safe mv`) because it *is* the safety layer — each rename is
@@ -24,11 +31,23 @@
 # every move through `git-safe mv` would double-validate for no gain.
 #
 # Written: 2026-04-21 for Bucket G.1 fleet-unblock deadline.
-# Version: 1.0.0 (provenance: 20260421-bucket-g1)
+# Updated: 2026-05-09 — v1.1.0: extend default map with v46.1 prefix moves
+#          (apps/ → src/apps/, starter-packs/ → src/spec-provider/starter-packs/).
+#          Both mdpal-app (#866) and mdpal-cli (#865) hit the gap simultaneously;
+#          other pre-Phase-4 worktrees (designex, devex, iscp) would too.
+# Updated: 2026-05-09 — v1.2.0: extend default map with V5 Phase 4 src/ split
+#          entries (workstreams, principals, REFERENCE moved to src/agency/;
+#          workstream 'the-agency' renamed to 'agency'). Per dispatch #869:
+#          mdpal-cli ran v1.1 cleanly but worktree-sync produced 618 conflicts
+#          because v1.1 was waves 1+2 only. v1.2 adds wave-3. Map now covers
+#          BOTH input states: never-migrated branches (claude/-prefixed) AND
+#          v1.1-applied branches (agency/-prefixed). Longest-prefix-first sort
+#          routes each file to the right composed transform in one pass.
+# Version: 1.2.0 (provenance: 20260509-mdpal-wave3)
 #
 set -euo pipefail
 
-TOOL_VERSION="1.0.0"
+TOOL_VERSION="1.2.0"
 SCRIPT_NAME="great-rename-migrate"
 
 # ANSI colors
@@ -40,10 +59,46 @@ BOLD="\033[1m"
 NC="\033[0m"
 
 # Default rename map — space-delimited pairs "old_prefix new_prefix".
-# Longer prefixes must come first so they match before shorter ones.
+# Order in this array does not matter functionally — the loader sorts entries
+# by old-prefix length DESCENDING at runtime so longer prefixes match first.
+# Order is grouped by rename wave for human readability.
+#
+# Composability: the map covers BOTH input states. A never-migrated branch
+# (claude/-prefixed paths) gets the FULL composed transform in one pass —
+# wave-3 entries with the claude/ prefix include the V5 split. A
+# v1.1-already-applied branch (agency/-prefixed paths) gets only the
+# wave-3 incremental — the agency/-prefixed entries below match those.
+# Longest-prefix-first sorting at runtime routes each file correctly.
 DEFAULT_MAP=(
+    # Wave 1 — Great Rename (v46.0 framework reorg).
+    # Catch-all for non-V5-moved subdirs (tools/, agents/, config/, etc.):
     "claude/ agency/"
     "tests/ src/tests/"
+
+    # Wave 2 — v46.1 src/ split (apps + spec-provider relocation):
+    "starter-packs/ src/spec-provider/starter-packs/"
+    "apps/ src/apps/"
+    # Wave 2b — composed: claude/starter-packs/ direct (longer prefix wins
+    # over claude/, sends never-migrated branches straight to spec-provider):
+    "claude/starter-packs/ src/spec-provider/starter-packs/"
+    # Wave 2c — incremental: agency/starter-packs/ for v1.1-applied branches:
+    "agency/starter-packs/ src/spec-provider/starter-packs/"
+
+    # Wave 3 — V5 Phase 4 src/ split (added 2026-05-09 per dispatch #869).
+    # Selected agency/ subdirs moved under src/agency/ as canonical source;
+    # agency/ retains a build-output mirror that gets regenerated. Workstream
+    # 'the-agency' was renamed to 'agency' in the same wave.
+    #
+    # For never-migrated branches (composed: claude/ → agency/ → src/agency/):
+    "claude/workstreams/the-agency/ src/agency/workstreams/agency/"
+    "claude/workstreams/ src/agency/workstreams/"
+    "claude/principals/ src/agency/principals/"
+    "claude/REFERENCE/ src/agency/REFERENCE/"
+    # For v1.1-already-applied branches (incremental wave-3 only):
+    "agency/workstreams/the-agency/ src/agency/workstreams/agency/"
+    "agency/workstreams/ src/agency/workstreams/"
+    "agency/principals/ src/agency/principals/"
+    "agency/REFERENCE/ src/agency/REFERENCE/"
 )
 
 usage() {
@@ -58,7 +113,16 @@ Options:
   --apply              Execute the renames via 'git mv'.
   --map <file>         Use a custom rename map file (one pair per line:
                        "<old_prefix> <new_prefix>"). Default: built-in map
-                       covering claude/ → agency/ and tests/ → src/tests/.
+                       covers all three rename waves:
+                         Wave 1: claude/ → agency/, tests/ → src/tests/
+                         Wave 2: apps/ → src/apps/,
+                                 starter-packs/ → src/spec-provider/starter-packs/
+                         Wave 3: agency/{workstreams,principals,REFERENCE}/
+                                 → src/agency/{...}/ (V5 Phase 4 src/ split),
+                                 agency/workstreams/the-agency/ renamed to
+                                 agency/workstreams/agency/.
+                       Map covers both never-migrated (claude/-prefixed) and
+                       v1.1-applied (agency/-prefixed) input states.
   -h, --help           Show this help.
   -v, --version        Show tool version.
 
@@ -190,7 +254,7 @@ validate_prefix_pair() {
 
 # Load rename map — both old + new split on any whitespace (robust to
 # tabs, multiple spaces, trailing whitespace).
-declare -a RENAME_MAP
+declare -a RENAME_MAP=()
 if [[ -n "$MAP_FILE" ]]; then
     _lineno=0
     # `|| [[ -n "$line" ]]` picks up a final line with no trailing newline.
@@ -247,10 +311,14 @@ info "Scanned ${#CANDIDATES[@]} file(s) in worktree"
 echo
 
 # Compute rename plan
-declare -a PLAN_FROM PLAN_TO
-declare -a SKIP_TARGET_EXISTS
-declare -a SKIP_DUP_TARGET
-declare -a NO_MATCH
+# Initialize as empty arrays (=()): a bare `declare -a FOO` leaves FOO unset on
+# some bash builds (e.g. alpine's), so a later `${#FOO[@]}` / `"${FOO[@]}"` trips
+# `set -u` "unbound variable". Explicit =() is defined on every bash. (#42 — the
+# container test-isolation gate surfaced this; macOS bash tolerated the bare form.)
+declare -a PLAN_FROM=() PLAN_TO=()
+declare -a SKIP_TARGET_EXISTS=()
+declare -a SKIP_DUP_TARGET=()
+declare -a NO_MATCH=()
 
 for f in "${CANDIDATES[@]}"; do
     matched=0
@@ -374,7 +442,7 @@ echo
 echo -e "${BOLD}Next steps:${NC}"
 echo "  1. Review: ${GREEN}git status${NC}"
 echo "  2. Diff:   ${GREEN}git diff --cached --stat${NC}"
-echo "  3. Commit: ${GREEN}git-safe-commit \"migrate branch: claude/ → agency/ + tests/ → src/tests/\" --no-work-item${NC}"
+echo "  3. Commit: ${GREEN}git-safe-commit \"migrate branch: apply great-rename default map\" --no-work-item${NC}"
 echo "  4. Sync:   ${GREEN}./agency/tools/worktree-sync --auto${NC}"
 echo "  5. Residual content conflicts: see fleet-rename dispatch for mapping"
 

--- a/src/agency/tools/lib/_container-runtime
+++ b/src/agency/tools/lib/_container-runtime
@@ -16,12 +16,19 @@
 #   source "$PROJECT_ROOT/agency/tools/lib/_container-runtime"
 #   container_backend                     # -> apple | docker  (stdout; rc1 if none)
 #   container_available                   # rc0 if a usable backend exists
-#   container_run <image> [--] <cmd...>   # run cmd in a throwaway container
+#   container_run [--mount <spec>]... [--env <K=V>]... <image> [--] <cmd...>
+#                                         # run cmd in a throwaway container
 #
 # container_run passes stdout/stderr through and returns the command's exit code.
-# Backend CLIs are near-identical OCI (`container run --rm` / `docker run --rm`),
-# so dispatch is intentionally thin; add a backend by extending the case arms in
-# _crt_have + container_run.
+# --mount <spec> maps to `-v <spec>` (repeatable, e.g. "/host:/guest:ro"); --env
+# <K=V> maps to `-e K=V`. Command args after the image are passed as argv, never
+# a shell string, so callers never string-splice untrusted values.
+#
+# NOTE on architecture: unlike _provider-resolve (which resolves a per-provider
+# TOOL FILE the caller execs), the two OCI backends here are near-identical CLIs
+# (`container run --rm` / `docker run --rm`), so their logic is inlined in the
+# case arms rather than living in separate container-apple / container-docker
+# tools. Add a backend by extending the case arms in _crt_have + container_run.
 
 # Load _path-resolve for AGENCY_PROJECT_ROOT + _pr_yaml_get (config reads),
 # mirroring how _provider-resolve bootstraps. Best-effort: the adapter still
@@ -72,18 +79,34 @@ container_backend() {
 # container_available -> rc0 if a usable backend exists
 container_available() { container_backend >/dev/null 2>&1; }
 
-# container_run <image> [--] <cmd...> -> run cmd in a throwaway container.
-# Removes the container on exit (--rm); returns the command's exit code.
+# container_run [--mount <spec>]... [--env <K=V>]... <image> [--] <cmd...>
+# Run cmd in a throwaway container. Removes it on exit (--rm); returns the
+# command's exit code. Command args are passed as argv (never a shell string).
 container_run() {
-    local image="$1"; shift
+    local -a mounts=() envs=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --mount) [[ $# -lt 2 ]] && { echo "container_run: --mount needs a value" >&2; return 2; }
+                     mounts+=("-v" "$2"); shift 2 ;;
+            --env)   [[ $# -lt 2 ]] && { echo "container_run: --env needs a value" >&2; return 2; }
+                     envs+=("-e" "$2"); shift 2 ;;
+            --)      shift; break ;;
+            *)       break ;;
+        esac
+    done
+    local image="${1:-}"; shift || true
     [[ "${1:-}" == "--" ]] && shift
+    [[ -z "$image" ]] && { echo "container_run: image required" >&2; return 2; }
     local backend
     backend="$(container_backend)" || {
         echo "_container-runtime: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker" >&2
         return 127
     }
+    # ${arr[@]+"${arr[@]}"} expands to nothing when the array is empty, which is
+    # bash-3.2-safe under `set -u` (a bare "${arr[@]}" on an empty array errors
+    # there). Keeps this sourceable into set -u callers like container-test-run.
     case "$backend" in
-        apple)  container run --rm "$image" "$@" ;;
-        docker) docker    run --rm "$image" "$@" ;;
+        apple)  container run --rm ${mounts[@]+"${mounts[@]}"} ${envs[@]+"${envs[@]}"} "$image" "$@" ;;
+        docker) docker    run --rm ${mounts[@]+"${mounts[@]}"} ${envs[@]+"${envs[@]}"} "$image" "$@" ;;
     esac
 }

--- a/src/agency/tools/lib/_container-runtime
+++ b/src/agency/tools/lib/_container-runtime
@@ -1,0 +1,89 @@
+#!/bin/bash
+#
+# _container-runtime - container backend abstraction (Apple `container` + Docker)
+#
+# One interface, interchangeable OCI backends. Same shape as _provider-resolve:
+# sourced, silent, non-blocking, bash-3.2-safe (no associative arrays). The
+# active backend comes from agency.yaml `container.provider` (auto|apple|docker);
+# env CONTAINER_PROVIDER overrides. "auto" prefers Apple `container` (native,
+# daemonless, Apple-Silicon macOS) and falls back to Docker.
+#
+# Why an abstraction (not "Apple Containers everywhere"): Apple `container` is
+# the better runtime on Apple Silicon, but Docker is what runs on Linux/CI/Intel.
+# Callers say "run this in a throwaway container"; the backend is a config detail.
+#
+# Usage:
+#   source "$PROJECT_ROOT/agency/tools/lib/_container-runtime"
+#   container_backend                     # -> apple | docker  (stdout; rc1 if none)
+#   container_available                   # rc0 if a usable backend exists
+#   container_run <image> [--] <cmd...>   # run cmd in a throwaway container
+#
+# container_run passes stdout/stderr through and returns the command's exit code.
+# Backend CLIs are near-identical OCI (`container run --rm` / `docker run --rm`),
+# so dispatch is intentionally thin; add a backend by extending the case arms in
+# _crt_have + container_run.
+
+# Load _path-resolve for AGENCY_PROJECT_ROOT + _pr_yaml_get (config reads),
+# mirroring how _provider-resolve bootstraps. Best-effort: the adapter still
+# works with env/auto-detect if config is unreadable.
+if [[ -z "${AGENCY_PROJECT_ROOT:-}" ]] || ! declare -f _pr_yaml_get >/dev/null 2>&1; then
+    _crt_lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    [[ -f "$_crt_lib_dir/_path-resolve" ]] && source "$_crt_lib_dir/_path-resolve"
+fi
+
+# _crt_configured_provider -> container.provider from agency.yaml, else "auto".
+# Env CONTAINER_PROVIDER wins (for tests / one-off overrides).
+_crt_configured_provider() {
+    if [[ -n "${CONTAINER_PROVIDER:-}" ]]; then
+        printf '%s' "$CONTAINER_PROVIDER"; return 0
+    fi
+    local yaml="${AGENCY_PROJECT_ROOT:-.}/agency/config/agency.yaml" val=""
+    if declare -f _pr_yaml_get >/dev/null 2>&1 && [[ -f "$yaml" ]]; then
+        val="$(_pr_yaml_get "container" "provider" "$yaml" 2>/dev/null)"
+        val="${val//\"/}"; val="${val//\'/}"; val="${val// /}"; val="${val//$'\r'/}"
+    fi
+    printf '%s' "${val:-auto}"
+}
+
+# _crt_have <apple|docker> -> rc0 if that backend's CLI is on PATH
+_crt_have() {
+    case "$1" in
+        apple)  command -v container >/dev/null 2>&1 ;;
+        docker) command -v docker    >/dev/null 2>&1 ;;
+        *)      return 1 ;;
+    esac
+}
+
+# container_backend -> resolved backend name (apple|docker) on stdout; rc1 if none
+container_backend() {
+    local pref; pref="$(_crt_configured_provider)"
+    case "$pref" in
+        apple|docker)
+            _crt_have "$pref" && { printf '%s' "$pref"; return 0; }
+            return 1 ;;
+        auto|"")
+            if _crt_have apple;  then printf 'apple';  return 0; fi
+            if _crt_have docker; then printf 'docker'; return 0; fi
+            return 1 ;;
+        *) return 1 ;;
+    esac
+}
+
+# container_available -> rc0 if a usable backend exists
+container_available() { container_backend >/dev/null 2>&1; }
+
+# container_run <image> [--] <cmd...> -> run cmd in a throwaway container.
+# Removes the container on exit (--rm); returns the command's exit code.
+container_run() {
+    local image="$1"; shift
+    [[ "${1:-}" == "--" ]] && shift
+    local backend
+    backend="$(container_backend)" || {
+        echo "_container-runtime: no container backend available — install Apple 'container' (Apple Silicon macOS) or Docker" >&2
+        return 127
+    }
+    case "$backend" in
+        apple)  container run --rm "$image" "$@" ;;
+        docker) docker    run --rm "$image" "$@" ;;
+    esac
+}

--- a/src/agency/tools/lib/_iscp-db
+++ b/src/agency/tools/lib/_iscp-db
@@ -270,8 +270,16 @@ _iscp_run_migrations() {
             return 1
         }
 
-        # Execute migration in a transaction with version bump
+        # Execute migration in a transaction with version bump.
+        # `.bail on` is REQUIRED: without it the sqlite3 CLI prints an error but
+        # CONTINUES to the next statements, so a failing ${migration_sql} would
+        # still run `PRAGMA user_version` + COMMIT — bumping (and committing) the
+        # version even though the migration failed, while the shell still sees a
+        # non-zero exit. With `.bail on`, sqlite3 stops at the first error inside
+        # the open BEGIN and exits, leaving the transaction to auto-rollback so
+        # the version stays put. macOS sqlite masked this; alpine surfaced it. (#42)
         sqlite3 "$db_path" << SQL
+.bail on
 ${preamble}
 BEGIN;
 ${migration_sql}

--- a/src/agency/tools/lib/_sha256
+++ b/src/agency/tools/lib/_sha256
@@ -1,0 +1,25 @@
+#!/bin/bash
+#
+# _sha256 - portable SHA-256 helper (sourced).
+#
+# macOS ships `shasum` (a perl tool); Linux/alpine ship `sha256sum` (coreutils)
+# but usually NOT shasum. Both emit "<hex>  <name>" at -a 256 and every caller
+# takes field 1, so they are drop-in equivalents. Resolving ONCE, here, keeps a
+# single definition instead of the per-tool copies that previously drifted
+# (diff-hash/stage-hash/monitor-register) and must all move together for the next
+# platform quirk (QG design finding, #42).
+#
+# Usage (after sourcing):
+#   _sha256 <file>...     # hash each file        (shasum/sha256sum <file>...)
+#   printf '%s' "$x" | _sha256   # hash stdin      (no args -> reads stdin)
+#
+# Callers pull field 1 themselves, e.g. `_sha256 "$f" | cut -d' ' -f1` or
+# `... | _sha256 | awk '{print $1}'`. If NEITHER tool exists, _sha256 errors and
+# returns 2 at CALL time (not source time), so sourcing never kills the caller.
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256 "$@"; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum "$@"; }
+else
+    _sha256() { echo "_sha256: neither 'shasum' nor 'sha256sum' found on PATH" >&2; return 2; }
+fi

--- a/src/agency/tools/lib/_test-isolation
+++ b/src/agency/tools/lib/_test-isolation
@@ -94,19 +94,17 @@ test_isolation_setup() {
     # 2. Explicit ISCP DB path — belt-and-suspenders on top of HOME override
     export ISCP_DB_PATH="${BATS_TEST_TMPDIR}/test-iscp.db"
 
-    # 3. Git config isolation — prevent any writes to live .git/config, AND
-    #    supply a hermetic fallback identity. GLOBAL points at a throwaway
-    #    config carrying a deterministic test identity (+ init.defaultBranch)
-    #    rather than /dev/null: tests that create a repo and commit WITHOUT
-    #    setting local user.* otherwise rely on git's ambient auto-identity,
-    #    which macOS derives from the system but a minimal Linux container
-    #    cannot — failing "Author identity unknown" (#42, container gate).
-    #    Global level (not env GIT_AUTHOR_*) means a test's own local
-    #    `git config user.*` still WINS, so per-test attribution is unchanged;
-    #    this only backstops the no-local-config case. SYSTEM stays /dev/null.
-    export GIT_CONFIG_GLOBAL="${BATS_TEST_TMPDIR}/fake-gitconfig"
+    # 3. Git config isolation — prevent any writes to live .git/config.
+    #    Deliberately /dev/null (NOT a fallback identity): several tests assert
+    #    on the UNCONFIGURED-identity path (e.g. "#204 git-safe-commit errors
+    #    loudly when git identity is unconfigured") and on the default branch,
+    #    so a blanket ambient identity here regresses them. Tests that DO commit
+    #    must set their own local `git config user.*` in their fixture (the
+    #    hermetic pattern). The handful that rely on git's macOS auto-identity
+    #    are tracked as test-portability debt (#42 / flag #264), to be hardened
+    #    per-test rather than globally.
+    export GIT_CONFIG_GLOBAL=/dev/null
     export GIT_CONFIG_SYSTEM=/dev/null
-    printf '[user]\n\tname = agency-test\n\temail = agency-test@localhost\n[init]\n\tdefaultBranch = main\n' > "$GIT_CONFIG_GLOBAL"
 
     # 4. Snapshot live .git/config checksum for guard validation
     if [[ -f "$REPO_ROOT/.git/config" ]]; then

--- a/src/agency/tools/lib/_test-isolation
+++ b/src/agency/tools/lib/_test-isolation
@@ -94,9 +94,19 @@ test_isolation_setup() {
     # 2. Explicit ISCP DB path — belt-and-suspenders on top of HOME override
     export ISCP_DB_PATH="${BATS_TEST_TMPDIR}/test-iscp.db"
 
-    # 3. Git config isolation — prevent any writes to live .git/config
-    export GIT_CONFIG_GLOBAL=/dev/null
+    # 3. Git config isolation — prevent any writes to live .git/config, AND
+    #    supply a hermetic fallback identity. GLOBAL points at a throwaway
+    #    config carrying a deterministic test identity (+ init.defaultBranch)
+    #    rather than /dev/null: tests that create a repo and commit WITHOUT
+    #    setting local user.* otherwise rely on git's ambient auto-identity,
+    #    which macOS derives from the system but a minimal Linux container
+    #    cannot — failing "Author identity unknown" (#42, container gate).
+    #    Global level (not env GIT_AUTHOR_*) means a test's own local
+    #    `git config user.*` still WINS, so per-test attribution is unchanged;
+    #    this only backstops the no-local-config case. SYSTEM stays /dev/null.
+    export GIT_CONFIG_GLOBAL="${BATS_TEST_TMPDIR}/fake-gitconfig"
     export GIT_CONFIG_SYSTEM=/dev/null
+    printf '[user]\n\tname = agency-test\n\temail = agency-test@localhost\n[init]\n\tdefaultBranch = main\n' > "$GIT_CONFIG_GLOBAL"
 
     # 4. Snapshot live .git/config checksum for guard validation
     if [[ -f "$REPO_ROOT/.git/config" ]]; then

--- a/src/agency/tools/monitor-register
+++ b/src/agency/tools/monitor-register
@@ -32,6 +32,18 @@
 
 set -euo pipefail
 
+# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
+# (coreutils). Equivalent at -a 256 (callers take field 1). Keeps the monitor
+# key stable across macOS and the Linux test/CI container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum; }
+else
+    echo "Error: monitor-register requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
@@ -53,7 +65,7 @@ cmdline_hash() {
     else
         cmdline=$(ps -p "$pid" -o command= 2>/dev/null || echo "")
     fi
-    printf '%s' "$cmdline" | shasum -a 256 | awk '{print $1}' | cut -c1-16
+    printf '%s' "$cmdline" | _sha256 | awk '{print $1}' | cut -c1-16
 }
 
 # ── modes ───────────────────────────────────────────────────────────────────

--- a/src/agency/tools/monitor-register
+++ b/src/agency/tools/monitor-register
@@ -32,19 +32,15 @@
 
 set -euo pipefail
 
-# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
-# (coreutils). Equivalent at -a 256 (callers take field 1). Keeps the monitor
-# key stable across macOS and the Linux test/CI container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum; }
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on Linux),
+# resolved in one place across diff-hash/stage-hash/monitor-register (#42).
+if [[ -f "$SCRIPT_DIR/lib/_sha256" ]]; then
+    source "$SCRIPT_DIR/lib/_sha256"
 else
-    echo "Error: monitor-register requires 'shasum' or 'sha256sum' on PATH" >&2
+    echo "Error: monitor-register requires agency/tools/lib/_sha256" >&2
     exit 2
 fi
-
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 if [[ -n "${CLAUDE_PROJECT_DIR:-}" ]]; then
     REPO_ROOT="$CLAUDE_PROJECT_DIR"

--- a/src/agency/tools/pr-create
+++ b/src/agency/tools/pr-create
@@ -71,16 +71,21 @@ echo "✓ On branch: $BRANCH"
 # The value is already captured by `head` before the signal; `|| true` keeps
 # that nondeterministic pipeline failure from aborting the whole script. A
 # genuine empty result still falls through to the -z checks below.
-NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs ls -t 2>/dev/null | head -1 || true)
+# `xargs -r` (--no-run-if-empty) is REQUIRED: without it, GNU xargs (Linux)
+# runs `ls -t` with NO args when find matches nothing, which lists the CURRENT
+# DIRECTORY and returns a spurious entry (e.g. "usr") — the -z check then passes
+# and the tool tries to verify a non-receipt. BSD xargs (macOS) skips on empty by
+# default AND supports -r, so -r is correct on both. (#42, container gate.)
+NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/workstreams" \( -path "*/qgr/*.md" -o -path "*/rgr/*.md" \) 2>/dev/null | xargs -r ls -t 2>/dev/null | head -1 || true)
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 2: legacy flat receipts dir
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/agency/receipts" -name "*.md" -not -name ".gitkeep" -print0 2>/dev/null | xargs -0 -r ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then
     # Tier 3: old usr/ location
-    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 ls -t 2>/dev/null | head -1 || true)
+    NEWEST_RECEIPT=$(find "$REPO_ROOT/usr" -name "qgr-*.md" -print0 2>/dev/null | xargs -0 -r ls -t 2>/dev/null | head -1 || true)
 fi
 
 if [[ -z "$NEWEST_RECEIPT" ]]; then

--- a/src/agency/tools/principal
+++ b/src/agency/tools/principal
@@ -75,8 +75,10 @@ main() {
 
     REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
 
-    # If already set in environment, use that
-    if [ -n "$PRINCIPAL" ]; then
+    # If already set in environment, use that. Default-expand so an unset
+    # PRINCIPAL doesn't trip `set -u` (#42 — surfaced by the container gate,
+    # where the env var is absent; the bare "$PRINCIPAL" errored "unbound").
+    if [ -n "${PRINCIPAL:-}" ]; then
         verbose_echo "Using PRINCIPAL from environment: $PRINCIPAL"
         echo "$PRINCIPAL"
         trap - EXIT

--- a/src/agency/tools/release
+++ b/src/agency/tools/release
@@ -120,7 +120,15 @@ fi
 # such as `vversion$test.3.0` can never be selected as the "last release" — which
 # would otherwise feed a non-numeric component into bump_version's arithmetic.
 get_last_release() {
-    git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1
+    # Capture the full tag list first, then take the first line via parameter
+    # expansion — NOT `| head -n 1`. Under `set -o pipefail`, head closing the
+    # pipe early makes `git tag` die with SIGPIPE (exit 141) once its output
+    # overflows the ~64KB pipe buffer (i.e. once enough tags exist), and that
+    # 141 propagates out of the `$(...)` and trips `set -e`. (#42 — the
+    # container gate reproduced this deterministically against a 620-tag repo.)
+    local _tags
+    _tags=$(git tag -l 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname)
+    printf '%s\n' "${_tags%%$'\n'*}"
 }
 
 # Extract version from tag

--- a/src/agency/tools/settings-merge
+++ b/src/agency/tools/settings-merge
@@ -88,11 +88,15 @@ MERGED=$(jq -s '
   . as $merged_hooks |
 
   # Build final result
+  # Object-construction values that use the `*` merge operator MUST be
+  # parenthesized: jq 1.7.x rejects a bare `*` as an object value ("unexpected
+  # '*', expecting '}'"), while jq 1.8.x tolerates it. Parens are valid on both.
+  # (#42 — the container test-isolation gate ships jq 1.7.1; host had 1.8.1.)
   $target * {
     hooks: $merged_hooks,
-    permissions: ($target.permissions // {}) * {
+    permissions: (($target.permissions // {}) * {
       allow: array_union($target.permissions.allow // []; $template.permissions.allow // [])
-    }
+    })
   }
 ' "$TARGET" "$TEMPLATE")
 

--- a/src/agency/tools/stage-hash
+++ b/src/agency/tools/stage-hash
@@ -23,21 +23,17 @@
 
 set -euo pipefail
 
-# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
-# (coreutils). Identical output at -a 256 (callers take field 1). Resolving once
-# keeps hashes stable across macOS and the Linux test/CI container (#42).
-if command -v shasum >/dev/null 2>&1; then
-    _sha256() { shasum -a 256; }
-elif command -v sha256sum >/dev/null 2>&1; then
-    _sha256() { sha256sum; }
-else
-    echo "Error: stage-hash requires 'shasum' or 'sha256sum' on PATH" >&2
-    exit 2
-fi
-
 TOOL_VERSION="2.0.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# Portable SHA-256 via the shared helper (shasum on macOS || sha256sum on Linux),
+# resolved in one place across diff-hash/stage-hash/monitor-register (#42).
+if [[ -f "$SCRIPT_DIR/lib/_sha256" ]]; then
+    source "$SCRIPT_DIR/lib/_sha256"
+else
+    echo "Error: stage-hash requires agency/tools/lib/_sha256" >&2
+    exit 2
+fi
 if [[ -f "$SCRIPT_DIR/lib/_log-helper" ]]; then
     # shellcheck source=lib/_log-helper
     source "$SCRIPT_DIR/lib/_log-helper"

--- a/src/agency/tools/stage-hash
+++ b/src/agency/tools/stage-hash
@@ -23,6 +23,18 @@
 
 set -euo pipefail
 
+# Portable SHA-256: macOS ships `shasum` (perl), Linux/alpine ship `sha256sum`
+# (coreutils). Identical output at -a 256 (callers take field 1). Resolving once
+# keeps hashes stable across macOS and the Linux test/CI container (#42).
+if command -v shasum >/dev/null 2>&1; then
+    _sha256() { shasum -a 256; }
+elif command -v sha256sum >/dev/null 2>&1; then
+    _sha256() { sha256sum; }
+else
+    echo "Error: stage-hash requires 'shasum' or 'sha256sum' on PATH" >&2
+    exit 2
+fi
+
 TOOL_VERSION="2.0.0"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -113,7 +125,7 @@ for file in "${STAGED[@]}"; do
     fi
 done
 
-HASH=$(printf '%s' "$HASH_INPUT" | shasum -a 256 | awk '{print $1}' | cut -c1-7)
+HASH=$(printf '%s' "$HASH_INPUT" | _sha256 | awk '{print $1}' | cut -c1-7)
 
 if [[ "$JSON" == "true" ]]; then
     printf '{\n  "hash": "%s",\n  "fileCount": %d,\n  "files": [\n    %s\n  ]\n}\n' \

--- a/src/agency/tools/worktree-sync
+++ b/src/agency/tools/worktree-sync
@@ -42,14 +42,37 @@ fi
 AUTO_MODE=false
 MODE="manual"
 STASHED=false
+# Issue #195: label every stash we take with pid+timestamp so we can pop
+# it by ref (`git stash pop stash@{N}`) rather than blindly popping the
+# top of the stack. Prevents cross-worktree stash pollution when multiple
+# worktree-sync runs interleave.
+STASH_LABEL="worktree-sync-$$-$(date +%s)"
+STASH_REF=""
 
-# EXIT trap: ensure stash is always popped if script aborts mid-flight
+# EXIT trap: ensure our labelled stash is always popped if script aborts
+# mid-flight. Resolve by label, not by position.
 _cleanup() {
     if [[ "$STASHED" == true ]]; then
-        git stash pop --quiet 2>/dev/null || true
+        local _ref
+        _ref=$(_resolve_stash_ref 2>/dev/null || true)
+        if [[ -n "$_ref" ]]; then
+            git stash pop --quiet "$_ref" 2>/dev/null || true
+        fi
+        # No blind pop — if we can't find our label, leave the stash alone.
+        # Safer to leak than to pop someone else's work.
     fi
 }
 trap _cleanup EXIT
+
+# Resolve our labelled stash to its ref (stash@{N}) so we pop the right one.
+# Issue #195: multiple worktree-sync runs may interleave; never blind-pop.
+_resolve_stash_ref() {
+    git stash list 2>/dev/null | awk -v lbl="$STASH_LABEL" '
+        index($0, lbl) {
+            # stash list format: "stash@{0}: On branch: worktree-sync-PID-TS"
+            n = index($0, ":"); ref = substr($0, 1, n-1); print ref; exit
+        }'
+}
 
 show_help() {
     echo "Usage: worktree-sync [--auto] [--version] [--help]"
@@ -86,7 +109,14 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
     exit 1
 }
 
-MAIN_CHECKOUT=$(git worktree list 2>/dev/null | head -1 | awk '{print $1}')
+# Capture the full listing, then take the first line's first field via parameter
+# expansion — NOT `| head -1`. Under `set -o pipefail`, head closing the pipe
+# after the first line makes `git worktree list` die with SIGPIPE (exit 141) as
+# it writes the remaining linked worktrees, and that 141 propagates out of the
+# `$(...)` and trips `set -e`. (#42 — the container gate hit this deterministically.)
+_wt_list=$(git worktree list 2>/dev/null)
+MAIN_CHECKOUT="${_wt_list%%$'\n'*}"   # first line (main checkout is always first)
+MAIN_CHECKOUT="${MAIN_CHECKOUT%% *}"  # first whitespace-delimited field (the path)
 if [[ -z "$MAIN_CHECKOUT" ]] || [[ ! -d "$MAIN_CHECKOUT" ]]; then
     echo "worktree-sync: cannot determine main checkout" >&2
     exit 1
@@ -151,7 +181,10 @@ DIRTY=$(git status --porcelain 2>/dev/null)
 
 if [[ -n "$DIRTY" ]]; then
     if [[ "$AUTO_MODE" == true ]]; then
-        git stash --quiet 2>/dev/null
+        # Issue #195: push with explicit message so we can pop-by-ref.
+        # `git stash push -m` is the portable form (git 2.13+). Always include
+        # --include-untracked so untracked files survive the merge too.
+        git stash push -u --quiet -m "$STASH_LABEL" 2>/dev/null
         STASHED=true
     else
         DIRTY_COUNT=$(echo "$DIRTY" | grep -c . || echo 0)
@@ -198,14 +231,17 @@ else
             echo "  WARNING: git merge --abort failed — repo may not be fully restored." >&2
         fi
 
-        # Unstash if we stashed (disable trap since we're handling it)
+        # Unstash if we stashed (disable trap since we're handling it).
+        # Issue #195: pop by label, not by position.
         STASH_MSG="no stash taken"
         if [[ "$STASHED" == true ]]; then
             STASHED=false
-            if git stash pop --quiet 2>/dev/null; then
-                STASH_MSG="stashed work restored via git stash pop"
+            local _ref
+            _ref=$(_resolve_stash_ref 2>/dev/null || true)
+            if [[ -n "$_ref" ]] && git stash pop --quiet "$_ref" 2>/dev/null; then
+                STASH_MSG="stashed work restored via git stash pop ($STASH_LABEL)"
             else
-                STASH_MSG="stash pop failed — your stashed work is still in git stash (run 'git stash list')"
+                STASH_MSG="stash pop failed — your stashed work is still in git stash as '$STASH_LABEL' (run 'git stash list')"
             fi
         fi
         echo "  Stash: $STASH_MSG." >&2
@@ -254,8 +290,11 @@ if [[ "$MERGED" == true ]]; then
     # Files changed in agency/ namespace
     CHANGED_FILES=$(git diff "$PRE_MERGE_HEAD"..HEAD --name-only -- agency/ .claude/ CLAUDE.md 2>/dev/null || echo "")
 
-    # Check for CLAUDE.md changes
-    if echo "$CHANGED_FILES" | grep -qE "CLAUDE\.md|CLAUDE-THEAGENCY\.md" 2>/dev/null; then
+    # Check for CLAUDE.md changes. Use a bash regex, NOT `echo | grep -q`: under
+    # pipefail, grep -q closing the pipe on first match can SIGPIPE the echo
+    # (exit 141) when CHANGED_FILES is large, tripping set -e (#42, same class as
+    # the head-pipe above). A pure-bash match has no pipe to break.
+    if [[ "$CHANGED_FILES" =~ (CLAUDE\.md|CLAUDE-THEAGENCY\.md) ]]; then
         CLAUDE_MD_CHANGED=true
     fi
 
@@ -263,11 +302,12 @@ if [[ "$MERGED" == true ]]; then
     DISPATCHES=$(echo "$CHANGED_FILES" | grep -E "dispatch" 2>/dev/null || echo "")
 fi
 
-# --- Unstash if we stashed ---
+# --- Unstash if we stashed (pop by label — issue #195) ---
 UNSTASH_CONFLICT=false
 if [[ "$STASHED" == true ]]; then
     STASHED=false  # Disable trap — we're handling it
-    if ! git stash pop --quiet 2>/dev/null; then
+    _STASH_REF_NOW=$(_resolve_stash_ref 2>/dev/null || true)
+    if [[ -z "$_STASH_REF_NOW" ]] || ! git stash pop --quiet "$_STASH_REF_NOW" 2>/dev/null; then
         UNSTASH_CONFLICT=true
     fi
 fi

--- a/src/tests/tools/agency-init.bats
+++ b/src/tests/tools/agency-init.bats
@@ -59,6 +59,11 @@ run_agency() {
     local tmpdir
     tmpdir=$(mktemp -d)
     git -C "$tmpdir" init -b main 2>/dev/null
+    # Local identity: test_isolation nulls global/system git config, so a commit
+    # here needs explicit user.* — git's ambient auto-identity is unavailable in
+    # a hermetic/container run (#42).
+    git -C "$tmpdir" config user.email "test@test.invalid"
+    git -C "$tmpdir" config user.name "test"
     git -C "$tmpdir" commit --allow-empty -m "init" 2>/dev/null
     mkdir -p "$tmpdir/.claude" "$tmpdir/agency/config"
     echo "framework:" > "$tmpdir/agency/config/agency.yaml"

--- a/src/tests/tools/captain-release-notes.bats
+++ b/src/tests/tools/captain-release-notes.bats
@@ -272,8 +272,11 @@ PRIOR
         --captain "test-captain" --workstream "mockproj" --dry-run
     [ "$status" -eq 0 ]
     [[ "$output" == *"Ignoring unusable end_version"* ]]
-    # Output path stays inside the workstream.
-    [[ "$output" != *"/tmp/pwned"* ]]
+    # Output path stays inside the workstream. (We can't assert the raw string
+    # "/tmp/pwned" is absent from output — the "Ignoring unusable" warning above
+    # legitimately ECHOES the rejected value, which contains it. The real
+    # security property is that the traversal never becomes the OUTPUT PATH,
+    # which the workstream-relative path assertion below verifies. #42.)
     [[ "$output" == *"agency/workstreams/mockproj/release-notes/release-notes-"* ]]
 }
 

--- a/src/tests/tools/git-captain.bats
+++ b/src/tests/tools/git-captain.bats
@@ -937,3 +937,51 @@ _setup_origin_with_tag() {
     assert_success
     assert_output_contains "tag-delete"
 }
+
+@test "tag-delete: ABORTS (fails closed) when origin is unreadable" {
+    # No origin remote at all → the ls-remote safety check must fail the whole
+    # command, NEVER proceed to delete unguarded.
+    cd "${BATS_TEST_TMPDIR}"
+    git tag v9.9.9-local
+    run ./agency/tools/git-captain tag-delete v9.9.9-local
+    assert_failure
+    assert_output_contains "Could not read origin tags"
+    run git rev-parse --verify --quiet "refs/tags/v9.9.9-local"
+    assert_success                              # not deleted — failed closed
+}
+
+@test "tag-delete: does NOT false-die when origin has ZERO tags (empty is valid)" {
+    # Regression for the QG CODE-2 bug: `git ls-remote | grep -v` exits 1 on an
+    # empty (tagless) origin, which under pipefail wrongly tripped the || die.
+    cd "${BATS_TEST_TMPDIR}"
+    local up="${BATS_TEST_TMPDIR}/upstream.git"
+    git init --bare --quiet "$up"
+    git remote add origin "$up"
+    git push --quiet origin main               # push a commit, but NO tags
+    git tag v5.5.5-local                        # a purely local tag
+    run ./agency/tools/git-captain tag-delete v5.5.5-local
+    assert_success                              # must NOT die on empty origin tags
+    assert_output_contains "Deleted 1"
+    run git rev-parse --verify --quiet "refs/tags/v5.5.5-local"
+    assert_failure                              # actually deleted
+}
+
+@test "tag-delete: --match with zero matches deletes nothing" {
+    _setup_origin_with_tag
+    git tag keepme-notmatching
+    run ./agency/tools/git-captain tag-delete --local-only --match '^NOPE'
+    assert_success
+    assert_output_contains "No local-only tags to delete"
+    run git rev-parse --verify --quiet "refs/tags/keepme-notmatching"
+    assert_success                              # untouched
+}
+
+@test "tag-delete: --local-only sweep skips a tag that is both local and on origin" {
+    _setup_origin_with_tag                      # v1.0.0 is local AND on origin
+    git tag v2.0.0-junk                         # local-only
+    run ./agency/tools/git-captain tag-delete --local-only --match '^v'
+    assert_success
+    assert_output_contains "Deleted 1"          # only v2.0.0-junk, not v1.0.0
+    run git rev-parse --verify --quiet "refs/tags/v1.0.0"
+    assert_success                              # origin tag survived the sweep
+}

--- a/src/tests/tools/git-captain.bats
+++ b/src/tests/tools/git-captain.bats
@@ -852,3 +852,88 @@ make_conflicting_branches() {
     run cat conflict.txt
     assert_output_contains "branch-b line"    # working tree restored
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# tag-delete — safe bulk deletion of LOCAL-ONLY tags (#42 / flag #264)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Helper: add a bare origin remote carrying one tag (v1.0.0), so the origin
+# safety guard has a remote to query. Leaves the local repo with that tag too.
+_setup_origin_with_tag() {
+    cd "${BATS_TEST_TMPDIR}"
+    local up="${BATS_TEST_TMPDIR}/upstream.git"
+    git init --bare --quiet "$up"
+    git remote add origin "$up"
+    git tag v1.0.0
+    git push --quiet origin main --tags
+}
+
+@test "tag-delete: deletes a local-only tag" {
+    _setup_origin_with_tag
+    git tag v9.9.9-local                       # never pushed
+    run ./agency/tools/git-captain tag-delete v9.9.9-local
+    assert_success
+    assert_output_contains "Deleted 1"
+    run git rev-parse --verify --quiet "refs/tags/v9.9.9-local"
+    assert_failure                              # gone
+}
+
+@test "tag-delete: REFUSES a tag present on origin (safety guard)" {
+    _setup_origin_with_tag
+    run ./agency/tools/git-captain tag-delete v1.0.0
+    assert_success                              # not an error — just refuses
+    assert_output_contains "present on origin"
+    run git rev-parse --verify --quiet "refs/tags/v1.0.0"
+    assert_success                              # still there
+}
+
+@test "tag-delete: --dry-run deletes nothing" {
+    _setup_origin_with_tag
+    git tag v9.9.9-local
+    run ./agency/tools/git-captain tag-delete --dry-run v9.9.9-local
+    assert_success
+    assert_output_contains "DRY RUN"
+    run git rev-parse --verify --quiet "refs/tags/v9.9.9-local"
+    assert_success                              # NOT deleted
+}
+
+@test "tag-delete: --local-only --match sweeps local-only tags, keeps origin" {
+    _setup_origin_with_tag
+    git tag v2.0.0-junk
+    git tag v3.0.0-junk
+    git tag REQUEST-keepme                      # does not match ^v
+    run ./agency/tools/git-captain tag-delete --local-only --match '^v'
+    assert_success
+    assert_output_contains "Deleted 2"
+    run git rev-parse --verify --quiet "refs/tags/v2.0.0-junk"; assert_failure
+    run git rev-parse --verify --quiet "refs/tags/v1.0.0";       assert_success  # origin kept
+    run git rev-parse --verify --quiet "refs/tags/REQUEST-keepme"; assert_success # non-match kept
+}
+
+@test "tag-delete: --stdin reads names" {
+    _setup_origin_with_tag
+    git tag v4.0.0-junk
+    run bash -c 'printf "v4.0.0-junk\n" | ./agency/tools/git-captain tag-delete --stdin'
+    assert_success
+    assert_output_contains "Deleted 1"
+}
+
+@test "tag-delete: no names provided fails" {
+    _setup_origin_with_tag
+    run ./agency/tools/git-captain tag-delete
+    assert_failure
+    assert_output_contains "No tag names"
+}
+
+@test "tag-delete: skips a name that does not exist locally" {
+    _setup_origin_with_tag
+    run ./agency/tools/git-captain tag-delete v0.0.0-nonexistent
+    assert_success
+    assert_output_contains "No local-only tags to delete"
+}
+
+@test "tag-delete appears in --help" {
+    run ./agency/tools/git-captain --help
+    assert_success
+    assert_output_contains "tag-delete"
+}

--- a/src/tests/tools/pkg-manager.bats
+++ b/src/tests/tools/pkg-manager.bats
@@ -180,6 +180,17 @@ pkg() {  # pkg [<json body>]
 }
 
 @test "pkg-manager: nothing installed at all fails cleanly" {
+    # resolve() runs with PATH="$STUBS:/usr/bin:/bin:/usr/sbin:/sbin" — the
+    # system bindirs are included for coreutils. That assumes package managers
+    # live OUTSIDE them (true on macOS: brew/nvm put npm in /usr/local/bin). On
+    # a distro that installs npm to /usr/bin (e.g. alpine apk in the test
+    # container), the "nothing installed" premise can't hold with this PATH, so
+    # skip rather than false-fail. (#42)
+    for d in /usr/bin /bin /usr/sbin /sbin; do
+        for m in npm pnpm yarn bun; do
+            [[ -x "$d/$m" ]] && skip "a system package manager ($d/$m) is on the resolve PATH; cannot simulate 'nothing installed'"
+        done
+    done
     pkg
     run resolve
     [ "$status" -eq 1 ]

--- a/src/tests/tools/principal.bats
+++ b/src/tests/tools/principal.bats
@@ -227,9 +227,13 @@ load 'test_helper'
 
     run_tool principal-create "$test_name"
 
-    # Verify v2 directory structure created
+    # Verify v2 directory structure created. Assert on README.md, which BOTH
+    # code paths produce: the v2-template path copies agency/templates/principal-v2/*
+    # (top-level template files + README.md, no scripts/ subdir), and the fallback
+    # path writes its own README.md. The old `scripts/ || claude/` assertion only
+    # matched the fallback path, so it stale-failed whenever the template exists. (#42)
     [[ -d "usr/$test_name" ]]
-    [[ -d "usr/$test_name/claude" ]] || [[ -d "usr/$test_name/scripts" ]]
+    [[ -f "usr/$test_name/README.md" ]]
     # Verify NOT created at legacy path
     [[ ! -d "claude/principals/$test_name" ]]
 

--- a/src/tests/tools/principal.bats
+++ b/src/tests/tools/principal.bats
@@ -57,6 +57,16 @@ load 'test_helper'
     [[ -n "$output" ]]
 }
 
+@test "principal: succeeds with PRINCIPAL unset (set -u guard, #42)" {
+    # Explicitly clear PRINCIPAL so the `[ -n "${PRINCIPAL:-}" ]` guard is
+    # actually exercised. Without the :- default this trips "unbound variable"
+    # under set -u — a regression that only surfaces in a clean-env/container
+    # run, which the ambient-dependent test above would miss.
+    run env -u PRINCIPAL bash "${TOOLS_DIR}/principal"
+    assert_success
+    [[ -n "$output" ]]
+}
+
 # ─────────────────────────────────────────────────────────────────────────────
 # principal-create - Version and Help
 # ─────────────────────────────────────────────────────────────────────────────

--- a/src/tests/tools/release.bats
+++ b/src/tests/tools/release.bats
@@ -90,17 +90,20 @@ load 'test_helper'
 
 @test "release: accepts 'patch' as version" {
     run bash -c "echo y | \"${TOOLS_DIR}/release\" patch --dry-run 2>&1"
-    [[ ! "$output" =~ "invalid" ]] && [[ ! "$output" =~ "unknown" ]]
+    # Assert positive ACCEPTANCE (release computed a New release), not the absence
+    # of "invalid"/"unknown" anywhere — those words legitimately appear in the
+    # generated changelog's commit messages, so the old blanket check was fragile.
+    [[ "$output" == *"Would create tag"* ]]
 }
 
 @test "release: accepts 'minor' as version" {
     run bash -c "echo y | \"${TOOLS_DIR}/release\" minor --dry-run 2>&1"
-    [[ ! "$output" =~ "invalid" ]] && [[ ! "$output" =~ "unknown" ]]
+    [[ "$output" == *"Would create tag"* ]]
 }
 
 @test "release: accepts 'major' as version" {
     run bash -c "echo y | \"${TOOLS_DIR}/release\" major --dry-run 2>&1"
-    [[ ! "$output" =~ "invalid" ]] && [[ ! "$output" =~ "unknown" ]]
+    [[ "$output" == *"Would create tag"* ]]
 }
 
 @test "release: accepts semver version" {

--- a/src/tests/tools/release.bats
+++ b/src/tests/tools/release.bats
@@ -129,3 +129,31 @@ load 'test_helper'
     [[ ! "$output" =~ "syntax error" ]]
 }
 
+# ─────────────────────────────────────────────────────────────────────────────
+# get_last_release SIGPIPE regression (#42) — `git tag ... | head -1` under
+# `set -o pipefail` dies with SIGPIPE (141) once the tag list overflows the pipe
+# buffer, aborting release before it prints anything.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "release: get_last_release has no head-pipe (SIGPIPE structural guard, #42)" {
+    # Fast + deterministic reintroduction guard: the tag lookup must not pipe
+    # `git tag` into head/sed-q/awk-exit (any early-closing reader).
+    run bash -c "grep -nE 'git tag[^|]*\\| *(head|sed|awk)' '${TOOLS_DIR}/release' || true"
+    assert_success
+    [[ -z "$output" ]]
+}
+
+@test "release: --changelog survives a large tag list without SIGPIPE (#42)" {
+    local repo="${BATS_TEST_TMPDIR}/manytags"
+    mkdir -p "$repo"
+    cd "$repo"
+    git init -q -b main
+    git -c user.email=t@t -c user.name=t commit -q --allow-empty -m init
+    # Enough tags that git flushes in multiple writes — the old code SIGPIPE'd.
+    local i
+    for i in $(seq 1 400); do git tag "v0.0.$i"; done
+    run bash "${TOOLS_DIR}/release" 99.99.99 --changelog
+    [ "$status" -eq 0 ]                          # NOT 141
+    [[ "$output" == *"Changes"* ]]
+}
+

--- a/src/tests/tools/sandbox-sync.bats
+++ b/src/tests/tools/sandbox-sync.bats
@@ -210,17 +210,21 @@ YAML
 @test "sandbox-sync: skips commands with '..' in filename (no symlink created)" {
     _setup_fixture jordan testuser
     cd "$FIX"
-    # basename("...evil.md") == "...evil.md" — contains '..'
-    echo "evil" > "usr/jordan/commands/...evil.md"
+    # "bad..evil.md" contains '..' but has NO leading dot, so the tool's `*.md`
+    # glob actually enumerates it and the _is_safe_name '..' check fires. (A
+    # leading-dot name like "...evil.md" is skipped by the glob before the safety
+    # check ever runs — safe by omission, but it does NOT exercise the warning
+    # path this test is asserting. #42.)
+    echo "evil" > "usr/jordan/commands/bad..evil.md"
     echo "# good" > "usr/jordan/commands/good.md"
 
     run env HOME="$ORIGINAL_HOME" USER=testuser ./agency/tools/sandbox-sync
     [ "$status" -eq 0 ]
-    [[ "$output" == *"unsafe command filename"* ]] || [[ "$output" == *"...evil.md"* ]]
+    [[ "$output" == *"unsafe command filename"* ]] || [[ "$output" == *"bad..evil.md"* ]]
     # Good file still gets symlinked
     [ -L .claude/commands/usr-jordan.good.md ]
     # Unsafe file does NOT get symlinked
-    [ ! -L ".claude/commands/usr-jordan....evil.md" ]
+    [ ! -L ".claude/commands/usr-jordan.bad..evil.md" ]
 }
 
 @test "sandbox-sync: skips agent dirs with '..' in name" {

--- a/src/tests/tools/test-agency-update-prune-safety.bats
+++ b/src/tests/tools/test-agency-update-prune-safety.bats
@@ -100,7 +100,8 @@ _run_update() {
     AGENCY_SOURCE="$SANDBOX/source" \
     CLAUDE_PROJECT_DIR="$SANDBOX/target" \
     SB_TARGET="$SANDBOX/target" \
-    bash -c 'AGENCY_ARGS=("--force" "--yes" "$@" "$SB_TARGET"); source /Users/jdm/code/the-agency/agency/tools/lib/_agency-update; _update_main' _run_update "$@" 2>&1
+    AGENCY_LIB="${BATS_TEST_DIRNAME}/../../../agency/tools/lib/_agency-update" \
+    bash -c 'AGENCY_ARGS=("--force" "--yes" "$@" "$SB_TARGET"); source "$AGENCY_LIB"; _update_main' _run_update "$@" 2>&1
 }
 
 @test "default (no --prune): nothing deleted, including framework orphans, adopter-custom untouched" {

--- a/src/tests/tools/test-session-pause.bats
+++ b/src/tests/tools/test-session-pause.bats
@@ -495,6 +495,10 @@ line2"
 # specific abort message varies (git-safe-add vs cp), but the CONTRACT is
 # that exit 1 always comes with both status= and error_reason= keys.
 @test "filesystem failure in coord pipeline always emits structured abort" {
+    # Root bypasses file permissions, so chmod 000 does NOT make the file
+    # unreadable — the failure this test forces can't occur as root (e.g. in a
+    # containerized run). Skip rather than false-fail. (#42)
+    [[ "$(id -u)" -eq 0 ]] && skip "chmod-based permission denial is ineffective as root"
     chmod 000 usr/testp/testa/testa-handoff.md 2>/dev/null || skip "cannot change permissions"
     run _run_pause --framing continuation --trigger archive-fail
     chmod 644 usr/testp/testa/testa-handoff.md 2>/dev/null || true

--- a/src/tests/tools/worktree-create.bats
+++ b/src/tests/tools/worktree-create.bats
@@ -586,7 +586,12 @@ make_origin_repo() {
     # Explicit wins — and the shadowing must be announced, not silent.
     run "$TOOL" explicit --branch stale-pr --from origin/main
     [ "$status" -eq 0 ]
-    [[ "$output" != *"tracking origin/stale-pr"* ]]
+    # The tool announces the shadow as "--from wins, NOT tracking origin/stale-pr".
+    # Assert that positive announcement — a bare `!= *"tracking origin/stale-pr"*`
+    # is defeated by the "NOT tracking origin/stale-pr" phrasing (the substring is
+    # present inside the negation). The actual no-track guarantee is verified by
+    # the SHA check below (wt_sha == origin/main, not stale-pr). (#42)
+    [[ "$output" == *"NOT tracking origin/stale-pr"* ]]
     [[ "$output" == *"--from wins"* ]]
 
     local wt="${TEST_REPO}/.claude/worktrees/explicit"

--- a/src/tests/tools/worktree-sync.bats
+++ b/src/tests/tools/worktree-sync.bats
@@ -194,3 +194,25 @@ teardown_main_branch_repo() {
         return 1
     fi
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# SIGPIPE regression guards (#42) — `git worktree list | head -1` and
+# `echo "$X" | grep -q` both die with SIGPIPE (141) under `set -o pipefail` when
+# the reader closes the pipe early on large output, aborting the sync. Setting up
+# enough linked worktrees / changed files to reproduce is expensive, so guard
+# structurally against reintroduction of the anti-patterns.
+# ─────────────────────────────────────────────────────────────────────────────
+
+@test "worktree-sync: does not pipe 'git worktree list' into head (SIGPIPE guard, #42)" {
+    run bash -c "grep -nE 'git worktree list[^|]*\\| *head' '${REPO_ROOT}/agency/tools/worktree-sync' || true"
+    assert_success
+    [[ -z "$output" ]]
+}
+
+@test "worktree-sync: does not use 'echo | grep -q' for CLAUDE.md detection (SIGPIPE guard, #42)" {
+    # The CLAUDE.md-changed check must be a pure-bash match, not echo | grep -q
+    # (grep -q closes the pipe on first match → SIGPIPE on a large CHANGED_FILES).
+    run bash -c "grep -nE 'echo .*CHANGED_FILES.* \\| *grep -q' '${REPO_ROOT}/agency/tools/worktree-sync' || true"
+    assert_success
+    [[ -z "$output" ]]
+}

--- a/src/tools-developer/iscp-migrate
+++ b/src/tools-developer/iscp-migrate
@@ -260,7 +260,10 @@ migrate_dispatches() {
             has_frontmatter=true
         fi
 
-        local dtype from_agent to_agent date_val status_val subject priority
+        # Initialize empty: a bare `local x` leaves x UNSET, so referencing it
+        # under `set -u` (e.g. the no-frontmatter branch below reads $from_agent
+        # before the YAML branch assigns it) trips "unbound variable". (#42)
+        local dtype="" from_agent="" to_agent="" date_val="" status_val="" subject="" priority=""
 
         if [[ "$has_frontmatter" == "true" ]]; then
             dtype=$(_yaml_field "$content" "type")

--- a/usr/jordan/_land-container-test-isolation/dispatches/commit-to-captain-committed-f0c52db3-on-land-container-test-isolatio-20260819-1734.md
+++ b/usr/jordan/_land-container-test-isolation/dispatches/commit-to-captain-committed-f0c52db3-on-land-container-test-isolatio-20260819-1734.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-container-test-isolation
+to: the-agency/jordan/captain
+date: 2026-08-19T09:34
+status: created
+priority: normal
+subject: "Committed f0c52db3 on _land-container-test-isolation: chore(manifest): bump agency_version 46.43 → 46.44 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed f0c52db3 on _land-container-test-isolation: chore(manifest): bump agency_version 46.43 → 46.44 for PR landing (captain)
+
+## Commit: f0c52db3
+
+**Branch:** _land-container-test-isolation
+**Agent:** the-agency/jordan/_land-container-test-isolation
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.43 → 46.44 for PR landing (captain)
+
+### Metadata
+- commit_hash: f0c52db3
+- branch: _land-container-test-isolation
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/captain/briefings/apple-containers-test-isolation-42-20260818.md
+++ b/usr/jordan/captain/briefings/apple-containers-test-isolation-42-20260818.md
@@ -1,0 +1,99 @@
+# Research brief — Apple Containers for test isolation (issue #42)
+
+**Date:** 2026-08-18 · **Author:** captain · **Status:** decision-ready
+**Reframed #42:** "the purpose was TEST ISOLATION (which holds); research Apple
+Containers as the better isolation mechanism than docker."
+
+## TL;DR — the hypothesis reverses
+
+Apple Containers is genuinely strong technology, but for issue #42 it is the
+**wrong tool**, and adopting it would *mask* our actual bug rather than fix it.
+**Recommendation: fix the bats isolation in-process** (extend the existing
+`_test-isolation` helper). Apple Containers is a macOS-dev-only nicety with
+**zero CI benefit** and doesn't address the defect. This contradicts the initial
+"Apple Containers is the better way" framing — the evidence says otherwise, and
+this session's own failures are the proof.
+
+## What Apple Containers is
+
+- `apple/container` (CLI) + `apple/containerization` (Swift framework), announced
+  WWDC 2025, Apache-2.0, ~49k stars, v1.0.0 (2026-06-09) → v1.2.2 (2026-08-08).
+- Isolation model: **each container runs in its own lightweight VM** on
+  `Virtualization.framework` (Swift `vminitd` as PID 1, gRPC-over-vsock, ext4
+  rootfs, per-container IP). A *stronger* boundary than Docker's shared-kernel.
+
+## Three findings that decide it
+
+1. **CI cannot use it — at all.** GitHub-hosted macOS runners are themselves VMs;
+   **nested virtualization is unsupported** (Apple Virtualization.framework
+   limitation). The request to expose it (`actions/runner-images` #13505) was
+   **closed "not planned."** And our CI is **Linux** — a macOS-only,
+   Apple-Silicon-only tool is a non-starter there by definition. Using it in CI
+   would require a **self-hosted bare-metal Apple Silicon runner fleet** (real
+   infra cost) and *still* only exercise the macOS path.
+
+2. **Hard platform floor.** Full functionality needs **macOS 26 "Tahoe" +
+   Apple Silicon**. macOS 15 works only with degraded networking. This conflicts
+   with the framework's portability posture (bash 3.2 floor, macOS-primary dev
+   but **Linux CI**).
+
+3. **It masks the real bug.** Our leaks — a buggy test creating **~90 real git
+   tags**, **worktrees leaking into the live checkout**, dependence on a
+   **gitignored dev-only dir**, **order-dependence** through shared FS state —
+   are all the *same class*: **a test operated on the real repo dir instead of a
+   temp fixture.** These are test-authoring/filesystem/git-state bugs, not
+   kernel/process-isolation bugs. A per-file VM hides them **on one developer's
+   Mac** while the identical un-isolated tests keep running on Linux CI, where
+   isolation matters most.
+
+## The real fix (already 80% built)
+
+The repo already ships `agency/tools/lib/_test-isolation`
+(`test_isolation_setup`/`_teardown`): fake `HOME`, explicit `ISCP_DB_PATH`,
+`GIT_CONFIG_GLOBAL=/dev/null`, unsets leaked `GIT_DIR`/author vars, snapshots
+`.git/config` + framework dirs for debris detection.
+
+**The gap it does NOT close:** tests that `cd` into `REPO_ROOT` and run git
+against the **real `.git`** — config is isolated, but the object/ref store is
+not. That's exactly the tag/worktree leak this session hit. **The fix is a
+bounded extension of the helper we already have:**
+
+- Force offending tests into a **throwaway fixture repo** (`git init` under
+  `$BATS_TEST_TMPDIR`), never the live `.git`.
+- Add a **teardown guard** that fails loudly if the live repo's tag-count or
+  worktree-list changed during a test (the `worktree-create.bats` file already
+  does exactly this leak-diff pattern — generalize it).
+- Zero-pip, bash 3.2, **runs identically on macOS dev and Linux CI.**
+
+This session already fixed 3 instances by hand (release `--dry-run` hermeticity,
+the gitignored-`housekeeping/` dependency, the worktree-name collision). The
+extension systematizes that so a leak fails the test instead of scribbling on
+the repo.
+
+## Options compared
+
+| Option | True FS/git isolation | Helps Linux CI | Cost | macOS-only |
+|---|---|---|---|---|
+| **(a) Apple Containers** | Yes (per-VM) | **No** | macOS 26 + ASi floor; VM plumbing | **Yes** |
+| **(b) In-process bats (extend `_test-isolation`)** | Fully achievable | **Yes** | Lowest — extend existing helper | No |
+| **(c) Cross-platform container (Colima dev / Docker CI)** | Yes | **Yes** | Container image + daemon | No |
+
+## Recommendation
+
+1. **Do (b) now** — extend `_test-isolation` with a fixture-repo mode + a
+   live-repo leak guard, and route the git-touching tests through it. This is the
+   correct, portable, low-cost fix for #42 and directly prevents a repeat of the
+   90-tag incident. Small, well-scoped build.
+2. **Keep (c) on the shelf** as the escalation *only if* isolation needs later
+   grow beyond filesystem/git (e.g. network or PID isolation) — because it's the
+   only container option that also protects CI.
+3. **Do not adopt (a) for #42.** A time-boxed Apple Containers prototype is
+   defensible only as a *separate* macOS-native build/test convenience (possibly
+   relevant to the mdpal-app / mock-and-mark macOS workstreams) — never as the
+   answer to #42 and never as a CI dependency.
+
+## Sources
+apple/container + apple/containerization (GitHub); WWDC25 session 346 "Meet
+Containerization"; GitHub Actions hosted-runners reference (nested-virt
+unsupported); actions/runner-images #13505 (closed not-planned); The New Stack
+Apple-vs-Docker; repo `agency/tools/lib/_test-isolation`.

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,95 +1,82 @@
 ---
 type: session
 agent: the-agency/jordan/captain
-date: 2026-08-14T02:20
-trigger: compact-prepare
-branch: main
+date: 2026-08-19T04:30
+trigger: compact-container-isolation-42
+branch: container-test-isolation
 mode: continuation
 next-action: |
-  After /compact, run /compact-resume, then BUILD #144 — the hookify canary
-  test harness (principal greenlit it as the next real build). The 40 hookify
-  enforcement rules are effectively UNTESTED: canaries exist at
-  src/tests/hookify/canaries/*.canary (35 files) but nothing runs them.
-  Canary format: frontmatter `expected_decision: block|warn` + `expected_match:
-  <substr>` + `---BODY---` + the command. The main evaluator is
-  agency/hooks/block-raw-tools.sh (PreToolUse hook: reads JSON on stdin,
-  `.tool_input.command`; emits `{"decision":"block","reason":...}` or nothing).
-  BUT hookify has MULTIPLE evaluators — a proper harness must route each canary
-  to its correct evaluator (block-raw-tools.sh handles the raw-tool/compound
-  ones; others may be separate hooks). Investigate the full hookify dispatch
-  architecture FIRST, then build a bats harness that loops every canary, feeds
-  its BODY through the right evaluator, and asserts expected_decision. Model the
-  invocation on agency/hooks/__tests__/block-raw-tools.test.sh (assert_hook
-  helper: `echo "$json" | "$HOOK"`). Do it PROPERLY (it's load-bearing test
-  infra) — QG with the real reviewer agents, then land via pr-captain-land.
+  MAKE IT SO — continue the container test-isolation build (#42), driving the
+  small steps WITH the principal (they approved "your call — small steps").
+  Everything is checkpointed on branch container-test-isolation (commit 83217224),
+  Apple `container` is installed + its service RUNNING, image built, mechanism
+  PROVEN. Resume at step (2): run the WHOLE bats suite inside the container via
+  `./agency/tools/container-test-run` (no args) to surface any tool the Dockerfile
+  is missing (add to agency/containers/test-runner/Dockerfile), then the other
+  steps below. Do NOT re-litigate container-vs-in-process — that's decided
+  (container substrate); do NOT conflate CI with GitHub Linux runners.
 ---
 
-# Captain handoff — B2 largely cleared; #144 is the next real build (post-compact)
+# Captain handoff — container test-isolation (#42), mid-build (post-compact)
 
-## The arc since last compact
-Resumed at v46.28. Delivered the full **a/b/c mandate** THEN swept the B2
-backlog. **14 PRs landed this session, v46.28 → v46.42, main clean.**
+## Immediate next action: "Make it so" — the small steps (principal-approved)
+Drive these WITH the principal, small commits, on branch `container-test-isolation`:
+1. **Working-tree mode** — runner currently tests COMMITTED HEAD (`git clone /src /work`).
+   Add a mode that tests the working tree (copy tracked+untracked, EXCLUDE
+   node_modules + .claude/worktrees), so it tests uncommitted changes.
+2. **Run the WHOLE suite in-container** (DO THIS FIRST) — `./agency/tools/container-test-run`
+   (no args → runs bats:all set). Surfaces missing image deps; add them to the Dockerfile, rebuild.
+3. **Wire it in** — `test-run --isolated` (or make isolated the default locally).
+4. **Prove the Docker backend** — `CONTAINER_PROVIDER=docker ./agency/tools/container-test-run ...`
+   (Docker IS installed but its DAEMON IS DOWN — needs Docker Desktop started first).
+5. **Land it** — QG + commit + PR (it's a WIP checkpoint now, not QG'd/landed).
 
-## Landed this session (14 PRs)
-- #466 v46.29 delivery-path hardening · #467 v46.30 mdslidepal-mac (34 fixes) ·
-  #468 v46.31 mdpal-app (8 fixes) · #469 v46.32 pr-captain-land cleanup (flag
-  #236) · #470 v46.33 worktree-create DWIM · #471 v46.34 captain-release-notes
-  (#426 revived) · #472 v46.35 its metadata fix · #473 v46.36 REFERENCE-path
-  sweep + validator (flag #213) · #474 v46.37 reviewer-agent registration
-  (#186/#194) · #475 v46.38 agent-import fix (#246) · #476 v46.39 git-captain
-  cherry-pick+merge (#120/#109) · #477 v46.40 diff-hash --working (#207) ·
-  #478 v46.41 mdpal migration (#183) · #479 v46.42 designex bats (#138/#139).
-- The delivery tooling now SELF-COMPLETES (pr-captain-land fixed in #469/#472) —
-  a normal land needs no manual scratch cleanup. Bootstrap-land ONLY for changes
-  to pr-captain-land itself.
+## What's built (branch container-test-isolation, checkpoint 83217224, mirrored to src/)
+- **agency/tools/lib/_container-runtime** — OCI backend ABSTRACTION. Functions:
+  `container_backend` (→apple|docker), `container_available`, `container_run <img> -- <cmd>`.
+  Backend from agency.yaml `container.provider` (auto|apple|docker); env CONTAINER_PROVIDER
+  overrides. Follows the DevEx `_provider-resolve` pattern (sourced/silent/bash-3.2).
+- **agency/tools/container-test-run** — the runner: mount repo READ-ONLY → `git clone` to
+  writable /work in a throwaway container → run bats there → discard. Host structurally protected.
+- **agency/containers/test-runner/Dockerfile** — alpine:3.20 + bash git bats jq python3 coreutils findutils grep sed gawk. Image tag: `the-agency-test-runner:latest`.
+- **agency.yaml** — new `container:` provider section (next to `preview:`).
 
-## B2 disposition (principal-approved this session)
-- **BUILD next → #144 hookify canary harness** (see next-action). The one clear
-  worthwhile build remaining.
-- **CLOSE:** #143 (loosen pnpm validator — DON'T; weakens a guard) · #106
-  (already addressed in #207's committed-vs-working clarification).
-- **#42 docker-test — NOT closed. REFRAMED:** the purpose was TEST ISOLATION
-  (which holds). Principal's direction: **research Apple Containers as the better
-  isolation mechanism** than docker. → a research task, then build. Track it.
-- **Audits → captain-log reports (not PRs):** #41 CI health, #149/#8 command
-  audit, #14/#40 structure audit. Run + report.
-- **Skills — principal to pick which (if any):** #47 /why-did-this-fail, #77
-  /make-slides, #152/#80 /seed, #137/#190/#192 anthropic-feedback. Each its own
-  effort.
-- **Murky — need scoping before build:** #94/#142 (git-safe-commit does NOT check
-  receipts — that's the qgr-require hook; where the boundary/format check belongs
-  needs deciding) · #145 (no crisp `## Class` convention exists) · #86 (Dependabot
-  in preflight — network on every session start; needs a design decision).
-- **Low-value/captures:** #81 gitignore (preventive; files not even present) ·
-  seeds #62/#65/#31/#129/#123 (better written by the idea's owner).
+## Environment state (this machine: Apple Silicon, macOS 26.2)
+- Apple `container` v1.2.2 INSTALLED (brew install container). Service RUNNING
+  (`container system start` done, kata guest kernel installed). Image built.
+- Docker v29.2.1 installed but DAEMON NOT REACHABLE (the "cannot connect to daemon" pain).
+- PROVEN: git tag created inside the container did NOT reach host (620→620, no proof tag);
+  `container-test-run src/tests/tools/agency-version.bats` → all green in-container.
 
-## In flight (delegated — will return as dispatches)
-- **designex #254** (dispatch 1045): decide + fix designsystem-add's dead template
-  (design-systems tree archived to flotsam) — re-point / restore / retire. Their
-  call. Also #148 designex Phase 1.5.
-- **App agents' dispatched work** (act on their next cycle): mdslidepal-mac
-  contract rulings (#1004) + smart-quotes (#1003); mdpal-app DiffView/MDPAL_MOCK
-  (#1001); mdpal-cli --content-stdin (#1002).
+## The real goal (do not regress on these — principal corrected me 3×)
+- Apple Containers is a **SUBSTRATE decision**, not a #42 fix: everywhere we use Docker
+  + new areas are candidates. Build an **ABSTRACTION supporting BOTH Docker and Apple
+  Containers** (done: _container-runtime). Drive WITH the principal — NO separate workstream.
+- **CI = Continuous Integration (the practice), NOT "GitHub Linux runners."** It can run on
+  Apple Silicon. Don't repeat that conflation.
+- The pain is **LOCAL persistence** — local machine persists so test damage accumulates;
+  CI runners are ephemeral (self-isolating by disposal). A container is a **structural
+  backstop** (doesn't depend on tests being written correctly, which they keep not being).
+- #42's origin was the planned "docker-test"; Apple Containers is the better runtime on Apple Silicon.
+- Candidate register (for later): test isolation (#42, in progress), devex service composition,
+  starter-pack prototypes (nextjs/nestjs), app builds (mdpal/mock-and-mark/mdslidepal),
+  agency-init fresh-install verification, daemonless dev ergonomics.
 
-## Known follow-ups / flags filed this session
-- #229 git-sync (fixed #466) · #235/#244 QG discipline · #241 required_reading
-  (fixed #473) · #248 missing workstream fragments (CLAUDE-DESIGNEX/MDSLIDEPAL) +
-  per-agent CLAUDE docs — CONTENT GAP · #249 src/claude build-product vs
-  hand-editing both trees (process question) · #254 designsystem-add template.
-- Two devex/designex agents mislabeled by me mid-run this session — I now VERIFY
-  agent state before narrating it (lesson).
-
-## State
-- **main == origin/main == v46.42.** Clean tree.
-- Dispatch monitors were `unknown` post earlier compact — relaunch
-  /monitor-dispatches if needed.
-- Triage record: `agency/workstreams/agency/flag-triage-outcome-20260812.md`.
+## Session context / what shipped before this
+- **PR #480 / v46.43 LANDED**: bats:all 247→0 (tools/agents/docs fixture repair) + #144 hookify
+  canary harness. Local main reconciled to v46.43.
+- Flags filed: #256 (tool-create, done), #257 (src/agency hook drift), #258 (3 skipped backlog
+  probes #181/#205/#396), #259 (agency init README-install latent bug), #260 (release-bug
+  pollution tags — **actually 620 local tags**, need captain `git-captain tag` sweep; verify
+  not pushed first), #262 (git-safe-commit `git add -A` footgun).
+- **#42 research brief** at usr/jordan/captain/briefings/apple-containers-test-isolation-42-20260818.md
+  — its CONCLUSION IS NOW STALE (it argued in-process over Apple Containers; the principal's
+  decision reversed to container-substrate-with-abstraction). REWRITE its conclusion when convenient.
 
 ## On resume
-1. `/compact-resume` — verify tree, monitors, dispatch drift.
-2. Execute next-action: investigate hookify dispatch architecture, then build the
-   #144 canary harness properly (QG + land).
+1. `/compact-resume`.
+2. Execute next-action: `./agency/tools/container-test-run` (whole suite in-container) → fix image gaps → then steps 1,3,4,5. Confirm each small step with the principal (drive WITH them).
 
-— captain. B2 largely cleared; #144 next; #42 → Apple Containers research.
+— captain. Container test-isolation proven; making it so.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260819-043033-821.md
+++ b/usr/jordan/captain/history/handoff-20260819-043033-821.md
@@ -1,0 +1,95 @@
+---
+type: session
+agent: the-agency/jordan/captain
+date: 2026-08-14T02:20
+trigger: compact-prepare
+branch: main
+mode: continuation
+next-action: |
+  After /compact, run /compact-resume, then BUILD #144 — the hookify canary
+  test harness (principal greenlit it as the next real build). The 40 hookify
+  enforcement rules are effectively UNTESTED: canaries exist at
+  src/tests/hookify/canaries/*.canary (35 files) but nothing runs them.
+  Canary format: frontmatter `expected_decision: block|warn` + `expected_match:
+  <substr>` + `---BODY---` + the command. The main evaluator is
+  agency/hooks/block-raw-tools.sh (PreToolUse hook: reads JSON on stdin,
+  `.tool_input.command`; emits `{"decision":"block","reason":...}` or nothing).
+  BUT hookify has MULTIPLE evaluators — a proper harness must route each canary
+  to its correct evaluator (block-raw-tools.sh handles the raw-tool/compound
+  ones; others may be separate hooks). Investigate the full hookify dispatch
+  architecture FIRST, then build a bats harness that loops every canary, feeds
+  its BODY through the right evaluator, and asserts expected_decision. Model the
+  invocation on agency/hooks/__tests__/block-raw-tools.test.sh (assert_hook
+  helper: `echo "$json" | "$HOOK"`). Do it PROPERLY (it's load-bearing test
+  infra) — QG with the real reviewer agents, then land via pr-captain-land.
+---
+
+# Captain handoff — B2 largely cleared; #144 is the next real build (post-compact)
+
+## The arc since last compact
+Resumed at v46.28. Delivered the full **a/b/c mandate** THEN swept the B2
+backlog. **14 PRs landed this session, v46.28 → v46.42, main clean.**
+
+## Landed this session (14 PRs)
+- #466 v46.29 delivery-path hardening · #467 v46.30 mdslidepal-mac (34 fixes) ·
+  #468 v46.31 mdpal-app (8 fixes) · #469 v46.32 pr-captain-land cleanup (flag
+  #236) · #470 v46.33 worktree-create DWIM · #471 v46.34 captain-release-notes
+  (#426 revived) · #472 v46.35 its metadata fix · #473 v46.36 REFERENCE-path
+  sweep + validator (flag #213) · #474 v46.37 reviewer-agent registration
+  (#186/#194) · #475 v46.38 agent-import fix (#246) · #476 v46.39 git-captain
+  cherry-pick+merge (#120/#109) · #477 v46.40 diff-hash --working (#207) ·
+  #478 v46.41 mdpal migration (#183) · #479 v46.42 designex bats (#138/#139).
+- The delivery tooling now SELF-COMPLETES (pr-captain-land fixed in #469/#472) —
+  a normal land needs no manual scratch cleanup. Bootstrap-land ONLY for changes
+  to pr-captain-land itself.
+
+## B2 disposition (principal-approved this session)
+- **BUILD next → #144 hookify canary harness** (see next-action). The one clear
+  worthwhile build remaining.
+- **CLOSE:** #143 (loosen pnpm validator — DON'T; weakens a guard) · #106
+  (already addressed in #207's committed-vs-working clarification).
+- **#42 docker-test — NOT closed. REFRAMED:** the purpose was TEST ISOLATION
+  (which holds). Principal's direction: **research Apple Containers as the better
+  isolation mechanism** than docker. → a research task, then build. Track it.
+- **Audits → captain-log reports (not PRs):** #41 CI health, #149/#8 command
+  audit, #14/#40 structure audit. Run + report.
+- **Skills — principal to pick which (if any):** #47 /why-did-this-fail, #77
+  /make-slides, #152/#80 /seed, #137/#190/#192 anthropic-feedback. Each its own
+  effort.
+- **Murky — need scoping before build:** #94/#142 (git-safe-commit does NOT check
+  receipts — that's the qgr-require hook; where the boundary/format check belongs
+  needs deciding) · #145 (no crisp `## Class` convention exists) · #86 (Dependabot
+  in preflight — network on every session start; needs a design decision).
+- **Low-value/captures:** #81 gitignore (preventive; files not even present) ·
+  seeds #62/#65/#31/#129/#123 (better written by the idea's owner).
+
+## In flight (delegated — will return as dispatches)
+- **designex #254** (dispatch 1045): decide + fix designsystem-add's dead template
+  (design-systems tree archived to flotsam) — re-point / restore / retire. Their
+  call. Also #148 designex Phase 1.5.
+- **App agents' dispatched work** (act on their next cycle): mdslidepal-mac
+  contract rulings (#1004) + smart-quotes (#1003); mdpal-app DiffView/MDPAL_MOCK
+  (#1001); mdpal-cli --content-stdin (#1002).
+
+## Known follow-ups / flags filed this session
+- #229 git-sync (fixed #466) · #235/#244 QG discipline · #241 required_reading
+  (fixed #473) · #248 missing workstream fragments (CLAUDE-DESIGNEX/MDSLIDEPAL) +
+  per-agent CLAUDE docs — CONTENT GAP · #249 src/claude build-product vs
+  hand-editing both trees (process question) · #254 designsystem-add template.
+- Two devex/designex agents mislabeled by me mid-run this session — I now VERIFY
+  agent state before narrating it (lesson).
+
+## State
+- **main == origin/main == v46.42.** Clean tree.
+- Dispatch monitors were `unknown` post earlier compact — relaunch
+  /monitor-dispatches if needed.
+- Triage record: `agency/workstreams/agency/flag-triage-outcome-20260812.md`.
+
+## On resume
+1. `/compact-resume` — verify tree, monitors, dispatch drift.
+2. Execute next-action: investigate hookify dispatch architecture, then build the
+   #144 canary harness properly (QG + land).
+
+— captain. B2 largely cleared; #144 next; #42 → Apple Containers research.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `container-test-isolation` (untouched; this PR rides `_land-container-test-isolation`)
- Integrated in a scratch worktree cut from `origin/container-test-isolation`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-container-test-isolation-42-qgr-pr-prep-20260819-1701-7e39369.md` (hash `7e39369`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-container-test-isolation-qgr-pr-captain-land-20260819-1734-86b99ee.md` (hash `86b99ee`)
- `agency_version`: 46.43 → 46.44
- Release v46.44 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)