### PR TITLE
fix-config-dup-and-testrun-parsing

### DIFF
--- a/agency/config/agency.yaml
+++ b/agency/config/agency.yaml
@@ -57,11 +57,6 @@ framework:
 agents:
   default_model: "opus"  # opus, sonnet, haiku
 
-# Collaboration settings
-collaboration:
-  auto_sync: true  # Automatically push collaboration files
-  news_expiry_days: 7  # Mark old news as READ after N days
-
 # Quality gate settings
 quality:
   block_on_secrets: true
@@ -155,6 +150,8 @@ dispatches:
 # Each entry maps a collaborator name to its local checkout path and dispatch dirs.
 # Used by: collaboration-check tool (startup hook, dispatch loop)
 collaboration:
+  auto_sync: true          # Automatically push collaboration files
+  news_expiry_days: 7      # Mark old news as READ after N days
   repos:
     monofolk:
       path: "~/code/collaboration-monofolk"

--- a/agency/config/manifest.json
+++ b/agency/config/manifest.json
@@ -1,11 +1,11 @@
 {
   "schema_version": "1.0",
-  "agency_version": "46.47",
+  "agency_version": "46.48",
   "project": {
     "name": "the-agency",
     "created_at": "2026-01-15T04:54:46Z",
     "framework_version": "46.28",
-    "updated_at": "2026-09-03T14:58:49Z"
+    "updated_at": "2026-09-03T15:41:18Z"
   },
   "source": {
     "type": "local",
@@ -896,5 +896,5 @@
       "version": "1.0.3"
     }
   },
-  "updated_at": "2026-09-03T14:58:49Z"
+  "updated_at": "2026-09-03T15:41:18Z"
 }

--- a/agency/tools/test-run
+++ b/agency/tools/test-run
@@ -81,7 +81,8 @@ log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
 AGENCY_YAML="$REPO_ROOT/agency/config/agency.yaml"
 
 # Parse testing suites from agency.yaml
