### PR TITLE
dispatch-retention-policy

### DIFF
--- a/agency/config/agency.yaml
+++ b/agency/config/agency.yaml
@@ -145,6 +145,12 @@ testing:
 design:
   provider: "figma"  # Default: figma. Alternatives: sketch, adobe
 
+# Dispatch retention (ISCP)
+# commit-notify dispatches (the git-safe-commit firehose) auto-resolve after this
+# many days. `dispatch prune` reads it; session-preflight sweeps on session start.
+dispatches:
+  commit_retention_days: 7
+
 # Cross-repo collaboration
 # Each entry maps a collaborator name to its local checkout path and dispatch dirs.
 # Used by: collaboration-check tool (startup hook, dispatch loop)

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.45",
+  "agency_version": "46.46",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-09-03T12:33:47Z"
+    "updated_at": "2026-09-03T13:05:12Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-09-03T12:33:47Z"
+  "updated_at": "2026-09-03T13:05:12Z"
 }

--- a/agency/tools/dispatch
+++ b/agency/tools/dispatch
@@ -972,6 +972,61 @@ cmd_resolve() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# prune — bulk-resolve old FYI dispatches (retention policy)
+#
+# The commit-to-captain notify dispatch fires after every commit (git-safe-commit
+# #210 guard), so `commit`-type dispatches accumulate into an unbounded "unread"
+# firehose. They are pure notifications — no action, safe to auto-resolve once
+# stale. `prune` resolves every dispatch of a given TYPE older than N days.
+# Idempotent and safe to run repeatedly (e.g. at session start). Global by type
+# + age (a commit notice is noise regardless of recipient).
+# ─────────────────────────────────────────────────────────────────────────────
+cmd_prune() {
+    local type="commit" older_days="" dry_run="false"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --type)       [[ -n "${2:-}" ]] || { echo "Error: --type requires a value" >&2; return 1; }
+                          type="$2"; shift 2 ;;
+            --older-days) [[ "${2:-}" =~ ^[0-9]+$ ]] || { echo "Error: --older-days requires an integer" >&2; return 1; }
+                          older_days="$2"; shift 2 ;;
+            --dry-run)    dry_run="true"; shift ;;
+            *)            echo "Error: unknown option '$1' (usage: dispatch prune [--type <t>] [--older-days <N>] [--dry-run])" >&2; return 1 ;;
+        esac
+    done
+
+    # Retention window: --older-days > dispatches.commit_retention_days > 7.
+    if [[ -z "$older_days" ]]; then
+        older_days="$("$SCRIPT_DIR/config" get dispatches.commit_retention_days 2>/dev/null || true)"
+        [[ "$older_days" =~ ^[0-9]+$ ]] || older_days="7"
+    fi
+
+    iscp_db_init
+
+    # Cutoff timestamp (UTC, now - older_days) via stdlib python — matches the
+    # 'YYYY-MM-DDTHH:MM' created_at format so string comparison is chronological.
+    local cutoff
+    cutoff="$(python3 -c "import sys,datetime as d; print((d.datetime.utcnow()-d.timedelta(days=int(sys.argv[1]))).strftime('%Y-%m-%dT%H:%M'))" "$older_days")"
+
+    local where="type = :type AND status != 'resolved' AND created_at < :cutoff"
+    local n
+    n=$(iscp_db_query "SELECT count(*) FROM dispatches WHERE $where" ":type" "$type" ":cutoff" "$cutoff")
+    n="${n:-0}"
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo "dispatch prune: would resolve $n '$type' dispatch(es) older than ${older_days}d (before $cutoff)"
+        return 0
+    fi
+    if [[ "$n" -eq 0 ]]; then
+        return 0
+    fi
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M)
+    iscp_db_exec "UPDATE dispatches SET status = 'resolved', resolved_at = :now WHERE $where" \
+        ":now" "$now" ":type" "$type" ":cutoff" "$cutoff"
+    echo "dispatch prune: resolved $n '$type' dispatch(es) older than ${older_days}d"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # status — Show full record for a dispatch
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_status() {
@@ -1024,6 +1079,7 @@ Usage:
   dispatch reply <id> "msg"    — quick response to a dispatch
   dispatch check
   dispatch resolve <id> [--response <id>]
+  dispatch prune [--type <t>] [--older-days <N>] [--dry-run]
   dispatch status <id>
   dispatch --version
   dispatch --help
@@ -1073,6 +1129,10 @@ case "$subcmd" in
     resolve)
         shift; cmd_resolve "$@"
         log_end "$RUN_ID" "success" "0" "0" "dispatch resolve"
+        ;;
+    prune)
+        shift; cmd_prune "$@"
+        log_end "$RUN_ID" "success" "0" "0" "dispatch prune"
         ;;
     status)
         shift; cmd_status "$@"

--- a/agency/tools/session-preflight
+++ b/agency/tools/session-preflight
@@ -161,7 +161,7 @@ fi
 # Retention sweep: auto-resolve stale commit-notify dispatches (the
 # git-safe-commit firehose) before counting, so "unread" reflects actionable
 # items, not months of FYI notices. Idempotent + cheap (one UPDATE, no-op when
-# nothing is old). Window from collaboration.commit_dispatch_retention_days (7d).
+# nothing is old). Window from dispatches.commit_retention_days (default 7d).
 bash "$SCRIPT_DIR/dispatch" prune --type commit >/dev/null 2>&1 || true
 
 dispatch_check=$(bash "$SCRIPT_DIR/dispatch" check 2>/dev/null || true)

--- a/agency/tools/session-preflight
+++ b/agency/tools/session-preflight
@@ -158,6 +158,12 @@ fi
 
 # ── Check 4: No unread dispatches remaining ──────────────────────────────
 
+# Retention sweep: auto-resolve stale commit-notify dispatches (the
+# git-safe-commit firehose) before counting, so "unread" reflects actionable
+# items, not months of FYI notices. Idempotent + cheap (one UPDATE, no-op when
+# nothing is old). Window from collaboration.commit_dispatch_retention_days (7d).
+bash "$SCRIPT_DIR/dispatch" prune --type commit >/dev/null 2>&1 || true
+
 dispatch_check=$(bash "$SCRIPT_DIR/dispatch" check 2>/dev/null || true)
 if [[ -z "$dispatch_check" ]]; then
     report_pass "No unread dispatches"

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-dispatch-retention-policy-qgr-pr-captain-land-20260903-2105-c628152.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-dispatch-retention-policy-qgr-pr-captain-land-20260903-2105-c628152.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: dispatch-retention-policy
+diff_base: origin/main
+hash_a: a96b193900f986af9f7b211d28c7f109b81004494e2e11eca17aaeb2ce409f9a
+hash_b: dadb47e8f9facf2502432a17fb53ca85434fb3f5017990e9441d728e926d79a9
+hash_c: dadb47e8f9facf2502432a17fb53ca85434fb3f5017990e9441d728e926d79a9
+hash_d: dadb47e8f9facf2502432a17fb53ca85434fb3f5017990e9441d728e926d79a9
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: c628152505d037760fa4fe17e6a02580cff564cfd85061bb8f67ecc71135c7da
+date: 2026-09-03T21:05
+---
+
+# Receipt: pr-captain-land — dispatch-retention-policy
+
+## Chain of Trust
+- A (original): a96b193
+- B (findings): dadb47e
+- C (triage): dadb47e
+- D (principal): dadb47e — auto-approved — no principal 1B1
+- E (final): c628152
+
+## Review Summary
+Local-first landing of dispatch-retention-policy. Integrated in scratch worktree _land-dispatch-retention-policy cut from origin/dispatch-retention-policy; 1 local validation step(s) passed against origin/main; agency_version 46.45 → 46.46. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-dispatch-retention-policy-qgr-pr-prep-20260903-2101-a96b193.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-dispatch-retention-policy-qgr-pr-prep-20260903-2101-a96b193.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-dispatch-retention-policy-qgr-pr-prep-20260903-2101-a96b193.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: dispatch-retention-policy
+diff_base: origin/main
+hash_a: a8334ba94e0797dfdda3e78a8fc429030f2248253f7f4121e769cf551a4c5a26
+hash_b: 10fd580f75dd22159c29507bc8442bba2957e407113222875ec989889af04632
+hash_c: 5408ca3b4e6e9699c1aa3055ed159e1d360bd5a8416acb9b28e2c337cde0f94b
+hash_d: 5408ca3b4e6e9699c1aa3055ed159e1d360bd5a8416acb9b28e2c337cde0f94b
+hash_d_source: "auto-approved — no principal 1B1 transcript"
+hash_e: a96b193900f986af9f7b211d28c7f109b81004494e2e11eca17aaeb2ce409f9a
+date: 2026-09-03T21:01
+---
+
+# Receipt: pr-prep — dispatch-retention-policy
+
+## Chain of Trust
+- A (original): a8334ba
+- B (findings): 10fd580
+- C (triage): 5408ca3
+- D (principal): 5408ca3 — auto-approved — no principal 1B1 transcript
+- E (final): a96b193
+
+## Review Summary
+dispatch retention (#264-adjacent): dispatch prune + session-start auto-sweep + config knob; QG clean (no functional/injection bugs), +7 tests, dispatch.bats 62/0

--- a/src/agency/config/agency.yaml
+++ b/src/agency/config/agency.yaml
@@ -145,6 +145,12 @@ testing:
 design:
   provider: "figma"  # Default: figma. Alternatives: sketch, adobe
 
+# Dispatch retention (ISCP)
+# commit-notify dispatches (the git-safe-commit firehose) auto-resolve after this
+# many days. `dispatch prune` reads it; session-preflight sweeps on session start.
+dispatches:
+  commit_retention_days: 7
+
 # Cross-repo collaboration
 # Each entry maps a collaborator name to its local checkout path and dispatch dirs.
 # Used by: collaboration-check tool (startup hook, dispatch loop)

--- a/src/agency/tools/dispatch
+++ b/src/agency/tools/dispatch
@@ -972,6 +972,61 @@ cmd_resolve() {
 }
 
 # ─────────────────────────────────────────────────────────────────────────────
+# prune — bulk-resolve old FYI dispatches (retention policy)
+#
+# The commit-to-captain notify dispatch fires after every commit (git-safe-commit
+# #210 guard), so `commit`-type dispatches accumulate into an unbounded "unread"
+# firehose. They are pure notifications — no action, safe to auto-resolve once
+# stale. `prune` resolves every dispatch of a given TYPE older than N days.
+# Idempotent and safe to run repeatedly (e.g. at session start). Global by type
+# + age (a commit notice is noise regardless of recipient).
+# ─────────────────────────────────────────────────────────────────────────────
+cmd_prune() {
+    local type="commit" older_days="" dry_run="false"
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --type)       [[ -n "${2:-}" ]] || { echo "Error: --type requires a value" >&2; return 1; }
+                          type="$2"; shift 2 ;;
+            --older-days) [[ "${2:-}" =~ ^[0-9]+$ ]] || { echo "Error: --older-days requires an integer" >&2; return 1; }
+                          older_days="$2"; shift 2 ;;
+            --dry-run)    dry_run="true"; shift ;;
+            *)            echo "Error: unknown option '$1' (usage: dispatch prune [--type <t>] [--older-days <N>] [--dry-run])" >&2; return 1 ;;
+        esac
+    done
+
+    # Retention window: --older-days > dispatches.commit_retention_days > 7.
+    if [[ -z "$older_days" ]]; then
+        older_days="$("$SCRIPT_DIR/config" get dispatches.commit_retention_days 2>/dev/null || true)"
+        [[ "$older_days" =~ ^[0-9]+$ ]] || older_days="7"
+    fi
+
+    iscp_db_init
+
+    # Cutoff timestamp (UTC, now - older_days) via stdlib python — matches the
+    # 'YYYY-MM-DDTHH:MM' created_at format so string comparison is chronological.
+    local cutoff
+    cutoff="$(python3 -c "import sys,datetime as d; print((d.datetime.utcnow()-d.timedelta(days=int(sys.argv[1]))).strftime('%Y-%m-%dT%H:%M'))" "$older_days")"
+
+    local where="type = :type AND status != 'resolved' AND created_at < :cutoff"
+    local n
+    n=$(iscp_db_query "SELECT count(*) FROM dispatches WHERE $where" ":type" "$type" ":cutoff" "$cutoff")
+    n="${n:-0}"
+
+    if [[ "$dry_run" == "true" ]]; then
+        echo "dispatch prune: would resolve $n '$type' dispatch(es) older than ${older_days}d (before $cutoff)"
+        return 0
+    fi
+    if [[ "$n" -eq 0 ]]; then
+        return 0
+    fi
+    local now
+    now=$(date -u +%Y-%m-%dT%H:%M)
+    iscp_db_exec "UPDATE dispatches SET status = 'resolved', resolved_at = :now WHERE $where" \
+        ":now" "$now" ":type" "$type" ":cutoff" "$cutoff"
+    echo "dispatch prune: resolved $n '$type' dispatch(es) older than ${older_days}d"
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
 # status — Show full record for a dispatch
 # ─────────────────────────────────────────────────────────────────────────────
 cmd_status() {
@@ -1024,6 +1079,7 @@ Usage:
   dispatch reply <id> "msg"    — quick response to a dispatch
   dispatch check
   dispatch resolve <id> [--response <id>]
+  dispatch prune [--type <t>] [--older-days <N>] [--dry-run]
   dispatch status <id>
   dispatch --version
   dispatch --help
@@ -1073,6 +1129,10 @@ case "$subcmd" in
     resolve)
         shift; cmd_resolve "$@"
         log_end "$RUN_ID" "success" "0" "0" "dispatch resolve"