-# Returns lines of: suite_name|command|description
+# Returns tab-separated lines of: suite_name<TAB>command<TAB>description
+# (TAB, not '|', so a command containing '|'/'||' is never truncated.)
 _read_suites() {
     if [[ ! -f "$AGENCY_YAML" ]]; then
         return 1

--- a/agency/tools/test-run
+++ b/agency/tools/test-run
@@ -111,7 +111,7 @@ _read_suites() {
             if [[ "$line" =~ ^[[:space:]]{4}[a-z] && "$line" =~ :$ ]]; then
                 # Emit previous suite if complete
                 if [[ -n "$current_suite" && -n "$current_command" ]]; then
-                    echo "${current_suite}|${current_command}|${current_desc}"
+                    printf '%s\t%s\t%s\n' "$current_suite" "$current_command" "$current_desc"
                 fi
                 current_suite="${line%%:*}"
                 current_suite="${current_suite#"${current_suite%%[![:space:]]*}"}"  # trim leading spaces
@@ -147,7 +147,7 @@ _read_suites() {
 
     # Emit last suite
     if [[ -n "$current_suite" && -n "$current_command" ]]; then
-        echo "${current_suite}|${current_command}|${current_desc}"
+        printf '%s\t%s\t%s\n' "$current_suite" "$current_command" "$current_desc"
     fi
 }
 
@@ -191,7 +191,7 @@ fi
 if [[ "$LIST_ONLY" == "true" ]]; then
     echo "Configured test suites:"
     echo ""
-    while IFS='|' read -r name cmd desc; do
+    while IFS=$'\t' read -r name cmd desc; do
         printf "  %-20s %s\n" "$name" "${desc:-$cmd}"
     done <<< "$SUITES"
     exit 0
@@ -203,7 +203,7 @@ passed=0
 failed=0
 failed_names=()
 
-while IFS='|' read -r name cmd desc; do
+while IFS=$'\t' read -r name cmd desc; do
     # Filter if --suite specified
     if [[ -n "$SUITE_FILTER" && "$name" != "$SUITE_FILTER" ]]; then
         continue

--- a/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-captain-land-20260903-2341-4b4f296.md
+++ b/agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-captain-land-20260903-2341-4b4f296.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-captain-land
+org: the-agency-ai
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-config-dup-and-testrun-parsing
+diff_base: origin/main
+hash_a: ce2de4aff5fee196dd4f0ca20d3a85dc7a086900e3c0efac4600c9a8cce1a294
+hash_b: 1cb7691f29c51e7100b51dd67e1a9795db06ab292f01ae728fcfed6e53a7a91e
+hash_c: 1cb7691f29c51e7100b51dd67e1a9795db06ab292f01ae728fcfed6e53a7a91e
+hash_d: 1cb7691f29c51e7100b51dd67e1a9795db06ab292f01ae728fcfed6e53a7a91e
+hash_d_source: "auto-approved — no principal 1B1"
+hash_e: 4b4f296e4768ff8abec24d5bbeb7e5a79bbe2a1327af923b13da1c2248550f5e
+date: 2026-09-03T23:41
+---
+
+# Receipt: pr-captain-land — fix-config-dup-and-testrun-parsing
+
+## Chain of Trust
+- A (original): ce2de4a
+- B (findings): 1cb7691
+- C (triage): 1cb7691
+- D (principal): 1cb7691 — auto-approved — no principal 1B1
+- E (final): 4b4f296
+
+## Review Summary
+Local-first landing of fix-config-dup-and-testrun-parsing. Integrated in scratch worktree _land-fix-config-dup-and-testrun-parsing cut from origin/fix-config-dup-and-testrun-parsing; 1 local validation step(s) passed against origin/main; agency_version 46.47 → 46.48. Chains to agent receipt agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-prep-20260903-2338-ce2de4a.md.

--- a/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-prep-20260903-2338-ce2de4a.md
+++ b/agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-prep-20260903-2338-ce2de4a.md
@@ -1,0 +1,30 @@
+---
+receipt_version: 1
+type: qgr
+boundary: pr-prep
+org: the-agency
+principal: jordan
+agent: captain
+workstream: agency
+project: fix-config-dup-and-testrun-parsing
+diff_base: origin/main
+hash_a: f86ce81ccdc4ed971d0bab5942f2893f6b5f66e0f84d6bffaeccc35358ed0113
+hash_b: fe0c2b7e1c82364df25ccae84e27f41a36765c016d7aed1ad9814f4cccb0ed47
+hash_c: f2e8faf94ba658953f24b3bd4d3c527da272bd815e1ea074e0fb62713ed81c37
+hash_d: f2e8faf94ba658953f24b3bd4d3c527da272bd815e1ea074e0fb62713ed81c37
+hash_d_source: "auto-approved — no principal 1B1 transcript"
+hash_e: ce2de4aff5fee196dd4f0ca20d3a85dc7a086900e3c0efac4600c9a8cce1a294
+date: 2026-09-03T23:38
+---
+
+# Receipt: pr-prep — fix-config-dup-and-testrun-parsing
+
+## Chain of Trust
+- A (original): f86ce81
+- B (findings): fe0c2b7
+- C (triage): f2e8faf
+- D (principal): f2e8faf — auto-approved — no principal 1B1 transcript
+- E (final): ce2de4a
+
+## Review Summary
+2 flagged bugs: agency.yaml dup collaboration key (#240) + test-run |-delimiter truncation (#242); QG clean, both regression-pinned, +tests

--- a/src/agency/config/agency.yaml
+++ b/src/agency/config/agency.yaml
@@ -57,11 +57,6 @@ framework:
 agents:
   default_model: "opus"  # opus, sonnet, haiku
 
-# Collaboration settings
-collaboration:
-  auto_sync: true  # Automatically push collaboration files
-  news_expiry_days: 7  # Mark old news as READ after N days
-
 # Quality gate settings
 quality:
   block_on_secrets: true
@@ -155,6 +150,8 @@ dispatches:
 # Each entry maps a collaborator name to its local checkout path and dispatch dirs.
 # Used by: collaboration-check tool (startup hook, dispatch loop)
 collaboration:
+  auto_sync: true          # Automatically push collaboration files
+  news_expiry_days: 7      # Mark old news as READ after N days
   repos:
     monofolk:
       path: "~/code/collaboration-monofolk"

--- a/src/agency/tools/test-run
+++ b/src/agency/tools/test-run
@@ -81,7 +81,8 @@ log_step() { echo -e "${BLUE}[STEP]${NC} $1"; }
 AGENCY_YAML="$REPO_ROOT/agency/config/agency.yaml"
 
 # Parse testing suites from agency.yaml
-# Returns lines of: suite_name|command|description
+# Returns tab-separated lines of: suite_name<TAB>command<TAB>description
+# (TAB, not '|', so a command containing '|'/'||' is never truncated.)
 _read_suites() {
     if [[ ! -f "$AGENCY_YAML" ]]; then
         return 1

--- a/src/agency/tools/test-run
+++ b/src/agency/tools/test-run
@@ -111,7 +111,7 @@ _read_suites() {
             if [[ "$line" =~ ^[[:space:]]{4}[a-z] && "$line" =~ :$ ]]; then
                 # Emit previous suite if complete
                 if [[ -n "$current_suite" && -n "$current_command" ]]; then
-                    echo "${current_suite}|${current_command}|${current_desc}"
+                    printf '%s\t%s\t%s\n' "$current_suite" "$current_command" "$current_desc"
                 fi
                 current_suite="${line%%:*}"
                 current_suite="${current_suite#"${current_suite%%[![:space:]]*}"}"  # trim leading spaces
@@ -147,7 +147,7 @@ _read_suites() {
 
     # Emit last suite
     if [[ -n "$current_suite" && -n "$current_command" ]]; then
-        echo "${current_suite}|${current_command}|${current_desc}"
+        printf '%s\t%s\t%s\n' "$current_suite" "$current_command" "$current_desc"
     fi
 }
 
@@ -191,7 +191,7 @@ fi
 if [[ "$LIST_ONLY" == "true" ]]; then
     echo "Configured test suites:"
     echo ""
-    while IFS='|' read -r name cmd desc; do
+    while IFS=$'\t' read -r name cmd desc; do
         printf "  %-20s %s\n" "$name" "${desc:-$cmd}"
     done <<< "$SUITES"
     exit 0
@@ -203,7 +203,7 @@ passed=0
 failed=0
 failed_names=()
 
-while IFS='|' read -r name cmd desc; do
+while IFS=$'\t' read -r name cmd desc; do
     # Filter if --suite specified
     if [[ -n "$SUITE_FILTER" && "$name" != "$SUITE_FILTER" ]]; then
         continue

--- a/src/tests/tools/config.bats
+++ b/src/tests/tools/config.bats
@@ -137,3 +137,16 @@ load 'test_helper'
     [[ ! "$output" =~ "syntax error" ]]
 }
 
+@test "config: the real agency.yaml has no duplicate top-level keys (#240)" {
+    # Duplicate top-level keys are silently last-wins-shadowed by YAML (both
+    # pyyaml and yaml_lite), so a second 'collaboration:' key hid the first's
+    # settings. Guard against reintroduction.
+    local dups
+    dups=$(grep -E '^[a-zA-Z_][a-zA-Z0-9_]*:' "${REPO_ROOT}/agency/config/agency.yaml" \
+             | sed 's/:.*//' | sort | uniq -d)
+    if [[ -n "$dups" ]]; then
+        echo "duplicate top-level keys in agency.yaml: $dups" >&2
+        return 1
+    fi
+}
+

--- a/src/tests/tools/test-run.bats
+++ b/src/tests/tools/test-run.bats
@@ -61,12 +61,20 @@ _code() { grep -vE '^[[:space:]]*#' "$1"; }
 @test "test-run --isolated: a NON-bats suite falls back to the host (not the container)" {
     # mdpal's command is a swift-test shell command, not 'bats ...'; under
     # --isolated it must run on the HOST, never route to container-test-run.
-    # (We assert the ROUTING, not mdpal's own exit — its command is a no-op-ish
-    # swift test that may fail when apps/mdpal is absent; #-delimiter parsing of
-    # its '|| true' is a separate pre-existing test-run bug, flagged.)
     run env CONTAINER_PROVIDER=nonexistent bash "$TR" --isolated --suite mdpal
+    assert_success
     assert_output_contains "host — not a bats suite"
     [[ "$output" != *"container-test-run:"* ]]
+}
+
+@test "test-run: suite commands containing '|' are NOT truncated (tab-delimited parse)" {
+    # Regression for the |-delimiter bug: mdpal's command ends in '|| true'. If
+    # the name|command|desc parse split on '|', the '|| true' (and the soft-skip
+    # it provides) would be lost and the suite would fail when apps/mdpal is absent.
+    run bash "$TR" --suite mdpal
+    assert_success
+    # literal glob match (assert_output_contains treats '|' as a regex alternation)
+    [[ "$output" == *'|| true'* ]]
 }
 
 # ── Structural guards on the container-test-run integration (code, not comments) ──

--- a/src/tests/tools/test-run.bats
+++ b/src/tests/tools/test-run.bats
@@ -77,6 +77,27 @@ _code() { grep -vE '^[[:space:]]*#' "$1"; }
     [[ "$output" == *'|| true'* ]]
 }
 
+@test "test-run: a single-'|' suite command survives parsing (fixture, not prod config)" {
+    # Decoupled from mdpal: a synthetic suite whose command contains a single '|'
+    # and NO description, so `--list` displays the COMMAND. Parsed WHOLE
+    # (tab-delimited) it shows 'echo a | grep a'; if the '|' delimiter regressed,
+    # the command truncates to 'echo a ' and the '| grep a' vanishes.
+    local repo="$BATS_TEST_TMPDIR/pipe-repo"
+    mkdir -p "$repo/agency/config"
+    cat > "$repo/agency/config/agency.yaml" <<'YAML'
+testing:
+  provider: "multi"
+  suites:
+    piped:
+      command: "echo a | grep a"
+YAML
+    cd "$repo"
+    git init -q
+    run bash "$TR" --list
+    assert_success
+    [[ "$output" == *'| grep a'* ]]
+}
+
 # ── Structural guards on the container-test-run integration (code, not comments) ──
 
 @test "test-run: --isolated actually invokes container-test-run (code path)" {

--- a/usr/jordan/_land-fix-config-dup-and-testrun-parsing/dispatches/commit-to-captain-committed-7beaf411-on-land-fix-config-dup-and-test-20260903-2341.md
+++ b/usr/jordan/_land-fix-config-dup-and-testrun-parsing/dispatches/commit-to-captain-committed-7beaf411-on-land-fix-config-dup-and-test-20260903-2341.md
@@ -1,0 +1,31 @@
+---
+type: commit
+from: the-agency/jordan/_land-fix-config-dup-and-testrun-parsing
+to: the-agency/jordan/captain
+date: 2026-09-03T15:41
+status: created
+priority: normal
+subject: "Committed 7beaf411 on _land-fix-config-dup-and-testrun-parsing: chore(manifest): bump agency_version 46.47 → 46.48 for PR landing (captain)"
+in_reply_to: null
+---
+
+# Committed 7beaf411 on _land-fix-config-dup-and-testrun-parsing: chore(manifest): bump agency_version 46.47 → 46.48 for PR landing (captain)
+
+## Commit: 7beaf411
+
+**Branch:** _land-fix-config-dup-and-testrun-parsing
+**Agent:** the-agency/jordan/_land-fix-config-dup-and-testrun-parsing
+**Message:** housekeeping/captain: chore(manifest): bump agency_version 46.47 → 46.48 for PR landing (captain)
+
+### Metadata
+- commit_hash: 7beaf411
+- branch: _land-fix-config-dup-and-testrun-parsing
+- files_changed: 1
+- stage: none
+- stage_hash: none
+- work_item: none
+
+### Files Changed
+```
+agency/config/manifest.json
+```

--- a/usr/jordan/captain/captain-handoff.md
+++ b/usr/jordan/captain/captain-handoff.md
@@ -1,72 +1,60 @@
 ---
 type: session
 agent: the-agency/jordan/captain
-date: 2026-08-19T09:40
-trigger: container-42-landed
+date: 2026-09-03T23:00
+trigger: plan-complete
 branch: main
 mode: resumption
 next-action: |
-  SHIPPED — container test-isolation (#42) landed as PR #481 / release v46.44.
-  On main, clean, main == origin/main. No blocking next action. When convenient:
-  (1) /captain-sync-all to propagate the merge to the fleet worktrees (designex,
-  devex, iscp, mdpal-*, mock-and-mark — several are Great-Rename-parked, sync-all
-  skips those). (2) Address flag #264 (host-env hygiene: config pyyaml zero-pip
-  violation + host python 3.9) so host bats:all / commit-precheck go green again.
-  (3) Optional step 3/4 of the container plan: wire container-test-run into the
-  gate as the default (test-run --isolated) + working-tree mode + prove Docker backend.
+  PLAN COMPLETE (1→2→4→3, all landed v46.45–v46.47). On main, clean, in sync.
+  No blocking next action. Open follow-ups when convenient: (a) flag #264-dup
+  (two 'collaboration:' keys in agency.yaml — last-wins shadow); (b) test-run
+  '|'-delimiter parsing truncates suite commands containing '||' (mdpal '|| true');
+  (c) Docker backend LIVE proof belongs in Linux CI (routing already verified);
+  (d) 2 parked worktrees (devex, mock-and-mark) still on Great-Rename debt —
+  un-park via great-rename-migrate, not a blind sync.
 ---
 
-# Captain handoff — container test-isolation (#42) SHIPPED
+# Captain handoff — 4-item plan COMPLETE
 
-## What shipped (PR #481, release v46.44, merge c8e49032)
-Container test-isolation: an abstraction over Docker + Apple Containers for running
-the bats suite in a disposable container so leaky tests can't trash the local repo.
-Ran the WHOLE suite in-container and drove failures **230 → 0**. The container earned
-its keep as a portability/CI gate — it caught ~12 REAL cross-platform bugs macOS hid:
+## The plan (principal's order 1→2→4→3) — all done
+- **① config stdlib-only (#264)** → PR #483 / **v46.45**. Dropped pyyaml for a new
+  stdlib `agency/tools/lib/yaml_lite.py` (nested maps/lists/flow/scalars, PyYAML-
+  parity on agency.yaml). Restores the normal commit gate (no more --no-verify).
+  A pyyaml-POISON regression guard proves config never imports yaml. QG found+fixed
+  10 (list-colon misparse, numeric coercion, nested-flow, + the cascading
+  sandbox-sync fixture dep on the new lib).
+- **② Fleet sync** → 6 worktrees synced to main; devex + mock-and-mark SKIPPED
+  (Great-Rename conflicts — parked, correct).
+- **④ Dispatch retention** → PR #484 / **v46.46**. Drained the 144-deep commit-notify
+  firehose; new `dispatch prune [--type --older-days --dry-run]` + session-preflight
+  auto-sweep + `dispatches.commit_retention_days: 7` knob. QG clean, +12 tests.
+- **③ Container gate (#42 step 3)** → PR #485 / **v46.47**. `container-test-run
+  --working-tree` (overlays uncommitted changes onto the clone) + `test-run
+  --isolated` (routes bats suites into the container). On Apple containers. QG:
+  no aborts/escape/injection; added a '..'-path-component guard to the overlay,
+  unknown-flag rejection, pre-gate diagnostics (host-testable routing), 14 tests.
+  Docker backend: routing verified (CONTAINER_PROVIDER=docker → docker dispatch,
+  standard alpine OCI); LIVE proof deferred to Linux CI (not this Apple-Silicon box).
 
-- set -u unbound: great-rename-migrate (5 arrays), principal, iscp-migrate
-- SIGPIPE-under-pipefail (`| head`): release get_last_release, worktree-sync (×2)
-- jq 1.7 object-merge syntax: settings-merge
-- shasum(macOS-only)→portable _sha256 (now a shared lib): diff-hash/stage-hash/monitor-register
-- iscp-db migration rollback committed the version bump on failure (`.bail on`)
-- pr-create empty-`xargs` listed cwd on Linux → phantom receipt (`xargs -r`)
+## Releases this arc
+v46.44 (container test-isolation #42) · v46.45 (#264) · v46.46 (retention) · v46.47 (gate).
 
-Plus 7 image deps (sqlite/zip/py3-yaml/rsync/gh/node/pnpm), 8 host-coupled test fixes,
-and a new **git-captain tag-delete** tool (origin-safety guard: never deletes an
-on-origin tag) used to sweep 364 junk release-bug tags (0 origin tags touched).
+## How to use the new container gate
+- `test-run --isolated` — run the bats suites in a disposable Apple container.
+- `test-run --working-tree` — same, but tests UNCOMMITTED changes (implies --isolated).
+- `container-test-run [--working-tree] <paths>` — direct.
+- Note: full-suite container runs occasionally get killed near the end; the tools/
+  segment (1800+ tests) completes reliably — run segments separately if needed.
 
-## QG (receipt: agency/workstreams/agency/qgr/...qgr-pr-prep-20260819-1701-7e39369.md)
-4 reviewer agents found 9 real findings IN the branch's own code (PAT-leak edge case,
-tag-delete zero-tag false-die, TESTS injection, container_run dead code, _sha256
-triplication, + 5 test-coverage gaps). ALL fixed + pinned by +11 new tests. Container
-suite re-verified 0 failures / 1805 passed. Landed via pr-captain-land with container
-validation (clone-scratch-to-temp-repo → container-test-run, since a worktree's .git
-can't be cloned directly — this is why step 3 (wire container into the gate) matters).
+## Flags filed this session (for triage)
+- #264-dup: agency.yaml has two 'collaboration:' keys (shadowing).
+- test-run '|'-delimiter suite-command truncation (mdpal '|| true').
+- (earlier) #264 host-env hygiene, tag-sweep tooling, etc.
 
-## Key files (all on main now)
-- agency/tools/lib/_container-runtime (abstraction: container_backend/available/run w/ --mount/--env)
-- agency/tools/container-test-run (the isolated runner)
-- agency/containers/test-runner/Dockerfile (alpine image, tag the-agency-test-runner:latest)
-- agency/tools/lib/_sha256 (new shared portable-hash lib)
-- agency/tools/git-captain (tag-delete subcommand)
-- agency/config/agency.yaml (container: provider section)
+## State
+On main, clean, main == origin/main. Releases current to v46.47.
 
-## Open flags / follow-ups
-- **#264** host-env hygiene: `config` (core tool, dep of principal + much) requires
-  pyyaml → ZERO-PIP VIOLATION; host python is 3.9 (< 3.13 floor); these make host
-  bats:all / commit-precheck red (why this branch's commits used --no-verify). FIX:
-  make config stdlib-only. Also: git-captain tag-delete now exists (the tag-sweep blocker).
-- Fleet worktree sync pending (/captain-sync-all).
-- Container plan remaining: step 3 (test-run --isolated default + working-tree mode),
-  step 4 (prove Docker backend — daemon was down).
-- Stale: usr/jordan/captain/briefings/apple-containers-test-isolation-42-20260818.md
-  conclusion (argued in-process; reversed to container-substrate — now SHIPPED).
-
-## Environment
-- Apple `container` v1.2.2 running; image built. Docker installed, daemon down.
-- Full container run occasionally gets killed near the end (intermittent) — the
-  tools/ segment (1805 tests) completes reliably; run segments separately if needed.
-
-— captain. #42 shipped. 230→0, ~12 real bugs caught, QG-clean, released v46.44.
+— captain. Plan complete: 4 items, 3 PRs (#483/#484/#485), 3 releases, all QG'd.
 
 *OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*

--- a/usr/jordan/captain/history/handoff-20260903-230009-456.md
+++ b/usr/jordan/captain/history/handoff-20260903-230009-456.md
@@ -1,0 +1,72 @@
+---
+type: session
+agent: the-agency/jordan/captain
+date: 2026-08-19T09:40
+trigger: container-42-landed
+branch: main
+mode: resumption
+next-action: |
+  SHIPPED — container test-isolation (#42) landed as PR #481 / release v46.44.
+  On main, clean, main == origin/main. No blocking next action. When convenient:
+  (1) /captain-sync-all to propagate the merge to the fleet worktrees (designex,
+  devex, iscp, mdpal-*, mock-and-mark — several are Great-Rename-parked, sync-all
+  skips those). (2) Address flag #264 (host-env hygiene: config pyyaml zero-pip
+  violation + host python 3.9) so host bats:all / commit-precheck go green again.
+  (3) Optional step 3/4 of the container plan: wire container-test-run into the
+  gate as the default (test-run --isolated) + working-tree mode + prove Docker backend.
+---
+
+# Captain handoff — container test-isolation (#42) SHIPPED
+
+## What shipped (PR #481, release v46.44, merge c8e49032)
+Container test-isolation: an abstraction over Docker + Apple Containers for running
+the bats suite in a disposable container so leaky tests can't trash the local repo.
+Ran the WHOLE suite in-container and drove failures **230 → 0**. The container earned
+its keep as a portability/CI gate — it caught ~12 REAL cross-platform bugs macOS hid:
+
+- set -u unbound: great-rename-migrate (5 arrays), principal, iscp-migrate
+- SIGPIPE-under-pipefail (`| head`): release get_last_release, worktree-sync (×2)
+- jq 1.7 object-merge syntax: settings-merge
+- shasum(macOS-only)→portable _sha256 (now a shared lib): diff-hash/stage-hash/monitor-register
+- iscp-db migration rollback committed the version bump on failure (`.bail on`)
+- pr-create empty-`xargs` listed cwd on Linux → phantom receipt (`xargs -r`)
+
+Plus 7 image deps (sqlite/zip/py3-yaml/rsync/gh/node/pnpm), 8 host-coupled test fixes,
+and a new **git-captain tag-delete** tool (origin-safety guard: never deletes an
+on-origin tag) used to sweep 364 junk release-bug tags (0 origin tags touched).
+
+## QG (receipt: agency/workstreams/agency/qgr/...qgr-pr-prep-20260819-1701-7e39369.md)
+4 reviewer agents found 9 real findings IN the branch's own code (PAT-leak edge case,
+tag-delete zero-tag false-die, TESTS injection, container_run dead code, _sha256
+triplication, + 5 test-coverage gaps). ALL fixed + pinned by +11 new tests. Container
+suite re-verified 0 failures / 1805 passed. Landed via pr-captain-land with container
+validation (clone-scratch-to-temp-repo → container-test-run, since a worktree's .git
+can't be cloned directly — this is why step 3 (wire container into the gate) matters).
+
+## Key files (all on main now)
+- agency/tools/lib/_container-runtime (abstraction: container_backend/available/run w/ --mount/--env)
+- agency/tools/container-test-run (the isolated runner)
+- agency/containers/test-runner/Dockerfile (alpine image, tag the-agency-test-runner:latest)
+- agency/tools/lib/_sha256 (new shared portable-hash lib)
+- agency/tools/git-captain (tag-delete subcommand)
+- agency/config/agency.yaml (container: provider section)
+
+## Open flags / follow-ups
+- **#264** host-env hygiene: `config` (core tool, dep of principal + much) requires
+  pyyaml → ZERO-PIP VIOLATION; host python is 3.9 (< 3.13 floor); these make host
+  bats:all / commit-precheck red (why this branch's commits used --no-verify). FIX:
+  make config stdlib-only. Also: git-captain tag-delete now exists (the tag-sweep blocker).
+- Fleet worktree sync pending (/captain-sync-all).
+- Container plan remaining: step 3 (test-run --isolated default + working-tree mode),
+  step 4 (prove Docker backend — daemon was down).
+- Stale: usr/jordan/captain/briefings/apple-containers-test-isolation-42-20260818.md
+  conclusion (argued in-process; reversed to container-substrate — now SHIPPED).
+
+## Environment
+- Apple `container` v1.2.2 running; image built. Docker installed, daemon down.
+- Full container run occasionally gets killed near the end (intermittent) — the
+  tools/ segment (1805 tests) completes reliably; run segments separately if needed.
+
+— captain. #42 shipped. 230→0, ~12 real bugs caught, QG-clean, released v46.44.
+
+*OFFENDERS WILL BE FED TO THE — CUTE — ATTACK KITTENS!*


### PR DESCRIPTION
Captain-landed via `/pr-captain-land` — **local-first** flow.

The work was integrated and validated locally BEFORE this PR existed. CI here
is confirmation, not the gate.

- Source branch: `fix-config-dup-and-testrun-parsing` (untouched; this PR rides `_land-fix-config-dup-and-testrun-parsing`)
- Integrated in a scratch worktree cut from `origin/fix-config-dup-and-testrun-parsing`, verified to contain `origin/main`
- Agent QGR receipt: `agency/workstreams/agency/qgr/the-agency-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-prep-20260903-2338-ce2de4a.md` (hash `ce2de4a`) — verified before any mutation
- Local validation: 1 local validation step(s) passed against origin/main
- Captain landing receipt: `agency/workstreams/agency/qgr/the-agency-ai-jordan-captain-agency-fix-config-dup-and-testrun-parsing-qgr-pr-captain-land-20260903-2341-4b4f296.md` (hash `4b4f296`)
- `agency_version`: 46.47 → 46.48
- Release v46.48 cut on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)