+        ;;
+    prune)
+        shift; cmd_prune "$@"
+        log_end "$RUN_ID" "success" "0" "0" "dispatch prune"
         ;;
     status)
         shift; cmd_status "$@"

--- a/src/agency/tools/session-preflight
+++ b/src/agency/tools/session-preflight
@@ -52,13 +52,70 @@ echo "Session Preflight"
 echo "─────────────────"
 
 # ── Check 1: Working tree clean ──────────────────────────────────────────
+# Issue #199: framework hooks themselves write to tracked and untracked
+# paths during SessionStart — the preflight's own callers are producing
+# dirty state. We filter known framework-owned churn patterns from the
+# dirty count so user-space dirt still fails, but framework-managed files
+# (tool-runs log, session-handoff writes, archived handoffs) don't.
+#
+# Paths filtered as framework-owned:
+#   - .claude/logs/                          (hook-generated logs)
+#   - agency/logs/                           (hook-generated logs, v46 location)
+#   - usr/*/captain/captain-handoff.md       (SessionStart handoff rewrite)
+#   - usr/*/captain/history/                 (archived handoffs, untracked)
+#   - usr/*/tool-runs.jsonl                  (tool-run log)
+#
+# Rationale (from issue #199): these are hook outputs the agent cannot
+# commit or stash sensibly without either polluting history with framework
+# churn or losing framework state. User can override the filter by setting
+# AGENCY_PREFLIGHT_STRICT_DIRTY=1 (all dirt fails).
 
-dirty_count=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null | wc -l | tr -d ' ')
-if [[ "$dirty_count" -eq 0 ]]; then
-    report_pass "Working tree clean"
+_is_framework_owned() {
+    # Takes a `git status --porcelain` path (without status prefix), returns
+    # 0 if the path matches a framework-owned pattern, 1 otherwise.
+    local path="$1"
+    case "$path" in
+        .claude/logs/*)                         return 0 ;;
+        agency/logs/*)                          return 0 ;;
+        usr/*/captain/captain-handoff.md)       return 0 ;;
+        usr/*/captain/history/*)                return 0 ;;
+        usr/*/tool-runs.jsonl)                  return 0 ;;
+    esac
+    return 1
+}
+
+porcelain=$(git -C "$REPO_ROOT" status --porcelain 2>/dev/null || true)
+total_count=0
+user_count=0
+framework_count=0
+
+if [[ -n "$porcelain" ]]; then
+    while IFS= read -r line; do
+        [[ -z "$line" ]] && continue
+        total_count=$((total_count + 1))
+        # Strip the 2-char status prefix + space to get the path
+        path="${line:3}"
+        # Rename/copy entries look like "R  old -> new"; take the new side.
+        if [[ "$path" == *" -> "* ]]; then
+            path="${path#*-> }"
+        fi
+        if [[ "${AGENCY_PREFLIGHT_STRICT_DIRTY:-0}" != "1" ]] && _is_framework_owned "$path"; then
+            framework_count=$((framework_count + 1))
+        else
+            user_count=$((user_count + 1))
+        fi
+    done <<< "$porcelain"
+fi
+
+if [[ "$user_count" -eq 0 ]]; then
+    if [[ "$framework_count" -gt 0 ]]; then
+        report_pass "Working tree clean (framework-owned churn: $framework_count file(s) filtered)"
+    else
+        report_pass "Working tree clean"
+    fi
 else
-    report_fail "Working tree dirty ($dirty_count files)" \
-        "Commit or stash changes: git status"
+    report_fail "Working tree dirty ($user_count user-space file(s); $framework_count framework-owned filtered)" \
+        "Commit or stash user-space changes: ./agency/tools/git-safe status"
 fi
 
 # ── Check 2: Worktree synced with main ───────────────────────────────────
@@ -101,6 +158,12 @@ fi
 
 # ── Check 4: No unread dispatches remaining ──────────────────────────────
 
+# Retention sweep: auto-resolve stale commit-notify dispatches (the
+# git-safe-commit firehose) before counting, so "unread" reflects actionable
+# items, not months of FYI notices. Idempotent + cheap (one UPDATE, no-op when
+# nothing is old). Window from collaboration.commit_dispatch_retention_days (7d).
+bash "$SCRIPT_DIR/dispatch" prune --type commit >/dev/null 2>&1 || true
+
 dispatch_check=$(bash "$SCRIPT_DIR/dispatch" check 2>/dev/null || true)
 if [[ -z "$dispatch_check" ]]; then
     report_pass "No unread dispatches"
@@ -112,12 +175,19 @@ else
         "Run: dispatch list, then dispatch read <id>"
 fi
 
-# ── Check 5: Dispatch monitor running ────────────────────────────────────
-# We can't directly detect Monitor tool tasks from bash.
-# Instead, we remind the agent to start it.
-
-report_warn "Dispatch monitor — verify it is running" \
-    "Run: /monitor-dispatches (if not already started this session)"
+# ── Check 5: Dispatch monitor reminder ───────────────────────────────────
+# Issue #201: Check 5 used to hard-code report_warn, so every preflight
+# reported "1 action" regardless of whether the monitor was already running.
+# That undermined trust in the check. We cannot directly detect Monitor
+# tool tasks from bash (they're harness-side), so the check is now
+# informational by default. Agents who want a real assertion can set
+# AGENCY_PREFLIGHT_MONITOR_STRICT=1 to force the warn behavior.
+if [[ "${AGENCY_PREFLIGHT_MONITOR_STRICT:-0}" == "1" ]]; then
+    report_warn "Dispatch monitor — verify it is running" \
+        "Run: /monitor-dispatches (if not already started this session)"
+else
+    [[ "$QUIET" == "false" ]] && echo "  ℹ  Dispatch monitor — start with /monitor-dispatches if not already running (informational)"
+fi
 
 # ── Summary ──────────────────────────────────────────────────────────────
 

--- a/src/agency/tools/session-preflight
+++ b/src/agency/tools/session-preflight
@@ -161,7 +161,7 @@ fi
 # Retention sweep: auto-resolve stale commit-notify dispatches (the
 # git-safe-commit firehose) before counting, so "unread" reflects actionable
 # items, not months of FYI notices. Idempotent + cheap (one UPDATE, no-op when
-# nothing is old). Window from collaboration.commit_dispatch_retention_days (7d).
+# nothing is old). Window from dispatches.commit_retention_days (default 7d).
 bash "$SCRIPT_DIR/dispatch" prune --type commit >/dev/null 2>&1 || true
 
 dispatch_check=$(bash "$SCRIPT_DIR/dispatch" check 2>/dev/null || true)

--- a/src/tests/tools/dispatch.bats
+++ b/src/tests/tools/dispatch.bats
@@ -621,3 +621,54 @@ _create_dispatch() {
         --body-file "$body_path"
     [ "$status" -eq 0 ]
 }
+
+# ─────────────────────────────────────────────────────────────────────────────
+# prune — retention sweep for the commit-notify firehose (#264-adjacent)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Backdate a dispatch's created_at by N days (for age-based prune tests).
+_backdate() { _db_query "UPDATE dispatches SET created_at = strftime('%Y-%m-%dT%H:%M', 'now', '-${2} days') WHERE id = ${1};"; }
+
+@test "dispatch prune: resolves a stale commit dispatch" {
+    _create_dispatch "old notice" commit
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    _backdate "$id" 30
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resolved 1"* ]]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" = "resolved" ]
+}
+
+@test "dispatch prune: keeps a recent commit dispatch" {
+    _create_dispatch "fresh notice" commit
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" != "resolved" ]
+}
+
+@test "dispatch prune: --dry-run resolves nothing" {
+    _create_dispatch "old notice" commit
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    _backdate "$id" 30
+    run "$DISPATCH" prune --type commit --older-days 7 --dry-run
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"would resolve 1"* ]]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" != "resolved" ]
+}
+
+@test "dispatch prune: only affects the named type" {
+    _create_dispatch "old real dispatch" dispatch
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    _backdate "$id" 30
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    # a 'dispatch'-type message is NOT pruned by a commit sweep
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" != "resolved" ]
+}
+
+@test "dispatch prune: appears in --help" {
+    run "$DISPATCH" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dispatch prune"* ]]
+}

--- a/src/tests/tools/dispatch.bats
+++ b/src/tests/tools/dispatch.bats
@@ -667,8 +667,79 @@ _backdate() { _db_query "UPDATE dispatches SET created_at = strftime('%Y-%m-%dT%
     [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" != "resolved" ]
 }
 
+@test "dispatch prune: defaults to a 7-day window when no flag/config" {
+    # No --older-days and no config in this fixture → prune falls back to 7d.
+    _create_dispatch "old default-window notice" commit
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    _backdate "$id" 10
+    run "$DISPATCH" prune --type commit
+    [ "$status" -eq 0 ]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" = "resolved" ]
+}
+
+@test "dispatch prune: is idempotent (second run is a no-op)" {
+    _create_dispatch "stale" commit
+    local id; id=$(_db_query "SELECT id FROM dispatches ORDER BY id DESC LIMIT 1;")
+    _backdate "$id" 30
+    "$DISPATCH" prune --type commit --older-days 7 >/dev/null
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    # nothing left to resolve → no "resolved N" line
+    [[ "$output" != *"resolved 1"* ]]
+}
+
+@test "dispatch prune: resolves only the stale ones in a mixed set (exact count)" {
+    local a b c d e
+    _create_dispatch "old 1" commit; a=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$a" 30
+    _create_dispatch "old 2" commit; b=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$b" 20
+    _create_dispatch "old 3" commit; c=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$c" 8
+    _create_dispatch "fresh 1" commit; d=$(_db_query "SELECT max(id) FROM dispatches;")
+    _create_dispatch "fresh 2" commit; e=$(_db_query "SELECT max(id) FROM dispatches;")
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"resolved 3 "* ]]     # exactly 3 (trailing space guards vs 30/31)
+    for id in "$a" "$b" "$c"; do [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" = "resolved" ]; done
+    for id in "$d" "$e"; do [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" != "resolved" ]; done
+}
+
+@test "dispatch prune: boundary — exactly N days kept, older resolved" {
+    _create_dispatch "exactly 7d" commit; local at7; at7=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$at7" 7
+    _create_dispatch "8d old" commit; local at8; at8=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$at8" 8
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    # created_at < cutoff is strict: a dispatch exactly 7d old is NOT before the
+    # (now-7d) cutoff, so it survives; 8d is resolved.
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $at7;")" != "resolved" ]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $at8;")" = "resolved" ]
+}
+
+@test "dispatch prune: --older-days 0 resolves anything older than now" {
+    _create_dispatch "yesterday" commit; local id; id=$(_db_query "SELECT max(id) FROM dispatches;"); _backdate "$id" 1
+    run "$DISPATCH" prune --type commit --older-days 0
+    [ "$status" -eq 0 ]
+    [ "$(_db_query "SELECT status FROM dispatches WHERE id = $id;")" = "resolved" ]
+}
+
+@test "dispatch prune: does not re-touch an already-resolved dispatch" {
+    _create_dispatch "already done" commit; local id; id=$(_db_query "SELECT max(id) FROM dispatches;")
+    _backdate "$id" 30
+    _db_query "UPDATE dispatches SET status='resolved', resolved_at='2020-01-01T00:00' WHERE id = $id;"
+    run "$DISPATCH" prune --type commit --older-days 7
+    [ "$status" -eq 0 ]
+    # resolved_at untouched (status != 'resolved' guard excludes it)
+    [ "$(_db_query "SELECT resolved_at FROM dispatches WHERE id = $id;")" = "2020-01-01T00:00" ]
+}
+
 @test "dispatch prune: appears in --help" {
     run "$DISPATCH" --help
     [ "$status" -eq 0 ]
     [[ "$output" == *"dispatch prune"* ]]
+}
+
+@test "session-preflight wires the commit-dispatch auto-sweep" {
+    # The retention policy only works if preflight actually calls prune at
+    # session start. Structural guard against silent removal (session-preflight
+    # has no unit harness of its own). #264-adjacent.
+    run grep -qE 'dispatch" prune --type commit' "$REPO_ROOT/agency/tools/session-preflight"
+    [ "$status" -eq 0 ]
 }

--- a/usr/jordan/_land-dispatch-retention-policy/dispatches/commit-to-captain-committed-43aadc9a-on-land-dispatch-retention-poli-20260903-2105.md
+++ b/usr/jordan/_land-dispatch-retention-policy/dispatches/commit-to-captain-committed-43aadc9a-on-land-dispatch-retention-poli-20260903-2105.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-dispatch-retention-policy
+to: the-agency/jordan/captain
+date: 2026-09-03T13:05
+status: created
+priority: normal
+subject: "Committed 43aadc9a on _land-dispatch-retention-policy: chore(manifest): bump agency_version 46.45 → 46.46 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 43aadc9a on _land-dispatch-retention-policy: chore(manifest): bump agency_version 46.45 → 46.46 for PR landing (captain)
+
+## Commit: 43aadc9a
+
+**Branch:** _land-dispatch-retention-policy
+**Agent:** the-agency/jordan/_land-dispatch-retention-policy
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.45 → 46.46 for PR landing (captain)
+
+### Metadata
+- commit_hash: 43aadc9a
+- branch: _land-dispatch-retention-policy
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `dispatch-retention-policy` (untouched; this PR rides `_land-dispatch-retention-policy`)
- Integrated in a scratch worktree cut from `origin/dispatch-retention-policy`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-dispatch-retention-policy-qgr-pr-prep-20260903-2101-a96b193.md` (hash `a96b193`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-dispatch-retention-policy-qgr-pr-captain-land-20260903-2105-c628152.md` (hash `c628152`)
- `agency_version`: 46.45 → 46.46
- Release v46.46 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)